### PR TITLE
test: add missing coverage + rate_limits retention cleanup (PR #201 follow-ups)

### DIFF
--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -367,13 +367,14 @@ CREATE INDEX IF NOT EXISTS idx_auth_audit_timestamp ON auth_audit(timestamp);
 CREATE INDEX IF NOT EXISTS idx_auth_audit_ip ON auth_audit(ip_address);
 CREATE INDEX IF NOT EXISTS idx_rate_limit_ip ON rate_limit(ip_address);
 
--- Globally-consistent sliding-window rate limit counters (D1-backed, for auth/subscription endpoints)
+-- Globally-consistent fixed-window rate limit counters (D1-backed, for auth/subscription endpoints)
 CREATE TABLE IF NOT EXISTS rate_limits (
   key TEXT PRIMARY KEY,
   count INTEGER NOT NULL DEFAULT 0,
   window_start INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );
+CREATE INDEX IF NOT EXISTS idx_rate_limits_updated_at ON rate_limits (updated_at);
 
 -- ============================================
 -- TEST ACCOUNTS (passwords set by scripts/setup-local-db.sh)

--- a/functions/api/admin/__tests__/trusted-devices.test.js
+++ b/functions/api/admin/__tests__/trusted-devices.test.js
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "vitest";
+import { createTestEnv, mockUsers } from "../../test-utils.js";
+import { onRequestGet, onRequestDelete } from "../trusted-devices.js";
+
+const BASE_URL = "https://example.test/api/admin/trusted-devices";
+
+function makeCtx(env, userId) {
+  return { env, data: { user: { userId, role: "editor", email: "editor@test" } } };
+}
+
+function insertDevice(rawDb, { userId, expired = false } = {}) {
+  const expiresExpr = expired
+    ? "datetime('now', '-1 day')"
+    : "datetime('now', '+30 days')";
+  const info = rawDb
+    .prepare(
+      `INSERT INTO trusted_devices (user_id, token, device_fingerprint, ip_address, user_agent, expires_at, last_used_at)
+       VALUES (?, ?, 'fp', '1.2.3.4', 'Mozilla/5.0', ${expiresExpr}, datetime('now'))`,
+    )
+    .run(userId, crypto.randomUUID());
+  return rawDb.prepare("SELECT * FROM trusted_devices WHERE id = ?").get(info.lastInsertRowid);
+}
+
+describe("GET /api/admin/trusted-devices", () => {
+  test("returns only non-expired devices for the requesting user", async () => {
+    const { env, rawDb } = createTestEnv({ role: "editor" });
+    insertDevice(rawDb, { userId: mockUsers.editor.id });
+    insertDevice(rawDb, { userId: mockUsers.editor.id });
+    insertDevice(rawDb, { userId: mockUsers.editor.id, expired: true }); // should not appear
+    insertDevice(rawDb, { userId: mockUsers.admin.id });                 // another user's device
+
+    const response = await onRequestGet({
+      request: new Request(BASE_URL),
+      ...makeCtx(env, mockUsers.editor.id),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.devices).toHaveLength(2);
+    // Sensitive token field must not be exposed
+    expect(payload.devices[0]).not.toHaveProperty("token");
+    expect(payload.devices[0]).toHaveProperty("id");
+    expect(payload.devices[0]).toHaveProperty("ip_address");
+  });
+
+  test("returns empty array when user has no trusted devices", async () => {
+    const { env } = createTestEnv({ role: "editor" });
+
+    const response = await onRequestGet({
+      request: new Request(BASE_URL),
+      ...makeCtx(env, mockUsers.editor.id),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.devices).toEqual([]);
+  });
+});
+
+describe("DELETE /api/admin/trusted-devices", () => {
+  test("successfully revokes own device", async () => {
+    const { env, rawDb } = createTestEnv({ role: "editor" });
+    const device = insertDevice(rawDb, { userId: mockUsers.editor.id });
+
+    const response = await onRequestDelete({
+      request: new Request(BASE_URL, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ deviceId: device.id }),
+      }),
+      ...makeCtx(env, mockUsers.editor.id),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(rawDb.prepare("SELECT * FROM trusted_devices WHERE id = ?").get(device.id)).toBeUndefined();
+  });
+
+  test("returns 404 when deviceId belongs to a different user (enumeration protection)", async () => {
+    const { env, rawDb } = createTestEnv({ role: "editor" });
+    const adminDevice = insertDevice(rawDb, { userId: mockUsers.admin.id });
+
+    const response = await onRequestDelete({
+      request: new Request(BASE_URL, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ deviceId: adminDevice.id }),
+      }),
+      ...makeCtx(env, mockUsers.editor.id),
+    });
+
+    expect(response.status).toBe(404);
+    // Admin's device must be untouched
+    expect(rawDb.prepare("SELECT * FROM trusted_devices WHERE id = ?").get(adminDevice.id)).toBeTruthy();
+  });
+
+  test("returns 400 when deviceId is missing", async () => {
+    const { env } = createTestEnv({ role: "editor" });
+
+    const response = await onRequestDelete({
+      request: new Request(BASE_URL, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      ...makeCtx(env, mockUsers.editor.id),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  test("ownership check works when userId is passed as a string (D1 integer vs Lucia string)", async () => {
+    const { env, rawDb } = createTestEnv({ role: "editor" });
+    const device = insertDevice(rawDb, { userId: mockUsers.editor.id });
+
+    // Simulate Lucia returning userId as a string
+    const response = await onRequestDelete({
+      request: new Request(BASE_URL, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ deviceId: device.id }),
+      }),
+      env,
+      data: { user: { userId: String(mockUsers.editor.id), role: "editor", email: "editor@test" } },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+  });
+});

--- a/functions/api/admin/maintenance/__tests__/cleanup-sessions.test.js
+++ b/functions/api/admin/maintenance/__tests__/cleanup-sessions.test.js
@@ -50,6 +50,22 @@ describe("POST /api/admin/maintenance/cleanup-sessions", () => {
       )
       .run();
 
+    // Stale rate_limits row (updated >30 min ago)
+    const staleUpdatedAt = Math.floor(Date.now() / 1000) - 2000;
+    rawDb
+      .prepare(
+        "INSERT INTO rate_limits (key, count, window_start, updated_at) VALUES (?, 5, ?, ?)",
+      )
+      .run("1.2.3.4:/api/auth", staleUpdatedAt, staleUpdatedAt);
+
+    // Recent rate_limits row — should survive
+    const recentUpdatedAt = Math.floor(Date.now() / 1000) - 60;
+    rawDb
+      .prepare(
+        "INSERT INTO rate_limits (key, count, window_start, updated_at) VALUES (?, 1, ?, ?)",
+      )
+      .run("5.6.7.8:/api/auth", recentUpdatedAt, recentUpdatedAt);
+
     const request = new Request(
       "https://example.test/api/admin/maintenance/cleanup-sessions",
       { method: "POST", headers },
@@ -63,6 +79,7 @@ describe("POST /api/admin/maintenance/cleanup-sessions", () => {
     expect(payload.sessions_deleted).toBe(1);
     expect(payload.auth_audit_deleted).toBe(1);
     expect(payload.audit_log_deleted).toBe(1);
+    expect(payload.rate_limits_deleted).toBe(1);
 
     // Active rows must survive
     expect(rawDb.prepare("SELECT COUNT(*) as c FROM lucia_sessions WHERE id = ?").get("active-token").c).toBe(1);

--- a/functions/api/admin/maintenance/retention.js
+++ b/functions/api/admin/maintenance/retention.js
@@ -5,12 +5,14 @@
 //   auth_attempts:   30 days  (rate-limit counters; contains IPs/emails)
 //   auth_audit:      90 days  (short-lived security telemetry; contains IPs)
 //   audit_log:       1 year   (admin action history; longer legitimate interest)
+//   rate_limits:     2× max window (30 min) — stale fixed-window counters; uses
+//                    unixepoch() because the column stores integer seconds
 
 export async function runRetentionCleanup(env) {
   const { DB } = env;
   const nowUnix = Math.floor(Date.now() / 1000);
 
-  const [sessions, authAttempts, authAudit, adminAudit] = await Promise.all([
+  const [sessions, authAttempts, authAudit, adminAudit, rateLimits] = await Promise.all([
     DB.prepare("DELETE FROM lucia_sessions WHERE expires_at < ?")
       .bind(nowUnix)
       .run(),
@@ -20,6 +22,8 @@ export async function runRetentionCleanup(env) {
       .run(),
     DB.prepare("DELETE FROM audit_log WHERE created_at < datetime('now', '-1 year')")
       .run(),
+    DB.prepare("DELETE FROM rate_limits WHERE updated_at < unixepoch() - 1800")
+      .run(),
   ]);
 
   return {
@@ -27,5 +31,6 @@ export async function runRetentionCleanup(env) {
     auth_attempts_deleted: authAttempts.meta.changes,
     auth_audit_deleted: authAudit.meta.changes,
     audit_log_deleted: adminAudit.meta.changes,
+    rate_limits_deleted: rateLimits.meta.changes,
   };
 }

--- a/functions/api/admin/maintenance/retention.js
+++ b/functions/api/admin/maintenance/retention.js
@@ -5,8 +5,10 @@
 //   auth_attempts:   30 days  (rate-limit counters; contains IPs/emails)
 //   auth_audit:      90 days  (short-lived security telemetry; contains IPs)
 //   audit_log:       1 year   (admin action history; longer legitimate interest)
-//   rate_limits:     2× max window (30 min) — stale fixed-window counters; uses
-//                    unixepoch() because the column stores integer seconds
+//   rate_limits:     30 min (1800s) — stale fixed-window counters. The largest
+//                    configured window is 300s so this is intentionally 6× to
+//                    give a buffer against races. Uses unixepoch() because the
+//                    column stores integer seconds, not ISO text.
 
 export async function runRetentionCleanup(env) {
   const { DB } = env;

--- a/functions/api/auth/__tests__/reset-password-validate.test.js
+++ b/functions/api/auth/__tests__/reset-password-validate.test.js
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "vitest";
+import { createTestEnv, mockUsers } from "../../test-utils.js";
+import { onRequestPost } from "../reset-password/validate.js";
+
+const BASE_URL = "https://example.test/api/auth/reset-password/validate";
+
+/**
+ * Inserts a password_reset_token row and returns the token string.
+ * `created_by` is required (NOT NULL FK) — use admin as the issuer.
+ */
+function insertToken(rawDb, { userId = mockUsers.editor.id, used = 0, expired = false, userInactive = false } = {}) {
+  if (userInactive) {
+    rawDb.prepare("UPDATE users SET is_active = 0 WHERE id = ?").run(userId);
+  }
+
+  const token = crypto.randomUUID();
+  // Use -2 days (not -1 hour) for expired: SQLite datetime() returns UTC but
+  // Node.js parses the space-separated string as local time, so a short offset
+  // can appear in the future on UTC-negative machines.
+  const expiresExpr = expired ? "datetime('now', '-2 days')" : "datetime('now', '+30 days')";
+  rawDb
+    .prepare(
+      `INSERT INTO password_reset_tokens (user_id, token, created_by, expires_at, used)
+       VALUES (?, ?, ?, ${expiresExpr}, ?)`,
+    )
+    .run(userId, token, mockUsers.admin.id, used);
+  return token;
+}
+
+describe("POST /api/auth/reset-password/validate", () => {
+  test("returns valid user info for a valid token", async () => {
+    const { env, rawDb } = createTestEnv();
+    const token = insertToken(rawDb, { userId: mockUsers.editor.id });
+
+    const response = await onRequestPost({
+      request: new Request(BASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      }),
+      env,
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.valid).toBe(true);
+    expect(payload.user.email).toBe(mockUsers.editor.email);
+    expect(payload).toHaveProperty("expiresAt");
+  });
+
+  test("returns 400 TOKEN_INVALID for unknown token", async () => {
+    const { env } = createTestEnv();
+
+    const response = await onRequestPost({
+      request: new Request(BASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: "no-such-token" }),
+      }),
+      env,
+    });
+
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.code).toBe("TOKEN_INVALID");
+  });
+
+  test("returns 400 TOKEN_INVALID for an already-used token", async () => {
+    const { env, rawDb } = createTestEnv();
+    const token = insertToken(rawDb, { used: 1 });
+
+    const response = await onRequestPost({
+      request: new Request(BASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      }),
+      env,
+    });
+
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.code).toBe("TOKEN_INVALID");
+  });
+
+  test("returns 400 TOKEN_EXPIRED for an expired token", async () => {
+    const { env, rawDb } = createTestEnv();
+    const token = insertToken(rawDb, { expired: true });
+
+    const response = await onRequestPost({
+      request: new Request(BASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      }),
+      env,
+    });
+
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.code).toBe("TOKEN_EXPIRED");
+  });
+
+  test("returns 400 USER_INACTIVE for a token belonging to an inactive user", async () => {
+    const { env, rawDb } = createTestEnv();
+    const token = insertToken(rawDb, { userInactive: true });
+
+    const response = await onRequestPost({
+      request: new Request(BASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      }),
+      env,
+    });
+
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.code).toBe("USER_INACTIVE");
+  });
+
+  test("returns 400 for missing token field", async () => {
+    const { env } = createTestEnv();
+
+    const response = await onRequestPost({
+      request: new Request(BASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      env,
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  test("returns 400 for invalid JSON body", async () => {
+    const { env } = createTestEnv();
+
+    const response = await onRequestPost({
+      request: new Request(BASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not valid json{{",
+      }),
+      env,
+    });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -267,6 +267,13 @@ export function createTestDB() {
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
     );
+
+    CREATE TABLE rate_limits (
+      key TEXT PRIMARY KEY,
+      count INTEGER NOT NULL DEFAULT 0,
+      window_start INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
   `);
 
   const insertUser = db.prepare(

--- a/migrations/0029_rate_limits_updated_at_index.sql
+++ b/migrations/0029_rate_limits_updated_at_index.sql
@@ -1,0 +1,8 @@
+-- Migration: Add index on rate_limits.updated_at
+--
+-- The retention job deletes stale rate_limits rows by updated_at. Without an
+-- index, this requires a full table scan which can time out under a large
+-- table (e.g., after a sustained IP-spray attack). This index makes the
+-- DELETE O(log n) + rows deleted instead of O(n).
+
+CREATE INDEX IF NOT EXISTS idx_rate_limits_updated_at ON rate_limits (updated_at);


### PR DESCRIPTION
## Summary

Follow-up to #201 — two items deferred during review to keep that diff reviewable.

- **retention.js**: adds a fifth parallel `DELETE` to clean up stale `rate_limits` rows (those with `updated_at` older than 2× the max auth window = 30 min). Returns `rate_limits_deleted` in the summary. Prevents the table from growing unbounded under brute-force/spray attacks.
- **test-utils.js**: adds `rate_limits` table to the shared in-memory schema so the new retention test and rate-limit tests have a complete DB.
- **cleanup-sessions.test.js**: seeds a stale and a recent `rate_limits` row; verifies only the stale one is deleted and `rate_limits_deleted: 1` is returned.
- **trusted-devices.test.js** (new): covers `GET` (filters expired rows and other users' devices) and `DELETE` (own device, cross-user 404 enumeration protection, missing id, string vs numeric `userId` type coercion).
- **reset-password-validate.test.js** (new): covers valid token, `TOKEN_INVALID` (unknown + already-used), `TOKEN_EXPIRED`, `USER_INACTIVE`, missing field, and malformed JSON.

## Test plan

- [ ] `npm test` — all 29 test files pass (235 tests)
- [ ] Confirm `rate_limits_deleted` appears in cleanup endpoint response after seeding a stale row

🤖 Generated with [Claude Code](https://claude.com/claude-code)