### PR TITLE
Rename to Mobile Schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Long Weekend Band Crawl Vol. 14
+# Long Weekend Band Crawl Mobile Schedule
 
 A mobile-first web app that lets attendees build and view their personalized schedules for the Long Weekend Band Crawl. Select bands, see conflicts, and get "coming up in X minutes" reminders.
 
@@ -147,7 +147,8 @@ Modern browsers with ES2020+ support:
 
 This repository is hosted on GitHub at [`BreakableHoodie/longweekend-bandcrawl`](https://github.com/BreakableHoodie/longweekend-bandcrawl).
 
-1. **Push the latest code**  
+1. **Push the latest code**
+
    ```bash
    git status
    git add .
@@ -156,17 +157,20 @@ This repository is hosted on GitHub at [`BreakableHoodie/longweekend-bandcrawl`]
    ```
 
 2. **Connect the repo to Cloudflare Pages**
+
    - In the Cloudflare dashboard go to **Pages → Create a project → Connect to Git**.
    - Authorise the Cloudflare Pages GitHub app and grant it access to `BreakableHoodie/longweekend-bandcrawl`.
    - Pick `main` as the production branch and add `dev` as a preview branch so staging deploys happen automatically.
 
 3. **Configure build settings**
+
    - **Project root:** `frontend`
    - **Build command:** `npm run build`
    - **Output directory:** `dist`
    - Set `NODE_VERSION=18` (Build settings → Environment variables) to match the local toolchain.
 
 4. **Deploy**
+
    - Cloudflare installs dependencies, runs the Vite build, and publishes to the `*.pages.dev` domain.
    - Add your custom domain in **Pages → Custom domains** when ready.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Long Weekend Band Crawl Vol. 14 - Build your personalized schedule">
+    <meta name="description" content="Long Weekend Band Crawl Mobile Schedule - Build your personalized lineup">
     <meta name="theme-color" content="#2d2554">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
@@ -21,7 +21,7 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
-    <title>Long Weekend Band Crawl Vol. 14</title>
+    <title>Long Weekend Band Crawl Mobile Schedule</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Long Weekend Band Crawl Vol. 14",
+  "name": "Long Weekend Band Crawl Mobile Schedule",
   "short_name": "Band Crawl",
   "description": "Build your personalized schedule for Long Weekend Band Crawl",
   "start_url": "/",

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -60,7 +60,7 @@ function Header({ view, setView }) {
               : "opacity-100 translate-y-0 text-center"
           }`}
         >
-          Sunday October 12th 2025 - Vol. 14
+          Sunday October 12th 2025 · Mobile Schedule
         </p>
         <div
           className={`flex justify-center items-center gap-6 sm:gap-8 transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] ${


### PR DESCRIPTION
## Summary
- retitle the app as "Long Weekend Band Crawl Mobile Schedule"
- update meta tags, manifest, and hero header copy
- run deploy workflow on pull_request and skip deploy for non-push events