### PR TITLE
Refactor admin band management form logic

### DIFF
--- a/frontend/src/admin/BandForm.jsx
+++ b/frontend/src/admin/BandForm.jsx
@@ -1,0 +1,207 @@
+import PropTypes from 'prop-types'
+
+export default function BandForm({
+  events,
+  venues,
+  formData,
+  submitting,
+  mode,
+  showEventIntro,
+  onChange,
+  onSubmit,
+  onCancel,
+  conflicts,
+}) {
+  const requireSchedule = Boolean(formData.event_id)
+  const submitLabel = submitting ? 'Saving...' : mode === 'edit' ? 'Update Performance' : 'Add Performance'
+
+  return (
+    <form onSubmit={onSubmit}>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+        <div className="sm:col-span-2">
+          <label htmlFor="band-name" className="block text-white mb-2 text-sm">
+            Band Name *
+          </label>
+          <input
+            id="band-name"
+            type="text"
+            name="name"
+            value={formData.name}
+            onChange={onChange}
+            className="w-full px-3 py-2 rounded bg-band-navy text-white border border-gray-600 focus:border-band-orange focus:outline-none"
+            required
+            placeholder="The Rockers"
+          />
+        </div>
+
+        <div className="sm:col-span-2">
+          <label htmlFor="band-event" className="block text-white mb-2 text-sm">
+            Event
+          </label>
+          <select
+            id="band-event"
+            name="event_id"
+            value={formData.event_id}
+            onChange={onChange}
+            className="w-full px-3 py-2 rounded bg-band-navy text-white border border-gray-600 focus:border-band-orange focus:outline-none"
+          >
+            <option value="">No event assigned yet</option>
+            {events.map(event => (
+              <option key={event.id} value={event.id}>
+                {event.name}
+              </option>
+            ))}
+          </select>
+          <p className="text-white/60 text-xs mt-2">
+            Leave this blank to keep the band available or move it between events later.
+          </p>
+        </div>
+
+        {showEventIntro && (
+          <div className="sm:col-span-2">
+            <div className="bg-blue-900/20 border border-blue-600 rounded p-3 text-sm text-blue-100">
+              You can create bands and venues independently from events. Assign them now or keep them available to attach later.
+            </div>
+          </div>
+        )}
+
+        <div className="sm:col-span-2">
+          <label htmlFor="band-venue" className="block text-white mb-2 text-sm">
+            Venue <span className="text-gray-400 text-xs ml-2">(optional)</span>
+          </label>
+          <select
+            id="band-venue"
+            name="venue_id"
+            value={formData.venue_id}
+            onChange={onChange}
+            className="w-full px-3 py-2 rounded bg-band-navy text-white border border-gray-600 focus:border-band-orange focus:outline-none"
+          >
+            <option value="">No venue assigned yet</option>
+            {venues.map(venue => (
+              <option key={venue.id} value={venue.id}>
+                {venue.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {requireSchedule && (
+          <>
+            <div>
+              <label htmlFor="band-start-time" className="block text-white mb-2 text-sm">
+                Start Time
+              </label>
+              <input
+                id="band-start-time"
+                type="time"
+                name="start_time"
+                value={formData.start_time}
+                onChange={onChange}
+                className="w-full px-3 py-2 rounded bg-band-navy text-white border border-gray-600 focus:border-band-orange focus:outline-none"
+                required={requireSchedule}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="band-duration" className="block text-white mb-2 text-sm">
+                Duration (minutes)
+                <span className="text-gray-400 text-xs ml-2">or set end time below</span>
+              </label>
+              <input
+                id="band-duration"
+                type="number"
+                name="duration"
+                value={formData.duration}
+                onChange={onChange}
+                className="w-full px-3 py-2 rounded bg-band-navy text-white border border-gray-600 focus:border-band-orange focus:outline-none"
+                placeholder="45"
+                min="1"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="band-end-time" className="block text-white mb-2 text-sm">
+                End Time
+                <span className="text-gray-400 text-xs ml-2">or set duration above</span>
+              </label>
+              <input
+                id="band-end-time"
+                type="time"
+                name="end_time"
+                value={formData.end_time}
+                onChange={onChange}
+                className="w-full px-3 py-2 rounded bg-band-navy text-white border border-gray-600 focus:border-band-orange focus:outline-none"
+                required={requireSchedule}
+              />
+            </div>
+          </>
+        )}
+
+        <div className="sm:col-span-2">
+          <label htmlFor="band-url" className="block text-white mb-2 text-sm">
+            Website / Social Media <span className="text-gray-400 text-xs ml-2">(optional)</span>
+          </label>
+          <input
+            id="band-url"
+            type="url"
+            name="url"
+            value={formData.url}
+            onChange={onChange}
+            className="w-full px-3 py-2 rounded bg-band-navy text-white border border-gray-600 focus:border-band-orange focus:outline-none"
+            placeholder="https://example.com"
+          />
+        </div>
+      </div>
+
+      {requireSchedule && conflicts.length > 0 && (
+        <div className="bg-red-900/30 border border-red-600 rounded p-3 mb-4">
+          <p className="text-red-200 text-sm font-semibold mb-1">Time Conflict Detected!</p>
+          <p className="text-red-200 text-sm">This time overlaps with: {conflicts.join(', ')}</p>
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="px-4 py-2 bg-band-orange text-white rounded hover:bg-orange-600 disabled:opacity-50 transition-colors"
+        >
+          {submitLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}
+
+BandForm.propTypes = {
+  events: PropTypes.arrayOf(PropTypes.object).isRequired,
+  venues: PropTypes.arrayOf(PropTypes.object).isRequired,
+  formData: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    event_id: PropTypes.string.isRequired,
+    venue_id: PropTypes.string.isRequired,
+    start_time: PropTypes.string.isRequired,
+    end_time: PropTypes.string.isRequired,
+    duration: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+  submitting: PropTypes.bool.isRequired,
+  mode: PropTypes.oneOf(['create', 'edit']).isRequired,
+  showEventIntro: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  conflicts: PropTypes.arrayOf(PropTypes.string),
+}
+
+BandForm.defaultProps = {
+  showEventIntro: false,
+  conflicts: [],
+}

--- a/frontend/src/admin/utils/timeUtils.js
+++ b/frontend/src/admin/utils/timeUtils.js
@@ -1,0 +1,160 @@
+const MINUTES_PER_DAY = 24 * 60
+
+const isNumber = value => typeof value === 'number' && Number.isFinite(value)
+
+export const parseTimeToMinutes = time => {
+  if (!time) return null
+  const [hours, minutes] = time.split(':').map(Number)
+  if (!isNumber(hours) || !isNumber(minutes)) {
+    return null
+  }
+  return hours * 60 + minutes
+}
+
+const normalizeEndMinutes = (startMinutes, endMinutes) => {
+  if (!isNumber(startMinutes) || !isNumber(endMinutes)) {
+    return null
+  }
+  return endMinutes <= startMinutes ? endMinutes + MINUTES_PER_DAY : endMinutes
+}
+
+export const buildTimeIntervals = (startTime, endTime) => {
+  const startMinutes = parseTimeToMinutes(startTime)
+  const endMinutes = parseTimeToMinutes(endTime)
+  if (startMinutes == null || endMinutes == null) {
+    return []
+  }
+
+  const normalizedEnd = normalizeEndMinutes(startMinutes, endMinutes)
+  if (normalizedEnd == null) {
+    return []
+  }
+
+  return [
+    [startMinutes, normalizedEnd],
+    [startMinutes + MINUTES_PER_DAY, normalizedEnd + MINUTES_PER_DAY],
+  ]
+}
+
+export const calculateEndTimeFromDuration = (startTime, durationMinutes) => {
+  if (!startTime || durationMinutes === '' || durationMinutes == null) {
+    return ''
+  }
+
+  const duration = Number(durationMinutes)
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return ''
+  }
+
+  const [hours, minutes] = startTime.split(':').map(Number)
+  if (!isNumber(hours) || !isNumber(minutes)) {
+    return ''
+  }
+
+  const totalMinutes = hours * 60 + minutes + duration
+  const normalizedMinutes = ((totalMinutes % MINUTES_PER_DAY) + MINUTES_PER_DAY) % MINUTES_PER_DAY
+  const endHours = Math.floor(normalizedMinutes / 60)
+  const endMins = normalizedMinutes % 60
+
+  return `${String(endHours).padStart(2, '0')}:${String(endMins).padStart(2, '0')}`
+}
+
+export const deriveDurationMinutes = (startTime, endTime) => {
+  const startMinutes = parseTimeToMinutes(startTime)
+  const endMinutes = parseTimeToMinutes(endTime)
+  if (startMinutes == null || endMinutes == null) {
+    return null
+  }
+
+  const normalizedEnd = normalizeEndMinutes(startMinutes, endMinutes)
+  if (normalizedEnd == null) {
+    return null
+  }
+
+  return normalizedEnd - startMinutes
+}
+
+const intervalsOverlap = (intervalA, intervalB) => intervalA[0] < intervalB[1] && intervalB[0] < intervalA[1]
+
+export const detectConflicts = (candidateBand, bands) => {
+  if (!candidateBand || !bands?.length) {
+    return []
+  }
+
+  const { event_id: eventId, venue_id: venueId, start_time: startTime, end_time: endTime, id } = candidateBand
+  if (!eventId || !venueId || !startTime || !endTime) {
+    return []
+  }
+
+  const bandIntervals = buildTimeIntervals(startTime, endTime)
+  if (!bandIntervals.length) {
+    return []
+  }
+
+  return bands
+    .filter(other => {
+      if (!other) return false
+      if (id != null && other.id === id) return false
+      if (!other.event_id || !other.venue_id) return false
+      return Number(other.event_id) === Number(eventId) && Number(other.venue_id) === Number(venueId)
+    })
+    .filter(other => {
+      const otherIntervals = buildTimeIntervals(other.start_time, other.end_time)
+      return otherIntervals.some(intervalB => bandIntervals.some(intervalA => intervalsOverlap(intervalA, intervalB)))
+    })
+    .map(other => other.name)
+}
+
+export const formatTimeLabel = time => {
+  if (!time) return '—'
+  const [hours, minutes] = time.split(':')
+  const parsedHours = Number(hours)
+  if (!isNumber(parsedHours)) {
+    return '—'
+  }
+
+  const period = parsedHours >= 12 ? 'PM' : 'AM'
+  const displayHour = parsedHours === 0 ? 12 : parsedHours > 12 ? parsedHours - 12 : parsedHours
+  return `${displayHour}:${minutes} ${period}`
+}
+
+export const formatTimeRangeLabel = (startTime, endTime) => {
+  const startLabel = formatTimeLabel(startTime)
+  const endLabel = formatTimeLabel(endTime)
+  if (startLabel === '—' && endLabel === '—') {
+    return '—'
+  }
+  return `${startLabel} – ${endLabel}`
+}
+
+export const formatDurationLabel = (startTime, endTime) => {
+  const durationMinutes = deriveDurationMinutes(startTime, endTime)
+  if (durationMinutes == null) {
+    return '—'
+  }
+  return `${durationMinutes} min`
+}
+
+export const sortBandsByStart = bands => {
+  if (!Array.isArray(bands)) {
+    return []
+  }
+
+  return [...bands].sort((bandA, bandB) => {
+    const aMinutes = parseTimeToMinutes(bandA?.start_time)
+    const bMinutes = parseTimeToMinutes(bandB?.start_time)
+
+    if (aMinutes == null && bMinutes == null) {
+      return (bandA?.name || '').localeCompare(bandB?.name || '')
+    }
+
+    if (aMinutes == null) return 1
+    if (bMinutes == null) return -1
+
+    if (aMinutes === bMinutes) {
+      return (bandA?.name || '').localeCompare(bandB?.name || '')
+    }
+
+    return aMinutes - bMinutes
+  })
+}


### PR DESCRIPTION
## Summary
- extract a reusable BandForm component and shared time utility helpers to keep form handling consistent
- update the admin bands tab to use the new form, memoized sorting, and conflict detection helpers while keeping bands and venues event-independent
- normalize display helpers for times and durations so unassigned bands render safe fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe69fa90148320ab72bf67b0a7d834