### PR TITLE
Move warning indicators inline on band cards

### DIFF
--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -5,7 +5,16 @@ import { Link } from 'react-router-dom'
 import { slugifyBandName } from '../utils/slugify'
 import { getTimeDescription, isHappeningNow } from '../utils/timeFilter'
 
-function BandCard({ band, isSelected, onToggle, showVenue = true, clickable = true, onRemove, warningType, warningText }) {
+function BandCard({
+  band,
+  isSelected,
+  onToggle,
+  showVenue = true,
+  clickable = true,
+  onRemove,
+  warningType,
+  warningText,
+}) {
   const handleToggle = () => {
     if (!clickable) return
     onToggle?.(band.id)
@@ -105,15 +114,10 @@ function BandCard({ band, isSelected, onToggle, showVenue = true, clickable = tr
         {warningType && warningText && (
           <div
             className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold mt-1 ${
-              warningType === 'overlap'
-                ? 'bg-yellow-500/30 text-yellow-200'
-                : 'bg-red-500/30 text-red-200'
+              warningType === 'overlap' ? 'bg-yellow-500/30 text-yellow-200' : 'bg-red-500/30 text-red-200'
             }`}
           >
-            <FontAwesomeIcon
-              icon={warningType === 'overlap' ? faBolt : faTriangleExclamation}
-              aria-hidden="true"
-            />
+            <FontAwesomeIcon icon={warningType === 'overlap' ? faBolt : faTriangleExclamation} aria-hidden="true" />
             <span>{warningText}</span>
           </div>
         )}

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -400,7 +400,8 @@ function MySchedule({ bands, onToggleBand, onClearSchedule, showPast, onToggleSh
               <div className="flex items-center gap-3 text-yellow-200 font-semibold">
                 <FontAwesomeIcon icon={faBolt} className="text-yellow-300 text-xl flex-shrink-0" aria-hidden="true" />
                 <p className="text-sm sm:text-base leading-normal">
-                  {overlaps.length} band{overlaps.length !== 1 ? 's' : ''} happening at the same time — you&apos;ll need to choose!
+                  {overlaps.length} band{overlaps.length !== 1 ? 's' : ''} happening at the same time — you&apos;ll need
+                  to choose!
                 </p>
               </div>
             </div>
@@ -408,9 +409,14 @@ function MySchedule({ bands, onToggleBand, onClearSchedule, showPast, onToggleSh
           {conflicts.length > 0 && (
             <div className="bg-red-500/20 border border-red-500/50 rounded-lg p-4 leading-normal">
               <div className="flex items-center gap-3 text-red-200 font-semibold">
-                <FontAwesomeIcon icon={faTriangleExclamation} className="text-red-300 text-xl flex-shrink-0" aria-hidden="true" />
+                <FontAwesomeIcon
+                  icon={faTriangleExclamation}
+                  className="text-red-300 text-xl flex-shrink-0"
+                  aria-hidden="true"
+                />
                 <p className="text-sm sm:text-base leading-normal">
-                  {conflicts.length} overlapping set{conflicts.length !== 1 ? 's' : ''} — you may not catch every full set.
+                  {conflicts.length} overlapping set{conflicts.length !== 1 ? 's' : ''} — you may not catch every full
+                  set.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Moved schedule conflict/overlap warning icons from outside band cards to always-visible inline pills inside BandCard
- Fixed top warning banner alignment (centered nested spans → left-aligned flex layout)
- Removed external emoji indicators that broke card grid alignment
- Warning pills show which specific band conflicts (e.g. "Same time as Band X")

## Test plan
- [ ] Verify band cards with overlapping times show yellow "Same time as..." pill
- [ ] Verify band cards with conflicts show red "Overlaps with..." pill
- [ ] Verify cards without warnings render unchanged
- [ ] Verify top warning banners are left-aligned with icon + text
- [ ] Verify card grid alignment is consistent across all states

🤖 Generated with [Claude Code](https://claude.com/claude-code)