### PR TITLE
feat(admin): allow past dates for archived events

### DIFF
--- a/functions/api/admin/events.js
+++ b/functions/api/admin/events.js
@@ -112,12 +112,14 @@ export async function onRequestPost(context) {
       theme_colors,
     } = validation.sanitized;
 
-    // Validate date is not in past
+    // Validate date is not in past (unless status is archived for retroactive events)
     const eventDate = new Date(date);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    if (eventDate < today) {
-      return validationErrorResponse("Date cannot be in the past");
+    if (eventDate < today && status !== "archived") {
+      return validationErrorResponse(
+        "Date cannot be in the past (use archived status for past events)",
+      );
     }
 
     // Check if slug already exists


### PR DESCRIPTION
## Summary

- Enable creating retroactive events with past dates when status is "archived"
- Aligns backend validation with existing frontend logic
- Helps build out historical roster of artists and event statistics

## Changes

Modified `functions/api/admin/events.js` to allow past dates when `status === "archived"`:

```javascript
// Before
if (eventDate < today) {

// After
if (eventDate < today && status !== "archived") {
```

## Test plan

- [x] All 198 existing tests pass
- [ ] Create new event with status "archived" and past date - should succeed
- [ ] Create new event with status "draft" and past date - should fail with helpful message

🤖 Generated with [Claude Code](https://claude.ai/code)