### PR TITLE
deps: upgrade react and react-dom to v19

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "quill": "^2.0.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-helmet-async": "^2.0.5",
+        "react-helmet-async": "^3.0.0",
         "react-quill-new": "^3.7.0",
         "react-router-dom": "^7.9.4",
         "react-swipeable": "^7.0.2"
@@ -10676,9 +10676,9 @@
       "license": "MIT"
     },
     "node_modules/react-helmet-async": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
-      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "invariant": "^2.2.4",
@@ -10686,7 +10686,7 @@
         "shallowequal": "^1.1.0"
       },
       "peerDependencies": {
-        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "quill": "^2.0.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-helmet-async": "^2.0.5",
+    "react-helmet-async": "^3.0.0",
     "react-quill-new": "^3.7.0",
     "react-router-dom": "^7.9.4",
     "react-swipeable": "^7.0.2"


### PR DESCRIPTION
## Summary

- Bumps `react` and `react-dom` from `^18.2.0` to `^19.2.4`
- Bumps `@types/react` from `^18.2.43` to `^19.2.14`
- Bumps `@types/react-dom` from `^18.2.17` to `^19.2.3`

Replaces Dependabot PR #108 which only bumped `react` + `@types/react`, leaving `@types/react-dom` at v18 which caused a peer dependency conflict during install.

## Test plan
- [ ] Build passes
- [ ] App renders correctly
- [ ] No React 19 deprecation warnings in console