### PR TITLE
fix: wrangler JSON parsing, performances trigger, prettier

### DIFF
--- a/frontend/src/admin/AdminPanel.jsx
+++ b/frontend/src/admin/AdminPanel.jsx
@@ -34,6 +34,11 @@ export default function AdminPanel({ currentUser, onLogout }) {
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false)
   const [showMfaModal, setShowMfaModal] = useState(false)
 
+  const showToast = useCallback((message, type = 'success') => {
+    setToast({ message, type })
+    setTimeout(() => setToast(null), 5000)
+  }, [])
+
   const loadEvents = useCallback(async () => {
     try {
       setLoading(true)
@@ -53,7 +58,7 @@ export default function AdminPanel({ currentUser, onLogout }) {
     } finally {
       setLoading(false)
     }
-  }, [onLogout])
+  }, [onLogout, showToast])
 
   // Load events on mount
   useEffect(() => {
@@ -114,15 +119,6 @@ export default function AdminPanel({ currentUser, onLogout }) {
     }
   }, [activeTab, canManageUsers])
 
-  /**
-   * Show toast notification
-   * @param {string} message - Message to display
-   * @param {string} type - 'success' or 'error'
-   */
-  const showToast = useCallback((message, type = 'success') => {
-    setToast({ message, type })
-    setTimeout(() => setToast(null), 5000)
-  }, [])
 
   const handleLogout = () => {
     setShowLogoutConfirm(true)

--- a/frontend/src/admin/AdminPanel.jsx
+++ b/frontend/src/admin/AdminPanel.jsx
@@ -119,7 +119,6 @@ export default function AdminPanel({ currentUser, onLogout }) {
     }
   }, [activeTab, canManageUsers])
 
-
   const handleLogout = () => {
     setShowLogoutConfirm(true)
   }

--- a/migrations/0032_make-performance-venue-time-optional.sql
+++ b/migrations/0032_make-performance-venue-time-optional.sql
@@ -43,4 +43,11 @@ CREATE INDEX IF NOT EXISTS idx_performances_band ON performances(band_profile_id
 CREATE INDEX IF NOT EXISTS idx_performances_venue ON performances(venue_id);
 CREATE INDEX IF NOT EXISTS idx_performances_event_time ON performances(event_id, start_time);
 
+-- Restore trigger dropped by table recreation
+CREATE TRIGGER IF NOT EXISTS update_performances_timestamp
+AFTER UPDATE ON performances
+BEGIN
+  UPDATE performances SET updated_at = datetime('now') WHERE id = NEW.id;
+END;
+
 PRAGMA foreign_keys = ON;

--- a/migrations/0033_restore_performances_trigger.sql
+++ b/migrations/0033_restore_performances_trigger.sql
@@ -1,0 +1,10 @@
+-- Migration: 0033_restore_performances_trigger
+-- Description: Restore update_performances_timestamp trigger dropped when
+--   migration 0032 recreated the performances table. Without this trigger,
+--   performances.updated_at is not bumped on UPDATE.
+
+CREATE TRIGGER IF NOT EXISTS update_performances_timestamp
+AFTER UPDATE ON performances
+BEGIN
+  UPDATE performances SET updated_at = datetime('now') WHERE id = NEW.id;
+END;

--- a/scripts/verify-remote-d1-schema.mjs
+++ b/scripts/verify-remote-d1-schema.mjs
@@ -119,24 +119,25 @@ async function runWranglerQuery(databaseName, query) {
   return { stdout, stderr };
 }
 
-function parseWranglerTable(stdout) {
+function parseWranglerJson(stdout) {
   const jsonMatch = stdout.match(/\[[\s\S]*\]/);
-  if (!jsonMatch) return { headers: [], rows: [] };
+  if (!jsonMatch) return { parsedOk: false, headers: [], rows: [] };
 
   let parsed;
   try {
     parsed = JSON.parse(jsonMatch[0]);
   } catch {
-    return { headers: [], rows: [] };
+    return { parsedOk: false, headers: [], rows: [] };
   }
 
   const results = parsed[0]?.results;
-  if (!results || results.length === 0) return { headers: [], rows: [] };
+  if (!Array.isArray(results)) return { parsedOk: false, headers: [], rows: [] };
+  if (results.length === 0) return { parsedOk: true, headers: [], rows: [] };
 
   const headers = Object.keys(results[0]);
   const rows = results.map((obj) => headers.map((h) => obj[h] ?? null));
 
-  return { headers, rows };
+  return { parsedOk: true, headers, rows };
 }
 
 async function verifyTables(databaseName) {
@@ -145,9 +146,9 @@ async function verifyTables(databaseName) {
     .map((table) => `'${table}'`)
     .join(', ')}) ORDER BY name;`;
   const { stdout, stderr } = await runWranglerQuery(databaseName, query);
-  const parsed = parseWranglerTable(stdout);
+  const parsed = parseWranglerJson(stdout);
 
-  if (parsed.headers.length === 0) {
+  if (!parsed.parsedOk) {
     const stdoutSnippet = stdout.trim().slice(0, MAX_ERROR_OUTPUT_LENGTH);
     throw new Error(
       [
@@ -182,10 +183,10 @@ async function verifyColumns(databaseName, table, columns) {
     databaseName,
     `PRAGMA table_info(${table});`
   );
-  const parsed = parseWranglerTable(stdout);
+  const parsed = parseWranglerJson(stdout);
   const nameIndex = parsed.headers.indexOf('name');
 
-  if (parsed.rows.length === 0 || nameIndex === -1) {
+  if (!parsed.parsedOk || nameIndex === -1) {
     const stdoutSnippet = stdout.trim().slice(0, MAX_ERROR_OUTPUT_LENGTH);
     throw new Error(
       [

--- a/scripts/verify-remote-d1-schema.mjs
+++ b/scripts/verify-remote-d1-schema.mjs
@@ -108,7 +108,7 @@ async function checkWranglerExists() {
 async function runWranglerQuery(databaseName, query) {
   const { stdout, stderr } = await execFileAsync(
     wranglerBin,
-    ['d1', 'execute', databaseName, '--remote', '--command', query],
+    ['d1', 'execute', databaseName, '--remote', '--json', '--command', query],
     {
       cwd: process.cwd(),
       env: process.env,
@@ -120,21 +120,21 @@ async function runWranglerQuery(databaseName, query) {
 }
 
 function parseWranglerTable(stdout) {
-  const rowLines = stdout
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith('│') && line.endsWith('│'));
+  const jsonMatch = stdout.match(/\[[\s\S]*\]/);
+  if (!jsonMatch) return { headers: [], rows: [] };
 
-  if (rowLines.length === 0) {
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonMatch[0]);
+  } catch {
     return { headers: [], rows: [] };
   }
 
-  const parseRow = (line) =>
-    line
-      .split('│')
-      .slice(1, -1)
-      .map((cell) => cell.trim());
-  const [headers, ...rows] = rowLines.map(parseRow);
+  const results = parsed[0]?.results;
+  if (!results || results.length === 0) return { headers: [], rows: [] };
+
+  const headers = Object.keys(results[0]);
+  const rows = results.map((obj) => headers.map((h) => obj[h] ?? null));
 
   return { headers, rows };
 }


### PR DESCRIPTION
## Summary

- **`scripts/verify-remote-d1-schema.mjs`**: Add `--json` flag to wrangler calls and parse structured JSON output. Wrangler 4.85 changed from `│`-delimited table output to JSON, breaking the schema verifier after #229 merged.
- **`migrations/0032`**: Restore the `update_performances_timestamp` trigger after the `DROP TABLE / RENAME` sequence — without this, local dev migrations silently lose the `updated_at` auto-bump.
- **`migrations/0033`** (new): Same trigger restoration for production, where 0032 already ran without it (confirmed missing via `sqlite_master` query).
- **`frontend/src/admin/AdminPanel.jsx`**: Move `showToast` above `loadEvents` and add it to the `useCallback` dep array (fixes exhaustive-deps warning); remove extra blank line for Prettier.

## Test plan

- [ ] CI passes all checks on this PR (especially Format Check and Migrate/Verify)
- [ ] `performances.updated_at` is bumped on UPDATE after 0033 runs in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)