### PR TITLE
feat: Event Lifecycle Hub — Phase 1 (reveal mode, band follows, shareable URLs) + Phase 2 (recap page, archive import)

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -189,7 +189,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
 
       - name: Install frontend dependencies
         working-directory: frontend

--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS events (
   venue_info TEXT,
   social_links TEXT,
   theme_colors TEXT,
+  reveal_mode INTEGER NOT NULL DEFAULT 0,
   created_by_user_id INTEGER,
   updated_by_user_id INTEGER,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -78,6 +79,8 @@ CREATE TABLE IF NOT EXISTS performances (
   band_id INTEGER,
   band_name TEXT,
   stage TEXT,
+  is_announced INTEGER NOT NULL DEFAULT 1,
+  band_follow_notified INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   created_by_user_id INTEGER,
   updated_by_user_id INTEGER,
@@ -345,6 +348,19 @@ CREATE TABLE IF NOT EXISTS rate_limit (
   lockout_until TEXT,
   last_attempt TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS band_follows (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT NOT NULL,
+  band_profile_id INTEGER NOT NULL REFERENCES band_profiles(id) ON DELETE CASCADE,
+  verified INTEGER NOT NULL DEFAULT 0,
+  verification_token TEXT UNIQUE,
+  unsubscribe_token TEXT UNIQUE NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(email, band_profile_id)
+);
+CREATE INDEX IF NOT EXISTS idx_band_follows_band ON band_follows(band_profile_id);
+CREATE INDEX IF NOT EXISTS idx_band_follows_email ON band_follows(email);
 
 -- ============================================
 -- INDEXES

--- a/docs/superpowers/plans/2026-05-02-event-lifecycle-hub-phase2.md
+++ b/docs/superpowers/plans/2026-05-02-event-lifecycle-hub-phase2.md
@@ -1,0 +1,808 @@
+# Event Lifecycle Hub — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a post-event recap page at `/events/:slug/recap` and a historical archive backfill admin UI that lets the organizer paste a band list to create archived events.
+
+**Architecture:** The recap API handler at `functions/api/events/[id]/recap.js` accepts slug or numeric ID, uses a correlated EXISTS subquery to classify first-timers vs returning acts, and aggregates stats in JavaScript. The public React page at `frontend/src/pages/EventRecapPage.jsx` is lazy-loaded. The historical import modal at `frontend/src/admin/HistoricalImportModal.jsx` reuses existing `eventsApi.create()` + `bandsApi.create()` — no new API endpoints.
+
+**Tech Stack:** Cloudflare Pages Functions, D1/SQLite, React 19, React Router v7, Vitest
+
+---
+
+### Task 1: Recap API Endpoint
+
+**Files:**
+- Create: `functions/api/events/[id]/recap.js`
+- Create: `functions/api/events/__tests__/recap.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `functions/api/events/__tests__/recap.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { onRequestGet } from '../[id]/recap.js'
+import { createTestEnv, insertEvent, insertVenue, insertBand } from '../../test-utils.js'
+
+describe('GET /api/events/:id/recap', () => {
+  it('returns 404 for non-archived events', async () => {
+    const { env, rawDb } = createTestEnv()
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
+    const event = insertEvent(rawDb, { name: 'Draft Fest', slug: 'draft-fest' })
+    // status defaults to null / not archived
+
+    const res = await onRequestGet({
+      request: new Request('https://example.test/api/events/draft-fest/recap'),
+      env,
+      params: { id: 'draft-fest' },
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns stats and bands for an archived event by slug', async () => {
+    const { env, rawDb } = createTestEnv()
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
+    const event = insertEvent(rawDb, { name: 'LWBC Vol5', slug: 'lwbc-vol5' })
+    rawDb.prepare("UPDATE events SET status='archived', is_published=1 WHERE id=?").run(event.id)
+    const venue = insertVenue(rawDb, { name: 'The Main Stage' })
+    insertBand(rawDb, { name: 'Band A', event_id: event.id, venue_id: venue.id })
+    insertBand(rawDb, { name: 'Band B', event_id: event.id, venue_id: venue.id })
+
+    const res = await onRequestGet({
+      request: new Request('https://example.test/api/events/lwbc-vol5/recap'),
+      env,
+      params: { id: 'lwbc-vol5' },
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.event.slug).toBe('lwbc-vol5')
+    expect(data.stats.total_sets).toBe(2)
+    expect(data.stats.venue_count).toBe(1)
+    expect(data.bands).toHaveLength(2)
+  })
+
+  it('accepts numeric id', async () => {
+    const { env, rawDb } = createTestEnv()
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
+    const event = insertEvent(rawDb, { name: 'LWBC Vol4', slug: 'lwbc-vol4' })
+    rawDb.prepare("UPDATE events SET status='archived', is_published=1 WHERE id=?").run(event.id)
+    insertBand(rawDb, { name: 'Solo Act', event_id: event.id })
+
+    const res = await onRequestGet({
+      request: new Request(`https://example.test/api/events/${event.id}/recap`),
+      env,
+      params: { id: String(event.id) },
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.event.id).toBe(event.id)
+  })
+
+  it('classifies first-timers vs returning acts', async () => {
+    const { env, rawDb } = createTestEnv()
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
+
+    // Create a prior event and a band that played it
+    const priorEvent = insertEvent(rawDb, { name: 'LWBC Vol3', slug: 'lwbc-vol3' })
+    rawDb.prepare("UPDATE events SET status='archived', is_published=1 WHERE id=?").run(priorEvent.id)
+    const returningBand = insertBand(rawDb, { name: 'Returning Band', event_id: priorEvent.id })
+
+    // Current event with one returning + one new band
+    const event = insertEvent(rawDb, { name: 'LWBC Vol4', slug: 'lwbc-vol4b' })
+    rawDb.prepare("UPDATE events SET status='archived', is_published=1 WHERE id=?").run(event.id)
+
+    // Reuse same band_profile_id for the returning band
+    rawDb.prepare(
+      'INSERT INTO performances (event_id, band_profile_id) VALUES (?, ?)'
+    ).run(event.id, returningBand.band_profile_id)
+
+    // New band (first timer)
+    insertBand(rawDb, { name: 'New Band', event_id: event.id })
+
+    const res = await onRequestGet({
+      request: new Request(`https://example.test/api/events/${event.id}/recap`),
+      env,
+      params: { id: String(event.id) },
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.stats.first_timers).toBe(1)
+    expect(data.stats.returning_acts).toBe(1)
+  })
+
+  it('returns 503 if public gate is off', async () => {
+    const { env, rawDb } = createTestEnv()
+    // PUBLIC_DATA_PUBLISH_ENABLED not set
+    const event = insertEvent(rawDb, { name: 'Gated', slug: 'gated' })
+    rawDb.prepare("UPDATE events SET status='archived', is_published=1 WHERE id=?").run(event.id)
+
+    const res = await onRequestGet({
+      request: new Request('https://example.test/api/events/gated/recap'),
+      env,
+      params: { id: 'gated' },
+    })
+    expect(res.status).toBe(503)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/andrelevesque/Projects/settimesdotca/.worktrees/feat-event-lifecycle-hub
+npx vitest run functions/api/events/__tests__/recap.test.js
+```
+
+Expected: FAIL — `Cannot find module '../[id]/recap.js'`
+
+- [ ] **Step 3: Implement the endpoint**
+
+Create `functions/api/events/[id]/recap.js`:
+
+```js
+import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
+
+export async function onRequestGet(context) {
+  const { env, params } = context;
+  const gate = getPublicDataGateResponse(env);
+  if (gate) return gate;
+  const { DB } = env;
+
+  const idOrSlug = params.id;
+  let event;
+  try {
+    if (/^\d+$/.test(idOrSlug)) {
+      event = await DB.prepare(
+        `SELECT id, name, slug, date, status FROM events WHERE id = ? AND status = 'archived'`
+      ).bind(Number(idOrSlug)).first();
+    } else {
+      event = await DB.prepare(
+        `SELECT id, name, slug, date, status FROM events WHERE slug = ? AND status = 'archived'`
+      ).bind(idOrSlug).first();
+    }
+  } catch (err) {
+    console.error("[recap] DB error resolving event:", err);
+    return new Response(JSON.stringify({ error: "Failed to fetch recap" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (!event) {
+    return new Response(JSON.stringify({ error: "Recap not available for this event" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { results: rows } = await DB.prepare(`
+      SELECT
+        bp.id   AS band_id,
+        bp.name AS band_name,
+        bp.genre,
+        bp.photo_url,
+        p.start_time,
+        p.end_time,
+        v.id   AS venue_id,
+        v.name AS venue_name,
+        CASE WHEN EXISTS (
+          SELECT 1 FROM performances p2
+          WHERE p2.band_profile_id = bp.id AND p2.event_id != ?
+        ) THEN 1 ELSE 0 END AS is_returning
+      FROM performances p
+      JOIN band_profiles bp ON p.band_profile_id = bp.id
+      LEFT JOIN venues v ON p.venue_id = v.id
+      WHERE p.event_id = ?
+      ORDER BY p.start_time NULLS LAST, bp.name
+    `).bind(event.id, event.id).all();
+
+    const venueIds = new Set();
+    let firstTimers = 0;
+    let returningActs = 0;
+
+    const bands = rows.map((row) => {
+      if (row.venue_id) venueIds.add(row.venue_id);
+      if (row.is_returning) returningActs++;
+      else firstTimers++;
+      return {
+        id: row.band_id,
+        name: row.band_name,
+        genre: row.genre,
+        photo_url: row.photo_url,
+        start_time: row.start_time,
+        end_time: row.end_time,
+        venue_id: row.venue_id,
+        venue_name: row.venue_name,
+        is_returning: Boolean(row.is_returning),
+      };
+    });
+
+    return new Response(
+      JSON.stringify({
+        event: { id: event.id, name: event.name, slug: event.slug, date: event.date },
+        stats: {
+          total_sets: bands.length,
+          venue_count: venueIds.size,
+          first_timers: firstTimers,
+          returning_acts: returningActs,
+        },
+        bands,
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "public, max-age=3600",
+        },
+      }
+    );
+  } catch (err) {
+    console.error("[recap] Error building recap:", err);
+    return new Response(JSON.stringify({ error: "Failed to fetch recap" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run functions/api/events/__tests__/recap.test.js
+```
+
+Expected: 5 tests passing
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+```bash
+npx vitest run
+```
+
+Expected: All tests passing
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add functions/api/events/\[id\]/recap.js functions/api/events/__tests__/recap.test.js
+git commit -m "feat: add GET /api/events/:id/recap endpoint"
+```
+
+---
+
+### Task 2: Event Recap Frontend Page
+
+**Files:**
+- Create: `frontend/src/pages/EventRecapPage.jsx`
+- Modify: `frontend/src/main.jsx` (add lazy import + route)
+
+- [ ] **Step 1: Create the page component**
+
+Create `frontend/src/pages/EventRecapPage.jsx`:
+
+```jsx
+import { useEffect, useState } from 'react'
+import { Helmet, HelmetProvider } from 'react-helmet-async'
+import { Link, useParams } from 'react-router-dom'
+import { fetchPublicJson } from '../utils/publicApi'
+import { formatTimeRange, parseLocalDate } from '../utils/timeFormat'
+import { Loading, Alert } from '../components/ui'
+
+export default function EventRecapPage() {
+  const { slug } = useParams()
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetchPublicJson(`/api/events/${slug}/recap`)
+      .then((res) => {
+        if (!cancelled) setData(res)
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message || 'Failed to load recap')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
+  }, [slug])
+
+  if (loading) return <Loading />
+  if (error)
+    return (
+      <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
+        <Alert type="error">{error}</Alert>
+      </div>
+    )
+  if (!data) return null
+
+  const { event, stats, bands } = data
+  const eventDate = parseLocalDate(event.date)
+  const formattedDate = eventDate
+    ? eventDate.toLocaleDateString('en-CA', { year: 'numeric', month: 'long', day: 'numeric' })
+    : event.date
+
+  return (
+    <HelmetProvider>
+      <Helmet>
+        <title>{event.name} — Recap | SetTimes</title>
+        <meta name="description" content={`${event.name} recap: ${stats.total_sets} sets across ${stats.venue_count} venues.`} />
+      </Helmet>
+      <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple text-white">
+        <div className="max-w-3xl mx-auto px-4 py-8">
+          {/* Back */}
+          <Link
+            to="/"
+            className="text-accent-400 hover:underline text-sm mb-6 inline-block focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+          >
+            ← All Events
+          </Link>
+
+          {/* Header */}
+          <header className="mb-8">
+            <p className="text-accent-300 text-sm font-medium uppercase tracking-wider mb-1">
+              Event Recap
+            </p>
+            <h1 className="text-3xl font-bold mb-1">{event.name}</h1>
+            <p className="text-gray-400">{formattedDate}</p>
+          </header>
+
+          {/* Stats */}
+          <section className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8" aria-label="Event statistics">
+            <StatCard label="Sets" value={stats.total_sets} />
+            <StatCard label="Venues" value={stats.venue_count} />
+            <StatCard label="First Timers" value={stats.first_timers} />
+            <StatCard label="Returning Acts" value={stats.returning_acts} />
+          </section>
+
+          {/* Band list */}
+          <section aria-label="Full lineup">
+            <h2 className="text-xl font-semibold mb-4">Full Lineup</h2>
+            <ul className="space-y-2">
+              {bands.map((band) => (
+                <li
+                  key={band.id}
+                  className="bg-white/5 rounded-lg px-4 py-3 flex items-center justify-between gap-3"
+                >
+                  <div>
+                    <Link
+                      to={`/band/${band.id}`}
+                      className="font-medium hover:text-accent-400 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+                    >
+                      {band.name}
+                    </Link>
+                    {band.venue_name && (
+                      <p className="text-gray-400 text-sm">{band.venue_name}</p>
+                    )}
+                  </div>
+                  <div className="text-right text-sm text-gray-300 shrink-0">
+                    {band.start_time
+                      ? formatTimeRange(band.start_time, band.end_time)
+                      : ''}
+                    {!band.is_returning && (
+                      <span className="ml-2 text-xs bg-accent-500/20 text-accent-300 px-2 py-0.5 rounded-full">
+                        First timer
+                      </span>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* Subscribe CTA */}
+          <div className="mt-10 text-center">
+            <p className="text-gray-400 mb-3">Don't miss the next one.</p>
+            <Link
+              to="/subscribe"
+              className="inline-block bg-accent-500 hover:bg-accent-600 text-white font-medium px-6 py-2 rounded-lg transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+            >
+              Get notified
+            </Link>
+          </div>
+        </div>
+      </div>
+    </HelmetProvider>
+  )
+}
+
+function StatCard({ label, value }) {
+  return (
+    <div className="bg-white/5 rounded-lg px-4 py-3 text-center">
+      <p className="text-2xl font-bold">{value}</p>
+      <p className="text-gray-400 text-sm">{label}</p>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Add lazy import and route to `main.jsx`**
+
+In `frontend/src/main.jsx`, after the `BandProfilePage` lazy import line, add:
+
+```js
+const EventRecapPage = lazy(() => import('./pages/EventRecapPage.jsx'))
+```
+
+Then add the route before the `/band/:id` route:
+
+```jsx
+<Route
+  path="/events/:slug/recap"
+  element={
+    <ErrorBoundary title="Recap Error" message="Unable to load event recap. Please try again.">
+      <Suspense fallback={<LoadingFallback />}>
+        <EventRecapPage />
+      </Suspense>
+    </ErrorBoundary>
+  }
+/>
+```
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+cd /Users/andrelevesque/Projects/settimesdotca/.worktrees/feat-event-lifecycle-hub
+npx vitest run
+```
+
+Expected: All tests passing (no new tests for the React page — manual QA in browser)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/EventRecapPage.jsx frontend/src/main.jsx
+git commit -m "feat: add /events/:slug/recap page"
+```
+
+---
+
+### Task 3: Historical Import Modal
+
+**Files:**
+- Create: `frontend/src/admin/HistoricalImportModal.jsx`
+
+The modal is a two-step wizard:
+- Step 1: Event info (name, date — auto-generates slug from name, status will be `archived`)
+- Step 2: Band list (textarea, one name per line)
+
+It calls `eventsApi.create()` then loops over band names calling `bandsApi.create()`. No new API endpoints needed — the existing `POST /api/admin/bands` handler already does find-or-create by `name_normalized`.
+
+- [ ] **Step 1: Build the component**
+
+Create `frontend/src/admin/HistoricalImportModal.jsx`:
+
+```jsx
+import { useState } from 'react'
+import { eventsApi, bandsApi } from '../utils/adminApi'
+
+const buttonFocusClass =
+  'border border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple'
+
+function generateSlug(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+}
+
+export default function HistoricalImportModal({ onClose, onImported }) {
+  const [step, setStep] = useState(1) // 1 = event info, 2 = band list
+  const [eventName, setEventName] = useState('')
+  const [eventDate, setEventDate] = useState('')
+  const [bandListText, setBandListText] = useState('')
+  const [createdEvent, setCreatedEvent] = useState(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [progress, setProgress] = useState(null) // { done, total }
+  const [errors, setErrors] = useState([])
+
+  async function handleCreateEvent(e) {
+    e.preventDefault()
+    if (!eventName.trim() || !eventDate) return
+    setSubmitting(true)
+    setErrors([])
+    try {
+      const slug = generateSlug(eventName)
+      const result = await eventsApi.create({
+        name: eventName.trim(),
+        date: eventDate,
+        slug,
+        status: 'archived',
+        is_published: 0,
+      })
+      setCreatedEvent(result.event || result)
+      setStep(2)
+    } catch (err) {
+      setErrors([err.message || 'Failed to create event'])
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleImportBands(e) {
+    e.preventDefault()
+    const names = bandListText
+      .split('\n')
+      .map((n) => n.trim())
+      .filter(Boolean)
+    if (names.length === 0) return
+
+    setSubmitting(true)
+    setErrors([])
+    setProgress({ done: 0, total: names.length })
+    const failed = []
+
+    for (let i = 0; i < names.length; i++) {
+      try {
+        await bandsApi.create({ eventId: createdEvent.id, name: names[i] })
+      } catch (err) {
+        failed.push(`${names[i]}: ${err.message || 'unknown error'}`)
+      }
+      setProgress({ done: i + 1, total: names.length })
+    }
+
+    setSubmitting(false)
+    if (failed.length > 0) {
+      setErrors(failed)
+    } else {
+      onImported?.()
+      onClose()
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="import-modal-title"
+    >
+      <div className="bg-bg-purple rounded-xl shadow-xl w-full max-w-md p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 id="import-modal-title" className="text-lg font-semibold text-white">
+            Import Historical Event{step === 2 ? ` — ${createdEvent?.name}` : ''}
+          </h2>
+          <button
+            onClick={onClose}
+            className={`text-gray-400 hover:text-white ${buttonFocusClass} rounded`}
+            aria-label="Close modal"
+            disabled={submitting}
+          >
+            ✕
+          </button>
+        </div>
+
+        {errors.length > 0 && (
+          <div className="mb-4 bg-red-900/30 text-red-300 rounded-lg p-3 text-sm">
+            {errors.map((err, i) => (
+              <p key={i}>{err}</p>
+            ))}
+          </div>
+        )}
+
+        {step === 1 && (
+          <form onSubmit={handleCreateEvent} className="space-y-4">
+            <div>
+              <label className="block text-sm text-gray-300 mb-1" htmlFor="hist-event-name">
+                Event Name
+              </label>
+              <input
+                id="hist-event-name"
+                type="text"
+                value={eventName}
+                onChange={(e) => setEventName(e.target.value)}
+                required
+                placeholder="Long Weekend Band Crawl Vol. 3"
+                className="w-full bg-white/10 text-white rounded-lg px-3 py-2 text-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-300 mb-1" htmlFor="hist-event-date">
+                Date
+              </label>
+              <input
+                id="hist-event-date"
+                type="date"
+                value={eventDate}
+                onChange={(e) => setEventDate(e.target.value)}
+                required
+                className="w-full bg-white/10 text-white rounded-lg px-3 py-2 text-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+              />
+            </div>
+            <div className="flex justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className={`px-4 py-2 text-sm text-gray-300 hover:text-white rounded-lg ${buttonFocusClass}`}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !eventName.trim() || !eventDate}
+                className={`px-4 py-2 text-sm bg-accent-500 hover:bg-accent-600 disabled:opacity-50 text-white rounded-lg ${buttonFocusClass}`}
+              >
+                {submitting ? 'Creating…' : 'Next: Add Bands →'}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {step === 2 && (
+          <form onSubmit={handleImportBands} className="space-y-4">
+            <div>
+              <label className="block text-sm text-gray-300 mb-1" htmlFor="hist-band-list">
+                Band Names (one per line)
+              </label>
+              <textarea
+                id="hist-band-list"
+                value={bandListText}
+                onChange={(e) => setBandListText(e.target.value)}
+                rows={10}
+                placeholder="The Raging Hormones&#10;Velvet Thunder&#10;Disco Apocalypse"
+                className="w-full bg-white/10 text-white rounded-lg px-3 py-2 text-sm font-mono focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                Existing band profiles will be matched by name. New profiles will be created automatically.
+              </p>
+            </div>
+            {progress && (
+              <p className="text-sm text-gray-300">
+                Importing… {progress.done} / {progress.total}
+              </p>
+            )}
+            <div className="flex justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className={`px-4 py-2 text-sm text-gray-300 hover:text-white rounded-lg ${buttonFocusClass}`}
+                disabled={submitting}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !bandListText.trim()}
+                className={`px-4 py-2 text-sm bg-accent-500 hover:bg-accent-600 disabled:opacity-50 text-white rounded-lg ${buttonFocusClass}`}
+              >
+                {submitting ? `Importing… ${progress?.done ?? 0}/${progress?.total ?? 0}` : 'Import Bands'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Run the full test suite to check for regressions**
+
+```bash
+cd /Users/andrelevesque/Projects/settimesdotca/.worktrees/feat-event-lifecycle-hub
+npx vitest run
+```
+
+Expected: All tests passing
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/admin/HistoricalImportModal.jsx
+git commit -m "feat: add HistoricalImportModal component for archive backfill"
+```
+
+---
+
+### Task 4: Wire Historical Import into EventsTab
+
+**Files:**
+- Modify: `frontend/src/admin/EventsTab.jsx`
+
+Add an "Import historical event" button that opens `HistoricalImportModal`. The button should only appear for admin-role users (editors do not have permission to create archived events). Place the button in the header area near the existing "New Event" button.
+
+- [ ] **Step 1: Read the current EventsTab header area to find the button placement**
+
+Read `frontend/src/admin/EventsTab.jsx` lines 1–150 to locate the "New Event" button and the user role check pattern already present in the file.
+
+- [ ] **Step 2: Add the import and state to EventsTab**
+
+At the top of `EventsTab.jsx`, add the import:
+
+```js
+import HistoricalImportModal from './HistoricalImportModal'
+```
+
+Inside the component, add state:
+
+```js
+const [showHistoricalImport, setShowHistoricalImport] = useState(false)
+```
+
+- [ ] **Step 3: Add the "Import historical event" button**
+
+Locate the area where the "New Event" button is rendered. Wrap both buttons in the same container. Only show the import button when the current user has admin role.
+
+The `currentUser` is available via `useEventContext()` as `context.user`. The pattern for role checks elsewhere in the admin panel is `currentUser?.role === 'admin'`.
+
+Add the button next to the existing "New Event" button:
+
+```jsx
+{currentUser?.role === 'admin' && (
+  <button
+    onClick={() => setShowHistoricalImport(true)}
+    className={`px-3 py-1.5 text-sm text-gray-300 hover:text-white border border-white/20 hover:border-white/40 rounded-lg transition-colors ${buttonFocusClass}`}
+  >
+    Import historical event
+  </button>
+)}
+```
+
+- [ ] **Step 4: Render the modal**
+
+At the bottom of the EventsTab JSX return, just before the closing `</div>`, add:
+
+```jsx
+{showHistoricalImport && (
+  <HistoricalImportModal
+    onClose={() => setShowHistoricalImport(false)}
+    onImported={() => {
+      setShowHistoricalImport(false)
+      loadEvents()
+    }}
+  />
+)}
+```
+
+Where `loadEvents` is the function that refreshes the event list (check the component for its exact name — it may be `fetchEvents`, `refreshEvents`, or `loadData`).
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+cd /Users/andrelevesque/Projects/settimesdotca/.worktrees/feat-event-lifecycle-hub
+npx vitest run
+```
+
+Expected: All tests passing
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/admin/EventsTab.jsx
+git commit -m "feat: add 'Import historical event' button to EventsTab"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+| Requirement | Task |
+|---|---|
+| `GET /api/events/:slug/recap` returns stats + band list | Task 1 |
+| Recap only for archived events | Task 1 (404 for non-archived) |
+| First-timers vs returning acts classification | Task 1 |
+| Public gate enforcement | Task 1 |
+| `/events/:slug/recap` frontend route | Task 2 |
+| Lazy-loaded React page with stats, band list, subscribe CTA | Task 2 |
+| Historical import: create archived event | Task 3 |
+| Historical import: paste band list, find-or-create profiles | Task 3 |
+| Wire import button into EventsTab (admin only) | Task 4 |
+
+### No placeholders found.
+
+### Type consistency
+
+- `event.id` is numeric throughout (recap API returns `id: event.id` not slug)
+- `band.id` = `band_profile_id` from the DB (consistent with BandProfilePage which uses `/band/:id`)
+- `is_returning` is a boolean in the JS layer (coerced via `Boolean(row.is_returning)` from SQLite 0/1)
+- `eventsApi.create()` / `bandsApi.create()` match existing signatures in `adminApi.js`

--- a/docs/superpowers/plans/2026-05-02-event-lifecycle-hub.md
+++ b/docs/superpowers/plans/2026-05-02-event-lifecycle-hub.md
@@ -1,0 +1,1614 @@
+# Event Lifecycle Hub — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship three fan-facing features before May 17, 2026 — shareable schedule URLs, pre-event reveal mode, and band following — turning SetTimes.ca from a single-use schedule tool into a site fans return to.
+
+**Architecture:** Feature 1 is pure frontend (no backend changes). Features 2 and 3 each add one D1 migration, follow the existing Cloudflare Pages Functions request-handler pattern, and reuse the existing test-utils.js in-memory DB harness. Each feature is independently mergeable in order: 1 → 2 → 3.
+
+**Tech Stack:** React 19 + React Router 7 (frontend), Cloudflare Pages Functions / D1 (backend), Vitest (unit tests), better-sqlite3 (test DB), existing `createTestEnv` / `insertBand` / `insertEvent` helpers from `functions/api/test-utils.js`.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-event-lifecycle-hub-design.md`
+
+---
+
+## File Map
+
+### Feature 1 — Shareable Schedule URLs (no backend changes)
+| Action | File |
+|--------|------|
+| Modify | `frontend/src/App.jsx` |
+| Modify | `frontend/src/components/MySchedule.jsx` |
+
+### Feature 2 — Pre-Event Reveal Mode
+| Action | File |
+|--------|------|
+| Create | `migrations/0033_reveal_mode.sql` |
+| Modify | `functions/api/test-utils.js` |
+| Modify | `functions/api/schedule.js` |
+| Modify | `functions/api/admin/bands/[id].js` |
+| Create | `functions/api/admin/events/[id]/reveal-mode.js` |
+| Create | `functions/api/admin/bands/__tests__/announce.test.js` |
+| Modify | `frontend/src/admin/EventFormModal.jsx` |
+| Modify | `frontend/src/admin/LineupTab.jsx` |
+| Modify | `frontend/src/App.jsx` |
+
+### Feature 3 — Band Following
+| Action | File |
+|--------|------|
+| Create | `migrations/0034_band_follows.sql` |
+| Modify | `functions/api/test-utils.js` |
+| Create | `functions/api/bands/[name]/follow.js` |
+| Create | `functions/api/bands/__tests__/follow.test.js` |
+| Modify | `functions/api/admin/bands/[id].js` (add notification trigger to onRequestPatch) |
+| Modify | `frontend/src/pages/BandProfilePage.jsx` |
+
+---
+
+## Prerequisite Reading
+
+Before starting, open these files and understand them:
+- `frontend/src/App.jsx` — schedule state, `SELECTED_BANDS_KEY`, `getStoredSelection(slug)`, `toggleBand`, `ConfirmDialog` usage
+- `functions/api/schedule.js` — full handler; note the `INNER JOIN venues` bug (venue is optional since migration 0032 but the query still inner-joins)
+- `functions/api/admin/bands/[id].js` — `onRequestPut` pattern, `getBandId()`, `checkPermission`, `auditLog`
+- `functions/api/admin/events/[id]/publish.js` — action-endpoint pattern to copy for reveal-mode.js
+- `functions/api/test-utils.js` — `createTestEnv()`, `insertBand()`, `insertEvent()`, `insertVenue()` signatures
+
+---
+
+## Feature 1 — Shareable Schedule URLs
+
+### Task 1: Add Share button to MySchedule
+
+**Files:**
+- Modify: `frontend/src/components/MySchedule.jsx`
+
+**How sharing works:** `selectedBands` is an array of string IDs like `"the-sunset-trio-41"`. The numeric part after the last `-` is the `performance_id`. The URL encodes numeric performance IDs: `?s=41,42,77`. On the receiving end, `App.jsx` maps those numbers back to band string IDs.
+
+- [ ] **Step 1: Add the share button**
+
+Open `frontend/src/components/MySchedule.jsx`. Find the section rendering the "Copy Schedule" button. Add a "Share My Schedule" button immediately after it. The button is only shown when `bands.length > 0`.
+
+The full share URL encodes numeric performance IDs extracted from `band.id` (format: `"name-42"` — the number is the performance ID):
+
+```jsx
+// Add near the top of the component, after the existing copyButtonLabel state:
+const [shareButtonLabel, setShareButtonLabel] = useState('Share Schedule')
+
+// Add this function before the return statement:
+const handleShareSchedule = async () => {
+  const performanceIds = bands
+    .map(band => {
+      const parts = band.id.split('-')
+      return parts[parts.length - 1]
+    })
+    .filter(id => /^\d+$/.test(id))
+    .join(',')
+
+  const url = `${window.location.origin}${window.location.pathname}?s=${performanceIds}`
+  await copyToClipboard(url)
+  setShareButtonLabel('Link Copied!')
+  setTimeout(() => setShareButtonLabel('Share Schedule'), 2000)
+}
+```
+
+Then add the button in JSX next to "Copy Schedule" (copy the exact className from the Copy Schedule button):
+
+```jsx
+{bands.length > 0 && (
+  <button
+    onClick={handleShareSchedule}
+    className="..."  {/* copy exact className from Copy Schedule button */}
+    aria-label="Copy shareable link to your schedule"
+  >
+    <FontAwesomeIcon icon={faLink} className="mr-2" />
+    {shareButtonLabel}
+  </button>
+)}
+```
+
+Import `faLink` from `@fortawesome/free-solid-svg-icons` at the top of the file.
+
+- [ ] **Step 2: Run unit tests to confirm no regressions**
+
+```bash
+npm run test -- --reporter=verbose 2>&1 | grep -E "PASS|FAIL|MySchedule"
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/MySchedule.jsx
+git commit -m "feat: add Share Schedule button to MySchedule"
+```
+
+---
+
+### Task 2: Seed selectedBands from URL params in App.jsx
+
+**Files:**
+- Modify: `frontend/src/App.jsx`
+
+When a fan opens a share link like `/event/lwbc-vol6?s=41,42,77`, we map the numeric performance IDs back to string band IDs and seed localStorage.
+
+- [ ] **Step 1: Add useSearchParams import**
+
+At the top of `frontend/src/App.jsx`, add `useSearchParams` to the react-router-dom import:
+
+```js
+import { Link, useParams, useSearchParams } from 'react-router-dom'
+```
+
+- [ ] **Step 2: Destructure searchParams in the App component**
+
+Inside the `App()` function, after the `useParams()` call:
+
+```js
+const [searchParams, setSearchParams] = useSearchParams()
+```
+
+- [ ] **Step 3: Add the URL seeding effect**
+
+Add a new `useEffect` that runs after `bands` loads. Place it after the effect that syncs `selectedBands` to `localStorage` (around line 240 in the current file):
+
+```js
+useEffect(() => {
+  const sParam = searchParams.get('s')
+  if (!sParam || bands.length === 0) return
+
+  const requestedIds = new Set(
+    sParam.split(',').map(s => s.trim()).filter(s => /^\d+$/.test(s))
+  )
+
+  // Map numeric performance IDs back to band string IDs
+  const matchedStringIds = bands
+    .filter(band => {
+      const parts = band.id.split('-')
+      const perfId = parts[parts.length - 1]
+      return requestedIds.has(perfId)
+    })
+    .map(band => band.id)
+
+  if (matchedStringIds.length === 0) return
+
+  const existing = getStoredSelection(slug)
+
+  const applySelection = () => {
+    setSelectedBands(matchedStringIds)
+    setView('mine')
+    // Remove the ?s= param from the URL without a page reload
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.delete('s')
+      return next
+    }, { replace: true })
+  }
+
+  if (existing.length === 0) {
+    applySelection()
+  } else {
+    // Show confirmation before overwriting existing picks
+    setPendingSharedBands(matchedStringIds)
+    setSharedScheduleConfirmOpen(true)
+  }
+}, [bands, searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
+```
+
+- [ ] **Step 4: Add the new state variables and confirmation dialog**
+
+At the top of the `App()` function, add two new state vars after `clearConfirmOpen`:
+
+```js
+const [sharedScheduleConfirmOpen, setSharedScheduleConfirmOpen] = useState(false)
+const [pendingSharedBands, setPendingSharedBands] = useState([])
+```
+
+At the bottom of the JSX, add a second `ConfirmDialog` after the existing clear dialog:
+
+```jsx
+<ConfirmDialog
+  isOpen={sharedScheduleConfirmOpen}
+  title="Load Shared Schedule?"
+  message="Loading this shared schedule will replace your current picks."
+  confirmText="Load"
+  onConfirm={() => {
+    setSharedScheduleConfirmOpen(false)
+    setSelectedBands(pendingSharedBands)
+    setView('mine')
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.delete('s')
+      return next
+    }, { replace: true })
+    setPendingSharedBands([])
+  }}
+  onCancel={() => {
+    setSharedScheduleConfirmOpen(false)
+    setPendingSharedBands([])
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.delete('s')
+      return next
+    }, { replace: true })
+  }}
+/>
+```
+
+- [ ] **Step 5: Fix the LEFT JOIN bug in schedule.js while you're here**
+
+Open `functions/api/schedule.js`. Find the band query (around line 80). Change `INNER JOIN venues v ON p.venue_id = v.id` to `LEFT JOIN venues v ON p.venue_id = v.id`. Also update the venue field in the formatted response to handle null:
+
+```js
+venue: band.venue ?? null,  // was: band.venue (would be null for TBD bands already)
+```
+
+This is a correctness fix — since migration 0032 made venue optional, the INNER JOIN silently drops bands with no venue from the public schedule.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 7: Commit Feature 1**
+
+```bash
+git add frontend/src/App.jsx frontend/src/components/MySchedule.jsx functions/api/schedule.js
+git commit -m "feat: shareable schedule URLs via ?s= query param
+
+Fans can now share their MySchedule picks via a URL. Numeric performance
+IDs are encoded into ?s= and mapped back to band string IDs on load.
+Also fixes schedule.js INNER JOIN bug that dropped venue-less performers."
+```
+
+---
+
+## Feature 2 — Pre-Event Reveal Mode
+
+### Task 3: Create migration 0033
+
+**Files:**
+- Create: `migrations/0033_reveal_mode.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+```sql
+-- Migration: 0033_reveal_mode
+-- Description: Add reveal_mode to events (when true, only announced performances
+--   appear on the public schedule) and is_announced to performances (toggle per band).
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+--
+-- Safe defaults: reveal_mode=0 means existing events show all bands (no change).
+--   is_announced=1 means existing performances are visible by default.
+
+ALTER TABLE events ADD COLUMN reveal_mode INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE performances ADD COLUMN is_announced INTEGER NOT NULL DEFAULT 1;
+
+CREATE INDEX IF NOT EXISTS idx_performances_announced
+  ON performances(event_id, is_announced);
+```
+
+- [ ] **Step 2: Apply locally**
+
+```bash
+npm run migrate:local
+```
+
+Expected output: migration applied successfully, no errors.
+
+---
+
+### Task 4: Update test-utils.js schema
+
+**Files:**
+- Modify: `functions/api/test-utils.js`
+
+The in-memory test DB must match the real schema for tests to pass.
+
+- [ ] **Step 1: Add the two new columns**
+
+In `functions/api/test-utils.js`, find the `CREATE TABLE events` statement and add `reveal_mode`:
+
+```sql
+-- In the events CREATE TABLE, add after `updated_at TEXT DEFAULT (datetime('now'))`:
+reveal_mode INTEGER NOT NULL DEFAULT 0
+```
+
+Find the `CREATE TABLE performances` statement and add `is_announced`:
+
+```sql
+-- In the performances CREATE TABLE, add after `updated_at TEXT DEFAULT (datetime('now'))`:
+is_announced INTEGER NOT NULL DEFAULT 1
+```
+
+- [ ] **Step 2: Verify existing tests still pass**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all tests pass (new columns have safe defaults so nothing breaks).
+
+---
+
+### Task 5: Write failing tests for schedule reveal filter
+
+**Files:**
+- Create: `functions/api/__tests__/schedule-reveal.test.js`
+
+- [ ] **Step 1: Create the test file**
+
+```js
+import { describe, it, expect } from 'vitest'
+import { createTestEnv, insertEvent, insertVenue, insertBand } from '../test-utils'
+import * as scheduleHandler from '../schedule.js'
+
+describe('GET /api/schedule - reveal mode', () => {
+  it('returns all bands when reveal_mode is off', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6', status: 'draft', is_published: 1 })
+    rawDb.prepare('UPDATE events SET is_published=1 WHERE id=?').run(ev.id)
+    const venue = insertVenue(rawDb, { name: 'Venue A' })
+    insertBand(rawDb, { name: 'Announced Band', event_id: ev.id, venue_id: venue.id })
+    // Insert unannounced band
+    const unannounced = insertBand(rawDb, { name: 'Hidden Band', event_id: ev.id, venue_id: venue.id })
+    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(unannounced.id)
+
+    const req = new Request('https://example.test/api/schedule?event=vol6')
+    const res = await scheduleHandler.onRequestGet({ request: req, env })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    // reveal_mode=0: all bands returned regardless of is_announced
+    expect(data.bands.length).toBe(2)
+    expect(data.event.reveal_mode).toBe(0)
+  })
+
+  it('filters unannounced bands when reveal_mode is on', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal' })
+    rawDb.prepare('UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?').run(ev.id)
+    const venue = insertVenue(rawDb, { name: 'Venue B' })
+    const announced = insertBand(rawDb, { name: 'Visible Band', event_id: ev.id, venue_id: venue.id })
+    rawDb.prepare('UPDATE performances SET is_announced=1 WHERE id=?').run(announced.id)
+    const hidden = insertBand(rawDb, { name: 'Hidden Band', event_id: ev.id, venue_id: venue.id })
+    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(hidden.id)
+
+    const req = new Request('https://example.test/api/schedule?event=vol6-reveal')
+    const res = await scheduleHandler.onRequestGet({ request: req, env })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.bands.length).toBe(1)
+    expect(data.bands[0].name).toBe('Visible Band')
+    expect(data.event.reveal_mode).toBe(1)
+  })
+
+  it('includes reveal_mode in event metadata', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-meta' })
+    rawDb.prepare('UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?').run(ev.id)
+
+    const req = new Request('https://example.test/api/schedule?event=vol6-meta')
+    const res = await scheduleHandler.onRequestGet({ request: req, env })
+    const data = await res.json()
+    expect(data.event.reveal_mode).toBe(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```bash
+npm run test -- functions/api/__tests__/schedule-reveal.test.js --reporter=verbose
+```
+
+Expected: all 3 tests FAIL (reveal_mode column doesn't exist yet in the query).
+
+---
+
+### Task 6: Update schedule.js for reveal mode
+
+**Files:**
+- Modify: `functions/api/schedule.js`
+
+- [ ] **Step 1: Add reveal_mode to the events SELECT**
+
+Find both event queries (the `current` branch and the slug branch). Add `reveal_mode` to each SELECT:
+
+```sql
+-- current event query:
+SELECT id, name, date, slug, status, ticket_url, theme_colors, venue_info, social_links, reveal_mode
+FROM events
+WHERE is_published = 1
+  AND date >= date('now', '-6 hours')
+ORDER BY date ASC
+LIMIT 1
+
+-- slug event query:
+SELECT id, name, date, slug, status, ticket_url, theme_colors, venue_info, social_links, reveal_mode
+FROM events
+WHERE slug = ? AND (is_published = 1 OR status = 'archived')
+```
+
+- [ ] **Step 2: Add reveal mode filter to the performances query**
+
+Replace the performances query SQL with:
+
+```sql
+SELECT
+  p.id as performance_id,
+  b.id as band_id,
+  b.name,
+  p.start_time as startTime,
+  p.end_time as endTime,
+  b.social_links,
+  v.name as venue
+FROM performances p
+INNER JOIN band_profiles b ON p.band_profile_id = b.id
+LEFT JOIN venues v ON p.venue_id = v.id
+WHERE p.event_id = ?
+  AND (? = 0 OR p.is_announced = 1)
+ORDER BY p.start_time, v.name
+```
+
+Bind both `event.id` and `event.reveal_mode`:
+
+```js
+const bandsResult = await DB.prepare(`...sql above...`)
+  .bind(event.id, event.reveal_mode)
+  .all()
+```
+
+- [ ] **Step 3: Add reveal_mode to the event metadata response**
+
+In the `eventMetadata` object:
+
+```js
+const eventMetadata = {
+  id: event.id,
+  name: event.name,
+  date: event.date,
+  slug: event.slug,
+  ticket_url: event.ticket_url,
+  is_archived: event.status === 'archived',
+  reveal_mode: event.reveal_mode ?? 0,   // ← add this line
+  theme_colors: event.theme_colors,
+  venue_info: event.venue_info,
+  social_links: event.social_links,
+}
+```
+
+- [ ] **Step 4: Run the reveal mode tests**
+
+```bash
+npm run test -- functions/api/__tests__/schedule-reveal.test.js --reporter=verbose
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 7: Write failing tests for the announce PATCH endpoint
+
+**Files:**
+- Create: `functions/api/admin/bands/__tests__/announce.test.js`
+
+- [ ] **Step 1: Create the test file**
+
+```js
+import { describe, it, expect } from 'vitest'
+import { createTestEnv, insertEvent, insertVenue, insertBand } from '../../../test-utils'
+import * as bandIdHandler from '../[id].js'
+
+describe('PATCH /api/admin/bands/:id - announce toggle', () => {
+  it('announces a performance (sets is_announced=1)', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-announce' })
+    const venue = insertVenue(rawDb, { name: 'Venue X' })
+    const band = insertBand(rawDb, { name: 'Test Band', event_id: ev.id, venue_id: venue.id })
+    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(band.id)
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ is_announced: true }),
+    })
+    const res = await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'editor', id: 2 } },
+    })
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.performance.is_announced).toBe(1)
+
+    const row = rawDb.prepare('SELECT is_announced FROM performances WHERE id=?').get(band.id)
+    expect(row.is_announced).toBe(1)
+  })
+
+  it('unannounces a performance (sets is_announced=0)', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-unannounce' })
+    const venue = insertVenue(rawDb, { name: 'Venue Y' })
+    const band = insertBand(rawDb, { name: 'Visible Band', event_id: ev.id, venue_id: venue.id })
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ is_announced: false }),
+    })
+    const res = await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'editor', id: 2 } },
+    })
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.performance.is_announced).toBe(0)
+  })
+
+  it('returns 400 if is_announced is missing from body', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-bad' })
+    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ unrelated: true }),
+    })
+    const res = await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'editor', id: 2 } },
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('requires at least editor role', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'viewer' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-auth' })
+    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ is_announced: true }),
+    })
+    const res = await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'viewer', id: 3 } },
+    })
+
+    expect(res.status).toBe(403)
+  })
+})
+```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```bash
+npm run test -- functions/api/admin/bands/__tests__/announce.test.js --reporter=verbose
+```
+
+Expected: all 4 tests FAIL (`onRequestPatch is not a function`).
+
+---
+
+### Task 8: Add onRequestPatch to bands/[id].js
+
+**Files:**
+- Modify: `functions/api/admin/bands/[id].js`
+
+- [ ] **Step 1: Add the handler at the bottom of the file**
+
+At the end of `functions/api/admin/bands/[id].js`, after `onRequestDelete`, add:
+
+```js
+// PATCH - Toggle is_announced for a performance
+export async function onRequestPatch(context) {
+  const { request, env } = context
+  const { DB } = env
+
+  const permCheck = await checkPermission(context, 'editor')
+  if (permCheck.error) {
+    return permCheck.response
+  }
+
+  const performanceId = getBandId(request)
+  if (!performanceId || isNaN(performanceId)) {
+    return new Response(
+      JSON.stringify({ error: 'Bad request', message: 'Invalid performance ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  const body = await request.json().catch(() => ({}))
+  if (typeof body.is_announced !== 'boolean') {
+    return new Response(
+      JSON.stringify({ error: 'Bad request', message: 'is_announced (boolean) is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  const performance = await DB.prepare(
+    'SELECT id, is_announced FROM performances WHERE id = ?'
+  ).bind(performanceId).first()
+
+  if (!performance) {
+    return new Response(
+      JSON.stringify({ error: 'Not found', message: 'Performance not found' }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  const newValue = body.is_announced ? 1 : 0
+  await DB.prepare(
+    'UPDATE performances SET is_announced = ?, updated_at = datetime(\'now\') WHERE id = ?'
+  ).bind(newValue, performanceId).run()
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      performance: { id: Number(performanceId), is_announced: newValue },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  )
+}
+```
+
+- [ ] **Step 2: Run announce tests**
+
+```bash
+npm run test -- functions/api/admin/bands/__tests__/announce.test.js --reporter=verbose
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 9: Create reveal-mode toggle endpoint
+
+**Files:**
+- Create: `functions/api/admin/events/[id]/reveal-mode.js`
+
+This follows the same pattern as `functions/api/admin/events/[id]/publish.js`.
+
+- [ ] **Step 1: Create the file**
+
+```js
+// Admin event reveal-mode endpoint
+// POST /api/admin/events/{id}/reveal-mode
+// Body: { reveal_mode: boolean }
+// Returns: { success: true, event: { id, reveal_mode } }
+
+import { checkPermission, auditLog } from '../../_middleware.js'
+import { getClientIP } from '../../../../utils/request.js'
+
+export async function onRequestPost(context) {
+  const { request, env, params } = context
+  const { DB } = env
+  const eventId = params.id
+  const ipAddress = getClientIP(request)
+
+  try {
+    const auth = await checkPermission(context, 'editor')
+    if (auth.error) {
+      return auth.response
+    }
+
+    if (!eventId || isNaN(eventId)) {
+      return new Response(
+        JSON.stringify({ error: 'Bad request', message: 'Invalid event ID' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const body = await request.json().catch(() => ({}))
+    if (typeof body.reveal_mode !== 'boolean') {
+      return new Response(
+        JSON.stringify({ error: 'Bad request', message: 'reveal_mode (boolean) is required' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const event = await DB.prepare('SELECT id FROM events WHERE id = ?')
+      .bind(eventId)
+      .first()
+
+    if (!event) {
+      return new Response(
+        JSON.stringify({ error: 'Not found', message: 'Event not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const newValue = body.reveal_mode ? 1 : 0
+    await DB.prepare(
+      "UPDATE events SET reveal_mode = ?, updated_at = datetime('now') WHERE id = ?"
+    ).bind(newValue, eventId).run()
+
+    await auditLog(DB, {
+      action: newValue ? 'event_reveal_mode_on' : 'event_reveal_mode_off',
+      success: true,
+      ipAddress,
+      details: JSON.stringify({ event_id: eventId }),
+    })
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        event: { id: Number(eventId), reveal_mode: newValue },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  } catch (err) {
+    console.error('[reveal-mode] Error:', err)
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit Feature 2 backend**
+
+```bash
+git add migrations/0033_reveal_mode.sql \
+  functions/api/test-utils.js \
+  functions/api/schedule.js \
+  "functions/api/admin/bands/[id].js" \
+  "functions/api/admin/events/[id]/reveal-mode.js" \
+  functions/api/admin/bands/__tests__/announce.test.js \
+  "functions/api/__tests__/schedule-reveal.test.js"
+git commit -m "feat: reveal mode backend — migration, schedule filter, announce toggle, reveal-mode endpoint"
+```
+
+---
+
+### Task 10: Admin UI — Reveal Mode toggle in EventFormModal
+
+**Files:**
+- Modify: `frontend/src/admin/EventFormModal.jsx`
+
+- [ ] **Step 1: Read the current EventFormModal**
+
+Open `frontend/src/admin/EventFormModal.jsx`. Find where `is_published` is handled — you'll see a toggle or checkbox for it. The reveal mode toggle goes directly below it.
+
+- [ ] **Step 2: Add reveal_mode to form state**
+
+Find the `useState` for form fields. Add `reveal_mode: event?.reveal_mode ?? false` to the initial state object (or wherever `is_published` is tracked).
+
+- [ ] **Step 3: Add the toggle in JSX**
+
+After the `is_published` toggle section, add:
+
+```jsx
+<div className="flex items-center justify-between py-3 border-t border-white/10">
+  <div>
+    <label className="text-sm font-medium text-text-primary" htmlFor="reveal-mode">
+      Reveal mode
+    </label>
+    <p className="text-xs text-text-secondary mt-0.5">
+      When on, only announced bands appear on the public schedule.
+    </p>
+  </div>
+  <button
+    id="reveal-mode"
+    type="button"
+    role="switch"
+    aria-checked={formData.reveal_mode}
+    onClick={() => setFormData(prev => ({ ...prev, reveal_mode: !prev.reveal_mode }))}
+    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-accent-500 ${
+      formData.reveal_mode ? 'bg-accent-500' : 'bg-white/20'
+    }`}
+  >
+    <span
+      className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+        formData.reveal_mode ? 'translate-x-6' : 'translate-x-1'
+      }`}
+    />
+  </button>
+</div>
+```
+
+- [ ] **Step 4: Include reveal_mode in the save handler**
+
+Find where the form calls `fetch` or a save function. Include `reveal_mode: formData.reveal_mode` in the request body alongside the existing fields. After the event saves, if `reveal_mode` changed, call the reveal-mode endpoint:
+
+```js
+// After saving the event fields, toggle reveal_mode if it changed:
+if (formData.reveal_mode !== (event?.reveal_mode ?? false)) {
+  await fetch(`/api/admin/events/${event.id}/reveal-mode`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+    body: JSON.stringify({ reveal_mode: formData.reveal_mode }),
+  })
+}
+```
+
+(Use the same `csrfToken` already used in the form's save call.)
+
+- [ ] **Step 5: Verify no type errors**
+
+```bash
+npm --prefix frontend run build 2>&1 | tail -20
+```
+
+Expected: build succeeds with no errors.
+
+---
+
+### Task 11: Admin UI — Announce toggle in LineupTab
+
+**Files:**
+- Modify: `frontend/src/admin/LineupTab.jsx`
+
+- [ ] **Step 1: Read LineupTab**
+
+Open `frontend/src/admin/LineupTab.jsx`. Find the table/list row where each band is rendered. You'll add an eye icon toggle at the end of each row.
+
+- [ ] **Step 2: Add a toggleAnnounced handler**
+
+Near the other handler functions (edit, delete), add:
+
+```js
+const toggleAnnounced = async (performanceId, currentValue) => {
+  try {
+    const res = await fetch(`/api/admin/bands/${performanceId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken,
+      },
+      body: JSON.stringify({ is_announced: !currentValue }),
+    })
+    if (!res.ok) throw new Error('Failed to toggle announcement')
+    // Refresh the lineup list
+    await loadBands()
+  } catch (err) {
+    console.error('[LineupTab] toggleAnnounced error:', err)
+  }
+}
+```
+
+(Use the same `csrfToken` and `loadBands` already in the component.)
+
+- [ ] **Step 3: Add toggle button to each row**
+
+In the row JSX, add the toggle button (use `faEye` / `faEyeSlash` from FontAwesome):
+
+```jsx
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
+
+// In the row:
+{selectedEvent?.reveal_mode === 1 && (
+  <button
+    onClick={() => toggleAnnounced(band.id, band.is_announced)}
+    title={band.is_announced ? 'Announced — click to hide' : 'Hidden — click to announce'}
+    className={`p-1.5 rounded transition-colors ${
+      band.is_announced
+        ? 'text-green-400 hover:text-green-300'
+        : 'text-white/30 hover:text-white/60'
+    }`}
+    aria-label={band.is_announced ? `Unannounce ${band.name}` : `Announce ${band.name}`}
+  >
+    <FontAwesomeIcon icon={band.is_announced ? faEye : faEyeSlash} />
+  </button>
+)}
+```
+
+The button only shows when `selectedEvent?.reveal_mode === 1` so it doesn't clutter normal events.
+
+Note: the `band.is_announced` field must be included in the lineup API response. Check `functions/api/admin/bands.js` GET handler and add `p.is_announced` to the SELECT if it isn't already there.
+
+- [ ] **Step 4: Ensure is_announced is returned by the lineup GET**
+
+Open `functions/api/admin/bands.js`. Find the GET query that lists bands for an event. Add `p.is_announced` to the SELECT list if absent:
+
+```sql
+SELECT
+  p.id,
+  p.start_time,
+  p.end_time,
+  p.notes,
+  p.is_announced,   -- ← add this
+  ...
+```
+
+- [ ] **Step 5: Build check**
+
+```bash
+npm --prefix frontend run build 2>&1 | tail -20
+```
+
+Expected: no errors.
+
+---
+
+### Task 12: Public UI — Reveal mode teaser banner in App.jsx
+
+**Files:**
+- Modify: `frontend/src/App.jsx`
+
+When `eventData.reveal_mode === 1`, show a teaser banner below the onboarding hint.
+
+- [ ] **Step 1: Add the banner JSX**
+
+In `App.jsx`, find the `/* First-time onboarding hint */` section. After it, add:
+
+```jsx
+{/* Reveal mode teaser — more bands dropping soon */}
+{!isArchived && eventData?.reveal_mode === 1 && (
+  <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-accent-500/10 border border-accent-500/20 text-sm">
+    <FontAwesomeIcon icon={faBell} className="text-accent-400 shrink-0" aria-hidden="true" />
+    <p className="text-accent-300">
+      <span className="font-semibold">More bands dropping soon.</span>{' '}
+      <a href="/subscribe" className="underline hover:text-accent-200 transition-colors">
+        Subscribe for updates
+      </a>{' '}
+      or follow individual bands on their profile pages.
+    </p>
+  </div>
+)}
+```
+
+Import `faBell` from `@fortawesome/free-solid-svg-icons` (it may already be imported).
+
+- [ ] **Step 2: Build and run tests**
+
+```bash
+npm --prefix frontend run build 2>&1 | tail -5
+npm run test 2>&1 | tail -10
+```
+
+Expected: build succeeds, all tests pass.
+
+- [ ] **Step 3: Commit Feature 2 frontend**
+
+```bash
+git add frontend/src/admin/EventFormModal.jsx \
+  frontend/src/admin/LineupTab.jsx \
+  frontend/src/App.jsx \
+  functions/api/admin/bands.js
+git commit -m "feat: reveal mode admin UI — toggle in EventFormModal, announce toggle in LineupTab, teaser banner on public schedule"
+```
+
+---
+
+## Feature 3 — Band Following
+
+### Task 13: Create migration 0034
+
+**Files:**
+- Create: `migrations/0034_band_follows.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+```sql
+-- Migration: 0034_band_follows
+-- Description: New band_follows table (token-based email follows for individual bands)
+--   and band_follow_notified column on performances to prevent duplicate notifications
+--   when a band is announced multiple times.
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+CREATE TABLE band_follows (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT NOT NULL,
+  band_profile_id INTEGER NOT NULL REFERENCES band_profiles(id) ON DELETE CASCADE,
+  verified INTEGER NOT NULL DEFAULT 0,
+  verification_token TEXT UNIQUE,
+  unsubscribe_token TEXT UNIQUE NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(email, band_profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_band_follows_band ON band_follows(band_profile_id);
+CREATE INDEX IF NOT EXISTS idx_band_follows_email ON band_follows(email);
+
+ALTER TABLE performances ADD COLUMN band_follow_notified INTEGER NOT NULL DEFAULT 0;
+```
+
+- [ ] **Step 2: Apply locally**
+
+```bash
+npm run migrate:local
+```
+
+Expected: migration applied successfully.
+
+---
+
+### Task 14: Update test-utils.js for band_follows
+
+**Files:**
+- Modify: `functions/api/test-utils.js`
+
+- [ ] **Step 1: Add band_follows table to the in-memory schema**
+
+In `functions/api/test-utils.js`, after the `email_subscriptions` CREATE TABLE block, add:
+
+```sql
+CREATE TABLE band_follows (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT NOT NULL,
+  band_profile_id INTEGER NOT NULL REFERENCES band_profiles(id) ON DELETE CASCADE,
+  verified INTEGER NOT NULL DEFAULT 0,
+  verification_token TEXT UNIQUE,
+  unsubscribe_token TEXT UNIQUE NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(email, band_profile_id)
+);
+```
+
+- [ ] **Step 2: Add band_follow_notified to performances**
+
+In the `CREATE TABLE performances` block, add:
+
+```sql
+band_follow_notified INTEGER NOT NULL DEFAULT 0
+```
+
+- [ ] **Step 3: Run existing tests**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 15: Write failing tests for the band follow endpoint
+
+**Files:**
+- Create: `functions/api/bands/__tests__/follow.test.js`
+
+- [ ] **Step 1: Create the test file**
+
+```js
+import { describe, it, expect } from 'vitest'
+import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
+import * as followHandler from '../[name]/follow.js'
+
+describe('POST /api/bands/:name/follow', () => {
+  it('creates a band follow for a valid email and band', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-follow' })
+    const band = insertBand(rawDb, { name: 'Follow Band', event_id: ev.id })
+
+    const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com' }),
+    })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) } })
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.success).toBe(true)
+
+    const row = rawDb.prepare('SELECT * FROM band_follows WHERE email=? AND band_profile_id=?')
+      .get('fan@example.com', band.band_profile_id)
+    expect(row).toBeTruthy()
+    expect(row.verified).toBe(0)
+    expect(row.unsubscribe_token).toBeTruthy()
+  })
+
+  it('returns 400 for an invalid email', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-bad-email' })
+    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+
+    const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'not-an-email' }),
+    })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) } })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 silently if email already follows the band (no duplicate row)', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-dup' })
+    const band = insertBand(rawDb, { name: 'Dup Band', event_id: ev.id })
+
+    // Insert existing follow
+    rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, unsubscribe_token) VALUES (?, ?, ?)'
+    ).run('fan@example.com', band.band_profile_id, 'existing-token')
+
+    const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com' }),
+    })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) } })
+    expect(res.status).toBe(200)
+
+    // Still only one row
+    const rows = rawDb.prepare('SELECT * FROM band_follows WHERE email=? AND band_profile_id=?')
+      .all('fan@example.com', band.band_profile_id)
+    expect(rows.length).toBe(1)
+  })
+
+  it('returns 404 if band does not exist', async () => {
+    const { env } = createTestEnv()
+
+    const req = new Request('https://example.test/api/bands/99999/follow', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com' }),
+    })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: '99999' } })
+    expect(res.status).toBe(404)
+  })
+})
+```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```bash
+npm run test -- "functions/api/bands/__tests__/follow.test.js" --reporter=verbose
+```
+
+Expected: all 4 tests FAIL (file doesn't exist yet).
+
+---
+
+### Task 16: Create the band follow endpoint
+
+**Files:**
+- Create: `functions/api/bands/[name]/follow.js`
+
+First, check if `functions/api/bands/[name]/` directory exists. If not, create it (it likely exists since `bands/{name}.js` or `bands/[name].js` handles the public band profile).
+
+- [ ] **Step 1: Create the file**
+
+```js
+// POST /api/bands/:name/follow
+// Body: { email: string }
+// Stores a band follow. Email confirmation is skipped for MVP; follows are
+// stored unverified and notifications fire when the band is announced.
+
+import { isValidEmail } from '../../../utils/validation.js'
+import { generateToken } from '../../../utils/tokens.js'
+import { sendEmail, isEmailConfigured } from '../../../utils/email.js'
+
+const MAX_EMAIL_LENGTH = 320
+
+export async function onRequestPost(context) {
+  const { request, env, params } = context
+  const { DB } = env
+
+  try {
+    const body = await request.json().catch(() => ({}))
+    const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
+
+    if (!email || email.length > MAX_EMAIL_LENGTH || !isValidEmail(email)) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid email address' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Resolve band profile — params.name may be numeric ID or normalized name
+    const nameOrId = params.name
+    let band
+    if (/^\d+$/.test(nameOrId)) {
+      band = await DB.prepare('SELECT id, name FROM band_profiles WHERE id = ?')
+        .bind(Number(nameOrId)).first()
+    } else {
+      const normalized = nameOrId.toLowerCase().replace(/[^a-z0-9]/g, '')
+      band = await DB.prepare('SELECT id, name FROM band_profiles WHERE name_normalized = ?')
+        .bind(normalized).first()
+    }
+
+    if (!band) {
+      return new Response(
+        JSON.stringify({ error: 'Band not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Check for duplicate
+    const existing = await DB.prepare(
+      'SELECT id FROM band_follows WHERE email = ? AND band_profile_id = ?'
+    ).bind(email, band.id).first()
+
+    if (existing) {
+      // Return 200 silently — avoid email enumeration
+      return new Response(
+        JSON.stringify({ success: true }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const unsubscribeToken = generateToken()
+
+    await DB.prepare(
+      `INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token)
+       VALUES (?, ?, 1, ?)`
+    ).bind(email, band.id, unsubscribeToken).run()
+    // verified=1 immediately (no email confirmation for MVP; reduce friction)
+
+    // Optional: send a confirmation email
+    if (isEmailConfigured(env)) {
+      const publicUrl = env.PUBLIC_URL || 'https://settimes.ca'
+      const unsubUrl = `${publicUrl}/api/bands/${band.id}/unfollow?token=${unsubscribeToken}`
+      await sendEmail(env, {
+        to: email,
+        subject: `You're following ${band.name} on SetTimes`,
+        text: `You'll be notified when ${band.name} joins a lineup.\n\nUnfollow: ${unsubUrl}`,
+        html: `<p>You'll be notified when <strong>${band.name}</strong> joins a lineup.</p>
+               <p><a href="${unsubUrl}">Unfollow</a></p>`,
+      }).catch(() => {}) // fire-and-forget
+    }
+
+    return new Response(
+      JSON.stringify({ success: true }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  } catch (err) {
+    console.error('[band-follow] Error:', err)
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+}
+```
+
+- [ ] **Step 2: Run the follow tests**
+
+```bash
+npm run test -- "functions/api/bands/__tests__/follow.test.js" --reporter=verbose
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 17: Add notification trigger to announce PATCH handler
+
+**Files:**
+- Modify: `functions/api/admin/bands/[id].js`
+
+When `is_announced` flips from 0 → 1, email all verified followers of that band.
+
+- [ ] **Step 1: Write failing tests for notification trigger**
+
+Add to `functions/api/admin/bands/__tests__/announce.test.js`:
+
+```js
+it('sets band_follow_notified=1 when band is announced and followers exist', async () => {
+  const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+  const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-notify' })
+  rawDb.prepare('UPDATE events SET reveal_mode=1 WHERE id=?').run(ev.id)
+  const venue = insertVenue(rawDb, { name: 'Venue N' })
+  const band = insertBand(rawDb, { name: 'Notify Band', event_id: ev.id, venue_id: venue.id })
+  rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(band.id)
+
+  // Insert a verified follower
+  rawDb.prepare(
+    'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+  ).run('follower@example.com', band.band_profile_id, 'unsub-token-1')
+
+  const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify({ is_announced: true }),
+  })
+  await bandIdHandler.onRequestPatch({
+    request: req,
+    env,
+    data: { user: { role: 'editor', id: 2 } },
+  })
+
+  // Email sending is fire-and-forget and skipped in test env (no EMAIL_FROM configured).
+  // What we can assert is the DB flag that prevents re-notification.
+  const row = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
+  expect(row.band_follow_notified).toBe(1)
+})
+
+it('does not re-notify followers if band was already notified', async () => {
+  const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+  const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-renotify' })
+  const band = insertBand(rawDb, { name: 'Already Notified', event_id: ev.id })
+  // Set is_announced=0 but band_follow_notified=1 (was announced then un-announced)
+  rawDb.prepare('UPDATE performances SET is_announced=0, band_follow_notified=1 WHERE id=?').run(band.id)
+  rawDb.prepare(
+    'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+  ).run('follower2@example.com', band.band_profile_id, 'unsub-token-2')
+
+  const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify({ is_announced: true }),
+  })
+  const res = await bandIdHandler.onRequestPatch({
+    request: req,
+    env,
+    data: { user: { role: 'editor', id: 2 } },
+  })
+
+  expect(res.status).toBe(200)
+  // band_follow_notified should still be 1, no second notification sent
+  const row = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
+  expect(row.band_follow_notified).toBe(1)
+})
+```
+
+- [ ] **Step 2: Run to confirm new tests fail**
+
+```bash
+npm run test -- functions/api/admin/bands/__tests__/announce.test.js --reporter=verbose
+```
+
+Expected: the 2 new tests FAIL, the original 4 still PASS.
+
+- [ ] **Step 3: Update onRequestPatch to trigger notifications**
+
+In `functions/api/admin/bands/[id].js`, first add a static import at the top of the file (alongside the existing imports):
+
+```js
+import { sendEmail, isEmailConfigured } from '../../utils/email.js'
+```
+
+Then update the `onRequestPatch` handler. After the UPDATE statement, add:
+
+```js
+// Only notify on 0 → 1 transition, and only if not already notified
+if (newValue === 1 && performance.is_announced === 0) {
+  const alreadyNotified = await DB.prepare(
+    'SELECT band_follow_notified FROM performances WHERE id = ?'
+  ).bind(performanceId).first()
+
+  if (!alreadyNotified?.band_follow_notified) {
+    // Get band_profile_id for this performance
+    const perf = await DB.prepare(
+      'SELECT p.band_profile_id, bp.name as band_name, e.name as event_name FROM performances p JOIN band_profiles bp ON p.band_profile_id = bp.id JOIN events e ON p.event_id = e.id WHERE p.id = ?'
+    ).bind(performanceId).first()
+
+    if (perf) {
+      const { results: followers } = await DB.prepare(
+        'SELECT email, unsubscribe_token FROM band_follows WHERE band_profile_id = ? AND verified = 1'
+      ).bind(perf.band_profile_id).all()
+
+      if (followers.length > 0) {
+        // sendEmail and isEmailConfigured are imported statically at the top of [id].js
+        // (add: import { sendEmail, isEmailConfigured } from '../../utils/email.js')
+        const publicUrl = env.PUBLIC_URL || 'https://settimes.ca'
+
+        if (isEmailConfigured(env)) {
+          await Promise.allSettled(
+            followers.map(follower => {
+              const unsubUrl = `${publicUrl}/api/bands/${perf.band_profile_id}/unfollow?token=${follower.unsubscribe_token}`
+              return sendEmail(env, {
+                to: follower.email,
+                subject: `${perf.band_name} just joined the lineup!`,
+                text: `${perf.band_name} is now on the lineup for ${perf.event_name}.\n\nUnfollow: ${unsubUrl}`,
+                html: `<p><strong>${perf.band_name}</strong> is now on the lineup for <strong>${perf.event_name}</strong>.</p><p><a href="${unsubUrl}">Unfollow this band</a></p>`,
+              })
+            })
+          )
+        }
+
+        // Mark as notified so re-announcing doesn't re-send
+        await DB.prepare(
+          'UPDATE performances SET band_follow_notified = 1 WHERE id = ?'
+        ).bind(performanceId).run()
+      }
+    }
+  }
+}
+```
+
+Also update the response to include `band_follow_notified`:
+
+```js
+return new Response(
+  JSON.stringify({
+    success: true,
+    performance: {
+      id: Number(performanceId),
+      is_announced: newValue,
+      band_follow_notified: newValue === 1 ? 1 : (performance.band_follow_notified ?? 0),
+    },
+  }),
+  { status: 200, headers: { 'Content-Type': 'application/json' } }
+)
+```
+
+- [ ] **Step 4: Run announce tests**
+
+```bash
+npm run test -- functions/api/admin/bands/__tests__/announce.test.js --reporter=verbose
+```
+
+Expected: all 6 tests PASS.
+
+---
+
+### Task 18: Follow button on BandProfilePage
+
+**Files:**
+- Modify: `frontend/src/pages/BandProfilePage.jsx`
+
+- [ ] **Step 1: Add follow state**
+
+Near the top of the `BandProfilePage` component, add:
+
+```js
+const [followEmail, setFollowEmail] = useState('')
+const [followStatus, setFollowStatus] = useState('idle') // 'idle' | 'loading' | 'success' | 'error'
+const [followError, setFollowError] = useState('')
+```
+
+- [ ] **Step 2: Add submitFollow handler**
+
+```js
+const submitFollow = async e => {
+  e.preventDefault()
+  if (!followEmail.trim()) return
+  setFollowStatus('loading')
+  setFollowError('')
+  try {
+    const res = await fetch(`/api/bands/${bandData.id}/follow`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: followEmail.trim() }),
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.error || 'Something went wrong')
+    }
+    setFollowStatus('success')
+  } catch (err) {
+    setFollowStatus('error')
+    setFollowError(err.message)
+  }
+}
+```
+
+- [ ] **Step 3: Add follow section JSX**
+
+Find the section with social links or "Upcoming Shows". Add the follow form below it:
+
+```jsx
+<div className="mt-6 p-4 rounded-lg bg-white/5 border border-white/10">
+  <h3 className="text-sm font-semibold text-text-primary mb-1">
+    Follow {bandData.name}
+  </h3>
+  <p className="text-xs text-text-secondary mb-3">
+    Get notified when they join a new lineup.
+  </p>
+  {followStatus === 'success' ? (
+    <p className="text-sm text-green-400">
+      <FontAwesomeIcon icon={faCheck} className="mr-1.5" />
+      You&apos;re following {bandData.name}!
+    </p>
+  ) : (
+    <form onSubmit={submitFollow} className="flex gap-2">
+      <input
+        type="email"
+        value={followEmail}
+        onChange={e => setFollowEmail(e.target.value)}
+        placeholder="your@email.com"
+        required
+        className="flex-1 px-3 py-2 rounded bg-bg-navy text-white border border-white/20 focus:border-accent-500 focus:outline-none text-sm"
+        aria-label={`Email to follow ${bandData.name}`}
+      />
+      <Button type="submit" disabled={followStatus === 'loading'} size="sm">
+        {followStatus === 'loading' ? 'Saving…' : 'Follow'}
+      </Button>
+    </form>
+  )}
+  {followStatus === 'error' && (
+    <p className="text-xs text-red-400 mt-1">{followError}</p>
+  )}
+</div>
+```
+
+`faCheck` is already imported in `BandProfilePage.jsx`.
+
+- [ ] **Step 4: Build**
+
+```bash
+npm --prefix frontend run build 2>&1 | tail -10
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit Feature 3**
+
+```bash
+git add migrations/0034_band_follows.sql \
+  functions/api/test-utils.js \
+  "functions/api/bands/[name]/follow.js" \
+  "functions/api/bands/__tests__/follow.test.js" \
+  "functions/api/admin/bands/[id].js" \
+  frontend/src/pages/BandProfilePage.jsx
+git commit -m "feat: band following — follow endpoint, notification trigger on announce, Follow button on band profiles"
+```
+
+---
+
+## Apply Migrations to Production
+
+After all three features are merged to main:
+
+```bash
+npx wrangler d1 migrations apply settimes-production-db --remote
+```
+
+Verify with:
+
+```bash
+npx wrangler d1 execute settimes-production-db --remote \
+  --command "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"
+```
+
+Expected: `band_follows` appears in the list.
+
+---
+
+## Phase 2 Reminder (post May 17)
+
+- Post-event recap page: `GET /api/events/:slug/recap` + `frontend/src/pages/EventRecapPage.jsx`
+- Historical archive backfill admin UI: streamlined band-only lineup entry in `EventsTab.jsx`
+
+These have their own plan to be written separately.

--- a/docs/superpowers/specs/2026-05-02-event-lifecycle-hub-design.md
+++ b/docs/superpowers/specs/2026-05-02-event-lifecycle-hub-design.md
@@ -1,0 +1,256 @@
+# Event Lifecycle Hub — Design Spec
+
+**Date:** 2026-05-02
+**Status:** Approved
+**Hard deadline:** May 17, 2026 (next Long Weekend Band Crawl event)
+**Primary goal:** Give fans meaningful reasons to visit the site before, during, and after an event — turning a single-use schedule tool into a year-round destination.
+
+---
+
+## Problem Statement
+
+SetTimes.ca currently has no usage between events. Band profiles stay live year-round but there is no hook pulling fans back. The pre-event window is underutilized — fans can't share their schedule picks with friends, and there is no mechanism to build hype as the lineup is revealed progressively. Post-event, there is no recap or archive that rewards returning visitors.
+
+---
+
+## Ship Order
+
+### Phase 1 — Before May 17 (hype window)
+
+| # | Feature | Effort |
+|---|---------|--------|
+| 1 | Shareable schedule URLs | ~2 days |
+| 2 | Pre-event reveal mode | ~3 days |
+| 3 | "Notify me" band following | ~3 days |
+
+### Phase 2 — After May 17 (retention and archive)
+
+| # | Feature | Effort |
+|---|---------|--------|
+| 4 | Post-event recap page | ~2 days |
+| 5 | Historical archive backfill admin UI | ~2 days |
+
+Each feature is independently shippable with its own migration (if any) and PR.
+
+---
+
+## Feature 1: Shareable Schedule URLs
+
+### Goal
+Fans share their planned lineup with friends. Friends click the link, see the schedule pre-populated, and build their own. Zero friction — no account required.
+
+### Approach
+Encode selected performance IDs into a URL query param on the event schedule page:
+```
+/schedule/long-weekend-band-crawl-vol6?s=41,42,77
+```
+
+### Implementation
+
+**Frontend only — no new endpoints, no DB changes.**
+
+The schedule page lives in `frontend/src/App.jsx` at the `/event/:slug` route. The URL format for shared schedules:
+```
+/event/long-weekend-band-crawl-vol6?s=41,42,77
+```
+
+`frontend/src/App.jsx`
+- On mount, after the event data loads, parse `?s=` from `useSearchParams()`. Validate each ID against the loaded `bands` array (performance IDs). Seed the per-slug localStorage key with valid IDs.
+- Invalid or unknown IDs are silently dropped (graceful degradation if lineup changes).
+
+`frontend/src/components/MySchedule.jsx`
+- Add a "Share My Schedule" button alongside the existing "Copy Schedule" button.
+- On click: construct `window.location.origin + /event/${slug}?s=${selectedIds.join(',')}` and call the existing `copyToClipboard` utility.
+- Show transient confirmation ("Link copied!") using the same pattern as the existing copy button.
+
+### Edge Cases
+- If the lineup changes after a share link is created, unknown IDs are dropped silently — the fan sees a partial schedule with a note that some selections are no longer available.
+- Empty schedule: Share button is hidden (nothing to share).
+- URL length: 50 performance IDs at ~4 chars each = ~200 chars. Well within URL limits.
+
+### Testing
+- Unit: `scheduleStorage` correctly seeds localStorage from valid URL params; ignores invalid IDs.
+- Unit: Share button generates correct URL from current localStorage state.
+- E2E: Visit share URL → schedule pre-populated → Share button visible → copy produces same URL.
+
+---
+
+## Feature 2: Pre-Event Reveal Mode
+
+### Goal
+Organizer drips band announcements one at a time (or in batches), building weekly hype. The public schedule updates live as bands are announced. Unannounced bands are invisible to the public.
+
+### Schema Changes
+
+```sql
+-- Migration: 0033_reveal_mode.sql
+ALTER TABLE events ADD COLUMN reveal_mode INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE performances ADD COLUMN is_announced INTEGER NOT NULL DEFAULT 1;
+```
+
+Both default to the safe, backward-compatible state: existing events show everything.
+
+### API Changes
+
+`GET /api/schedule`
+- When `event.reveal_mode = 1`, filter performances to `is_announced = 1` only.
+- Admin-authenticated requests always see all performances regardless of `reveal_mode`.
+
+`GET /api/events/:id/details`
+- Same filter as above.
+
+`PATCH /api/admin/performances/:id` (**new endpoint** in `functions/api/admin/bands.js`)
+- Accept `is_announced` boolean in the request body.
+- Validates the performance belongs to an event the requesting admin can edit.
+- When `is_announced` flips `0 → 1`, triggers band-follower notifications (see Feature 3).
+
+`PATCH /api/admin/events/:id` (existing endpoint in `functions/api/admin/events.js`)
+- Accept `reveal_mode` boolean in the request body.
+
+### Admin UI Changes
+
+`frontend/src/admin/EventFormModal.jsx`
+- Add "Reveal mode" toggle (off by default). Helper text: *"When on, only announced bands appear on the public schedule."*
+
+`frontend/src/admin/LineupTab.jsx`
+- Each performance row gets an "Announced" toggle (eye icon or checkbox).
+- Rows with `is_announced = false` are visually dimmed in the admin view.
+- Bulk action: "Announce selected" added to `BulkActionBar`.
+
+### Public UI Changes
+
+`frontend/src/pages/SchedulePage.jsx` (or wherever the schedule is rendered)
+- When the API returns `reveal_mode: true` and fewer bands than expected (i.e., some are hidden), show a teaser banner:
+  *"More bands dropping soon — [subscribe to be notified](#follow)."*
+- Link anchor scrolls to a "Follow a band" or event subscription CTA.
+
+### Testing
+- Unit: schedule endpoint filters unannounced performances when reveal mode is on.
+- Unit: admin-authenticated requests bypass reveal filter.
+- Unit: toggling `is_announced` on a performance updates the public response immediately.
+- E2E: admin enables reveal mode → unannounced band invisible on public schedule → admin announces band → band appears.
+
+---
+
+## Feature 3: "Notify Me" Band Following
+
+### Goal
+Fans subscribe to individual bands. When an admin announces a band (flips `is_announced = 1`), followers of that band receive an email.
+
+This also serves as a general pre-event hook: fans following bands from past events get pulled back in when those bands appear on a new lineup.
+
+### Schema Changes
+
+```sql
+-- Migration: 0034_band_follows.sql
+ALTER TABLE email_subscriptions ADD COLUMN band_profile_id INTEGER REFERENCES band_profiles(id);
+```
+
+- `band_profile_id IS NULL` → existing event-level subscription (unchanged behavior).
+- `band_profile_id IS NOT NULL` → band-specific follow.
+
+The existing unsubscribe token, verification flow, and email delivery pipeline apply without modification.
+
+### API Changes
+
+`POST /api/subscriptions/subscribe`
+- Accept optional `band_profile_id` in the request body.
+- If provided, validate the band exists; store the follow. Skip the city/genre fields (not relevant for band follows).
+- Reuse existing Turnstile bot-protection check.
+
+`GET /api/subscriptions/verify` (existing)
+- No change — token-based verification works identically.
+
+`GET /api/subscriptions/unsubscribe` (existing)
+- No change — token-based unsubscribe works identically.
+
+### Notification Trigger
+
+`PATCH /api/admin/performances/:id` (the announce toggle from Feature 2)
+- When `is_announced` flips from `0 → 1`, query `email_subscriptions` for all confirmed followers of that `band_profile_id`.
+- Send each a transactional email: *"[Band Name] just joined the lineup for [Event Name]! Check out their set time."*
+- Fire-and-forget (do not block the API response on email delivery). Log failures to the existing audit log.
+- De-duplicate: if a performance is un-announced and then re-announced, do not re-notify the same follower. Track this with a `band_follow_notified` column on `performances` (boolean, default 0); set to 1 on first notification and never reset.
+
+### Public UI Changes
+
+`frontend/src/pages/BandProfilePage.jsx`
+- Add a "Follow [Band Name]" section below the profile hero.
+- Email input + submit button. Same visual pattern as the existing `/subscribe` page.
+- On submit: `POST /api/subscriptions/subscribe` with `band_profile_id`.
+- Success state: *"You're following [Band Name]. We'll email you when they join a lineup."*
+
+`frontend/src/admin/LineupTab.jsx`
+- After a band is announced, show a non-blocking toast: *"Notified N followers of [Band Name]."*
+
+### Testing
+- Unit: `POST /api/subscriptions/subscribe` with `band_profile_id` stores a band follow, not an event follow.
+- Unit: announcing a performance triggers emails to band followers only (not all subscribers).
+- Unit: existing event-level subscriptions unaffected by the schema change.
+- E2E: follow a band → admin announces band → verify notification email fired (mock email in test env).
+
+---
+
+## Feature 4: Post-Event Recap Page (Phase 2)
+
+### Goal
+Auto-generated event summary page that lives permanently at `/events/:slug/recap`. Rewards returning fans and feeds band profile traffic.
+
+### New Endpoint
+`GET /api/events/:slug/recap`
+
+Response shape:
+```json
+{
+  "event": { "name": "...", "date": "...", "slug": "..." },
+  "stats": {
+    "band_count": 24,
+    "venue_count": 6,
+    "total_sets": 28,
+    "first_timers": 8,
+    "returning_acts": 16
+  },
+  "bands": [ { "id": 7, "name": "...", "venue": "...", "startTime": "..." } ]
+}
+```
+
+"First timers" vs "returning acts" determined by checking whether `band_profile_id` has prior performances in other events.
+
+### New Frontend Page
+`frontend/src/pages/EventRecapPage.jsx`
+- Route: `/events/:slug/recap`
+- Shows event stats, band list with links to profiles, and a CTA to subscribe to the next event.
+
+---
+
+## Feature 5: Historical Archive Backfill Admin UI (Phase 2)
+
+### Goal
+Give the organizer a fast path to enter past LWBC events (bands only, no times required). The optional venue/time feature already landed — this is pure admin UX.
+
+### Admin UI Changes
+`frontend/src/admin/EventsTab.jsx`
+- "Import historical event" flow: create event with `is_archived = true` from the start, then a streamlined band-only lineup entry (no time fields shown, no venue required).
+- Supports copy-paste of a band list (newline-separated names) with fuzzy match against existing `band_profiles`.
+
+### No schema changes required.
+The `performances` table already supports null venue and null time (migration 0032 on the current branch).
+
+---
+
+## Architecture Notes
+
+- All three Phase 1 features are independently deployable. Merge order: Feature 1 → Feature 2 → Feature 3.
+- Feature 2 and 3 each require a D1 migration. Use the existing `npm run migrate:local` / `npm run migrate:remote` workflow.
+- The reveal mode filter in the schedule API must be covered by tests before merge — it is a security-adjacent gate (unpublished bands must not leak).
+- Band follow emails reuse the existing email delivery environment variables and sender configuration. No new secrets required.
+- URL param seeding in Feature 1 must not silently override an existing localStorage schedule. If the fan already has picks for that event slug, show a prompt: *"Load shared schedule? Your current picks will be replaced."* If no existing picks, seed silently.
+
+---
+
+## Out of Scope
+
+- Push notifications (requires service worker + permission flow — post-May-17 at earliest)
+- Photo uploads / R2 integration (separate feature track)
+- Multi-tenant / multi-org (long-term vision document)
+- Schedule conflict detection for fans (nice-to-have, revisit post-May-17)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -269,7 +269,10 @@ function App() {
     if (!sParam || bands.length === 0) return
 
     const requestedIds = new Set(
-      sParam.split(',').map(s => s.trim()).filter(s => /^\d+$/.test(s))
+      sParam
+        .split(',')
+        .map(s => s.trim())
+        .filter(s => /^\d+$/.test(s))
     )
 
     const matchedStringIds = bands
@@ -287,11 +290,14 @@ function App() {
     const applySelection = () => {
       setSelectedBands(matchedStringIds)
       setView('mine')
-      setSearchParams(prev => {
-        const next = new URLSearchParams(prev)
-        next.delete('s')
-        return next
-      }, { replace: true })
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          next.delete('s')
+          return next
+        },
+        { replace: true }
+      )
     }
 
     if (existing.length === 0) {
@@ -299,11 +305,14 @@ function App() {
     } else {
       setPendingSharedBands(matchedStringIds)
       setSharedScheduleConfirmOpen(true)
-      setSearchParams(prev => {
-        const next = new URLSearchParams(prev)
-        next.delete('s')
-        return next
-      }, { replace: true })
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          next.delete('s')
+          return next
+        },
+        { replace: true }
+      )
     }
   }, [bands, searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -314,7 +314,7 @@ function App() {
         { replace: true }
       )
     }
-  }, [bands, searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [bands, searchParams, slug])
 
   const trackScheduleBuilds = async bandsToTrack => {
     if (!eventData?.id || !Array.isArray(bandsToTrack) || bandsToTrack.length === 0) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,7 +2,7 @@ import { faBoxArchive, faCircleExclamation, faXmark } from '@fortawesome/free-so
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { lazy, Suspense, useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
 import Breadcrumbs from './components/Breadcrumbs'
 import ComingUp from './components/ComingUp'
 import Footer from './components/Footer'
@@ -139,6 +139,7 @@ const formatDebugInputValue = dateValue => {
 
 function App() {
   const { slug } = useParams()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [bands, setBands] = useState(FALLBACK_BANDS)
   const [eventData, setEventData] = useState(null)
   const [selectedBands, setSelectedBands] = useState(() => getStoredSelection(slug))
@@ -153,6 +154,8 @@ function App() {
   const [currentTime, setCurrentTime] = useState(() => new Date())
   const [debugTime, setDebugTime] = useState(() => getInitialDebugTime())
   const [clearConfirmOpen, setClearConfirmOpen] = useState(false)
+  const [sharedScheduleConfirmOpen, setSharedScheduleConfirmOpen] = useState(false)
+  const [pendingSharedBands, setPendingSharedBands] = useState([])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -260,6 +263,44 @@ function App() {
       console.warn('[App] Failed to persist selectedBands', error)
     }
   }, [selectedBands, slug])
+
+  useEffect(() => {
+    const sParam = searchParams.get('s')
+    if (!sParam || bands.length === 0) return
+
+    const requestedIds = new Set(
+      sParam.split(',').map(s => s.trim()).filter(s => /^\d+$/.test(s))
+    )
+
+    const matchedStringIds = bands
+      .filter(band => {
+        const parts = band.id.split('-')
+        const perfId = parts[parts.length - 1]
+        return requestedIds.has(perfId)
+      })
+      .map(band => band.id)
+
+    if (matchedStringIds.length === 0) return
+
+    const existing = getStoredSelection(slug)
+
+    const applySelection = () => {
+      setSelectedBands(matchedStringIds)
+      setView('mine')
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev)
+        next.delete('s')
+        return next
+      }, { replace: true })
+    }
+
+    if (existing.length === 0) {
+      applySelection()
+    } else {
+      setPendingSharedBands(matchedStringIds)
+      setSharedScheduleConfirmOpen(true)
+    }
+  }, [bands, searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const trackScheduleBuilds = async bandsToTrack => {
     if (!eventData?.id || !Array.isArray(bandsToTrack) || bandsToTrack.length === 0) {
@@ -556,6 +597,32 @@ function App() {
         }}
         onCancel={() => setClearConfirmOpen(false)}
         variant="danger"
+      />
+      <ConfirmDialog
+        isOpen={sharedScheduleConfirmOpen}
+        title="Load Shared Schedule?"
+        message="Loading this shared schedule will replace your current picks."
+        confirmText="Load"
+        onConfirm={() => {
+          setSharedScheduleConfirmOpen(false)
+          setSelectedBands(pendingSharedBands)
+          setView('mine')
+          setSearchParams(prev => {
+            const next = new URLSearchParams(prev)
+            next.delete('s')
+            return next
+          }, { replace: true })
+          setPendingSharedBands([])
+        }}
+        onCancel={() => {
+          setSharedScheduleConfirmOpen(false)
+          setPendingSharedBands([])
+          setSearchParams(prev => {
+            const next = new URLSearchParams(prev)
+            next.delete('s')
+            return next
+          }, { replace: true })
+        }}
       />
     </div>
   )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -299,6 +299,11 @@ function App() {
     } else {
       setPendingSharedBands(matchedStringIds)
       setSharedScheduleConfirmOpen(true)
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev)
+        next.delete('s')
+        return next
+      }, { replace: true })
     }
   }, [bands, searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -607,21 +612,11 @@ function App() {
           setSharedScheduleConfirmOpen(false)
           setSelectedBands(pendingSharedBands)
           setView('mine')
-          setSearchParams(prev => {
-            const next = new URLSearchParams(prev)
-            next.delete('s')
-            return next
-          }, { replace: true })
           setPendingSharedBands([])
         }}
         onCancel={() => {
           setSharedScheduleConfirmOpen(false)
           setPendingSharedBands([])
-          setSearchParams(prev => {
-            const next = new URLSearchParams(prev)
-            next.delete('s')
-            return next
-          }, { replace: true })
         }}
       />
     </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { faBoxArchive, faCircleExclamation, faXmark } from '@fortawesome/free-solid-svg-icons'
+import { faBell, faBoxArchive, faCircleExclamation, faXmark } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { lazy, Suspense, useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
@@ -500,6 +500,20 @@ function App() {
             >
               <FontAwesomeIcon icon={faXmark} />
             </button>
+          </div>
+        )}
+
+        {/* Reveal mode teaser — more bands dropping soon */}
+        {!isArchived && eventData?.reveal_mode === 1 && (
+          <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-accent-500/10 border border-accent-500/20 text-sm">
+            <FontAwesomeIcon icon={faBell} className="text-accent-400 shrink-0" aria-hidden="true" />
+            <p className="text-accent-300">
+              <span className="font-semibold">More bands dropping soon.</span>{' '}
+              <a href="/subscribe" className="underline hover:text-accent-200 transition-colors">
+                Subscribe for updates
+              </a>{' '}
+              or follow individual bands on their profile pages.
+            </p>
           </div>
         )}
 

--- a/frontend/src/admin/EventFormModal.jsx
+++ b/frontend/src/admin/EventFormModal.jsx
@@ -4,6 +4,7 @@ import { Button } from '../components/ui'
 import { eventsApi } from '../utils/adminApi'
 import { FIELD_LIMITS } from '../utils/validation'
 
+
 /**
  * EventFormModal - Modal for creating and editing events
  *
@@ -41,6 +42,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
     social_x: '',
     social_tiktok: '',
     social_youtube: '',
+    reveal_mode: false,
   })
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -97,6 +99,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
         social_x: socialLinks.x || socialLinks.twitter || '',
         social_tiktok: socialLinks.tiktok || '',
         social_youtube: socialLinks.youtube || '',
+        reveal_mode: event?.reveal_mode === 1 || event?.reveal_mode === true,
       })
       setSlugEdited(true) // Prevent auto-generation when editing
     } else {
@@ -114,6 +117,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
         social_x: '',
         social_tiktok: '',
         social_youtube: '',
+        reveal_mode: false,
       })
       setSlugEdited(false)
     }
@@ -255,6 +259,12 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
         data = await eventsApi.update(event.id, payload)
       } else {
         data = await eventsApi.create(payload)
+      }
+
+      // Update reveal mode if it changed (editing only — new events default to off)
+      const originalRevealMode = event?.reveal_mode === 1 || event?.reveal_mode === true
+      if (isEditing && formData.reveal_mode !== originalRevealMode) {
+        await eventsApi.setRevealMode(event.id, formData.reveal_mode)
       }
 
       // Success!
@@ -548,6 +558,36 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
                 </p>
               )}
             </div>
+
+            {/* Reveal Mode (editing only) */}
+            {isEditing && (
+              <div className="flex items-center justify-between py-3 border-t border-white/10">
+                <div>
+                  <label className="text-sm font-medium text-text-primary" htmlFor="reveal-mode">
+                    Reveal mode
+                  </label>
+                  <p className="text-xs text-text-secondary mt-0.5">
+                    When on, only announced bands appear on the public schedule.
+                  </p>
+                </div>
+                <button
+                  id="reveal-mode"
+                  type="button"
+                  role="switch"
+                  aria-checked={formData.reveal_mode}
+                  onClick={() => setFormData(prev => ({ ...prev, reveal_mode: !prev.reveal_mode }))}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-accent-500 ${
+                    formData.reveal_mode ? 'bg-accent-500' : 'bg-white/20'
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                      formData.reveal_mode ? 'translate-x-6' : 'translate-x-1'
+                    }`}
+                  />
+                </button>
+              </div>
+            )}
 
             {/* Actions */}
             <div className="flex flex-col sm:flex-row gap-3 pt-4">

--- a/frontend/src/admin/EventFormModal.jsx
+++ b/frontend/src/admin/EventFormModal.jsx
@@ -4,7 +4,6 @@ import { Button } from '../components/ui'
 import { eventsApi } from '../utils/adminApi'
 import { FIELD_LIMITS } from '../utils/validation'
 
-
 /**
  * EventFormModal - Modal for creating and editing events
  *

--- a/frontend/src/admin/EventsTab.jsx
+++ b/frontend/src/admin/EventsTab.jsx
@@ -1080,7 +1080,10 @@ export default function EventsTab({
       {/* Historical Import Modal */}
       {showHistoricalImport && (
         <HistoricalImportModal
-          onClose={() => setShowHistoricalImport(false)}
+          onClose={() => {
+            setShowHistoricalImport(false)
+            refreshEvents()
+          }}
           onImported={() => {
             setShowHistoricalImport(false)
             refreshEvents()

--- a/frontend/src/admin/EventsTab.jsx
+++ b/frontend/src/admin/EventsTab.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useCallback, memo } from 'react'
 import { eventsApi, bandsApi } from '../utils/adminApi'
 import { useEventContext } from '../contexts/EventContext'
 import EventFormModal from './EventFormModal'
+import HistoricalImportModal from './HistoricalImportModal'
 import EventStatusBadge from './components/EventStatusBadge'
 import EmbedCodeGenerator from './EmbedCodeGenerator'
 import MetricsDashboard from './MetricsDashboard'
@@ -397,6 +398,7 @@ export default function EventsTab({
 }) {
   const { refreshEvents } = useEventContext()
   const [showModal, setShowModal] = useState(false)
+  const [showHistoricalImport, setShowHistoricalImport] = useState(false)
   const [editingEvent, setEditingEvent] = useState(null)
   // duplication flow simplified: startDuplicate will perform duplication directly
   const [showEmbedCode, setShowEmbedCode] = useState(null)
@@ -1050,6 +1052,14 @@ export default function EventsTab({
             />
             <span>Show Archived</span>
           </label>
+          {!readOnly && canArchiveEvents && (
+            <button
+              onClick={() => setShowHistoricalImport(true)}
+              className={`px-3 py-2 text-sm text-gray-300 hover:text-white border border-white/20 hover:border-white/40 rounded transition-colors min-h-[44px] ${buttonFocusClass}`}
+            >
+              Import historical event
+            </button>
+          )}
           {!readOnly && (
             <button
               onClick={() => {
@@ -1066,6 +1076,17 @@ export default function EventsTab({
 
       {/* Help Panel */}
       {showHelp && <HelpPanel topic="events" isOpen={showHelp} onClose={() => setShowHelp(false)} />}
+
+      {/* Historical Import Modal */}
+      {showHistoricalImport && (
+        <HistoricalImportModal
+          onClose={() => setShowHistoricalImport(false)}
+          onImported={() => {
+            setShowHistoricalImport(false)
+            refreshEvents()
+          }}
+        />
+      )}
 
       {/* Event Form Modal */}
       {!readOnly && (

--- a/frontend/src/admin/HistoricalImportModal.jsx
+++ b/frontend/src/admin/HistoricalImportModal.jsx
@@ -101,7 +101,7 @@ export default function HistoricalImportModal({ onClose, onImported }) {
 
     const names = bandList
       .split('\n')
-      .map((n) => n.trim())
+      .map(n => n.trim())
       .filter(Boolean)
 
     if (names.length === 0) return
@@ -172,7 +172,10 @@ export default function HistoricalImportModal({ onClose, onImported }) {
                 errors[0]
               ) : (
                 <>
-                  <p>Import completed with {errors.length} failure{errors.length === 1 ? '' : 's'}. The following bands could not be added:</p>
+                  <p>
+                    Import completed with {errors.length} failure{errors.length === 1 ? '' : 's'}. The following bands
+                    could not be added:
+                  </p>
                   <ul className="mt-2 list-disc list-inside space-y-0.5">
                     {errors.map((msg, i) => (
                       <li key={i}>{msg}</li>
@@ -268,7 +271,7 @@ export default function HistoricalImportModal({ onClose, onImported }) {
                   onChange={e => setBandList(e.target.value)}
                   disabled={submitting}
                   rows={10}
-                  placeholder={"The Strokes\nArctic Monkeys\nPhoenix"}
+                  placeholder={'The Strokes\nArctic Monkeys\nPhoenix'}
                   className="w-full px-4 py-2 rounded bg-bg-navy text-white border border-gray-600 focus:border-accent-500 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 disabled:opacity-50 font-mono text-sm resize-y"
                 />
                 <p className="text-xs text-white/50 mt-1">

--- a/frontend/src/admin/HistoricalImportModal.jsx
+++ b/frontend/src/admin/HistoricalImportModal.jsx
@@ -1,0 +1,280 @@
+import { useState } from 'react'
+import { eventsApi, bandsApi } from '../utils/adminApi'
+
+/**
+ * HistoricalImportModal - Two-step wizard to back-fill archived events with band lineups
+ *
+ * Step 1: Event name + date → creates event with status "archived"
+ * Step 2: Paste band names (one per line) → sequentially creates band profiles
+ *
+ * @param {function} onClose - Close the modal
+ * @param {function} onImported - Called when import completes successfully (parent refreshes)
+ */
+export default function HistoricalImportModal({ onClose, onImported }) {
+  // --- Step 1 state ---
+  const [name, setName] = useState('')
+  const [date, setDate] = useState('')
+  const [slug, setSlug] = useState('')
+
+  // --- Step 2 state ---
+  const [step, setStep] = useState(1)
+  const [createdEvent, setCreatedEvent] = useState(null)
+  const [bandList, setBandList] = useState('')
+
+  // --- Shared state ---
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+  const [progress, setProgress] = useState(null) // { done, total } or null
+  const [failedBands, setFailedBands] = useState([])
+
+  // Auto-generate slug from name
+  const handleNameChange = e => {
+    const val = e.target.value
+    setName(val)
+    setSlug(
+      val
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .trim()
+        .replace(/\s+/g, '-')
+    )
+  }
+
+  // --- Step 1 submit ---
+  const handleStep1Submit = async e => {
+    e.preventDefault()
+    setError('')
+
+    const trimmedName = name.trim()
+    const trimmedDate = date.trim()
+
+    if (!trimmedName) {
+      setError('Event name is required.')
+      return
+    }
+    if (!trimmedDate) {
+      setError('Event date is required.')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const data = await eventsApi.create({
+        name: trimmedName,
+        date: trimmedDate,
+        slug,
+        status: 'archived',
+        is_published: 0,
+      })
+      setCreatedEvent(data.event)
+      setStep(2)
+    } catch (err) {
+      setError(err.message || 'Failed to create event. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // --- Step 2 submit ---
+  const handleStep2Submit = async e => {
+    e.preventDefault()
+    setError('')
+    setFailedBands([])
+
+    const lines = bandList
+      .split('\n')
+      .map(l => l.trim())
+      .filter(Boolean)
+
+    if (!lines.length) {
+      setError('Please enter at least one band name.')
+      return
+    }
+
+    setSubmitting(true)
+    setProgress({ done: 0, total: lines.length })
+
+    const failed = []
+
+    for (let i = 0; i < lines.length; i++) {
+      const bandName = lines[i]
+      try {
+        await bandsApi.create({ eventId: createdEvent.id, name: bandName })
+      } catch (err) {
+        failed.push(bandName)
+      }
+      setProgress({ done: i + 1, total: lines.length })
+    }
+
+    setSubmitting(false)
+    setProgress(null)
+
+    if (failed.length > 0) {
+      setFailedBands(failed)
+      setError(
+        `Import completed with ${failed.length} failure${failed.length === 1 ? '' : 's'}. The bands listed below could not be added.`
+      )
+    } else {
+      onImported()
+      onClose()
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="historical-import-title"
+    >
+      <div className="bg-bg-purple rounded-lg max-w-lg w-full max-h-[90vh] overflow-y-auto border border-accent-500/30">
+        <div className="p-6">
+          {/* Header */}
+          <div className="flex justify-between items-center mb-6">
+            <div>
+              <h2 id="historical-import-title" className="text-2xl font-bold text-accent-400">
+                Import Historical Event
+              </h2>
+              <p className="text-white/50 text-sm mt-0.5">Step {step} of 2</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="text-white/50 hover:text-white text-2xl transition-colors disabled:opacity-30 disabled:cursor-not-allowed focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple rounded"
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="mb-4 bg-red-900/30 text-red-300 rounded-lg p-3 text-sm" role="alert">
+              {error}
+              {failedBands.length > 0 && (
+                <ul className="mt-2 list-disc list-inside space-y-0.5">
+                  {failedBands.map(band => (
+                    <li key={band}>{band}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {/* Progress */}
+          {progress && (
+            <div className="mb-4 text-white/70 text-sm" aria-live="polite">
+              Importing… {progress.done} / {progress.total}
+            </div>
+          )}
+
+          {/* Step 1: Event info */}
+          {step === 1 && (
+            <form onSubmit={handleStep1Submit} className="space-y-4">
+              <div>
+                <label htmlFor="him-name" className="block text-white mb-2 text-sm font-medium">
+                  Event Name <span aria-hidden="true">*</span>
+                </label>
+                <input
+                  id="him-name"
+                  type="text"
+                  value={name}
+                  onChange={handleNameChange}
+                  required
+                  disabled={submitting}
+                  placeholder="e.g. Summerblast 2019"
+                  className="w-full min-h-[44px] px-4 py-2 rounded bg-bg-navy text-white border border-gray-600 focus:border-accent-500 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 disabled:opacity-50"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="him-date" className="block text-white mb-2 text-sm font-medium">
+                  Event Date <span aria-hidden="true">*</span>
+                </label>
+                <input
+                  id="him-date"
+                  type="date"
+                  value={date}
+                  onChange={e => setDate(e.target.value)}
+                  required
+                  disabled={submitting}
+                  className="w-full min-h-[44px] px-4 py-2 rounded bg-bg-navy text-white border border-gray-600 focus:border-accent-500 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 disabled:opacity-50"
+                />
+              </div>
+
+              {slug && (
+                <p className="text-xs text-white/40">
+                  Slug: <span className="font-mono">{slug}</span>
+                </p>
+              )}
+
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  disabled={submitting}
+                  className="px-4 py-2 rounded-lg text-white/70 hover:text-white transition-colors disabled:opacity-50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="px-4 py-2 bg-accent-500 hover:bg-accent-600 disabled:opacity-50 text-white rounded-lg transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                >
+                  {submitting ? 'Creating…' : 'Next: Add Bands'}
+                </button>
+              </div>
+            </form>
+          )}
+
+          {/* Step 2: Band list */}
+          {step === 2 && (
+            <form onSubmit={handleStep2Submit} className="space-y-4">
+              <p className="text-white/70 text-sm">
+                Event created: <span className="text-white font-medium">{createdEvent?.name}</span>
+              </p>
+
+              <div>
+                <label htmlFor="him-bands" className="block text-white mb-2 text-sm font-medium">
+                  Band Names
+                </label>
+                <textarea
+                  id="him-bands"
+                  value={bandList}
+                  onChange={e => setBandList(e.target.value)}
+                  disabled={submitting}
+                  rows={10}
+                  placeholder={"The Strokes\nArctic Monkeys\nPhoenix"}
+                  className="w-full px-4 py-2 rounded bg-bg-navy text-white border border-gray-600 focus:border-accent-500 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 disabled:opacity-50 font-mono text-sm resize-y"
+                />
+                <p className="text-xs text-white/50 mt-1">
+                  Existing band profiles will be matched by name. New profiles will be created automatically.
+                </p>
+              </div>
+
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  disabled={submitting}
+                  className="px-4 py-2 rounded-lg text-white/70 hover:text-white transition-colors disabled:opacity-50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                >
+                  Close
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="px-4 py-2 bg-accent-500 hover:bg-accent-600 disabled:opacity-50 text-white rounded-lg transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                >
+                  {submitting ? `Importing… ${progress?.done ?? 0} / ${progress?.total ?? 0}` : 'Import Bands'}
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/admin/HistoricalImportModal.jsx
+++ b/frontend/src/admin/HistoricalImportModal.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { eventsApi, bandsApi } from '../utils/adminApi'
 
 /**
@@ -23,37 +23,54 @@ export default function HistoricalImportModal({ onClose, onImported }) {
 
   // --- Shared state ---
   const [submitting, setSubmitting] = useState(false)
-  const [error, setError] = useState('')
+  const [errors, setErrors] = useState([])
   const [progress, setProgress] = useState(null) // { done, total } or null
-  const [failedBands, setFailedBands] = useState([])
 
-  // Auto-generate slug from name
+  // --- Refs ---
+  const bandTextareaRef = useRef(null)
+
+  // Focus the band textarea when advancing to step 2
+  useEffect(() => {
+    if (step === 2) {
+      bandTextareaRef.current?.focus()
+    }
+  }, [step])
+
+  // Close on Escape (unless submitting)
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (e.key === 'Escape' && !submitting) onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [submitting, onClose])
+
+  // Auto-generate slug from name — aligned with EventFormModal logic
   const handleNameChange = e => {
     const val = e.target.value
     setName(val)
     setSlug(
       val
         .toLowerCase()
-        .replace(/[^a-z0-9\s-]/g, '')
-        .trim()
-        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')
     )
   }
 
   // --- Step 1 submit ---
   const handleStep1Submit = async e => {
     e.preventDefault()
-    setError('')
+    setErrors([])
 
     const trimmedName = name.trim()
     const trimmedDate = date.trim()
 
     if (!trimmedName) {
-      setError('Event name is required.')
+      setErrors(['Event name is required.'])
       return
     }
     if (!trimmedDate) {
-      setError('Event date is required.')
+      setErrors(['Event date is required.'])
       return
     }
 
@@ -66,57 +83,57 @@ export default function HistoricalImportModal({ onClose, onImported }) {
         status: 'archived',
         is_published: 0,
       })
+      if (!data?.event?.id) {
+        throw new Error('Server did not return a valid event. Please try again.')
+      }
       setCreatedEvent(data.event)
       setStep(2)
     } catch (err) {
-      setError(err.message || 'Failed to create event. Please try again.')
+      setErrors([err.message || 'Failed to create event. Please try again.'])
     } finally {
       setSubmitting(false)
     }
   }
 
   // --- Step 2 submit ---
-  const handleStep2Submit = async e => {
+  async function handleStep2Submit(e) {
     e.preventDefault()
-    setError('')
-    setFailedBands([])
 
-    const lines = bandList
+    const names = bandList
       .split('\n')
-      .map(l => l.trim())
+      .map((n) => n.trim())
       .filter(Boolean)
 
-    if (!lines.length) {
-      setError('Please enter at least one band name.')
+    if (names.length === 0) return
+    if (names.length > 200) {
+      setErrors([`Too many bands (${names.length}). Maximum is 200 per import. Split into multiple imports.`])
       return
     }
 
     setSubmitting(true)
-    setProgress({ done: 0, total: lines.length })
+    setErrors([])
+    setProgress({ done: 0, total: names.length })
 
     const failed = []
 
-    for (let i = 0; i < lines.length; i++) {
-      const bandName = lines[i]
-      try {
-        await bandsApi.create({ eventId: createdEvent.id, name: bandName })
-      } catch (err) {
-        failed.push(bandName)
+    try {
+      for (let i = 0; i < names.length; i++) {
+        try {
+          await bandsApi.create({ eventId: createdEvent.id, name: names[i] })
+        } catch (err) {
+          failed.push(`${names[i]}: ${err.message || 'unknown error'}`)
+        }
+        setProgress({ done: i + 1, total: names.length })
       }
-      setProgress({ done: i + 1, total: lines.length })
-    }
 
-    setSubmitting(false)
-    setProgress(null)
-
-    if (failed.length > 0) {
-      setFailedBands(failed)
-      setError(
-        `Import completed with ${failed.length} failure${failed.length === 1 ? '' : 's'}. The bands listed below could not be added.`
-      )
-    } else {
-      onImported()
-      onClose()
+      if (failed.length > 0) {
+        setErrors(failed)
+      } else {
+        onImported?.()
+        onClose()
+      }
+    } finally {
+      setSubmitting(false)
     }
   }
 
@@ -148,16 +165,20 @@ export default function HistoricalImportModal({ onClose, onImported }) {
             </button>
           </div>
 
-          {/* Error */}
-          {error && (
+          {/* Errors */}
+          {errors.length > 0 && (
             <div className="mb-4 bg-red-900/30 text-red-300 rounded-lg p-3 text-sm" role="alert">
-              {error}
-              {failedBands.length > 0 && (
-                <ul className="mt-2 list-disc list-inside space-y-0.5">
-                  {failedBands.map(band => (
-                    <li key={band}>{band}</li>
-                  ))}
-                </ul>
+              {errors.length === 1 ? (
+                errors[0]
+              ) : (
+                <>
+                  <p>Import completed with {errors.length} failure{errors.length === 1 ? '' : 's'}. The following bands could not be added:</p>
+                  <ul className="mt-2 list-disc list-inside space-y-0.5">
+                    {errors.map((msg, i) => (
+                      <li key={i}>{msg}</li>
+                    ))}
+                  </ul>
+                </>
               )}
             </div>
           )}
@@ -242,6 +263,7 @@ export default function HistoricalImportModal({ onClose, onImported }) {
                 </label>
                 <textarea
                   id="him-bands"
+                  ref={bandTextareaRef}
                   value={bandList}
                   onChange={e => setBandList(e.target.value)}
                   disabled={submitting}

--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -739,7 +739,9 @@ export default function LineupTab({
                                   <button
                                     onClick={() => toggleAnnounced(band.id, band.is_announced)}
                                     disabled={togglingId === band.id}
-                                    title={band.is_announced ? 'Announced — click to hide' : 'Hidden — click to announce'}
+                                    title={
+                                      band.is_announced ? 'Announced — click to hide' : 'Hidden — click to announce'
+                                    }
                                     className={`p-1.5 rounded transition-colors ${
                                       band.is_announced
                                         ? 'text-green-400 hover:text-green-300'

--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -66,6 +66,7 @@ export default function LineupTab({
     facebook: '',
   })
   const [submitting, setSubmitting] = useState(false)
+  const [togglingId, setTogglingId] = useState(null)
   const [serverConflicts, setServerConflicts] = useState([])
 
   // Selected IDs for bulk delete within event
@@ -355,13 +356,15 @@ export default function LineupTab({
   }
 
   const toggleAnnounced = async (performanceId, currentValue) => {
+    setTogglingId(performanceId)
     try {
-      const res = await bandsApi.patch(performanceId, { is_announced: !currentValue })
-      if (!res) throw new Error('Failed to toggle announcement')
+      const res = await bandsApi.patch(performanceId, { is_announced: currentValue !== 1 })
+      if (!res.ok) throw new Error('Failed to toggle announcement')
       await loadData()
     } catch (err) {
       console.error('[LineupTab] toggleAnnounced error:', err)
-      showToast('Failed to toggle announcement', 'error')
+    } finally {
+      setTogglingId(null)
     }
   }
 
@@ -736,12 +739,13 @@ export default function LineupTab({
                                 {selectedEvent?.reveal_mode === 1 && (
                                   <button
                                     onClick={() => toggleAnnounced(band.id, band.is_announced)}
+                                    disabled={togglingId === band.id}
                                     title={band.is_announced ? 'Announced — click to hide' : 'Hidden — click to announce'}
                                     className={`p-1.5 rounded transition-colors ${
                                       band.is_announced
                                         ? 'text-green-400 hover:text-green-300'
                                         : 'text-white/30 hover:text-white/60'
-                                    }`}
+                                    } ${togglingId === band.id ? 'opacity-50 cursor-not-allowed' : ''}`}
                                     aria-label={band.is_announced ? `Unannounce ${band.name}` : `Announce ${band.name}`}
                                   >
                                     <FontAwesomeIcon icon={band.is_announced ? faEye : faEyeSlash} />
@@ -818,12 +822,13 @@ export default function LineupTab({
                             {selectedEvent?.reveal_mode === 1 && (
                               <button
                                 onClick={() => toggleAnnounced(band.id, band.is_announced)}
+                                disabled={togglingId === band.id}
                                 title={band.is_announced ? 'Announced — click to hide' : 'Hidden — click to announce'}
                                 className={`p-1.5 rounded transition-colors ${
                                   band.is_announced
                                     ? 'text-green-400 hover:text-green-300'
                                     : 'text-white/30 hover:text-white/60'
-                                }`}
+                                } ${togglingId === band.id ? 'opacity-50 cursor-not-allowed' : ''}`}
                                 aria-label={band.is_announced ? `Unannounce ${band.name}` : `Announce ${band.name}`}
                               >
                                 <FontAwesomeIcon icon={band.is_announced ? faEye : faEyeSlash} />

--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 import { bandsApi, venuesApi } from '../utils/adminApi'
 import BandForm from './BandForm'
 import BulkActionBar from './BulkActionBar'
@@ -21,7 +23,7 @@ import {
  */
 export default function LineupTab({
   selectedEventId,
-  selectedEvent: _selectedEvent,
+  selectedEvent,
   events,
   showToast,
   onEventFilterChange: _onEventFilterChange,
@@ -350,6 +352,17 @@ export default function LineupTab({
         }
       },
     })
+  }
+
+  const toggleAnnounced = async (performanceId, currentValue) => {
+    try {
+      const res = await bandsApi.patch(performanceId, { is_announced: !currentValue })
+      if (!res) throw new Error('Failed to toggle announcement')
+      await loadData()
+    } catch (err) {
+      console.error('[LineupTab] toggleAnnounced error:', err)
+      showToast('Failed to toggle announcement', 'error')
+    }
   }
 
   const startEdit = band => {
@@ -720,6 +733,20 @@ export default function LineupTab({
                             </td>
                             {!readOnly && (
                               <td className="px-4 py-3 flex justify-end gap-2">
+                                {selectedEvent?.reveal_mode === 1 && (
+                                  <button
+                                    onClick={() => toggleAnnounced(band.id, band.is_announced)}
+                                    title={band.is_announced ? 'Announced — click to hide' : 'Hidden — click to announce'}
+                                    className={`p-1.5 rounded transition-colors ${
+                                      band.is_announced
+                                        ? 'text-green-400 hover:text-green-300'
+                                        : 'text-white/30 hover:text-white/60'
+                                    }`}
+                                    aria-label={band.is_announced ? `Unannounce ${band.name}` : `Announce ${band.name}`}
+                                  >
+                                    <FontAwesomeIcon icon={band.is_announced ? faEye : faEyeSlash} />
+                                  </button>
+                                )}
                                 <button
                                   onClick={() => startEdit(band)}
                                   className="px-4 py-2 min-h-[44px] bg-blue-600 hover:bg-blue-700 text-white rounded text-sm"
@@ -788,6 +815,20 @@ export default function LineupTab({
                         </div>
                         {!readOnly && (
                           <div className="flex flex-wrap gap-2">
+                            {selectedEvent?.reveal_mode === 1 && (
+                              <button
+                                onClick={() => toggleAnnounced(band.id, band.is_announced)}
+                                title={band.is_announced ? 'Announced — click to hide' : 'Hidden — click to announce'}
+                                className={`p-1.5 rounded transition-colors ${
+                                  band.is_announced
+                                    ? 'text-green-400 hover:text-green-300'
+                                    : 'text-white/30 hover:text-white/60'
+                                }`}
+                                aria-label={band.is_announced ? `Unannounce ${band.name}` : `Announce ${band.name}`}
+                              >
+                                <FontAwesomeIcon icon={band.is_announced ? faEye : faEyeSlash} />
+                              </button>
+                            )}
                             <button
                               onClick={() => startEdit(band)}
                               className="px-4 py-2 min-h-[44px] bg-blue-600 hover:bg-blue-700 text-white rounded text-sm"

--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -361,7 +361,7 @@ export default function LineupTab({
       await bandsApi.patch(performanceId, { is_announced: currentValue !== 1 })
       await loadData()
     } catch (err) {
-      console.error('[LineupTab] toggleAnnounced error:', err)
+      showToast(err.message || 'Failed to update announced status', 'error')
     } finally {
       setTogglingId(null)
     }

--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -358,8 +358,7 @@ export default function LineupTab({
   const toggleAnnounced = async (performanceId, currentValue) => {
     setTogglingId(performanceId)
     try {
-      const res = await bandsApi.patch(performanceId, { is_announced: currentValue !== 1 })
-      if (!res.ok) throw new Error('Failed to toggle announcement')
+      await bandsApi.patch(performanceId, { is_announced: currentValue !== 1 })
       await loadData()
     } catch (err) {
       console.error('[LineupTab] toggleAnnounced error:', err)

--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -707,7 +707,7 @@ export default function LineupTab({
                         return (
                           <tr
                             key={band.id}
-                            className={`hover:bg-bg-navy/30 transition-colors ${conflicts.length ? 'bg-red-900/20' : ''} ${selectedIds.has(band.id) ? 'bg-blue-900/30' : ''}`}
+                            className={`hover:bg-bg-navy/30 transition-colors ${conflicts.length ? 'bg-red-900/20' : ''} ${selectedIds.has(band.id) ? 'bg-blue-900/30' : ''} ${selectedEvent?.reveal_mode === 1 && !band.is_announced ? 'opacity-50' : ''}`}
                           >
                             {!readOnly && (
                               <td className="px-4 py-3">
@@ -787,7 +787,7 @@ export default function LineupTab({
                     return (
                       <div
                         key={band.id}
-                        className={`px-4 py-3 space-y-2 ${conflicts.length ? 'bg-red-900/20' : ''} ${selectedIds.has(band.id) ? 'bg-blue-900/30' : ''}`}
+                        className={`px-4 py-3 space-y-2 ${conflicts.length ? 'bg-red-900/20' : ''} ${selectedIds.has(band.id) ? 'bg-blue-900/30' : ''} ${selectedEvent?.reveal_mode === 1 && !band.is_announced ? 'opacity-50' : ''}`}
                       >
                         <div className="flex items-start justify-between gap-3">
                           <label className="flex items-center gap-3 text-white">

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -321,10 +321,14 @@ function MySchedule({ bands, onToggleBand, onClearSchedule, showPast, onToggleSh
       .filter(id => /^\d+$/.test(id))
       .join(',')
 
+    if (!performanceIds) return
+
     const url = `${window.location.origin}${window.location.pathname}?s=${performanceIds}`
-    await copyToClipboard(url)
-    setShareButtonLabel('Link Copied!')
-    setTimeout(() => setShareButtonLabel('Share Schedule'), 2000)
+    const success = await copyToClipboard(url)
+    if (success) {
+      setShareButtonLabel('Link Copied!')
+      setTimeout(() => setShareButtonLabel('Share Schedule'), 2000)
+    }
   }
 
   return (
@@ -388,6 +392,7 @@ function MySchedule({ bands, onToggleBand, onClearSchedule, showPast, onToggleSh
                   onClick={handleShareSchedule}
                   className="text-xs px-3 py-1.5 rounded bg-bg-purple/60 border border-bg-purple/40 text-white flex items-center gap-2 transition-transform duration-150 hover:bg-bg-purple/80 hover:brightness-110 active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500 min-h-[44px]"
                   title={shareButtonLabel === 'Link Copied!' ? 'Share link copied to clipboard' : 'Share your schedule'}
+                  aria-label="Copy shareable link to your schedule"
                 >
                   <FontAwesomeIcon icon={shareButtonLabel === 'Link Copied!' ? faCheck : faLink} aria-hidden="true" />
                   <span className="transition-opacity duration-200 ease-in-out">{shareButtonLabel}</span>

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -11,6 +11,7 @@ import {
   faFaceSmile,
   faGuitar,
   faHourglassHalf,
+  faLink,
   faMusic,
   faPersonWalking,
   faPizzaSlice,
@@ -30,6 +31,7 @@ function MySchedule({ bands, onToggleBand, onClearSchedule, showPast, onToggleSh
   const [currentTime, setCurrentTime] = useState(() => (nowOverride ? new Date(nowOverride) : new Date()))
   const [copyButtonLabel, setCopyButtonLabel] = useState('Copy Schedule')
   const [isCopyingSchedule, setIsCopyingSchedule] = useState(false)
+  const [shareButtonLabel, setShareButtonLabel] = useState('Share Schedule')
 
   // Update current time every minute
   useEffect(() => {
@@ -310,6 +312,21 @@ function MySchedule({ bands, onToggleBand, onClearSchedule, showPast, onToggleSh
     return copyToClipboard(text)
   }
 
+  const handleShareSchedule = async () => {
+    const performanceIds = bands
+      .map(band => {
+        const parts = band.id.split('-')
+        return parts[parts.length - 1]
+      })
+      .filter(id => /^\d+$/.test(id))
+      .join(',')
+
+    const url = `${window.location.origin}${window.location.pathname}?s=${performanceIds}`
+    await copyToClipboard(url)
+    setShareButtonLabel('Link Copied!')
+    setTimeout(() => setShareButtonLabel('Share Schedule'), 2000)
+  }
+
   return (
     <div className="py-6 space-y-6 sm:space-y-8">
       <div className="max-w-5xl mx-auto space-y-4">
@@ -366,6 +383,16 @@ function MySchedule({ bands, onToggleBand, onClearSchedule, showPast, onToggleSh
                 <FontAwesomeIcon icon={copyButtonLabel === 'Copied!' ? faCheck : faCopy} aria-hidden="true" />
                 <span className="transition-opacity duration-200 ease-in-out">{copyButtonLabel}</span>
               </button>
+              {bands.length > 0 && (
+                <button
+                  onClick={handleShareSchedule}
+                  className="text-xs px-3 py-1.5 rounded bg-bg-purple/60 border border-bg-purple/40 text-white flex items-center gap-2 transition-transform duration-150 hover:bg-bg-purple/80 hover:brightness-110 active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500 min-h-[44px]"
+                  title={shareButtonLabel === 'Link Copied!' ? 'Share link copied to clipboard' : 'Share your schedule'}
+                >
+                  <FontAwesomeIcon icon={shareButtonLabel === 'Link Copied!' ? faCheck : faLink} aria-hidden="true" />
+                  <span className="transition-opacity duration-200 ease-in-out">{shareButtonLabel}</span>
+                </button>
+              )}
               <button
                 onClick={onClearSchedule}
                 className="text-xs px-3 py-1.5 rounded bg-red-500/20 border border-red-500/50 text-red-200 flex items-center gap-2 transition-transform duration-150 hover:bg-red-500/30 hover:brightness-110 active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-300"

--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -62,7 +62,7 @@ function ScheduleView({
     const aTime = typeof a.startMs === 'number' ? a.startMs : Date.parse(`${a.date}T${a.startTime}:00`)
     const bTime = typeof b.startMs === 'number' ? b.startMs : Date.parse(`${b.date}T${b.startTime}:00`)
     if (aTime === bTime) {
-      return a.venue.localeCompare(b.venue)
+      return (a.venue ?? '').localeCompare(b.venue ?? '')
     }
     return aTime - bTime
   })
@@ -83,7 +83,7 @@ function ScheduleView({
     })
 
     grouped.forEach(group => {
-      group.bands.sort((a, b) => a.venue.localeCompare(b.venue))
+      group.bands.sort((a, b) => (a.venue ?? '').localeCompare(b.venue ?? ''))
     })
 
     return grouped
@@ -119,7 +119,7 @@ function ScheduleView({
   })
 
   // Sort Now Playing by venue only (no time grouping)
-  nowPlaying.sort((a, b) => a.venue.localeCompare(b.venue))
+  nowPlaying.sort((a, b) => (a.venue ?? '').localeCompare(b.venue ?? ''))
 
   // Group upcoming and past bands by time
   const upcomingByTime = groupByTime(upcomingBands)

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -17,6 +17,7 @@ import './index.css'
 // Lazy load admin panel and band profiles (not needed for initial page load)
 const AdminApp = lazy(() => import('./admin/AdminApp.jsx'))
 const BandProfilePage = lazy(() => import('./pages/BandProfilePage.jsx'))
+const EventRecapPage = lazy(() => import('./pages/EventRecapPage.jsx'))
 
 const hostname = typeof window !== 'undefined' ? window.location.hostname || '' : ''
 const isPreviewBuild = hostname.startsWith('dev.') || hostname.endsWith('.pages.dev')
@@ -79,6 +80,18 @@ ReactDOM.createRoot(document.getElementById('root')).render(
             <Route path="/reset-password" element={<ResetPasswordPage />} />
             <Route path="/activate" element={<ActivatePage />} />
             <Route path="/privacy" element={<PrivacyPage />} />
+
+            {/* Event recap: Lazy loaded */}
+            <Route
+              path="/events/:slug/recap"
+              element={
+                <ErrorBoundary title="Event Recap Error" message="Unable to load event recap. Please try again.">
+                  <Suspense fallback={<LoadingFallback />}>
+                    <EventRecapPage />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
 
             {/* Band profiles: Lazy loaded */}
             <Route

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -567,7 +567,7 @@ export default function BandProfilePage() {
             {followStatus === 'success' ? (
               <p className="text-sm text-green-400">
                 <FontAwesomeIcon icon={faCheck} className="mr-1.5" />
-                You&apos;re following {profile.name}!
+                You&apos;re following {profile.name}! We&apos;ll email you when they join a lineup.
               </p>
             ) : (
               <form onSubmit={submitFollow} className="flex gap-2">

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -647,12 +647,8 @@ export default function BandProfilePage() {
 
           {/* Follow band */}
           <div className="mt-6 p-4 rounded-lg bg-white/5 border border-white/10">
-            <h3 className="text-sm font-semibold text-text-primary mb-1">
-              Follow {profile.name}
-            </h3>
-            <p className="text-xs text-text-secondary mb-3">
-              Get notified when they join a new lineup.
-            </p>
+            <h3 className="text-sm font-semibold text-text-primary mb-1">Follow {profile.name}</h3>
+            <p className="text-xs text-text-secondary mb-3">Get notified when they join a new lineup.</p>
             {followStatus === 'success' ? (
               <p className="text-sm text-green-400">
                 <FontAwesomeIcon icon={faCheck} className="mr-1.5" />
@@ -678,14 +674,10 @@ export default function BandProfilePage() {
                     {followStatus === 'loading' ? 'Saving…' : 'Follow'}
                   </Button>
                 </div>
-                {turnstileEnabled && (
-                  <div ref={turnstileContainerRef} className="mt-2" />
-                )}
+                {turnstileEnabled && <div ref={turnstileContainerRef} className="mt-2" />}
               </form>
             )}
-            {followStatus === 'error' && (
-              <p className="text-xs text-red-400 mt-1">{followError}</p>
-            )}
+            {followStatus === 'error' && <p className="text-xs text-red-400 mt-1">{followError}</p>}
           </div>
 
           {/* Two Column Layout: Stats/Facts + Shows */}

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -144,6 +144,9 @@ export default function BandProfilePage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [scheduleSelections, setScheduleSelections] = useState({}) // { eventSlug: Set of bandIds }
+  const [followEmail, setFollowEmail] = useState('')
+  const [followStatus, setFollowStatus] = useState('idle') // 'idle' | 'loading' | 'success' | 'error'
+  const [followError, setFollowError] = useState('')
   const [userHasSchedule] = useState(() => hasAnySchedule())
   const scheduleEventSlug = useMemo(() => getScheduleEventSlug(), [])
 
@@ -281,6 +284,29 @@ export default function BandProfilePage() {
     },
     [scheduleSelections, profile?.name]
   )
+
+  const submitFollow = async e => {
+    e.preventDefault()
+    if (!followEmail.trim()) return
+    setFollowStatus('loading')
+    setFollowError('')
+    try {
+      const res = await fetch(`/api/bands/${profile.id}/follow`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: followEmail.trim() }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error || 'Something went wrong')
+      }
+      setFollowStatus('success')
+    } catch (err) {
+      setFollowStatus('error')
+      setFollowError(err.message)
+    }
+  }
+
   if (loading) {
     return (
       <div className="min-h-screen bg-bg-navy flex items-center justify-center">
@@ -528,6 +554,40 @@ export default function BandProfilePage() {
                 !profile.description && <p className="text-white/30 text-sm italic">No links added yet.</p>
               )}
             </div>
+          </div>
+
+          {/* Follow band */}
+          <div className="mt-6 p-4 rounded-lg bg-white/5 border border-white/10">
+            <h3 className="text-sm font-semibold text-text-primary mb-1">
+              Follow {profile.name}
+            </h3>
+            <p className="text-xs text-text-secondary mb-3">
+              Get notified when they join a new lineup.
+            </p>
+            {followStatus === 'success' ? (
+              <p className="text-sm text-green-400">
+                <FontAwesomeIcon icon={faCheck} className="mr-1.5" />
+                You&apos;re following {profile.name}!
+              </p>
+            ) : (
+              <form onSubmit={submitFollow} className="flex gap-2">
+                <input
+                  type="email"
+                  value={followEmail}
+                  onChange={e => setFollowEmail(e.target.value)}
+                  placeholder="your@email.com"
+                  required
+                  className="flex-1 px-3 py-2 rounded bg-bg-navy text-white border border-white/20 focus:border-accent-500 focus:outline-none text-sm"
+                  aria-label={`Email to follow ${profile.name}`}
+                />
+                <Button type="submit" disabled={followStatus === 'loading'} size="sm">
+                  {followStatus === 'loading' ? 'Saving…' : 'Follow'}
+                </Button>
+              </form>
+            )}
+            {followStatus === 'error' && (
+              <p className="text-xs text-red-400 mt-1">{followError}</p>
+            )}
           </div>
 
           {/* Two Column Layout: Stats/Facts + Shows */}

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -26,6 +26,7 @@ import { formatTimeRange, parseLocalDate } from '../utils/timeFormat'
 import { safeExternalHref, safeInstagramHref } from '../utils/urlSafety'
 
 const SELECTED_BANDS_KEY = 'selectedBandsByEvent'
+const TURNSTILE_SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
 const ZERO_WIDTH_ENTITY_REGEX = /&shy;|&#173;|&#xad;|&ZeroWidthSpace;|&#8203;|&#x200B;/gi
 
 const NBSP_ENTITY_REGEX = /&nbsp;|&#160;|&#xA0;/gi
@@ -147,6 +148,11 @@ export default function BandProfilePage() {
   const [followEmail, setFollowEmail] = useState('')
   const [followStatus, setFollowStatus] = useState('idle') // 'idle' | 'loading' | 'success' | 'error'
   const [followError, setFollowError] = useState('')
+  const turnstileContainerRef = useRef(null)
+  const turnstileWidgetIdRef = useRef(null)
+  const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY || ''
+  const turnstileEnabled = Boolean(turnstileSiteKey)
+  const [turnstileToken, setTurnstileToken] = useState('')
   const [userHasSchedule] = useState(() => hasAnySchedule())
   const scheduleEventSlug = useMemo(() => getScheduleEventSlug(), [])
 
@@ -285,25 +291,97 @@ export default function BandProfilePage() {
     [scheduleSelections, profile?.name]
   )
 
+  useEffect(() => {
+    if (!turnstileEnabled) {
+      return undefined
+    }
+
+    let cancelled = false
+    let scriptElement = document.querySelector('script[data-turnstile-script="true"]')
+
+    const renderTurnstile = () => {
+      if (cancelled || !window.turnstile || !turnstileContainerRef.current) {
+        return
+      }
+      if (turnstileWidgetIdRef.current !== null) {
+        return
+      }
+
+      turnstileWidgetIdRef.current = window.turnstile.render(turnstileContainerRef.current, {
+        sitekey: turnstileSiteKey,
+        callback: token => {
+          setTurnstileToken(token)
+        },
+        'expired-callback': () => {
+          setTurnstileToken('')
+        },
+        'error-callback': () => {
+          setTurnstileToken('')
+        },
+      })
+    }
+
+    if (scriptElement) {
+      if (window.turnstile) {
+        renderTurnstile()
+      } else {
+        scriptElement.addEventListener('load', renderTurnstile)
+      }
+    } else {
+      const script = document.createElement('script')
+      script.src = TURNSTILE_SCRIPT_SRC
+      script.async = true
+      script.defer = true
+      script.setAttribute('data-turnstile-script', 'true')
+      script.addEventListener('load', renderTurnstile)
+      document.head.appendChild(script)
+      scriptElement = script
+    }
+
+    return () => {
+      cancelled = true
+      if (scriptElement) {
+        scriptElement.removeEventListener('load', renderTurnstile)
+      }
+      if (window.turnstile && turnstileWidgetIdRef.current !== null) {
+        window.turnstile.remove(turnstileWidgetIdRef.current)
+        turnstileWidgetIdRef.current = null
+      }
+    }
+  }, [turnstileEnabled, turnstileSiteKey])
+
   const submitFollow = async e => {
     e.preventDefault()
     if (!followEmail.trim()) return
+    if (turnstileEnabled && !turnstileToken) {
+      setFollowStatus('error')
+      setFollowError('Please complete the bot verification challenge.')
+      return
+    }
     setFollowStatus('loading')
     setFollowError('')
     try {
       const res = await fetch(`/api/bands/${profile.id}/follow`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: followEmail.trim() }),
+        body: JSON.stringify({ email: followEmail.trim(), turnstileToken }),
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
         throw new Error(err.error || 'Something went wrong')
       }
       setFollowStatus('success')
+      setTurnstileToken('')
+      if (turnstileEnabled && window.turnstile && turnstileWidgetIdRef.current !== null) {
+        window.turnstile.reset(turnstileWidgetIdRef.current)
+      }
     } catch (err) {
       setFollowStatus('error')
       setFollowError(err.message)
+      setTurnstileToken('')
+      if (turnstileEnabled && window.turnstile && turnstileWidgetIdRef.current !== null) {
+        window.turnstile.reset(turnstileWidgetIdRef.current)
+      }
     }
   }
 
@@ -570,19 +648,28 @@ export default function BandProfilePage() {
                 You&apos;re following {profile.name}! We&apos;ll email you when they join a lineup.
               </p>
             ) : (
-              <form onSubmit={submitFollow} className="flex gap-2">
-                <input
-                  type="email"
-                  value={followEmail}
-                  onChange={e => setFollowEmail(e.target.value)}
-                  placeholder="your@email.com"
-                  required
-                  className="flex-1 px-3 py-2 rounded bg-bg-navy text-white border border-white/20 focus:border-accent-500 focus:outline-none text-sm"
-                  aria-label={`Email to follow ${profile.name}`}
-                />
-                <Button type="submit" disabled={followStatus === 'loading'} size="sm">
-                  {followStatus === 'loading' ? 'Saving…' : 'Follow'}
-                </Button>
+              <form onSubmit={submitFollow} className="flex flex-col gap-2">
+                <div className="flex gap-2">
+                  <input
+                    type="email"
+                    value={followEmail}
+                    onChange={e => setFollowEmail(e.target.value)}
+                    placeholder="your@email.com"
+                    required
+                    className="flex-1 px-3 py-2 rounded bg-bg-navy text-white border border-white/20 focus:border-accent-500 focus:outline-none text-sm"
+                    aria-label={`Email to follow ${profile.name}`}
+                  />
+                  <Button
+                    type="submit"
+                    disabled={followStatus === 'loading' || (turnstileEnabled && !turnstileToken)}
+                    size="sm"
+                  >
+                    {followStatus === 'loading' ? 'Saving…' : 'Follow'}
+                  </Button>
+                </div>
+                {turnstileEnabled && (
+                  <div ref={turnstileContainerRef} className="mt-2" />
+                )}
               </form>
             )}
             {followStatus === 'error' && (

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -7,12 +7,13 @@ import { parseLocalDate } from '../utils/timeFormat'
 
 function StatCard({ label, value }) {
   return (
-    <div
-      className="bg-white/5 rounded-lg p-4 text-center"
-      aria-label={`${label}: ${value ?? '—'}`}
-    >
-      <div className="text-3xl font-bold text-white" aria-hidden="true">{value ?? '—'}</div>
-      <div className="text-sm text-white/60 mt-1" aria-hidden="true">{label}</div>
+    <div className="bg-white/5 rounded-lg p-4 text-center" aria-label={`${label}: ${value ?? '—'}`}>
+      <div className="text-3xl font-bold text-white" aria-hidden="true">
+        {value ?? '—'}
+      </div>
+      <div className="text-sm text-white/60 mt-1" aria-hidden="true">
+        {label}
+      </div>
     </div>
   )
 }
@@ -85,10 +86,7 @@ export default function EventRecapPage() {
         />
       </Helmet>
 
-      <main
-        id="main-content"
-        className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple px-4 py-10"
-      >
+      <main id="main-content" className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple px-4 py-10">
         <div className="max-w-3xl mx-auto">
           {/* Header */}
           <header className="mb-8 text-center">
@@ -111,7 +109,7 @@ export default function EventRecapPage() {
               {bands.length === 0 ? (
                 <li className="text-white/50 text-sm py-4 text-center">No performers recorded for this event.</li>
               ) : (
-                bands.map((band) => (
+                bands.map(band => (
                   <li key={band.id} className="bg-white/5 rounded-lg p-4 flex items-center justify-between gap-4">
                     <div className="flex-1 min-w-0">
                       <Link
@@ -120,12 +118,8 @@ export default function EventRecapPage() {
                       >
                         {band.name}
                       </Link>
-                      {band.genre && (
-                        <span className="ml-2 text-white/50 text-sm">{band.genre}</span>
-                      )}
-                      {band.venue_name && (
-                        <div className="text-white/50 text-sm mt-0.5">{band.venue_name}</div>
-                      )}
+                      {band.genre && <span className="ml-2 text-white/50 text-sm">{band.genre}</span>}
+                      {band.venue_name && <div className="text-white/50 text-sm mt-0.5">{band.venue_name}</div>}
                     </div>
                     <div className="flex items-center gap-2 shrink-0">
                       {band.is_returning === false && (

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -61,7 +61,16 @@ export default function EventRecapPage() {
   }
 
   const { event, stats, bands } = data ?? {}
-  const eventDate = event?.date ? (parseLocalDate(event.date) ?? new Date(event.date)) : null
+
+  if (!event || !stats || !Array.isArray(bands)) {
+    return (
+      <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
+        <Alert variant="error">Event recap data is unavailable.</Alert>
+      </div>
+    )
+  }
+
+  const eventDate = event.date ? (parseLocalDate(event.date) ?? new Date(event.date)) : null
   const formattedDate = eventDate
     ? eventDate.toLocaleDateString('en-CA', { year: 'numeric', month: 'long', day: 'numeric' })
     : 'Date TBD'

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react'
+import { Helmet } from 'react-helmet-async'
+import { Link, useParams } from 'react-router-dom'
+import { Alert, Loading } from '../components/ui'
+import { fetchPublicJson } from '../utils/publicApi'
+import { parseLocalDate } from '../utils/timeFormat'
+
+function StatCard({ label, value }) {
+  return (
+    <div className="bg-white/5 rounded-lg p-4 text-center">
+      <div className="text-3xl font-bold text-white">{value}</div>
+      <div className="text-sm text-white/60 mt-1">{label}</div>
+    </div>
+  )
+}
+
+export default function EventRecapPage() {
+  const { slug } = useParams()
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+
+    fetchPublicJson(`/api/events/${slug}/recap`)
+      .then(json => {
+        if (!cancelled) setData(json)
+      })
+      .catch(err => {
+        if (!cancelled) setError(err.message || 'Failed to load event recap.')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [slug])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-linear-to-br from-bg-navy to-bg-purple">
+        <Loading />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple p-6">
+        <Alert variant="error">{error}</Alert>
+      </div>
+    )
+  }
+
+  const { event, stats, bands } = data
+  const eventDate = parseLocalDate(event.date)
+  const formattedDate = eventDate.toLocaleDateString('en-CA', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+
+  return (
+    <>
+      <Helmet>
+        <title>{event.name} — Event Recap | SetTimes.ca</title>
+        <meta name="description" content={`Recap for ${event.name} on ${formattedDate}. ${stats.total_sets} sets across ${stats.venue_count} venues.`} />
+      </Helmet>
+
+      <main
+        id="main-content"
+        className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple px-4 py-10"
+      >
+        <div className="max-w-3xl mx-auto">
+          {/* Header */}
+          <header className="mb-8 text-center">
+            <h1 className="text-4xl font-bold text-white mb-2">{event.name}</h1>
+            <p className="text-white/60 text-lg">{formattedDate}</p>
+          </header>
+
+          {/* Stat cards */}
+          <section aria-label="Event statistics" className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-10">
+            <StatCard label="Total Sets" value={stats.total_sets} />
+            <StatCard label="Venues" value={stats.venue_count} />
+            <StatCard label="First Timers" value={stats.first_timers} />
+            <StatCard label="Returning Acts" value={stats.returning_acts} />
+          </section>
+
+          {/* Band list */}
+          <section aria-label="Performing bands">
+            <h2 className="text-xl font-semibold text-white mb-4">Lineup</h2>
+            <ul className="space-y-3">
+              {bands.map(band => (
+                <li key={band.id} className="bg-white/5 rounded-lg p-4 flex items-center justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <Link
+                      to={`/band/${band.id}`}
+                      className="text-accent-400 font-medium hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 rounded"
+                    >
+                      {band.name}
+                    </Link>
+                    {band.genre && (
+                      <span className="ml-2 text-white/50 text-sm">{band.genre}</span>
+                    )}
+                    {band.venue_name && (
+                      <div className="text-white/50 text-sm mt-0.5">{band.venue_name}</div>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {band.is_returning === false && (
+                      <span className="inline-block bg-accent-400/20 text-accent-400 text-xs font-medium px-2 py-0.5 rounded-full">
+                        First timer
+                      </span>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* Subscribe CTA */}
+          <section aria-label="Stay notified" className="mt-12 bg-white/5 rounded-lg p-6 text-center">
+            <h2 className="text-xl font-semibold text-white mb-2">Don&apos;t miss the next one</h2>
+            <p className="text-white/60 mb-4">Get notified when new events and lineups are announced.</p>
+            <Link
+              to="/subscribe"
+              className="inline-block bg-accent-400 text-bg-navy font-semibold px-6 py-2.5 rounded-lg hover:bg-accent-400/90 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+            >
+              Get notified
+            </Link>
+          </section>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -7,9 +7,12 @@ import { parseLocalDate } from '../utils/timeFormat'
 
 function StatCard({ label, value }) {
   return (
-    <div className="bg-white/5 rounded-lg p-4 text-center">
-      <div className="text-3xl font-bold text-white">{value}</div>
-      <div className="text-sm text-white/60 mt-1">{label}</div>
+    <div
+      className="bg-white/5 rounded-lg p-4 text-center"
+      aria-label={`${label}: ${value ?? '—'}`}
+    >
+      <div className="text-3xl font-bold text-white" aria-hidden="true">{value ?? '—'}</div>
+      <div className="text-sm text-white/60 mt-1" aria-hidden="true">{label}</div>
     </div>
   )
 }
@@ -57,19 +60,20 @@ export default function EventRecapPage() {
     )
   }
 
-  const { event, stats, bands } = data
-  const eventDate = parseLocalDate(event.date)
-  const formattedDate = eventDate.toLocaleDateString('en-CA', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
+  const { event, stats, bands } = data ?? {}
+  const eventDate = event?.date ? (parseLocalDate(event.date) ?? new Date(event.date)) : null
+  const formattedDate = eventDate
+    ? eventDate.toLocaleDateString('en-CA', { year: 'numeric', month: 'long', day: 'numeric' })
+    : 'Date TBD'
 
   return (
     <>
       <Helmet>
         <title>{event.name} — Event Recap | SetTimes.ca</title>
-        <meta name="description" content={`Recap for ${event.name} on ${formattedDate}. ${stats.total_sets} sets across ${stats.venue_count} venues.`} />
+        <meta
+          name="description"
+          content={`Recap for ${event.name} on ${formattedDate}. ${stats.total_sets ?? 0} sets across ${stats.venue_count ?? 0} venues.`}
+        />
       </Helmet>
 
       <main
@@ -85,41 +89,45 @@ export default function EventRecapPage() {
 
           {/* Stat cards */}
           <section aria-label="Event statistics" className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-10">
-            <StatCard label="Total Sets" value={stats.total_sets} />
-            <StatCard label="Venues" value={stats.venue_count} />
-            <StatCard label="First Timers" value={stats.first_timers} />
-            <StatCard label="Returning Acts" value={stats.returning_acts} />
+            <StatCard label="Total Sets" value={stats.total_sets ?? '—'} />
+            <StatCard label="Venues" value={stats.venue_count ?? '—'} />
+            <StatCard label="First Timers" value={stats.first_timers ?? '—'} />
+            <StatCard label="Returning Acts" value={stats.returning_acts ?? '—'} />
           </section>
 
           {/* Band list */}
           <section aria-label="Performing bands">
             <h2 className="text-xl font-semibold text-white mb-4">Lineup</h2>
             <ul className="space-y-3">
-              {bands.map(band => (
-                <li key={band.id} className="bg-white/5 rounded-lg p-4 flex items-center justify-between gap-4">
-                  <div className="flex-1 min-w-0">
-                    <Link
-                      to={`/band/${band.id}`}
-                      className="text-accent-400 font-medium hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 rounded"
-                    >
-                      {band.name}
-                    </Link>
-                    {band.genre && (
-                      <span className="ml-2 text-white/50 text-sm">{band.genre}</span>
-                    )}
-                    {band.venue_name && (
-                      <div className="text-white/50 text-sm mt-0.5">{band.venue_name}</div>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-2 shrink-0">
-                    {band.is_returning === false && (
-                      <span className="inline-block bg-accent-400/20 text-accent-400 text-xs font-medium px-2 py-0.5 rounded-full">
-                        First timer
-                      </span>
-                    )}
-                  </div>
-                </li>
-              ))}
+              {bands.length === 0 ? (
+                <li className="text-white/50 text-sm py-4 text-center">No performers recorded for this event.</li>
+              ) : (
+                bands.map((band) => (
+                  <li key={band.id} className="bg-white/5 rounded-lg p-4 flex items-center justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <Link
+                        to={`/band/${band.id}`}
+                        className="text-accent-400 font-medium hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 rounded"
+                      >
+                        {band.name}
+                      </Link>
+                      {band.genre && (
+                        <span className="ml-2 text-white/50 text-sm">{band.genre}</span>
+                      )}
+                      {band.venue_name && (
+                        <div className="text-white/50 text-sm mt-0.5">{band.venue_name}</div>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      {band.is_returning === false && (
+                        <span className="inline-block bg-accent-400/20 text-accent-400 text-xs font-medium px-2 py-0.5 rounded-full">
+                          First timer
+                        </span>
+                      )}
+                    </div>
+                  </li>
+                ))
+              )}
             </ul>
           </section>
 
@@ -129,7 +137,7 @@ export default function EventRecapPage() {
             <p className="text-white/60 mb-4">Get notified when new events and lineups are announced.</p>
             <Link
               to="/subscribe"
-              className="inline-block bg-accent-400 text-bg-navy font-semibold px-6 py-2.5 rounded-lg hover:bg-accent-400/90 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+              className="inline-block bg-accent-400 text-bg-navy font-semibold px-6 py-2.5 rounded-lg hover:bg-accent-400/90 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-bg-navy"
             >
               Get notified
             </Link>

--- a/frontend/src/utils/adminApi.js
+++ b/frontend/src/utils/adminApi.js
@@ -525,6 +525,16 @@ export const eventsApi = {
     })
     return handleResponse(response)
   },
+
+  async setRevealMode(eventId, revealMode) {
+    const response = await fetchWithCSRFRetry(`${API_BASE}/events/${eventId}/reveal-mode`, {
+      method: 'POST',
+      headers: getHeaders(),
+      credentials: 'include',
+      body: JSON.stringify({ reveal_mode: revealMode }),
+    })
+    return handleResponse(response)
+  },
 }
 
 // Venues API
@@ -636,6 +646,16 @@ export const bandsApi = {
         start_time: startTime || null,
         end_time: endTime || null,
       }),
+    })
+    return handleResponse(response)
+  },
+
+  async patch(bandId, data) {
+    const response = await fetchWithCSRFRetry(`${API_BASE}/bands/${bandId}`, {
+      method: 'PATCH',
+      headers: getHeaders(),
+      credentials: 'include',
+      body: JSON.stringify(data),
     })
     return handleResponse(response)
   },

--- a/functions/api/__tests__/schedule-reveal.test.js
+++ b/functions/api/__tests__/schedule-reveal.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { createTestEnv, insertEvent, insertVenue, insertBand } from '../test-utils'
+import * as scheduleHandler from '../schedule.js'
+
+describe('GET /api/schedule - reveal mode', () => {
+  it('returns all bands when reveal_mode is off', async () => {
+    const { env, rawDb } = createTestEnv()
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal-off', status: 'draft' })
+    rawDb.prepare('UPDATE events SET is_published=1 WHERE id=?').run(ev.id)
+    const venue = insertVenue(rawDb, { name: 'Venue A' })
+    insertBand(rawDb, { name: 'Announced Band', event_id: ev.id, venue_id: venue.id })
+    const unannounced = insertBand(rawDb, { name: 'Hidden Band', event_id: ev.id, venue_id: venue.id })
+    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(unannounced.id)
+
+    const req = new Request('https://example.test/api/schedule?event=vol6-reveal-off')
+    const res = await scheduleHandler.onRequestGet({ request: req, env })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    // reveal_mode=0: all bands returned regardless of is_announced
+    expect(data.bands.length).toBe(2)
+    expect(data.event.reveal_mode).toBe(0)
+  })
+
+  it('filters unannounced bands when reveal_mode is on', async () => {
+    const { env, rawDb } = createTestEnv()
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal-on' })
+    rawDb.prepare('UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?').run(ev.id)
+    const venue = insertVenue(rawDb, { name: 'Venue B' })
+    const announced = insertBand(rawDb, { name: 'Visible Band', event_id: ev.id, venue_id: venue.id })
+    rawDb.prepare('UPDATE performances SET is_announced=1 WHERE id=?').run(announced.id)
+    const hidden = insertBand(rawDb, { name: 'Hidden Band', event_id: ev.id, venue_id: venue.id })
+    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(hidden.id)
+
+    const req = new Request('https://example.test/api/schedule?event=vol6-reveal-on')
+    const res = await scheduleHandler.onRequestGet({ request: req, env })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.bands.length).toBe(1)
+    expect(data.bands[0].name).toBe('Visible Band')
+    expect(data.event.reveal_mode).toBe(1)
+  })
+
+  it('includes reveal_mode in event metadata', async () => {
+    const { env, rawDb } = createTestEnv()
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-meta' })
+    rawDb.prepare('UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?').run(ev.id)
+
+    const req = new Request('https://example.test/api/schedule?event=vol6-meta')
+    const res = await scheduleHandler.onRequestGet({ request: req, env })
+    const data = await res.json()
+    expect(data.event.reveal_mode).toBe(1)
+  })
+})

--- a/functions/api/admin/bands.js
+++ b/functions/api/admin/bands.js
@@ -171,6 +171,7 @@ export async function onRequestGet(context) {
           p.start_time,
           p.end_time,
           p.notes,
+          p.is_announced,
           bp.id as band_profile_id,
           bp.name,
           bp.genre,

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -730,7 +730,7 @@ export async function onRequestPatch(context) {
       ).bind(performanceId).first()
 
       if (perf) {
-        const { results: followers } = await DB.prepare(
+        const { results: followers = [] } = await DB.prepare(
           'SELECT email, unsubscribe_token FROM band_follows WHERE band_profile_id = ? AND verified = 1'
         ).bind(perf.band_profile_id).all()
 
@@ -748,7 +748,7 @@ export async function onRequestPatch(context) {
                 const unsubUrl = `${publicUrl}/api/bands/${perf.band_profile_id}/unfollow?token=${follower.unsubscribe_token}`
                 return sendEmail(env, {
                   to: follower.email,
-                  subject: `${escapeHtml(perf.band_name)} just joined the lineup for ${escapeHtml(perf.event_name)}!`,
+                  subject: `${perf.band_name} just joined the lineup for ${perf.event_name}!`,
                   text: `${perf.band_name} is now on the lineup for ${perf.event_name}.\n\nUnfollow: ${unsubUrl}`,
                   html: `<p><strong>${escapeHtml(perf.band_name)}</strong> is now on the lineup for <strong>${escapeHtml(perf.event_name)}</strong>.</p><p><a href="${unsubUrl}">Unfollow this band</a></p>`,
                 })

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -724,17 +724,29 @@ export async function onRequestPatch(context) {
 
         if (followers.length > 0 && isEmailConfigured(env)) {
           const publicUrl = env.PUBLIC_URL || 'https://settimes.ca'
-          await Promise.allSettled(
+          const emailResults = await Promise.allSettled(
             followers.map(follower => {
               const unsubUrl = `${publicUrl}/api/bands/${perf.band_profile_id}/unfollow?token=${follower.unsubscribe_token}`
               return sendEmail(env, {
                 to: follower.email,
-                subject: `${perf.band_name} just joined the lineup!`,
+                subject: `${perf.band_name} just joined the lineup for ${perf.event_name}!`,
                 text: `${perf.band_name} is now on the lineup for ${perf.event_name}.\n\nUnfollow: ${unsubUrl}`,
                 html: `<p><strong>${perf.band_name}</strong> is now on the lineup for <strong>${perf.event_name}</strong>.</p><p><a href="${unsubUrl}">Unfollow this band</a></p>`,
               })
             })
           )
+          const failedCount = emailResults.filter(r => r.status === 'rejected').length
+          if (failedCount > 0) {
+            await auditLog(
+              env,
+              user.userId,
+              'performance.announced.email_failure',
+              'performance',
+              Number(performanceId),
+              { failed_count: failedCount, band_name: perf.band_name },
+              ipAddress
+            ).catch(() => {})
+          }
         }
 
         await DB.prepare(

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -11,6 +11,7 @@ import {
   sanitizeString,
 } from "../../../utils/validation.js";
 import { getClientIP } from "../../../utils/request.js";
+import { sendEmail, isEmailConfigured } from '../../../utils/email.js'
 
 // Helper to extract band ID from path
 function getBandId(request) {
@@ -691,7 +692,7 @@ export async function onRequestPatch(context) {
     }
 
     const performance = await DB.prepare(
-      'SELECT id, is_announced FROM performances WHERE id = ?'
+      'SELECT id, is_announced, band_follow_notified FROM performances WHERE id = ?'
     ).bind(performanceId).first()
 
     if (!performance) {
@@ -706,6 +707,42 @@ export async function onRequestPatch(context) {
       "UPDATE performances SET is_announced = ?, updated_at = datetime('now') WHERE id = ?"
     ).bind(newValue, performanceId).run()
 
+    // Notify band followers on 0 → 1 transition (fire-and-forget, never re-notify)
+    if (newValue === 1 && performance.is_announced === 0 && !performance.band_follow_notified) {
+      const perf = await DB.prepare(
+        `SELECT p.band_profile_id, bp.name as band_name, e.name as event_name
+         FROM performances p
+         JOIN band_profiles bp ON p.band_profile_id = bp.id
+         JOIN events e ON p.event_id = e.id
+         WHERE p.id = ?`
+      ).bind(performanceId).first()
+
+      if (perf) {
+        const { results: followers } = await DB.prepare(
+          'SELECT email, unsubscribe_token FROM band_follows WHERE band_profile_id = ? AND verified = 1'
+        ).bind(perf.band_profile_id).all()
+
+        if (followers.length > 0 && isEmailConfigured(env)) {
+          const publicUrl = env.PUBLIC_URL || 'https://settimes.ca'
+          await Promise.allSettled(
+            followers.map(follower => {
+              const unsubUrl = `${publicUrl}/api/bands/${perf.band_profile_id}/unfollow?token=${follower.unsubscribe_token}`
+              return sendEmail(env, {
+                to: follower.email,
+                subject: `${perf.band_name} just joined the lineup!`,
+                text: `${perf.band_name} is now on the lineup for ${perf.event_name}.\n\nUnfollow: ${unsubUrl}`,
+                html: `<p><strong>${perf.band_name}</strong> is now on the lineup for <strong>${perf.event_name}</strong>.</p><p><a href="${unsubUrl}">Unfollow this band</a></p>`,
+              })
+            })
+          )
+        }
+
+        await DB.prepare(
+          'UPDATE performances SET band_follow_notified = 1 WHERE id = ?'
+        ).bind(performanceId).run()
+      }
+    }
+
     await auditLog(
       env,
       user.userId,
@@ -719,7 +756,13 @@ export async function onRequestPatch(context) {
     return new Response(
       JSON.stringify({
         success: true,
-        performance: { id: Number(performanceId), is_announced: newValue },
+        performance: {
+          id: Number(performanceId),
+          is_announced: newValue,
+          band_follow_notified: (newValue === 1 && performance.is_announced === 0 && !performance.band_follow_notified)
+            ? 1
+            : (performance.band_follow_notified ?? 0),
+        },
       }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }
     )

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -660,6 +660,57 @@ export async function onRequestPut(context) {
   }
 }
 
+// PATCH - Toggle is_announced for a performance
+export async function onRequestPatch(context) {
+  const { request, env } = context
+  const { DB } = env
+
+  const permCheck = await checkPermission(context, 'editor')
+  if (permCheck.error) {
+    return permCheck.response
+  }
+
+  const performanceId = getBandId(request)
+  if (!performanceId || isNaN(performanceId)) {
+    return new Response(
+      JSON.stringify({ error: 'Bad request', message: 'Invalid performance ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  const body = await request.json().catch(() => ({}))
+  if (typeof body.is_announced !== 'boolean') {
+    return new Response(
+      JSON.stringify({ error: 'Bad request', message: 'is_announced (boolean) is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  const performance = await DB.prepare(
+    'SELECT id, is_announced FROM performances WHERE id = ?'
+  ).bind(performanceId).first()
+
+  if (!performance) {
+    return new Response(
+      JSON.stringify({ error: 'Not found', message: 'Performance not found' }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  const newValue = body.is_announced ? 1 : 0
+  await DB.prepare(
+    "UPDATE performances SET is_announced = ?, updated_at = datetime('now') WHERE id = ?"
+  ).bind(newValue, performanceId).run()
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      performance: { id: Number(performanceId), is_announced: newValue },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  )
+}
+
 // DELETE - Delete band
 export async function onRequestDelete(context) {
   const { request, env } = context;

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -13,6 +13,10 @@ import {
 import { getClientIP } from "../../../utils/request.js";
 import { sendEmail, isEmailConfigured } from '../../../utils/email.js'
 
+const escapeHtml = s => String(s ?? '')
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+
 // Helper to extract band ID from path
 function getBandId(request) {
   const url = new URL(request.url);
@@ -702,12 +706,20 @@ export async function onRequestPatch(context) {
       )
     }
 
+    const linkedEvent = await getEventForPerformance(DB, performanceId)
+    if (linkedEvent?.status === 'archived') {
+      return new Response(
+        JSON.stringify({ error: 'Validation error', message: 'Archived event performances cannot be edited.' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
     const newValue = body.is_announced ? 1 : 0
     await DB.prepare(
       "UPDATE performances SET is_announced = ?, updated_at = datetime('now') WHERE id = ?"
     ).bind(newValue, performanceId).run()
 
-    // Notify band followers on 0 → 1 transition (fire-and-forget, never re-notify)
+    // Notify band followers on first 0 → 1 transition only
     if (newValue === 1 && performance.is_announced === 0 && !performance.band_follow_notified) {
       const perf = await DB.prepare(
         `SELECT p.band_profile_id, bp.name as band_name, e.name as event_name
@@ -722,48 +734,59 @@ export async function onRequestPatch(context) {
           'SELECT email, unsubscribe_token FROM band_follows WHERE band_profile_id = ? AND verified = 1'
         ).bind(perf.band_profile_id).all()
 
-        if (followers.length > 0 && isEmailConfigured(env)) {
-          const publicUrl = env.PUBLIC_URL || 'https://settimes.ca'
-          const emailResults = await Promise.allSettled(
-            followers.map(follower => {
-              const unsubUrl = `${publicUrl}/api/bands/${perf.band_profile_id}/unfollow?token=${follower.unsubscribe_token}`
-              return sendEmail(env, {
-                to: follower.email,
-                subject: `${perf.band_name} just joined the lineup for ${perf.event_name}!`,
-                text: `${perf.band_name} is now on the lineup for ${perf.event_name}.\n\nUnfollow: ${unsubUrl}`,
-                html: `<p><strong>${perf.band_name}</strong> is now on the lineup for <strong>${perf.event_name}</strong>.</p><p><a href="${unsubUrl}">Unfollow this band</a></p>`,
+        if (followers.length > 0) {
+          // Atomic claim: only the first concurrent request sees changes > 0.
+          // band_follow_notified stays 0 if no followers existed — preserving future notification eligibility.
+          const claimed = await DB.prepare(
+            'UPDATE performances SET band_follow_notified = 1 WHERE id = ? AND band_follow_notified = 0'
+          ).bind(performanceId).run()
+
+          if (claimed.meta.changes > 0 && isEmailConfigured(env)) {
+            const publicUrl = env.PUBLIC_URL || 'https://settimes.ca'
+            const emailResults = await Promise.allSettled(
+              followers.map(follower => {
+                const unsubUrl = `${publicUrl}/api/bands/${perf.band_profile_id}/unfollow?token=${follower.unsubscribe_token}`
+                return sendEmail(env, {
+                  to: follower.email,
+                  subject: `${escapeHtml(perf.band_name)} just joined the lineup for ${escapeHtml(perf.event_name)}!`,
+                  text: `${perf.band_name} is now on the lineup for ${perf.event_name}.\n\nUnfollow: ${unsubUrl}`,
+                  html: `<p><strong>${escapeHtml(perf.band_name)}</strong> is now on the lineup for <strong>${escapeHtml(perf.event_name)}</strong>.</p><p><a href="${unsubUrl}">Unfollow this band</a></p>`,
+                })
               })
-            })
-          )
-          const failedCount = emailResults.filter(r => r.status === 'rejected').length
-          if (failedCount > 0) {
-            await auditLog(
-              env,
-              user.userId,
-              'performance.announced.email_failure',
-              'performance',
-              Number(performanceId),
-              { failed_count: failedCount, band_name: perf.band_name },
-              ipAddress
-            ).catch(() => {})
+            )
+            // sendEmail returns {delivered:false} on failure rather than throwing — filter both rejection types
+            const failedCount = emailResults.filter(
+              r => r.status === 'rejected' || (r.status === 'fulfilled' && !r.value?.delivered)
+            ).length
+            if (failedCount > 0) {
+              await auditLog(
+                env,
+                user.userId,
+                'performance.announced.email_failure',
+                'performance',
+                Number(performanceId),
+                { failed_count: failedCount, band_name: perf.band_name },
+                ipAddress
+              ).catch(() => {})
+            }
           }
         }
-
-        await DB.prepare(
-          'UPDATE performances SET band_follow_notified = 1 WHERE id = ?'
-        ).bind(performanceId).run()
       }
     }
 
     await auditLog(
       env,
       user.userId,
-      'performance.announced',
+      newValue ? 'performance.announced' : 'performance.unannounced',
       'performance',
       Number(performanceId),
       { is_announced: newValue, changedBy: user.email },
       ipAddress
     )
+
+    const updated = await DB.prepare(
+      'SELECT band_follow_notified FROM performances WHERE id = ?'
+    ).bind(performanceId).first()
 
     return new Response(
       JSON.stringify({
@@ -771,9 +794,7 @@ export async function onRequestPatch(context) {
         performance: {
           id: Number(performanceId),
           is_announced: newValue,
-          band_follow_notified: (newValue === 1 && performance.is_announced === 0 && !performance.band_follow_notified)
-            ? 1
-            : (performance.band_follow_notified ?? 0),
+          band_follow_notified: updated?.band_follow_notified ?? 0,
         },
       }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -670,45 +670,66 @@ export async function onRequestPatch(context) {
     return permCheck.response
   }
 
-  const performanceId = getBandId(request)
-  if (!performanceId || isNaN(performanceId)) {
+  const user = permCheck.user
+  const ipAddress = getClientIP(request)
+
+  try {
+    const performanceId = getBandId(request)
+    if (!performanceId || isNaN(performanceId)) {
+      return new Response(
+        JSON.stringify({ error: 'Bad request', message: 'Invalid performance ID' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const body = await request.json().catch(() => ({}))
+    if (typeof body.is_announced !== 'boolean') {
+      return new Response(
+        JSON.stringify({ error: 'Bad request', message: 'is_announced (boolean) is required' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const performance = await DB.prepare(
+      'SELECT id, is_announced FROM performances WHERE id = ?'
+    ).bind(performanceId).first()
+
+    if (!performance) {
+      return new Response(
+        JSON.stringify({ error: 'Not found', message: 'Performance not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const newValue = body.is_announced ? 1 : 0
+    await DB.prepare(
+      "UPDATE performances SET is_announced = ?, updated_at = datetime('now') WHERE id = ?"
+    ).bind(newValue, performanceId).run()
+
+    await auditLog(
+      env,
+      user.userId,
+      'performance.announced',
+      'performance',
+      Number(performanceId),
+      { is_announced: newValue, changedBy: user.email },
+      ipAddress
+    )
+
     return new Response(
-      JSON.stringify({ error: 'Bad request', message: 'Invalid performance ID' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
+      JSON.stringify({
+        success: true,
+        performance: { id: Number(performanceId), is_announced: newValue },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  } catch (error) {
+    console.error('Error toggling is_announced:', error)
+    return new Response(
+      JSON.stringify({ error: 'Database error', message: 'Failed to update performance' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
     )
   }
-
-  const body = await request.json().catch(() => ({}))
-  if (typeof body.is_announced !== 'boolean') {
-    return new Response(
-      JSON.stringify({ error: 'Bad request', message: 'is_announced (boolean) is required' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    )
-  }
-
-  const performance = await DB.prepare(
-    'SELECT id, is_announced FROM performances WHERE id = ?'
-  ).bind(performanceId).first()
-
-  if (!performance) {
-    return new Response(
-      JSON.stringify({ error: 'Not found', message: 'Performance not found' }),
-      { status: 404, headers: { 'Content-Type': 'application/json' } }
-    )
-  }
-
-  const newValue = body.is_announced ? 1 : 0
-  await DB.prepare(
-    "UPDATE performances SET is_announced = ?, updated_at = datetime('now') WHERE id = ?"
-  ).bind(newValue, performanceId).run()
-
-  return new Response(
-    JSON.stringify({
-      success: true,
-      performance: { id: Number(performanceId), is_announced: newValue },
-    }),
-    { status: 200, headers: { 'Content-Type': 'application/json' } }
-  )
 }
 
 // DELETE - Delete band

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -734,14 +734,15 @@ export async function onRequestPatch(context) {
           'SELECT email, unsubscribe_token FROM band_follows WHERE band_profile_id = ? AND verified = 1'
         ).bind(perf.band_profile_id).all()
 
-        if (followers.length > 0) {
+        if (followers.length > 0 && isEmailConfigured(env)) {
           // Atomic claim: only the first concurrent request sees changes > 0.
-          // band_follow_notified stays 0 if no followers existed — preserving future notification eligibility.
+          // Latch is only set when email is actually configured — if email is temporarily
+          // misconfigured, band_follow_notified stays 0 so notifications can fire later.
           const claimed = await DB.prepare(
             'UPDATE performances SET band_follow_notified = 1 WHERE id = ? AND band_follow_notified = 0'
           ).bind(performanceId).run()
 
-          if (claimed.meta.changes > 0 && isEmailConfigured(env)) {
+          if (claimed.meta.changes > 0) {
             const publicUrl = env.PUBLIC_URL || 'https://settimes.ca'
             const emailResults = await Promise.allSettled(
               followers.map(follower => {

--- a/functions/api/admin/bands/__tests__/announce.test.js
+++ b/functions/api/admin/bands/__tests__/announce.test.js
@@ -91,6 +91,11 @@ describe('PATCH /api/admin/bands/:id - announce toggle', () => {
 
   it('sets band_follow_notified=1 when band is announced and followers exist', async () => {
     const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    env.EMAIL_PROVIDER = 'mailchannels'
+    env.EMAIL_FROM = 'noreply@settimes.ca'
+    // Stub fetch so sendEmail resolves without a real network call.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 202 }))
+
     const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-notify' })
     rawDb.prepare('UPDATE events SET reveal_mode=1 WHERE id=?').run(ev.id)
     const venue = insertVenue(rawDb, { name: 'Venue N' })
@@ -112,8 +117,8 @@ describe('PATCH /api/admin/bands/:id - announce toggle', () => {
       data: { user: { role: 'editor', id: 2 } },
     })
 
-    // Email is fire-and-forget and skipped (no EMAIL_FROM in test env).
-    // Assert the DB dedup flag was set.
+    vi.unstubAllGlobals()
+
     const row = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
     expect(row.band_follow_notified).toBe(1)
   })

--- a/functions/api/admin/bands/__tests__/announce.test.js
+++ b/functions/api/admin/bands/__tests__/announce.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { createTestEnv, insertEvent, insertVenue, insertBand } from '../../../test-utils'
+import * as bandIdHandler from '../[id].js'
+
+describe('PATCH /api/admin/bands/:id - announce toggle', () => {
+  it('announces a performance (sets is_announced=1)', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-announce' })
+    const venue = insertVenue(rawDb, { name: 'Venue X' })
+    const band = insertBand(rawDb, { name: 'Test Band', event_id: ev.id, venue_id: venue.id })
+    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(band.id)
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ is_announced: true }),
+    })
+    const res = await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'editor', id: 2 } },
+    })
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.performance.is_announced).toBe(1)
+
+    const row = rawDb.prepare('SELECT is_announced FROM performances WHERE id=?').get(band.id)
+    expect(row.is_announced).toBe(1)
+  })
+
+  it('unannounces a performance (sets is_announced=0)', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-unannounce' })
+    const venue = insertVenue(rawDb, { name: 'Venue Y' })
+    const band = insertBand(rawDb, { name: 'Visible Band', event_id: ev.id, venue_id: venue.id })
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ is_announced: false }),
+    })
+    const res = await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'editor', id: 2 } },
+    })
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.performance.is_announced).toBe(0)
+  })
+
+  it('returns 400 if is_announced is missing from body', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-bad' })
+    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ unrelated: true }),
+    })
+    const res = await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'editor', id: 2 } },
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('requires at least editor role', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'viewer' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-auth' })
+    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ is_announced: true }),
+    })
+    const res = await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'viewer', id: 3 } },
+    })
+
+    expect(res.status).toBe(403)
+  })
+})

--- a/functions/api/admin/bands/__tests__/announce.test.js
+++ b/functions/api/admin/bands/__tests__/announce.test.js
@@ -118,6 +118,30 @@ describe('PATCH /api/admin/bands/:id - announce toggle', () => {
     expect(row.band_follow_notified).toBe(1)
   })
 
+  it('does not set band_follow_notified when no followers exist', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-nofollowers' })
+    const band = insertBand(rawDb, { name: 'No Followers Band', event_id: ev.id })
+    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(band.id)
+    // No rows in band_follows for this band
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ is_announced: true }),
+    })
+    const res = await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'editor', id: 2 } },
+    })
+
+    expect(res.status).toBe(200)
+    const row = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
+    // Flag should remain 0 since there were no followers — future followers will still be notified
+    expect(row.band_follow_notified).toBe(0)
+  })
+
   it('does not set band_follow_notified again if band was already notified', async () => {
     const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
     const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-renotify' })

--- a/functions/api/admin/bands/__tests__/announce.test.js
+++ b/functions/api/admin/bands/__tests__/announce.test.js
@@ -88,4 +88,59 @@ describe('PATCH /api/admin/bands/:id - announce toggle', () => {
 
     expect(res.status).toBe(403)
   })
+
+  it('sets band_follow_notified=1 when band is announced and followers exist', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-notify' })
+    rawDb.prepare('UPDATE events SET reveal_mode=1 WHERE id=?').run(ev.id)
+    const venue = insertVenue(rawDb, { name: 'Venue N' })
+    const band = insertBand(rawDb, { name: 'Notify Band', event_id: ev.id, venue_id: venue.id })
+    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(band.id)
+
+    rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+    ).run('follower@example.com', band.band_profile_id, 'unsub-token-1')
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ is_announced: true }),
+    })
+    await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'editor', id: 2 } },
+    })
+
+    // Email is fire-and-forget and skipped (no EMAIL_FROM in test env).
+    // Assert the DB dedup flag was set.
+    const row = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
+    expect(row.band_follow_notified).toBe(1)
+  })
+
+  it('does not set band_follow_notified again if band was already notified', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-renotify' })
+    const band = insertBand(rawDb, { name: 'Already Notified', event_id: ev.id })
+    rawDb.prepare('UPDATE performances SET is_announced=0, band_follow_notified=1 WHERE id=?').run(band.id)
+
+    rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+    ).run('follower2@example.com', band.band_profile_id, 'unsub-token-2')
+
+    const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ is_announced: true }),
+    })
+    const res = await bandIdHandler.onRequestPatch({
+      request: req,
+      env,
+      data: { user: { role: 'editor', id: 2 } },
+    })
+
+    expect(res.status).toBe(200)
+    const row = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
+    expect(row.band_follow_notified).toBe(1)
+  })
 })

--- a/functions/api/admin/events/[id]/reveal-mode.js
+++ b/functions/api/admin/events/[id]/reveal-mode.js
@@ -1,0 +1,80 @@
+// Admin event reveal-mode endpoint
+// POST /api/admin/events/{id}/reveal-mode
+// Body: { reveal_mode: boolean }
+// Returns: { success: true, event: { id, reveal_mode } }
+
+import { checkPermission, auditLog } from "../../_middleware.js";
+import { getClientIP } from "../../../../utils/request.js";
+
+export async function onRequestPost(context) {
+  const { request, env, params } = context;
+  const { DB } = env;
+  const eventId = params.id;
+  const ipAddress = getClientIP(request);
+
+  try {
+    const auth = await checkPermission(context, "editor");
+    if (auth.error) {
+      return auth.response;
+    }
+
+    const currentUser = auth.user;
+
+    if (!eventId || isNaN(eventId)) {
+      return new Response(
+        JSON.stringify({ error: "Bad request", message: "Invalid event ID" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    if (typeof body.reveal_mode !== "boolean") {
+      return new Response(
+        JSON.stringify({ error: "Bad request", message: "reveal_mode (boolean) is required" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const event = await DB.prepare("SELECT id FROM events WHERE id = ?")
+      .bind(eventId)
+      .first();
+
+    if (!event) {
+      return new Response(
+        JSON.stringify({ error: "Not found", message: "Event not found" }),
+        { status: 404, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const newValue = body.reveal_mode ? 1 : 0;
+    await DB.prepare(
+      "UPDATE events SET reveal_mode = ?, updated_at = datetime('now') WHERE id = ?"
+    )
+      .bind(newValue, eventId)
+      .run();
+
+    await auditLog(
+      env,
+      currentUser.userId,
+      newValue ? "event_reveal_mode_on" : "event_reveal_mode_off",
+      "event",
+      eventId,
+      { event_id: eventId },
+      ipAddress
+    );
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        event: { id: Number(eventId), reveal_mode: newValue },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("[reveal-mode] Error:", err);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/functions/api/admin/events/[id]/reveal-mode.js
+++ b/functions/api/admin/events/[id]/reveal-mode.js
@@ -48,15 +48,15 @@ export async function onRequestPost(context) {
 
     const newValue = body.reveal_mode ? 1 : 0;
     await DB.prepare(
-      "UPDATE events SET reveal_mode = ?, updated_at = datetime('now') WHERE id = ?"
+      "UPDATE events SET reveal_mode = ?, updated_at = datetime('now'), updated_by_user_id = ? WHERE id = ?"
     )
-      .bind(newValue, eventId)
+      .bind(newValue, currentUser.userId, eventId)
       .run();
 
     await auditLog(
       env,
       currentUser.userId,
-      newValue ? "event_reveal_mode_on" : "event_reveal_mode_off",
+      newValue ? "event.reveal_mode.on" : "event.reveal_mode.off",
       "event",
       eventId,
       { event_id: eventId },

--- a/functions/api/admin/events/__tests__/reveal-mode.test.js
+++ b/functions/api/admin/events/__tests__/reveal-mode.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { createTestEnv, insertEvent } from '../../../test-utils'
+import { onRequestPost } from '../[id]/reveal-mode.js'
+
+describe('POST /api/admin/events/:id/reveal-mode', () => {
+  it('enables reveal mode on an event', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal' })
+
+    const res = await onRequestPost({
+      request: new Request(`https://example.test/api/admin/events/${ev.id}/reveal-mode`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify({ reveal_mode: true }),
+      }),
+      env,
+      params: { id: String(ev.id) },
+      data: { user: { role: 'editor', id: 2, userId: 2 } },
+    })
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.event.reveal_mode).toBe(1)
+
+    const row = rawDb.prepare('SELECT reveal_mode FROM events WHERE id=?').get(ev.id)
+    expect(row.reveal_mode).toBe(1)
+  })
+
+  it('disables reveal mode on an event', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal-off' })
+    rawDb.prepare('UPDATE events SET reveal_mode=1 WHERE id=?').run(ev.id)
+
+    const res = await onRequestPost({
+      request: new Request(`https://example.test/api/admin/events/${ev.id}/reveal-mode`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify({ reveal_mode: false }),
+      }),
+      env,
+      params: { id: String(ev.id) },
+      data: { user: { role: 'editor', id: 2, userId: 2 } },
+    })
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.event.reveal_mode).toBe(0)
+  })
+
+  it('returns 400 when reveal_mode is missing from body', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal-bad' })
+
+    const res = await onRequestPost({
+      request: new Request(`https://example.test/api/admin/events/${ev.id}/reveal-mode`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify({ other: true }),
+      }),
+      env,
+      params: { id: String(ev.id) },
+      data: { user: { role: 'editor', id: 2, userId: 2 } },
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 for a non-existent event', async () => {
+    const { env, headers } = createTestEnv({ role: 'editor' })
+
+    const res = await onRequestPost({
+      request: new Request('https://example.test/api/admin/events/99999/reveal-mode', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify({ reveal_mode: true }),
+      }),
+      env,
+      params: { id: '99999' },
+      data: { user: { role: 'editor', id: 2, userId: 2 } },
+    })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('requires at least editor role', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'viewer' })
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal-auth' })
+
+    const res = await onRequestPost({
+      request: new Request(`https://example.test/api/admin/events/${ev.id}/reveal-mode`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify({ reveal_mode: true }),
+      }),
+      env,
+      params: { id: String(ev.id) },
+      data: { user: { role: 'viewer', id: 3, userId: 3 } },
+    })
+
+    expect(res.status).toBe(403)
+  })
+})

--- a/functions/api/bands/[name]/follow.js
+++ b/functions/api/bands/[name]/follow.js
@@ -48,7 +48,7 @@ async function verifyTurnstile(request, env, token) {
 }
 
 export async function onRequestPost(context) {
-  const { request, env, params } = context;
+  const { request, env, params, waitUntil } = context;
   const { DB } = env;
 
   try {
@@ -109,18 +109,21 @@ export async function onRequestPost(context) {
     if (result.meta.changes > 0 && isEmailConfigured(env)) {
       const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
       const unsubUrl = `${publicUrl}/api/bands/${band.id}/unfollow?token=${unsubscribeToken}`;
-      sendEmail(env, {
-        to: email,
-        subject: `You're following ${band.name} on SetTimes`,
-        text: `You'll be notified when ${band.name} joins a lineup.\n\nUnfollow: ${unsubUrl}`,
-        html: `<p>You'll be notified when <strong>${escapeHtml(band.name)}</strong> joins a lineup.</p><p><a href="${unsubUrl}">Unfollow</a></p>`,
-      }).then(result => {
-        if (!result?.delivered) {
-          console.warn("[band-follow] Confirmation email not delivered:", result?.reason);
-        }
-      }).catch(err => {
-        console.error("[band-follow] Failed to send confirmation email:", err);
-      });
+      // Use waitUntil so the Worker stays alive for the email after the response is returned.
+      waitUntil(
+        sendEmail(env, {
+          to: email,
+          subject: `You're following ${band.name} on SetTimes`,
+          text: `You'll be notified when ${band.name} joins a lineup.\n\nUnfollow: ${unsubUrl}`,
+          html: `<p>You'll be notified when <strong>${escapeHtml(band.name)}</strong> joins a lineup.</p><p><a href="${unsubUrl}">Unfollow</a></p>`,
+        }).then(result => {
+          if (!result?.delivered) {
+            console.warn("[band-follow] Confirmation email not delivered:", result?.reason);
+          }
+        }).catch(err => {
+          console.error("[band-follow] Failed to send confirmation email:", err);
+        })
+      );
     }
 
     return new Response(JSON.stringify({ success: true }), {

--- a/functions/api/bands/[name]/follow.js
+++ b/functions/api/bands/[name]/follow.js
@@ -109,12 +109,18 @@ export async function onRequestPost(context) {
     if (result.meta.changes > 0 && isEmailConfigured(env)) {
       const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
       const unsubUrl = `${publicUrl}/api/bands/${band.id}/unfollow?token=${unsubscribeToken}`;
-      await sendEmail(env, {
+      sendEmail(env, {
         to: email,
         subject: `You're following ${band.name} on SetTimes`,
         text: `You'll be notified when ${band.name} joins a lineup.\n\nUnfollow: ${unsubUrl}`,
         html: `<p>You'll be notified when <strong>${escapeHtml(band.name)}</strong> joins a lineup.</p><p><a href="${unsubUrl}">Unfollow</a></p>`,
-      }).catch(() => {});
+      }).then(result => {
+        if (!result?.delivered) {
+          console.warn("[band-follow] Confirmation email not delivered:", result?.reason);
+        }
+      }).catch(err => {
+        console.error("[band-follow] Failed to send confirmation email:", err);
+      });
     }
 
     return new Response(JSON.stringify({ success: true }), {

--- a/functions/api/bands/[name]/follow.js
+++ b/functions/api/bands/[name]/follow.js
@@ -1,131 +1,131 @@
-import { isValidEmail } from '../../../utils/validation.js'
-import { generateToken } from '../../../utils/tokens.js'
-import { sendEmail, isEmailConfigured } from '../../../utils/email.js'
+import { isValidEmail } from "../../../utils/validation.js";
+import { generateToken } from "../../../utils/tokens.js";
+import { sendEmail, isEmailConfigured } from "../../../utils/email.js";
 
-const escapeHtml = s => String(s ?? '')
-  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  .replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+const escapeHtml = (s) =>
+  String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 
-const MAX_EMAIL_LENGTH = 320
+const MAX_EMAIL_LENGTH = 320;
 
 async function verifyTurnstile(request, env, token) {
-  const secret = env?.TURNSTILE_SECRET_KEY
+  const secret = env?.TURNSTILE_SECRET_KEY;
   if (!secret) {
-    return true
+    return true;
   }
 
-  if (!token || typeof token !== 'string') {
-    return false
+  if (!token || typeof token !== "string") {
+    return false;
   }
 
-  const ip = request.headers.get('CF-Connecting-IP') || ''
-  const formData = new URLSearchParams()
-  formData.set('secret', secret)
-  formData.set('response', token)
+  const ip = request.headers.get("CF-Connecting-IP") || "";
+  const formData = new URLSearchParams();
+  formData.set("secret", secret);
+  formData.set("response", token);
   if (ip) {
-    formData.set('remoteip', ip)
+    formData.set("remoteip", ip);
   }
 
   try {
     const response = await fetch(
-      'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
       {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: formData,
-      }
-    )
+      },
+    );
 
-    const result = await response.json().catch(() => ({}))
-    return Boolean(result?.success)
+    const result = await response.json().catch(() => ({}));
+    return Boolean(result?.success);
   } catch (_error) {
-    return false
+    return false;
   }
 }
 
 export async function onRequestPost(context) {
-  const { request, env, params } = context
-  const { DB } = env
+  const { request, env, params } = context;
+  const { DB } = env;
 
   try {
-    const body = await request.json().catch(() => ({}))
-    const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
-    const turnstileToken = body.turnstileToken
+    const body = await request.json().catch(() => ({}));
+    const email =
+      typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    const turnstileToken = body.turnstileToken;
 
     if (!email || email.length > MAX_EMAIL_LENGTH || !isValidEmail(email)) {
-      return new Response(
-        JSON.stringify({ error: 'Invalid email address' }),
-        { status: 400, headers: { 'Content-Type': 'application/json' } }
-      )
+      return new Response(JSON.stringify({ error: "Invalid email address" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
-    const turnstileValid = await verifyTurnstile(request, env, turnstileToken)
+    const turnstileValid = await verifyTurnstile(request, env, turnstileToken);
     if (!turnstileValid) {
       return new Response(
-        JSON.stringify({ error: 'Bot verification failed' }),
-        { status: 400, headers: { 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({ error: "Bot verification failed" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
     }
 
     // Resolve band profile — params.name may be numeric ID or normalized name
-    const nameOrId = params.name
-    let band
+    const nameOrId = params.name;
+    let band;
     if (/^\d+$/.test(nameOrId)) {
-      band = await DB.prepare('SELECT id, name FROM band_profiles WHERE id = ?')
-        .bind(Number(nameOrId)).first()
+      band = await DB.prepare("SELECT id, name FROM band_profiles WHERE id = ?")
+        .bind(Number(nameOrId))
+        .first();
     } else {
-      const normalized = nameOrId.toLowerCase().replace(/[^a-z0-9]/g, '')
-      band = await DB.prepare('SELECT id, name FROM band_profiles WHERE name_normalized = ?')
-        .bind(normalized).first()
+      const normalized = nameOrId.toLowerCase().replace(/[^a-z0-9]/g, "");
+      band = await DB.prepare(
+        "SELECT id, name FROM band_profiles WHERE name_normalized = ?",
+      )
+        .bind(normalized)
+        .first();
     }
 
     if (!band) {
-      return new Response(
-        JSON.stringify({ error: 'Band not found' }),
-        { status: 404, headers: { 'Content-Type': 'application/json' } }
-      )
+      return new Response(JSON.stringify({ error: "Band not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
-    // Return 200 silently for duplicates (avoid email enumeration)
-    const existing = await DB.prepare(
-      'SELECT id FROM band_follows WHERE email = ? AND band_profile_id = ?'
-    ).bind(email, band.id).first()
+    // Atomic upsert — INSERT OR IGNORE avoids the SELECT-then-INSERT race where two
+    // concurrent requests both pass the existence check and one hits the UNIQUE constraint.
+    const unsubscribeToken = generateToken();
+    const result = await DB.prepare(
+      `INSERT OR IGNORE INTO band_follows (email, band_profile_id, verified, unsubscribe_token)
+       VALUES (?, ?, 1, ?)`,
+    )
+      .bind(email, band.id, unsubscribeToken)
+      .run();
 
-    if (existing) {
-      return new Response(
-        JSON.stringify({ success: true }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
-    }
-
-    const unsubscribeToken = generateToken()
-
-    await DB.prepare(
-      `INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token)
-       VALUES (?, ?, 1, ?)`
-    ).bind(email, band.id, unsubscribeToken).run()
-
-    // Optional confirmation email — fire-and-forget
-    if (isEmailConfigured(env)) {
-      const publicUrl = env.PUBLIC_URL || 'https://settimes.ca'
-      const unsubUrl = `${publicUrl}/api/bands/${band.id}/unfollow?token=${unsubscribeToken}`
+    // Only send confirmation when a new row was actually inserted (changes=0 → already followed)
+    if (result.meta.changes > 0 && isEmailConfigured(env)) {
+      const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
+      const unsubUrl = `${publicUrl}/api/bands/${band.id}/unfollow?token=${unsubscribeToken}`;
       await sendEmail(env, {
         to: email,
         subject: `You're following ${band.name} on SetTimes`,
         text: `You'll be notified when ${band.name} joins a lineup.\n\nUnfollow: ${unsubUrl}`,
         html: `<p>You'll be notified when <strong>${escapeHtml(band.name)}</strong> joins a lineup.</p><p><a href="${unsubUrl}">Unfollow</a></p>`,
-      }).catch(() => {})
+      }).catch(() => {});
     }
 
-    return new Response(
-      JSON.stringify({ success: true }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    )
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
   } catch (err) {
-    console.error('[band-follow] Error:', err)
-    return new Response(
-      JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } }
-    )
+    console.error("[band-follow] Error:", err);
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/bands/[name]/follow.js
+++ b/functions/api/bands/[name]/follow.js
@@ -2,6 +2,10 @@ import { isValidEmail } from '../../../utils/validation.js'
 import { generateToken } from '../../../utils/tokens.js'
 import { sendEmail, isEmailConfigured } from '../../../utils/email.js'
 
+const escapeHtml = s => String(s ?? '')
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+
 const MAX_EMAIL_LENGTH = 320
 
 async function verifyTurnstile(request, env, token) {
@@ -109,7 +113,7 @@ export async function onRequestPost(context) {
         to: email,
         subject: `You're following ${band.name} on SetTimes`,
         text: `You'll be notified when ${band.name} joins a lineup.\n\nUnfollow: ${unsubUrl}`,
-        html: `<p>You'll be notified when <strong>${band.name}</strong> joins a lineup.</p><p><a href="${unsubUrl}">Unfollow</a></p>`,
+        html: `<p>You'll be notified when <strong>${escapeHtml(band.name)}</strong> joins a lineup.</p><p><a href="${unsubUrl}">Unfollow</a></p>`,
       }).catch(() => {})
     }
 

--- a/functions/api/bands/[name]/follow.js
+++ b/functions/api/bands/[name]/follow.js
@@ -4,6 +4,41 @@ import { sendEmail, isEmailConfigured } from '../../../utils/email.js'
 
 const MAX_EMAIL_LENGTH = 320
 
+async function verifyTurnstile(request, env, token) {
+  const secret = env?.TURNSTILE_SECRET_KEY
+  if (!secret) {
+    return true
+  }
+
+  if (!token || typeof token !== 'string') {
+    return false
+  }
+
+  const ip = request.headers.get('CF-Connecting-IP') || ''
+  const formData = new URLSearchParams()
+  formData.set('secret', secret)
+  formData.set('response', token)
+  if (ip) {
+    formData.set('remoteip', ip)
+  }
+
+  try {
+    const response = await fetch(
+      'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: formData,
+      }
+    )
+
+    const result = await response.json().catch(() => ({}))
+    return Boolean(result?.success)
+  } catch (_error) {
+    return false
+  }
+}
+
 export async function onRequestPost(context) {
   const { request, env, params } = context
   const { DB } = env
@@ -11,10 +46,19 @@ export async function onRequestPost(context) {
   try {
     const body = await request.json().catch(() => ({}))
     const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
+    const turnstileToken = body.turnstileToken
 
     if (!email || email.length > MAX_EMAIL_LENGTH || !isValidEmail(email)) {
       return new Response(
         JSON.stringify({ error: 'Invalid email address' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const turnstileValid = await verifyTurnstile(request, env, turnstileToken)
+    if (!turnstileValid) {
+      return new Response(
+        JSON.stringify({ error: 'Bot verification failed' }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       )
     }

--- a/functions/api/bands/[name]/follow.js
+++ b/functions/api/bands/[name]/follow.js
@@ -1,0 +1,83 @@
+import { isValidEmail } from '../../../utils/validation.js'
+import { generateToken } from '../../../utils/tokens.js'
+import { sendEmail, isEmailConfigured } from '../../../utils/email.js'
+
+const MAX_EMAIL_LENGTH = 320
+
+export async function onRequestPost(context) {
+  const { request, env, params } = context
+  const { DB } = env
+
+  try {
+    const body = await request.json().catch(() => ({}))
+    const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
+
+    if (!email || email.length > MAX_EMAIL_LENGTH || !isValidEmail(email)) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid email address' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Resolve band profile — params.name may be numeric ID or normalized name
+    const nameOrId = params.name
+    let band
+    if (/^\d+$/.test(nameOrId)) {
+      band = await DB.prepare('SELECT id, name FROM band_profiles WHERE id = ?')
+        .bind(Number(nameOrId)).first()
+    } else {
+      const normalized = nameOrId.toLowerCase().replace(/[^a-z0-9]/g, '')
+      band = await DB.prepare('SELECT id, name FROM band_profiles WHERE name_normalized = ?')
+        .bind(normalized).first()
+    }
+
+    if (!band) {
+      return new Response(
+        JSON.stringify({ error: 'Band not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Return 200 silently for duplicates (avoid email enumeration)
+    const existing = await DB.prepare(
+      'SELECT id FROM band_follows WHERE email = ? AND band_profile_id = ?'
+    ).bind(email, band.id).first()
+
+    if (existing) {
+      return new Response(
+        JSON.stringify({ success: true }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const unsubscribeToken = generateToken()
+
+    await DB.prepare(
+      `INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token)
+       VALUES (?, ?, 1, ?)`
+    ).bind(email, band.id, unsubscribeToken).run()
+
+    // Optional confirmation email — fire-and-forget
+    if (isEmailConfigured(env)) {
+      const publicUrl = env.PUBLIC_URL || 'https://settimes.ca'
+      const unsubUrl = `${publicUrl}/api/bands/${band.id}/unfollow?token=${unsubscribeToken}`
+      await sendEmail(env, {
+        to: email,
+        subject: `You're following ${band.name} on SetTimes`,
+        text: `You'll be notified when ${band.name} joins a lineup.\n\nUnfollow: ${unsubUrl}`,
+        html: `<p>You'll be notified when <strong>${band.name}</strong> joins a lineup.</p><p><a href="${unsubUrl}">Unfollow</a></p>`,
+      }).catch(() => {})
+    }
+
+    return new Response(
+      JSON.stringify({ success: true }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  } catch (err) {
+    console.error('[band-follow] Error:', err)
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+}

--- a/functions/api/bands/[name]/unfollow.js
+++ b/functions/api/bands/[name]/unfollow.js
@@ -18,7 +18,7 @@ export async function onRequestGet(context) {
 
     return new Response(
       '<html><body style="font-family:sans-serif;padding:2rem"><h2>Unfollowed</h2><p>You have been removed from this band\'s follower list.</p></body></html>',
-      { status: 200, headers: { 'Content-Type': 'text/html' } }
+      { status: 200, headers: { 'Content-Type': 'text/html', 'Cache-Control': 'no-store' } }
     )
   } catch (err) {
     console.error('[band-unfollow] Error:', err)

--- a/functions/api/bands/[name]/unfollow.js
+++ b/functions/api/bands/[name]/unfollow.js
@@ -1,0 +1,27 @@
+// GET /api/bands/:name/unfollow?token=...
+// Deletes the band follow associated with the unsubscribe token.
+// Returns 200 regardless of whether the token exists (avoid enumeration).
+
+export async function onRequestGet(context) {
+  const { request, env } = context
+  const { DB } = env
+
+  try {
+    const url = new URL(request.url)
+    const token = url.searchParams.get('token')
+
+    if (!token || token.length > 256) {
+      return new Response('Invalid token.', { status: 400, headers: { 'Content-Type': 'text/plain' } })
+    }
+
+    await DB.prepare('DELETE FROM band_follows WHERE unsubscribe_token = ?').bind(token).run()
+
+    return new Response(
+      '<html><body style="font-family:sans-serif;padding:2rem"><h2>Unfollowed</h2><p>You have been removed from this band\'s follower list.</p></body></html>',
+      { status: 200, headers: { 'Content-Type': 'text/html' } }
+    )
+  } catch (err) {
+    console.error('[band-unfollow] Error:', err)
+    return new Response('An error occurred.', { status: 500, headers: { 'Content-Type': 'text/plain' } })
+  }
+}

--- a/functions/api/bands/__tests__/follow.test.js
+++ b/functions/api/bands/__tests__/follow.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
+import * as followHandler from '../[name]/follow.js'
+
+describe('POST /api/bands/:name/follow', () => {
+  it('creates a band follow for a valid email and band', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-follow' })
+    const band = insertBand(rawDb, { name: 'Follow Band', event_id: ev.id })
+
+    const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com' }),
+    })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) } })
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.success).toBe(true)
+
+    const row = rawDb.prepare('SELECT * FROM band_follows WHERE email=? AND band_profile_id=?')
+      .get('fan@example.com', band.band_profile_id)
+    expect(row).toBeTruthy()
+    expect(row.verified).toBe(1)
+    expect(row.unsubscribe_token).toBeTruthy()
+  })
+
+  it('returns 400 for an invalid email', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-bad-email' })
+    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+
+    const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'not-an-email' }),
+    })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) } })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 silently if email already follows the band (no duplicate row)', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-dup' })
+    const band = insertBand(rawDb, { name: 'Dup Band', event_id: ev.id })
+
+    rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, unsubscribe_token) VALUES (?, ?, ?)'
+    ).run('fan@example.com', band.band_profile_id, 'existing-token')
+
+    const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com' }),
+    })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) } })
+    expect(res.status).toBe(200)
+
+    const rows = rawDb.prepare('SELECT * FROM band_follows WHERE email=? AND band_profile_id=?')
+      .all('fan@example.com', band.band_profile_id)
+    expect(rows.length).toBe(1)
+  })
+
+  it('returns 404 if band does not exist', async () => {
+    const { env } = createTestEnv()
+
+    const req = new Request('https://example.test/api/bands/99999/follow', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com' }),
+    })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: '99999' } })
+    expect(res.status).toBe(404)
+  })
+})

--- a/functions/api/bands/__tests__/follow.test.js
+++ b/functions/api/bands/__tests__/follow.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
 import * as followHandler from '../[name]/follow.js'
 
+const waitUntil = () => {}
+
 describe('POST /api/bands/:name/follow', () => {
   it('creates a band follow for a valid email and band', async () => {
     const { env, rawDb } = createTestEnv()
@@ -13,7 +15,7 @@ describe('POST /api/bands/:name/follow', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'fan@example.com' }),
     })
-    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) } })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) }, waitUntil })
 
     expect(res.status).toBe(200)
     const data = await res.json()
@@ -36,7 +38,7 @@ describe('POST /api/bands/:name/follow', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'not-an-email' }),
     })
-    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) } })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) }, waitUntil })
     expect(res.status).toBe(400)
   })
 
@@ -54,7 +56,7 @@ describe('POST /api/bands/:name/follow', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'fan@example.com' }),
     })
-    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) } })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) }, waitUntil })
     expect(res.status).toBe(200)
 
     const rows = rawDb.prepare('SELECT * FROM band_follows WHERE email=? AND band_profile_id=?')
@@ -70,7 +72,7 @@ describe('POST /api/bands/:name/follow', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'fan@example.com' }),
     })
-    const res = await followHandler.onRequestPost({ request: req, env, params: { name: '99999' } })
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: '99999' }, waitUntil })
     expect(res.status).toBe(404)
   })
 })

--- a/functions/api/bands/__tests__/unfollow.test.js
+++ b/functions/api/bands/__tests__/unfollow.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
+import { onRequestGet } from '../[name]/unfollow.js'
+
+describe('GET /api/bands/:name/unfollow', () => {
+  it('deletes the follow row for a valid token and returns 200 HTML', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-unfollow' })
+    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+    rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, unsubscribe_token) VALUES (?, ?, ?)'
+    ).run('fan@example.com', band.band_profile_id, 'valid-token-abc')
+
+    const res = await onRequestGet({
+      request: new Request('https://example.test/api/bands/1/unfollow?token=valid-token-abc'),
+      env,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('Unfollowed')
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+
+    const row = rawDb.prepare('SELECT * FROM band_follows WHERE unsubscribe_token=?').get('valid-token-abc')
+    expect(row).toBeUndefined()
+  })
+
+  it('returns 200 even when the token does not exist (avoids enumeration)', async () => {
+    const { env } = createTestEnv()
+
+    const res = await onRequestGet({
+      request: new Request('https://example.test/api/bands/1/unfollow?token=nonexistent-token'),
+      env,
+    })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 400 for a missing token', async () => {
+    const { env } = createTestEnv()
+
+    const res = await onRequestGet({
+      request: new Request('https://example.test/api/bands/1/unfollow'),
+      env,
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for a token that exceeds 256 characters', async () => {
+    const { env } = createTestEnv()
+    const longToken = 'a'.repeat(257)
+
+    const res = await onRequestGet({
+      request: new Request(`https://example.test/api/bands/1/unfollow?token=${longToken}`),
+      env,
+    })
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -1,0 +1,126 @@
+import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
+
+/**
+ * Public API: Get recap stats and band list for a single archived event
+ *
+ * GET /api/events/:id/recap
+ *
+ * Returns 404 if the event is not found or is not archived.
+ * Accepts numeric ID or slug in params.id.
+ */
+export async function onRequestGet(context) {
+  const { env, params } = context;
+
+  const gate = getPublicDataGateResponse(env);
+  if (gate) {
+    return gate;
+  }
+
+  const { DB } = env;
+
+  // Resolve event by numeric ID or slug
+  const rawId = params.id;
+  const numericId = Number(rawId);
+  const isNumeric = Number.isFinite(numericId) && String(numericId) === rawId;
+
+  try {
+    const event = isNumeric
+      ? await DB.prepare(
+          `SELECT id, name, slug, date FROM events WHERE id = ? AND status = 'archived' LIMIT 1`
+        )
+          .bind(numericId)
+          .first()
+      : await DB.prepare(
+          `SELECT id, name, slug, date FROM events WHERE slug = ? AND status = 'archived' LIMIT 1`
+        )
+          .bind(rawId)
+          .first();
+
+    if (!event) {
+      return new Response(
+        JSON.stringify({ error: "Event not found or not archived" }),
+        { status: 404, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const bandsResult = await DB.prepare(
+      `
+      SELECT
+        bp.id   AS band_id,
+        bp.name AS band_name,
+        bp.genre,
+        bp.photo_url,
+        p.start_time,
+        p.end_time,
+        v.id   AS venue_id,
+        v.name AS venue_name,
+        CASE WHEN EXISTS (
+          SELECT 1 FROM performances p2
+          WHERE p2.band_profile_id = bp.id AND p2.event_id != ?
+        ) THEN 1 ELSE 0 END AS is_returning
+      FROM performances p
+      JOIN band_profiles bp ON p.band_profile_id = bp.id
+      LEFT JOIN venues v ON p.venue_id = v.id
+      WHERE p.event_id = ?
+      ORDER BY p.start_time NULLS LAST, bp.name
+      `
+    )
+      .bind(event.id, event.id)
+      .all();
+
+    const rows = bandsResult.results || [];
+
+    // Aggregate stats from rows
+    const venueIds = new Set();
+    let firstTimers = 0;
+    let returningActs = 0;
+
+    const bands = rows.map((row) => {
+      if (row.venue_id) {
+        venueIds.add(row.venue_id);
+      }
+      const isReturning = row.is_returning === 1;
+      if (isReturning) {
+        returningActs++;
+      } else {
+        firstTimers++;
+      }
+
+      return {
+        id: row.band_id,
+        name: row.band_name,
+        genre: row.genre,
+        photo_url: row.photo_url,
+        start_time: row.start_time,
+        end_time: row.end_time,
+        venue_id: row.venue_id,
+        venue_name: row.venue_name,
+        is_returning: isReturning,
+      };
+    });
+
+    const stats = {
+      total_sets: rows.length,
+      venue_count: venueIds.size,
+      first_timers: firstTimers,
+      returning_acts: returningActs,
+    };
+
+    return new Response(
+      JSON.stringify({ event, stats, bands }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "public, max-age=3600",
+        },
+      }
+    );
+  } catch (error) {
+    console.error("Error fetching event recap:", error);
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch event recap" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -56,7 +56,10 @@ export async function onRequestGet(context) {
         v.name AS venue_name,
         CASE WHEN EXISTS (
           SELECT 1 FROM performances p2
-          WHERE p2.band_profile_id = bp.id AND p2.event_id != ?
+          JOIN events e2 ON p2.event_id = e2.id
+          WHERE p2.band_profile_id = bp.id
+            AND p2.event_id != ?
+            AND e2.status = 'archived'
         ) THEN 1 ELSE 0 END AS is_returning
       FROM performances p
       JOIN band_profiles bp ON p.band_profile_id = bp.id
@@ -100,7 +103,7 @@ export async function onRequestGet(context) {
     });
 
     const stats = {
-      total_sets: rows.length,
+      total_sets: rows.length, // performance slots; one band playing two sets counts as 2
       venue_count: venueIds.size,
       first_timers: firstTimers,
       returning_acts: returningActs,

--- a/functions/api/events/__tests__/recap.test.js
+++ b/functions/api/events/__tests__/recap.test.js
@@ -1,0 +1,211 @@
+import { describe, expect, test } from 'vitest';
+import { onRequestGet } from '../[id]/recap.js';
+import {
+  createTestEnv,
+  insertEvent,
+  insertVenue,
+  insertBand,
+} from '../../test-utils.js';
+
+describe('GET /api/events/:id/recap', () => {
+  test('returns 404 for a non-archived event', async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
+    const event = insertEvent(rawDb, {
+      name: 'Draft Event',
+      slug: 'draft-event',
+      date: '2024-08-03',
+      status: 'draft',
+    });
+
+    const request = new Request(
+      `https://example.test/api/events/${event.slug}/recap`
+    );
+    const response = await onRequestGet({
+      request,
+      env,
+      params: { id: event.slug },
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test('returns 200 with stats and bands for an archived event looked up by slug', async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
+    const event = insertEvent(rawDb, {
+      name: 'LWBC Vol5',
+      slug: 'lwbc-vol5',
+      date: '2024-08-03',
+      status: 'archived',
+    });
+
+    const venue = insertVenue(rawDb, { name: 'Main Stage', city: 'Portland' });
+    insertBand(rawDb, {
+      name: 'Band Alpha',
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: '19:00',
+      end_time: '20:00',
+    });
+
+    const request = new Request(
+      `https://example.test/api/events/${event.slug}/recap`
+    );
+    const response = await onRequestGet({
+      request,
+      env,
+      params: { id: event.slug },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+
+    const payload = await response.json();
+    expect(payload.event).toMatchObject({
+      id: event.id,
+      name: 'LWBC Vol5',
+      slug: 'lwbc-vol5',
+      date: '2024-08-03',
+    });
+    expect(payload.stats).toMatchObject({
+      total_sets: 1,
+      venue_count: 1,
+    });
+    expect(payload.bands).toHaveLength(1);
+    expect(payload.bands[0]).toMatchObject({
+      name: 'Band Alpha',
+      venue_id: venue.id,
+      venue_name: 'Main Stage',
+      start_time: '19:00',
+      end_time: '20:00',
+    });
+  });
+
+  test('returns 200 when looked up by numeric ID', async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
+    const event = insertEvent(rawDb, {
+      name: 'LWBC Vol6',
+      slug: 'lwbc-vol6',
+      date: '2024-09-15',
+      status: 'archived',
+    });
+
+    const venue = insertVenue(rawDb, { name: 'Side Stage', city: 'Portland' });
+    insertBand(rawDb, {
+      name: 'Band Beta',
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: '20:00',
+      end_time: '21:00',
+    });
+
+    const request = new Request(
+      `https://example.test/api/events/${event.id}/recap`
+    );
+    const response = await onRequestGet({
+      request,
+      env,
+      params: { id: String(event.id) },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.event.id).toBe(event.id);
+    expect(payload.bands).toHaveLength(1);
+  });
+
+  test('correctly classifies first-timers vs returning acts', async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
+
+    // Prior event
+    const priorEvent = insertEvent(rawDb, {
+      name: 'LWBC Vol4',
+      slug: 'lwbc-vol4',
+      date: '2023-08-01',
+      status: 'archived',
+    });
+
+    // Current event (archived)
+    const currentEvent = insertEvent(rawDb, {
+      name: 'LWBC Vol5',
+      slug: 'lwbc-vol5-ft',
+      date: '2024-08-03',
+      status: 'archived',
+    });
+
+    const venue = insertVenue(rawDb, { name: 'Main Stage', city: 'Portland' });
+
+    // Returning act: appears in prior event
+    const returningAct = insertBand(rawDb, {
+      name: 'Returning Band',
+      event_id: priorEvent.id,
+      venue_id: venue.id,
+      start_time: '18:00',
+      end_time: '19:00',
+    });
+
+    // Add the same band (by name, so same band_profile_id) to the current event
+    insertBand(rawDb, {
+      name: 'Returning Band',
+      event_id: currentEvent.id,
+      venue_id: venue.id,
+      start_time: '19:00',
+      end_time: '20:00',
+    });
+
+    // First-timer: only appears in the current event
+    insertBand(rawDb, {
+      name: 'New Band',
+      event_id: currentEvent.id,
+      venue_id: venue.id,
+      start_time: '20:00',
+      end_time: '21:00',
+    });
+
+    const request = new Request(
+      `https://example.test/api/events/${currentEvent.slug}/recap`
+    );
+    const response = await onRequestGet({
+      request,
+      env,
+      params: { id: currentEvent.slug },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    expect(payload.stats.total_sets).toBe(2);
+    expect(payload.stats.first_timers).toBe(1);
+    expect(payload.stats.returning_acts).toBe(1);
+
+    const returningBand = payload.bands.find((b) => b.name === 'Returning Band');
+    const newBand = payload.bands.find((b) => b.name === 'New Band');
+    expect(returningBand.is_returning).toBe(true);
+    expect(newBand.is_returning).toBe(false);
+  });
+
+  test('returns 503 when PUBLIC_DATA_PUBLISH_ENABLED is not set', async () => {
+    const { env, rawDb } = createTestEnv();
+    // Do NOT set PUBLIC_DATA_PUBLISH_ENABLED
+    const event = insertEvent(rawDb, {
+      name: 'LWBC Vol5',
+      slug: 'lwbc-vol5-gate',
+      date: '2024-08-03',
+      status: 'archived',
+    });
+
+    const request = new Request(
+      `https://example.test/api/events/${event.slug}/recap`
+    );
+    const response = await onRequestGet({
+      request,
+      env,
+      params: { id: event.slug },
+    });
+
+    expect(response.status).toBe(503);
+  });
+});

--- a/functions/api/events/__tests__/recap.test.js
+++ b/functions/api/events/__tests__/recap.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { onRequestGet } from '../[id]/recap.js';
 import {
   createTestEnv,
@@ -186,6 +186,41 @@ describe('GET /api/events/:id/recap', () => {
     expect(returningBand.is_returning).toBe(true);
     expect(newBand.is_returning).toBe(false);
   });
+
+  it('counts only assigned venues (null venue does not increment venue_count)', async () => {
+    const { env, rawDb } = createTestEnv()
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
+    const event = insertEvent(rawDb, { name: 'Mixed Venues', slug: 'mixed-venues' })
+    rawDb.prepare("UPDATE events SET status='archived', is_published=1 WHERE id=?").run(event.id)
+    const venue = insertVenue(rawDb, { name: 'Stage A' })
+    insertBand(rawDb, { name: 'Band With Venue', event_id: event.id, venue_id: venue.id })
+    insertBand(rawDb, { name: 'Band Without Venue', event_id: event.id }) // no venue
+
+    const res = await onRequestGet({
+      request: new Request(`https://example.test/api/events/${event.id}/recap`),
+      env,
+      params: { id: String(event.id) },
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.stats.venue_count).toBe(1) // only the one with a venue
+    expect(data.stats.total_sets).toBe(2) // both bands appear
+  })
+
+  it('returns 500 on DB error', async () => {
+    const { env } = createTestEnv()
+    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
+    env.DB = {
+      prepare: () => { throw new Error('simulated DB failure') },
+    }
+
+    const res = await onRequestGet({
+      request: new Request('https://example.test/api/events/any-slug/recap'),
+      env,
+      params: { id: 'any-slug' },
+    })
+    expect(res.status).toBe(500)
+  })
 
   test('returns 503 when PUBLIC_DATA_PUBLISH_ENABLED is not set', async () => {
     const { env, rawDb } = createTestEnv();

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -31,7 +31,7 @@ export async function onRequestGet(context) {
       // sets that span past midnight (e.g. 11:30pm-12:30am)
       event = await DB.prepare(
         `
-        SELECT id, name, date, slug, status, ticket_url, theme_colors, venue_info, social_links
+        SELECT id, name, date, slug, status, ticket_url, theme_colors, venue_info, social_links, reveal_mode
         FROM events
         WHERE is_published = 1
           AND date >= date('now', '-6 hours')
@@ -43,7 +43,7 @@ export async function onRequestGet(context) {
       // Get event by slug — includes archived events for read-only history browsing
       event = await DB.prepare(
         `
-        SELECT id, name, date, slug, status, ticket_url, theme_colors, venue_info, social_links
+        SELECT id, name, date, slug, status, ticket_url, theme_colors, venue_info, social_links, reveal_mode
         FROM events
         WHERE slug = ? AND (is_published = 1 OR status = 'archived')
       `,
@@ -84,10 +84,11 @@ export async function onRequestGet(context) {
       INNER JOIN band_profiles b ON p.band_profile_id = b.id
       LEFT JOIN venues v ON p.venue_id = v.id
       WHERE p.event_id = ?
+        AND (? = 0 OR p.is_announced = 1)
       ORDER BY p.start_time, v.name
     `,
     )
-      .bind(event.id)
+      .bind(event.id, event.reveal_mode ?? 0)
       .all();
 
     const bands = bandsResult.results || [];
@@ -143,6 +144,7 @@ export async function onRequestGet(context) {
       theme_colors: event.theme_colors,
       venue_info: event.venue_info,
       social_links: event.social_links,
+      reveal_mode: event.reveal_mode ?? 0,
     };
 
     return new Response(

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -82,7 +82,7 @@ export async function onRequestGet(context) {
         v.name as venue
       FROM performances p
       INNER JOIN band_profiles b ON p.band_profile_id = b.id
-      INNER JOIN venues v ON p.venue_id = v.id
+      LEFT JOIN venues v ON p.venue_id = v.id
       WHERE p.event_id = ?
       ORDER BY p.start_time, v.name
     `,
@@ -124,7 +124,7 @@ export async function onRequestGet(context) {
         performance_id: band.performance_id,
         band_profile_id: band.band_id,
         name: band.name,
-        venue: band.venue,
+        venue: band.venue ?? null,
         date: event.date,
         startTime: extractTime(band.startTime),
         endTime: extractTime(band.endTime),

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -159,7 +159,8 @@ export function createTestDB() {
       updated_by_user_id INTEGER REFERENCES users(id),
       created_at TEXT DEFAULT (datetime('now')),
       updated_at TEXT DEFAULT (datetime('now')),
-      is_announced INTEGER NOT NULL DEFAULT 1
+      is_announced INTEGER NOT NULL DEFAULT 1,
+      band_follow_notified INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE schedule_builds (
@@ -201,6 +202,17 @@ export function createTestDB() {
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       last_email_sent TEXT,
       UNIQUE(email, city, genre)
+    );
+
+    CREATE TABLE band_follows (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL,
+      band_profile_id INTEGER NOT NULL REFERENCES band_profiles(id) ON DELETE CASCADE,
+      verified INTEGER NOT NULL DEFAULT 0,
+      verification_token TEXT UNIQUE,
+      unsubscribe_token TEXT UNIQUE NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(email, band_profile_id)
     );
 
     CREATE TABLE password_reset_tokens (

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -109,7 +109,8 @@ export function createTestDB() {
       created_by_user_id INTEGER REFERENCES users(id),
       updated_by_user_id INTEGER,
       created_at TEXT DEFAULT (datetime('now')),
-      updated_at TEXT DEFAULT (datetime('now'))
+      updated_at TEXT DEFAULT (datetime('now')),
+      reveal_mode INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE band_profiles (
@@ -157,7 +158,8 @@ export function createTestDB() {
       created_by_user_id INTEGER REFERENCES users(id),
       updated_by_user_id INTEGER REFERENCES users(id),
       created_at TEXT DEFAULT (datetime('now')),
-      updated_at TEXT DEFAULT (datetime('now'))
+      updated_at TEXT DEFAULT (datetime('now')),
+      is_announced INTEGER NOT NULL DEFAULT 1
     );
 
     CREATE TABLE schedule_builds (

--- a/migrations/0034_reveal_mode.sql
+++ b/migrations/0034_reveal_mode.sql
@@ -1,0 +1,15 @@
+-- Migration: 0034_reveal_mode
+-- Description: Add reveal_mode to events (when true, only announced performances
+--   appear on the public schedule) and is_announced to performances (toggle per band).
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+--
+-- Safe defaults: reveal_mode=0 means existing events show all bands (no change).
+--   is_announced=1 means existing performances are visible by default.
+
+ALTER TABLE events ADD COLUMN reveal_mode INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE performances ADD COLUMN is_announced INTEGER NOT NULL DEFAULT 1;
+
+CREATE INDEX IF NOT EXISTS idx_performances_announced
+  ON performances(event_id, is_announced);

--- a/migrations/0035_band_follows.sql
+++ b/migrations/0035_band_follows.sql
@@ -1,0 +1,23 @@
+-- Migration: 0035_band_follows
+-- Description: New band_follows table (token-based email follows for individual bands)
+--   and band_follow_notified column on performances to prevent duplicate notifications
+--   when a band is announced multiple times.
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+CREATE TABLE band_follows (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT NOT NULL,
+  band_profile_id INTEGER NOT NULL REFERENCES band_profiles(id) ON DELETE CASCADE,
+  verified INTEGER NOT NULL DEFAULT 0,
+  verification_token TEXT UNIQUE,
+  unsubscribe_token TEXT UNIQUE NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(email, band_profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_band_follows_band ON band_follows(band_profile_id);
+CREATE INDEX IF NOT EXISTS idx_band_follows_email ON band_follows(email);
+
+ALTER TABLE performances ADD COLUMN band_follow_notified INTEGER NOT NULL DEFAULT 0;

--- a/scripts/verify-remote-d1-schema.mjs
+++ b/scripts/verify-remote-d1-schema.mjs
@@ -10,7 +10,7 @@ const execFileAsync = promisify(execFile);
 const MAX_ERROR_OUTPUT_LENGTH = 500;
 
 const REQUIRED_SCHEMA = {
-  events: ['id', 'slug', 'city', 'is_published'],
+  events: ['id', 'slug', 'city', 'is_published', 'reveal_mode'],
   venues: ['id', 'name', 'city'],
   band_profiles: ['id', 'name', 'name_normalized', 'genre', 'photo_url'],
   performances: [
@@ -20,6 +20,8 @@ const REQUIRED_SCHEMA = {
     'band_profile_id',
     'start_time',
     'end_time',
+    'is_announced',
+    'band_follow_notified',
   ],
   users: [
     'id',
@@ -68,6 +70,15 @@ const REQUIRED_SCHEMA = {
   trusted_devices: ['id', 'token', 'user_id', 'expires_at'],
   email_otp_codes: ['id', 'user_id', 'code_hash', 'expires_at', 'verified'],
   audit_log: ['id', 'user_id', 'action', 'resource_type', 'created_at'],
+  band_follows: [
+    'id',
+    'email',
+    'band_profile_id',
+    'verified',
+    'verification_token',
+    'unsubscribe_token',
+    'created_at',
+  ],
 };
 
 const wranglerBin = path.join(


### PR DESCRIPTION
## Summary

### Phase 1 (pre-event hype, before May 17)
- **Shareable schedule URLs** (`?s=41,42,77`): encode selected performance IDs into a URL param; visiting the link seeds the fan's schedule; overwrite prompt if picks already exist
- **Reveal mode**: admin toggles `reveal_mode` on an event; unannounced bands are hidden from the public schedule; eye-icon toggle per row in LineupTab; teaser banner on public schedule
- **"Notify me" band following**: fans follow bands via email on the band profile page (Turnstile-protected); when an admin announces a band, followers receive a one-time email notification; atomic dedup via `band_follow_notified` latch

### Phase 2 (post-event retention)
- **Recap page** (`/events/:slug/recap`): auto-generated post-event summary for archived events — stats (total sets, venues, first timers, returning acts), full lineup with band profile links, subscribe CTA
- **Recap API** (`GET /api/events/:id/recap`): accepts slug or numeric ID, archived-events only, correlated subquery classifies first-timers vs returning acts scoped to archived events only
- **Historical archive backfill UI**: "Import historical event" (admin only) in EventsTab — two-step modal that creates an archived event then bulk-imports band names (paste, one per line, 200 max)

## Migrations (must apply after merge)

Two migrations are included:

```
migrations/0034_reveal_mode.sql   — adds reveal_mode, is_announced
migrations/0035_band_follows.sql  — adds band_follows table, band_follow_notified
```

Apply with:
```bash
npx wrangler d1 migrations apply settimes-production-db --remote
```

## Test plan

- [ ] 298 tests passing across 39 test files (0 regressions)
- [ ] Manual — reveal mode: enable reveal mode on event → unannounced band hidden from public schedule → announce band → band appears
- [ ] Manual — band follow: follow a band on band profile page → admin announces band → confirm email sent (check logs)
- [ ] Manual — shareable URL: build schedule → click Share → paste URL in new tab → schedule pre-populated
- [ ] Manual — recap page: archive an event → visit `/events/:slug/recap` → verify stats, first-timer badges, band links
- [ ] Manual — historical import: admin → EventsTab → "Import historical event" → step 1 (name + date) → step 2 (paste band list) → confirm bands appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)