### PR TITLE
chore: add .mcp.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ e2e/visual-regression.spec.js-snapshots/
 # AI assistants (developer-specific)
 .claude/
 .serena/
+.mcp.json
 chatmodes/
 claudedocs/
 instructions/


### PR DESCRIPTION
## Summary

- `.mcp.json` is local MCP server configuration — developer-specific tooling, same category as `.claude/` and `.serena/` which are already gitignored
- Prevents accidental commits of local MCP config

🤖 Generated with [Claude Code](https://claude.com/claude-code)