### PR TITLE
fix: remove stale event_id from venues REQUIRED_SCHEMA

### DIFF
--- a/scripts/verify-remote-d1-schema.mjs
+++ b/scripts/verify-remote-d1-schema.mjs
@@ -11,7 +11,7 @@ const MAX_ERROR_OUTPUT_LENGTH = 500;
 
 const REQUIRED_SCHEMA = {
   events: ['id', 'slug', 'city', 'is_published'],
-  venues: ['id', 'event_id', 'name', 'city'],
+  venues: ['id', 'name', 'city'],
   band_profiles: ['id', 'name', 'name_normalized', 'genre', 'photo_url'],
   performances: [
     'id',


### PR DESCRIPTION
## Summary

The schema verifier was checking for `venues.event_id`, but that column doesn't exist — venues link to events through `performances`, not a direct FK. Caused the "Migrate and verify remote D1" CI step to fail after #231 merged.

One-line fix: remove `event_id` from the `venues` entry in `REQUIRED_SCHEMA`.

## Test plan

- [ ] CI passes the Migrate and verify remote D1 step

🤖 Generated with [Claude Code](https://claude.com/claude-code)