### PR TITLE
fix: install root dependencies in deploy job

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -189,7 +189,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
 
       - name: Install frontend dependencies
         working-directory: frontend


### PR DESCRIPTION
## Summary

- The `deploy` job was running `npm ci` only inside `frontend/`, so root `node_modules` was never present during `wrangler pages deploy`.
- Wrangler bundles `functions/` at deploy time and needs root packages (`lucia`, `@lucia-auth/adapter-sqlite`, `csrf-csrf`, `otplib`, `email-validator`). Without them, every production deploy fails with "Could not resolve" errors.
- Also adds `package-lock.json` to the `setup-node` `cache-dependency-path` so root deps are cached properly alongside frontend deps.

The `ci` (Test and build) job already had `Install root dependencies` at step 3 — this just mirrors that in the `deploy` job.

## Test plan

- [ ] Deploy to Cloudflare Pages step passes on next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)