### PR TITLE
Fix schedule smoke checks for no-current-event state

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -297,25 +297,38 @@ jobs:
           STATUS=$(curl --silent --show-error --location --write-out '%{http_code}' --output /tmp/settimes-schedule.json "$SMOKE_URL/api/schedule?event=current")
 
           if [ "$DEPLOY_ENV" = "production" ]; then
-            if [ "$STATUS" != "200" ]; then
-              echo "::error::Expected HTTP 200 from /api/schedule?event=current in production, got $STATUS"
+            if [ "$STATUS" != "200" ] && [ "$STATUS" != "404" ]; then
+              echo "::error::Expected HTTP 200 or 404 from /api/schedule?event=current in production, got $STATUS"
               cat /tmp/settimes-schedule.json
               exit 1
             fi
-          elif [ "$STATUS" != "200" ] && [ "$STATUS" != "503" ]; then
+          elif [ "$STATUS" != "200" ] && [ "$STATUS" != "404" ] && [ "$STATUS" != "503" ]; then
             echo "::error::Unexpected HTTP $STATUS from /api/schedule?event=current"
             exit 1
           fi
 
-          if [ "$STATUS" = "200" ]; then
-            node --input-type=module <<'EOF'
+          STATUS="$STATUS" node --input-type=module <<'EOF'
           import { readFile } from 'node:fs/promises'
 
+          const status = process.env.STATUS
           const raw = await readFile('/tmp/settimes-schedule.json', 'utf8')
           const parsed = JSON.parse(raw)
 
           if (!parsed || typeof parsed !== 'object') {
             throw new Error('Expected /api/schedule?event=current to return a JSON object')
           }
+
+          if (status === '200') {
+            if (!parsed.event || !Array.isArray(parsed.bands)) {
+              throw new Error('Expected successful /api/schedule?event=current response to include event metadata and bands')
+            }
+          } else if (status === '404') {
+            if (parsed.error !== 'Event not found' || parsed.message !== 'No published events available') {
+              throw new Error('Expected /api/schedule?event=current 404 to describe the missing published event state')
+            }
+          } else if (status === '503') {
+            if (parsed.error !== 'Public data is not yet published') {
+              throw new Error('Expected /api/schedule?event=current 503 to describe the publish gate state')
+            }
+          }
           EOF
-          fi

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -297,8 +297,8 @@ jobs:
           STATUS=$(curl --silent --show-error --location --write-out '%{http_code}' --output /tmp/settimes-schedule.json "$SMOKE_URL/api/schedule?event=current")
 
           if [ "$DEPLOY_ENV" = "production" ]; then
-            if [ "$STATUS" != "200" ] && [ "$STATUS" != "404" ]; then
-              echo "::error::Expected HTTP 200 or 404 from /api/schedule?event=current in production, got $STATUS"
+            if [ "$STATUS" != "200" ] && [ "$STATUS" != "404" ] && [ "$STATUS" != "503" ]; then
+              echo "::error::Expected HTTP 200, 404, or 503 from /api/schedule?event=current in production, got $STATUS"
               cat /tmp/settimes-schedule.json
               exit 1
             fi

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -52,30 +52,30 @@ SetTimes no longer uses the earlier shared-password admin flow. Admin access is 
 
 ### Discovery and read endpoints
 
-| Route | Method | Notes |
-| --- | --- | --- |
-| `/api/schedule` | `GET` | Returns `{ event, bands }` for `event=current` or a specific event slug. Archived events are readable by slug. Cache TTL comes from `SCHEDULE_CACHE_TTL_SECONDS` and defaults to 60 seconds. |
-| `/api/events/public` | `GET` | Public event listing with filters for `city`, `genre`, `limit` (max 100), and `upcoming` (defaults to true). Returns `{ events, filters, count, generated_at }`. |
-| `/api/events/timeline` | `GET` | Grouped timeline response with `now`, `upcoming`, and `past`. Supports `now`, `upcoming`, `past`, `includeBands`, and `pastLimit` (1-100, default 10). |
-| `/api/events/{id}/details` | `GET` | Returns one published or archived event with `bands`, `venues`, `band_count`, and `venue_count`. `{id}` must be numeric. |
-| `/api/bands/{name}` | `GET` | Returns a public band profile plus published performance history. `{name}` may be a numeric band ID or a normalized band name. |
-| `/api/bands/stats/{name}` | `GET` | Extended band profile endpoint with aggregate stats, upcoming shows, and history across published and archived events. |
-| `/api/feeds/ical` | `GET` | Returns `text/calendar` content. Supports `city` and `genre`; both default to `all`. |
-| `/api/metrics` | `POST` | Privacy-safe metrics ingestion. Accepts up to 50 events per batch and always answers `200 OK` on malformed or rejected payloads. |
-| `/api/schedule/build` | `POST` | Records schedule-build analytics. Requires `event_id`, `user_session`, and `performance_ids` or the legacy `band_ids` alias. |
+| Route                      | Method | Notes                                                                                                                                                                                                                                                                                                                                                                |
+| -------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/schedule`            | `GET`  | Returns `{ event, bands }` for `event=current` or a specific event slug. Archived events are readable by slug. When `event=current` has no published current or upcoming event, the route returns `404` with `{ error: "Event not found", message: "No published events available" }`. Cache TTL comes from `SCHEDULE_CACHE_TTL_SECONDS` and defaults to 60 seconds. |
+| `/api/events/public`       | `GET`  | Public event listing with filters for `city`, `genre`, `limit` (max 100), and `upcoming` (defaults to true). Returns `{ events, filters, count, generated_at }`.                                                                                                                                                                                                     |
+| `/api/events/timeline`     | `GET`  | Grouped timeline response with `now`, `upcoming`, and `past`. Supports `now`, `upcoming`, `past`, `includeBands`, and `pastLimit` (1-100, default 10).                                                                                                                                                                                                               |
+| `/api/events/{id}/details` | `GET`  | Returns one published or archived event with `bands`, `venues`, `band_count`, and `venue_count`. `{id}` must be numeric.                                                                                                                                                                                                                                             |
+| `/api/bands/{name}`        | `GET`  | Returns a public band profile plus published performance history. `{name}` may be a numeric band ID or a normalized band name.                                                                                                                                                                                                                                       |
+| `/api/bands/stats/{name}`  | `GET`  | Extended band profile endpoint with aggregate stats, upcoming shows, and history across published and archived events.                                                                                                                                                                                                                                               |
+| `/api/feeds/ical`          | `GET`  | Returns `text/calendar` content. Supports `city` and `genre`; both default to `all`.                                                                                                                                                                                                                                                                                 |
+| `/api/metrics`             | `POST` | Privacy-safe metrics ingestion. Accepts up to 50 events per batch and always answers `200 OK` on malformed or rejected payloads.                                                                                                                                                                                                                                     |
+| `/api/schedule/build`      | `POST` | Records schedule-build analytics. Requires `event_id`, `user_session`, and `performance_ids` or the legacy `band_ids` alias.                                                                                                                                                                                                                                         |
 
 ### Subscriptions and account recovery
 
-| Route | Method | Notes |
-| --- | --- | --- |
-| `/api/subscriptions/subscribe` | `POST` | Body: `{ email, city, genre, frequency, turnstileToken? }`. `frequency` must be `daily`, `weekly`, or `monthly`. |
-| `/api/subscriptions/verify` | `GET` | Verifies a subscription via `?token=` and redirects to `/subscribe?verified=true` on success. |
-| `/api/subscriptions/unsubscribe` | `GET` | Removes a subscription via `?token=` and returns an HTML confirmation page. |
-| `/api/auth/activate` | `POST` | Body: `{ token }`. Activates an invited user account. |
-| `/api/auth/resend-activation` | `POST` | Body: `{ email }`. Always returns a generic success payload to avoid account enumeration. |
-| `/api/auth/reset-password/validate` | `POST` | Body: `{ token }`. Validates a reset token without placing it in the URL. |
-| `/api/auth/reset-password` | `POST` | Body: `{ token, newPassword }`. Consumes the token, rotates the password, revokes sessions, and clears trusted devices. |
-| `/api/auth/reset-password` | `GET` | Intentionally unsupported. Returns `405` so reset tokens are never validated through query strings. |
+| Route                               | Method | Notes                                                                                                                   |
+| ----------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `/api/subscriptions/subscribe`      | `POST` | Body: `{ email, city, genre, frequency, turnstileToken? }`. `frequency` must be `daily`, `weekly`, or `monthly`.        |
+| `/api/subscriptions/verify`         | `GET`  | Verifies a subscription via `?token=` and redirects to `/subscribe?verified=true` on success.                           |
+| `/api/subscriptions/unsubscribe`    | `GET`  | Removes a subscription via `?token=` and returns an HTML confirmation page.                                             |
+| `/api/auth/activate`                | `POST` | Body: `{ token }`. Activates an invited user account.                                                                   |
+| `/api/auth/resend-activation`       | `POST` | Body: `{ email }`. Always returns a generic success payload to avoid account enumeration.                               |
+| `/api/auth/reset-password/validate` | `POST` | Body: `{ token }`. Validates a reset token without placing it in the URL.                                               |
+| `/api/auth/reset-password`          | `POST` | Body: `{ token, newPassword }`. Consumes the token, rotates the password, revokes sessions, and clears trusted devices. |
+| `/api/auth/reset-password`          | `GET`  | Intentionally unsupported. Returns `405` so reset tokens are never validated through query strings.                     |
 
 ### Public request notes
 
@@ -124,72 +124,72 @@ All admin routes require a valid session cookie. State-changing routes also requ
 
 ### Authentication and self-service
 
-| Route | Method | Minimum role | Notes |
-| --- | --- | --- | --- |
-| `/api/admin/auth/signup` | `POST` | none | Invite-only signup. The request role is ignored; the invite code determines the role. |
-| `/api/admin/auth/login` | `POST` | none | Body: `{ email, password }`. Returns either a session success response or `{ mfaRequired, mfaToken, user }`. |
-| `/api/admin/auth/mfa/verify` | `POST` | none | Body: `{ mfaToken, code, rememberDevice? }`. Completes login and can create a trusted-device cookie. |
-| `/api/admin/auth/logout` | `POST` | viewer | Invalidates the current session and clears session and CSRF cookies. |
-| `/api/admin/me` | `GET` | viewer | Returns `{ user, session, authenticated: true }` with safe session metadata only. |
-| `/api/admin/sessions` | `GET` | viewer | Lists the current user's active sessions. |
-| `/api/admin/sessions` | `DELETE` | viewer | Body: `{ sessionId }`. Revokes one of the current user's sessions. |
-| `/api/admin/sessions/revoke-all` | `POST` | viewer | Revokes all sessions for the current user and issues a fresh current-session cookie. |
-| `/api/admin/trusted-devices` | `GET` | viewer | Lists active trusted devices for the current user. |
-| `/api/admin/trusted-devices` | `DELETE` | viewer | Body: `{ deviceId }`. Revokes one trusted device. |
-| `/api/admin/mfa/status` | `GET` | viewer | Returns `totpEnabled`, `setupPending`, and `hasBackupCodes`. |
-| `/api/admin/mfa/setup` | `POST` | viewer | Generates a new TOTP secret and returns `{ secret, otpauthUrl }`. |
-| `/api/admin/mfa/enable` | `POST` | viewer | Body: `{ code }`. Verifies the code, enables TOTP, and returns new backup codes. |
-| `/api/admin/mfa/backup-codes` | `POST` | viewer | Body: `{ code }`. Regenerates backup codes after verifying a TOTP code. |
-| `/api/admin/mfa/disable` | `POST` | viewer | Body: `{ code }`. Accepts a TOTP or backup code and disables MFA. |
+| Route                            | Method   | Minimum role | Notes                                                                                                        |
+| -------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------ |
+| `/api/admin/auth/signup`         | `POST`   | none         | Invite-only signup. The request role is ignored; the invite code determines the role.                        |
+| `/api/admin/auth/login`          | `POST`   | none         | Body: `{ email, password }`. Returns either a session success response or `{ mfaRequired, mfaToken, user }`. |
+| `/api/admin/auth/mfa/verify`     | `POST`   | none         | Body: `{ mfaToken, code, rememberDevice? }`. Completes login and can create a trusted-device cookie.         |
+| `/api/admin/auth/logout`         | `POST`   | viewer       | Invalidates the current session and clears session and CSRF cookies.                                         |
+| `/api/admin/me`                  | `GET`    | viewer       | Returns `{ user, session, authenticated: true }` with safe session metadata only.                            |
+| `/api/admin/sessions`            | `GET`    | viewer       | Lists the current user's active sessions.                                                                    |
+| `/api/admin/sessions`            | `DELETE` | viewer       | Body: `{ sessionId }`. Revokes one of the current user's sessions.                                           |
+| `/api/admin/sessions/revoke-all` | `POST`   | viewer       | Revokes all sessions for the current user and issues a fresh current-session cookie.                         |
+| `/api/admin/trusted-devices`     | `GET`    | viewer       | Lists active trusted devices for the current user.                                                           |
+| `/api/admin/trusted-devices`     | `DELETE` | viewer       | Body: `{ deviceId }`. Revokes one trusted device.                                                            |
+| `/api/admin/mfa/status`          | `GET`    | viewer       | Returns `totpEnabled`, `setupPending`, and `hasBackupCodes`.                                                 |
+| `/api/admin/mfa/setup`           | `POST`   | viewer       | Generates a new TOTP secret and returns `{ secret, otpauthUrl }`.                                            |
+| `/api/admin/mfa/enable`          | `POST`   | viewer       | Body: `{ code }`. Verifies the code, enables TOTP, and returns new backup codes.                             |
+| `/api/admin/mfa/backup-codes`    | `POST`   | viewer       | Body: `{ code }`. Regenerates backup codes after verifying a TOTP code.                                      |
+| `/api/admin/mfa/disable`         | `POST`   | viewer       | Body: `{ code }`. Accepts a TOTP or backup code and disables MFA.                                            |
 
 ### Content, roster, and media
 
-| Route | Method | Minimum role | Notes |
-| --- | --- | --- | --- |
-| `/api/admin/events` | `GET` | viewer | Lists events. Supports `archived=true`, `limit`, and `offset`. |
-| `/api/admin/events` | `POST` | editor | Creates an event from the validated event schema. Admins may create archived events directly; editors may not. |
-| `/api/admin/events/{id}` | `PATCH` | editor | General event update route used by the current frontend. `slug` cannot be changed here. |
-| `/api/admin/events/{id}` | `DELETE` | admin | Deletes an event. If performances exist, repeat with `confirmCascade=true` in the body or query string. |
-| `/api/admin/events/{id}/edit` | `PUT` | editor | Narrow event-edit route for `{ name, date, slug, ticket_url }`. |
-| `/api/admin/events/{id}/publish` | `POST` | editor | Body: `{ publish: boolean }`. Refuses to publish an event with no performances. |
-| `/api/admin/events/{id}/archive` | `POST` | admin | Archives an event and clears `is_published`. |
-| `/api/admin/events/{id}/metrics` | `GET` | viewer | Schedule-build analytics for one event. |
-| `/api/admin/events/{id}/duplicate` | `POST` | editor | Body: `{ name, date, slug }`. Duplicates the event and its performances into a new draft event. |
-| `/api/admin/venues` | `GET` | viewer | Lists venues with band counts. Contact details are redacted for viewers. |
-| `/api/admin/venues` | `POST` | admin | Creates a new venue. |
-| `/api/admin/venues/{id}` | `PUT` | admin | Updates a venue. |
-| `/api/admin/venues/{id}` | `DELETE` | admin | Deletes a venue. |
-| `/api/admin/bands` | `GET` | viewer | Lists performances. Supports `event_id`, `limit`, and `offset`. Without `event_id`, profile-only rows are returned as synthetic IDs like `profile_123`. |
-| `/api/admin/bands` | `POST` | editor | Creates a performance plus band profile data, or a profile-only record when `eventId` is omitted. |
-| `/api/admin/bands/{id}` | `PUT` | editor | Updates a performance or a profile-only row. `{id}` may be a performance ID or a `profile_{id}` synthetic identifier. |
-| `/api/admin/bands/{id}` | `DELETE` | editor | Deletes one performance or one profile-only row, subject to archived-event protections. |
-| `/api/admin/bands/bulk-preview` | `POST` | editor | Preview bulk venue moves, time changes, or deletions before applying them. |
-| `/api/admin/bands/bulk` | `POST` | editor | Adds existing band profiles to an event lineup. Body: `{ band_profile_ids, event_id, venue_id, start_time?, end_time? }`. |
-| `/api/admin/bands/bulk` | `DELETE` | editor | Bulk deletes performances or profile-only rows. Body: `{ band_ids }`. |
-| `/api/admin/bands/photos` | `POST` | editor | `multipart/form-data` upload with `photo` and optional `band_id`. Stores assets in R2 and can update `photo_url`. |
-| `/api/admin/bands/stats/{name}` | `GET` | viewer | Internal stats and history view for a band profile. |
-| `/api/admin/performers` | `GET` | viewer | Lists the global performer registry. |
-| `/api/admin/performers` | `POST` | editor | Creates a global performer record. |
-| `/api/admin/performers/{id}` | `GET` | viewer | Returns one performer plus aggregate performance stats. |
-| `/api/admin/performers/{id}` | `PUT` | editor | Updates a performer record. |
-| `/api/admin/performers/{id}` | `DELETE` | admin | Deletes a performer if no performances still reference it. |
+| Route                              | Method   | Minimum role | Notes                                                                                                                                                   |
+| ---------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/admin/events`                | `GET`    | viewer       | Lists events. Supports `archived=true`, `limit`, and `offset`.                                                                                          |
+| `/api/admin/events`                | `POST`   | editor       | Creates an event from the validated event schema. Admins may create archived events directly; editors may not.                                          |
+| `/api/admin/events/{id}`           | `PATCH`  | editor       | General event update route used by the current frontend. `slug` cannot be changed here.                                                                 |
+| `/api/admin/events/{id}`           | `DELETE` | admin        | Deletes an event. If performances exist, repeat with `confirmCascade=true` in the body or query string.                                                 |
+| `/api/admin/events/{id}/edit`      | `PUT`    | editor       | Narrow event-edit route for `{ name, date, slug, ticket_url }`.                                                                                         |
+| `/api/admin/events/{id}/publish`   | `POST`   | editor       | Body: `{ publish: boolean }`. Refuses to publish an event with no performances.                                                                         |
+| `/api/admin/events/{id}/archive`   | `POST`   | admin        | Archives an event and clears `is_published`.                                                                                                            |
+| `/api/admin/events/{id}/metrics`   | `GET`    | viewer       | Schedule-build analytics for one event.                                                                                                                 |
+| `/api/admin/events/{id}/duplicate` | `POST`   | editor       | Body: `{ name, date, slug }`. Duplicates the event and its performances into a new draft event.                                                         |
+| `/api/admin/venues`                | `GET`    | viewer       | Lists venues with band counts. Contact details are redacted for viewers.                                                                                |
+| `/api/admin/venues`                | `POST`   | admin        | Creates a new venue.                                                                                                                                    |
+| `/api/admin/venues/{id}`           | `PUT`    | admin        | Updates a venue.                                                                                                                                        |
+| `/api/admin/venues/{id}`           | `DELETE` | admin        | Deletes a venue.                                                                                                                                        |
+| `/api/admin/bands`                 | `GET`    | viewer       | Lists performances. Supports `event_id`, `limit`, and `offset`. Without `event_id`, profile-only rows are returned as synthetic IDs like `profile_123`. |
+| `/api/admin/bands`                 | `POST`   | editor       | Creates a performance plus band profile data, or a profile-only record when `eventId` is omitted.                                                       |
+| `/api/admin/bands/{id}`            | `PUT`    | editor       | Updates a performance or a profile-only row. `{id}` may be a performance ID or a `profile_{id}` synthetic identifier.                                   |
+| `/api/admin/bands/{id}`            | `DELETE` | editor       | Deletes one performance or one profile-only row, subject to archived-event protections.                                                                 |
+| `/api/admin/bands/bulk-preview`    | `POST`   | editor       | Preview bulk venue moves, time changes, or deletions before applying them.                                                                              |
+| `/api/admin/bands/bulk`            | `POST`   | editor       | Adds existing band profiles to an event lineup. Body: `{ band_profile_ids, event_id, venue_id, start_time?, end_time? }`.                               |
+| `/api/admin/bands/bulk`            | `DELETE` | editor       | Bulk deletes performances or profile-only rows. Body: `{ band_ids }`.                                                                                   |
+| `/api/admin/bands/photos`          | `POST`   | editor       | `multipart/form-data` upload with `photo` and optional `band_id`. Stores assets in R2 and can update `photo_url`.                                       |
+| `/api/admin/bands/stats/{name}`    | `GET`    | viewer       | Internal stats and history view for a band profile.                                                                                                     |
+| `/api/admin/performers`            | `GET`    | viewer       | Lists the global performer registry.                                                                                                                    |
+| `/api/admin/performers`            | `POST`   | editor       | Creates a global performer record.                                                                                                                      |
+| `/api/admin/performers/{id}`       | `GET`    | viewer       | Returns one performer plus aggregate performance stats.                                                                                                 |
+| `/api/admin/performers/{id}`       | `PUT`    | editor       | Updates a performer record.                                                                                                                             |
+| `/api/admin/performers/{id}`       | `DELETE` | admin        | Deletes a performer if no performances still reference it.                                                                                              |
 
 ### User administration, invites, analytics, and maintenance
 
-| Route | Method | Minimum role | Notes |
-| --- | --- | --- | --- |
-| `/api/admin/users` | `GET` | admin | Lists all users, excluding password hashes. |
-| `/api/admin/users` | `POST` | admin | Creates an invite-backed user invitation and optionally emails the signup URL. |
-| `/api/admin/users/{id}` | `PATCH` | admin | Updates role and display-name fields. Prevents demoting the last active admin. |
-| `/api/admin/users/{id}` | `DELETE` | admin | Removes a user. |
-| `/api/admin/users/{id}/reset-password` | `POST` | admin | Body: `{ reason? }`. Creates a reset token, revokes sessions, clears trusted devices, and emails the reset URL. |
-| `/api/admin/users/{id}/toggle-status` | `POST` | admin | Activates or deactivates a user account. Deactivation revokes sessions. |
-| `/api/admin/invite-codes` | `GET` | admin | Lists invite codes. |
-| `/api/admin/invite-codes` | `POST` | admin | Body: `{ email?, role = "editor", expiresInDays = 7 }`. Creates an open or email-restricted invite. |
-| `/api/admin/invite-codes/{code}` | `DELETE` | admin | Revokes an invite code. |
-| `/api/admin/audit-log` | `GET` | admin | Query: `user_id`, `action`, `resource_type`, `limit` (max 100), and `offset`. |
-| `/api/admin/analytics/subscriptions` | `GET` | admin | Aggregate subscription analytics only; no subscriber PII is exposed. |
-| `/api/admin/maintenance/cleanup-sessions` | `POST` | admin | Runs the retention cleanup for expired sessions, MFA challenges, reset tokens, trusted devices, and security telemetry. |
+| Route                                     | Method   | Minimum role | Notes                                                                                                                   |
+| ----------------------------------------- | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `/api/admin/users`                        | `GET`    | admin        | Lists all users, excluding password hashes.                                                                             |
+| `/api/admin/users`                        | `POST`   | admin        | Creates an invite-backed user invitation and optionally emails the signup URL.                                          |
+| `/api/admin/users/{id}`                   | `PATCH`  | admin        | Updates role and display-name fields. Prevents demoting the last active admin.                                          |
+| `/api/admin/users/{id}`                   | `DELETE` | admin        | Removes a user.                                                                                                         |
+| `/api/admin/users/{id}/reset-password`    | `POST`   | admin        | Body: `{ reason? }`. Creates a reset token, revokes sessions, clears trusted devices, and emails the reset URL.         |
+| `/api/admin/users/{id}/toggle-status`     | `POST`   | admin        | Activates or deactivates a user account. Deactivation revokes sessions.                                                 |
+| `/api/admin/invite-codes`                 | `GET`    | admin        | Lists invite codes.                                                                                                     |
+| `/api/admin/invite-codes`                 | `POST`   | admin        | Body: `{ email?, role = "editor", expiresInDays = 7 }`. Creates an open or email-restricted invite.                     |
+| `/api/admin/invite-codes/{code}`          | `DELETE` | admin        | Revokes an invite code.                                                                                                 |
+| `/api/admin/audit-log`                    | `GET`    | admin        | Query: `user_id`, `action`, `resource_type`, `limit` (max 100), and `offset`.                                           |
+| `/api/admin/analytics/subscriptions`      | `GET`    | admin        | Aggregate subscription analytics only; no subscriber PII is exposed.                                                    |
+| `/api/admin/maintenance/cleanup-sessions` | `POST`   | admin        | Runs the retention cleanup for expired sessions, MFA challenges, reset tokens, trusted devices, and security telemetry. |
 
 ## Error handling
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -218,8 +218,8 @@ VALUES (
 
 ```javascript
 // Use Node.js with bcrypt
-const bcrypt = require('bcrypt');
-const hash = bcrypt.hashSync('your-secure-password', 10);
+const bcrypt = require("bcrypt");
+const hash = bcrypt.hashSync("your-secure-password", 10);
 console.log(hash);
 ```
 
@@ -425,7 +425,9 @@ curl https://settimes.ca
 
 ```bash
 curl https://settimes.ca/api/schedule?event=current
-# Should return JSON (may be empty initially)
+# Should return JSON with either:
+# - HTTP 200 and { event, bands } when a current/upcoming published event exists
+# - HTTP 404 and { error: "Event not found", message: "No published events available" } when none exists
 ```
 
 **Check Database:**
@@ -448,7 +450,7 @@ The GitHub Actions release workflow now runs an automated smoke suite after ever
 
 - `/` returns the public app HTML
 - `/admin` returns the admin shell HTML
-- `/api/schedule?event=current` returns valid JSON
+- `/api/schedule?event=current` returns valid JSON for the current publish state (`200`, `404`, or `503` depending on environment and available events)
 
 Manual post-release testing is still recommended for login, publishing, and other data-changing admin flows.
 

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -194,7 +194,7 @@ export default function BandProfilePage() {
 
   const errorStatus = error?.status || null
   const isPublishGateError = errorStatus === 503
-  const isNotFoundError = errorStatus === 404 || (!errorStatus && !profile)
+  const isNotFoundError = errorStatus === 404 || (!error && !profile)
 
   useEffect(() => {
     const loadProfile = async () => {


### PR DESCRIPTION
## Summary
- allow `/api/schedule?event=current` smoke checks to accept the legitimate `404` response when no published current/upcoming event exists
- validate the JSON payload for `200`, `404`, and `503` schedule responses instead of only checking status codes
- clarify the `/api/schedule` contract in the API and deployment docs

## Context
The post-merge production deploy for PR #234 failed in `Post-deploy smoke checks` even though the deployment itself was healthy. The workflow incorrectly assumed production must always return `200` from `/api/schedule?event=current`, but the endpoint intentionally returns:

- `200` when a current/upcoming published event exists
- `404` with `{"error":"Event not found","message":"No published events available"}` when none exists
- `503` when public data is intentionally gated off

## Validation
- `cd frontend && npm run test -- src/utils/__tests__/publicApi.test.js`
- `./frontend/node_modules/.bin/prettier --check .github/workflows/cloudflare-pages.yml docs/API_DOCUMENTATION.md docs/DEPLOYMENT.md`
- reviewed the failed run: https://github.com/BreakableHoodie/settimesdotca/actions/runs/25261634582/job/74069900395