### PR TITLE
fix: increase e2e job timeout to 35 min, add list reporter

### DIFF
--- a/.github/workflows/e2e-a11y-visual.yml
+++ b/.github/workflows/e2e-a11y-visual.yml
@@ -20,7 +20,7 @@ jobs:
     e2e-a11y-visual:
         name: e2e-a11y-visual
         runs-on: ubuntu-latest
-        timeout-minutes: 20
+        timeout-minutes: 35
 
         steps:
             - uses: actions/checkout@v6
@@ -112,7 +112,7 @@ jobs:
               env:
                   ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
                   ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
-              run: npx playwright test e2e/accessibility e2e/visual-regression.spec.js
+              run: npx playwright test e2e/accessibility e2e/visual-regression.spec.js --reporter=list,html
 
             - name: Upload Playwright report
               uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
     e2e:
         name: e2e
         runs-on: ubuntu-latest
-        timeout-minutes: 20
+        timeout-minutes: 35
 
         steps:
             - uses: actions/checkout@v6
@@ -126,7 +126,7 @@ jobs:
                   ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
                   ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
                   PLAYWRIGHT_SKIP_A11Y_VISUAL: 'true'
-              run: npx playwright test
+              run: npx playwright test --reporter=list,html
 
             - name: Upload Playwright report
               uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Increases e2e job `timeout-minutes` from 20 → 35 to give the full 85-test suite room to complete when some tests are slow or flaky with `retries: 2`
- Adds `--reporter=list,html` so per-test pass/fail names stream directly into the GitHub Actions log — no need to download the HTML artifact to identify which test failed

## Context

The server startup issue is fixed (PR #168). The 20-minute cap was silently killing the suite before all tests could complete — the e2e run now starts fine (server up in ~2s) but some tests with retries push past the 20-min wall.

## Test plan

- [ ] CI e2e job completes within 35 minutes with all tests shown inline in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)