### PR TITLE
fix: override uuid to ^14.0.0 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ e2e/visual-regression.spec.js-snapshots/
 .claude/
 .serena/
 .mcp.json
+workers-mcp-server/
 chatmodes/
 claudedocs/
 instructions/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11321,13 +11321,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,7 +80,7 @@
     "@lhci/cli": {
       "chrome-launcher": "1.2.1",
       "tmp": "0.2.5",
-      "uuid": "^14.0.0"
+      "uuid": "14.0.0"
     },
     "external-editor": {
       "tmp": "0.2.5"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,7 +79,8 @@
   "overrides": {
     "@lhci/cli": {
       "chrome-launcher": "1.2.1",
-      "tmp": "0.2.5"
+      "tmp": "0.2.5",
+      "uuid": "^14.0.0"
     },
     "external-editor": {
       "tmp": "0.2.5"


### PR DESCRIPTION
## Summary

- Overrides `uuid` to `^14.0.0` under `@lhci/cli` to resolve Dependabot alert [GHSA-w5hq-g745-h8pq](https://github.com/BreakableHoodie/settimesdotca/security/dependabot/49) (missing bounds check in v3/v5/v6 with caller-provided buffers)
- `@lhci/cli` only calls `uuid.v4()` so there is no behaviour change — `v4()` API is identical in v14
- Override is scoped to `@lhci/cli`'s dep tree, not applied globally

## Test plan

- [ ] `npm ls uuid` in `frontend/` shows `uuid@14.0.0` under `@lhci/cli`
- [ ] Dependabot alert #49 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)