### PR TITLE
fix: band profile pages return 404 when no published performances exist

### DIFF
--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -123,12 +123,6 @@ export async function onRequestGet(context) {
       .all();
 
     const allPerformances = performances.results || [];
-    if (allPerformances.length === 0) {
-      return new Response(
-        JSON.stringify({ error: "Band not found" }),
-        { status: 404, headers: { "Content-Type": "application/json" } },
-      );
-    }
 
     // Calculate statistics
     const today = new Date().toISOString().split("T")[0];


### PR DESCRIPTION
## Summary

- Removes the early-exit `404` in `GET /api/bands/stats/:name` that fired when a band profile had zero published performances
- Band profiles are now returned correctly even with empty `upcoming`/`past` arrays — stats default to `0`/`null` naturally

## Root Cause

`functions/api/bands/stats/[name].js` returned `404 "Band not found"` after querying performances and finding none. This was wrong: the band profile existed — it just had no published shows yet (or all shows were in unpublished/archived events).

Affected scenarios:
1. Profiles created via admin "Add Artist" (global, no event) — no `performances` row exists
2. Profiles where all events were later unpublished or archived

## Test plan

- [ ] Visit `/band/<id>` for a band with upcoming performances — profile loads normally
- [ ] Visit `/band/<id>` for a band with only past performances — profile loads normally  
- [ ] Visit `/band/<id>` for a band profile with **no** performances (global-add only) — profile loads with empty show sections instead of "Band Not Found"
- [ ] Visit `/band/nonexistent` — still returns "Band Not Found" (band_profile lookup still 404s correctly)

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)