### PR TITLE
fix: validateBandsData crashes on optional-venue bands (production)

### DIFF
--- a/frontend/src/utils/validation.js
+++ b/frontend/src/utils/validation.js
@@ -222,17 +222,8 @@ export function validateBandsData(data) {
     if (!band.name || typeof band.name !== 'string') {
       return { valid: false, error: 'Each band must have a name string' }
     }
-    if (!band.venue || typeof band.venue !== 'string') {
-      return { valid: false, error: 'Each band must have a venue string' }
-    }
     if (!band.date || typeof band.date !== 'string') {
       return { valid: false, error: 'Each band must have a date string' }
-    }
-    if (!band.startTime || typeof band.startTime !== 'string') {
-      return { valid: false, error: 'Each band must have a startTime string' }
-    }
-    if (!band.endTime || typeof band.endTime !== 'string') {
-      return { valid: false, error: 'Each band must have an endTime string' }
     }
   }
 


### PR DESCRIPTION
## Summary

- Production crash at `/event/lwbc16` (and any event with optional-venue or TBD-time bands)
- `validateBandsData` still required `venue`, `startTime`, and `endTime` on every band after PR #229 made these fields optional
- Removed the three now-invalid checks; only `name` and `date` are truly required

## Root cause

PR #229 made venue and time optional in the admin lineup editor and DB schema, but `validateBandsData` in `frontend/src/utils/validation.js` was not updated to match. Any event with at least one null-venue or TBD-time band would throw an error caught by the `ErrorBoundary`, showing "Each band must have a venue string" to users instead of the schedule.

## Test plan

- [ ] Visit `settimes.ca/event/lwbc16` — schedule should load
- [ ] Verify bands with null venue still display (showing no venue text)
- [ ] Verify existing events with full venue/time data still load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)