### PR TITLE
fix: provide fallback e2e credentials for Dependabot PRs

### DIFF
--- a/.github/workflows/e2e-a11y-visual.yml
+++ b/.github/workflows/e2e-a11y-visual.yml
@@ -52,8 +52,8 @@ jobs:
 
             - name: Initialize D1 database with schema
               env:
-                  E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
-                  E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
+                  E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD || 'ci-e2e-fallback-pw' }}
+                  E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL || 'ci-admin@settimes.ca' }}
               run: |
                   echo 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"' > .dev.vars
 
@@ -110,8 +110,8 @@ jobs:
 
             - name: Run Playwright tests (A11y + Visual)
               env:
-                  ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
-                  ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
+                  ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD || 'ci-e2e-fallback-pw' }}
+                  ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL || 'ci-admin@settimes.ca' }}
               run: npx playwright test e2e/accessibility e2e/visual-regression.spec.js --reporter=list,html
 
             - name: Upload Playwright report

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,8 +63,8 @@ jobs:
             - name: Initialize D1 database with schema
               if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true'
               env:
-                  E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
-                  E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
+                  E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD || 'ci-e2e-fallback-pw' }}
+                  E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL || 'ci-admin@settimes.ca' }}
               run: |
                   echo 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"' > .dev.vars
 
@@ -123,8 +123,8 @@ jobs:
             - name: Run Playwright tests
               if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true'
               env:
-                  ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
-                  ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
+                  ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD || 'ci-e2e-fallback-pw' }}
+                  ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL || 'ci-admin@settimes.ca' }}
                   PLAYWRIGHT_SKIP_A11Y_VISUAL: 'true'
               run: npx playwright test --reporter=list,html
 


### PR DESCRIPTION
## Summary

- GitHub restricts repository secrets on Dependabot-triggered workflows by default — only "Dependabot secrets" (configured separately) are injected
- Without `ADMIN_PASSWORD` set, `e2e/credentials.js` throws immediately and the entire test suite fails in ~1 minute
- Uses GitHub Actions expression `||` fallback so Dependabot PRs always get consistent CI-local credentials
- Both the database init step (which seeds the admin user) and the Playwright test runner use the same fallback, so the admin account is always present and always accessible

## Test plan

- [ ] Dependabot PRs should now pass e2e without needing repository secrets configured as Dependabot secrets
- [ ] Real runs (push to main/dev, non-Dependabot PRs) still use the real secrets — `secrets.E2E_ADMIN_PASSWORD` is non-empty, so `||` short-circuits and the fallback is never used

🤖 Generated with [Claude Code](https://claude.com/claude-code)