### PR TITLE
feat: server-side schedule sharing with OG previews (/s/[slug])

### DIFF
--- a/_routes.json
+++ b/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/api/*"],
+  "include": ["/api/*", "/s/*"],
   "exclude": []
 }

--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -397,6 +397,20 @@ CREATE TABLE IF NOT EXISTS rate_limits (
 );
 CREATE INDEX IF NOT EXISTS idx_rate_limits_updated_at ON rate_limits (updated_at);
 
+-- Schedule share link snapshots (server-side /s/[slug] sharing)
+CREATE TABLE IF NOT EXISTS share_links (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug            TEXT    NOT NULL UNIQUE,
+  event_id        INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  event_slug      TEXT    NOT NULL,
+  performance_ids TEXT    NOT NULL,
+  band_names      TEXT    NOT NULL,
+  created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+  expires_at      TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_share_links_slug ON share_links(slug);
+CREATE INDEX IF NOT EXISTS idx_share_links_expires_at ON share_links(expires_at);
+
 -- ============================================
 -- TEST ACCOUNTS (passwords set by scripts/setup-local-db.sh)
 -- ============================================

--- a/frontend/public/_routes.json
+++ b/frontend/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/api/*", "/sitemap.xml"],
+  "include": ["/api/*", "/s/*", "/sitemap.xml"],
   "exclude": ["/", "/admin/*", "/band/*", "/event/*", "/privacy", "/assets/*", "/favicon.ico", "/favicon.svg", "/favicon-*.png", "/apple-touch-icon.png", "/android-chrome-*.png", "/manifest.json", "/robots.txt", "/sw.js", "/offline.html"]
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -453,18 +453,18 @@ function App() {
     fetch(`/api/schedule/share/${encodeURIComponent(shareSlug)}`)
       .then(res => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then(data => {
-        const matchedIds = bands
-          .filter(band => {
-            const parts = band.id.split('-')
-            const perfId = Number(parts[parts.length - 1])
-            return data.performance_ids.includes(perfId)
-          })
-          .map(band => band.id)
+        const matchedBands = bands.filter(band => {
+          const parts = band.id.split('-')
+          const perfId = Number(parts[parts.length - 1])
+          return data.performance_ids.includes(perfId)
+        })
+        const matchedIds = matchedBands.map(band => band.id)
+        const matchedNames = matchedBands.map(band => band.name || '')
 
         if (matchedIds.length === 0) return
 
         setPendingSharedBands(matchedIds)
-        setPendingSharedBandNames(data.band_names)
+        setPendingSharedBandNames(matchedNames)
         setSharedScheduleConfirmOpen(true)
       })
       .catch(err => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -451,7 +451,7 @@ function App() {
     )
 
     fetch(`/api/schedule/share/${encodeURIComponent(shareSlug)}`)
-      .then(res => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then(res => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then(data => {
         const matchedIds = bands
           .filter(band => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -167,6 +167,7 @@ function App() {
   const [clearConfirmOpen, setClearConfirmOpen] = useState(false)
   const [sharedScheduleConfirmOpen, setSharedScheduleConfirmOpen] = useState(false)
   const [pendingSharedBands, setPendingSharedBands] = useState([])
+  const [pendingSharedBandNames, setPendingSharedBandNames] = useState([])
   const [lastClearedBands, setLastClearedBands] = useState([])
   const [scheduleToast, setScheduleToast] = useState(null)
   const scheduleToastTimeoutRef = useRef(null)
@@ -436,6 +437,41 @@ function App() {
     }
   }, [bands, searchParams, setSearchParams, showScheduleToast, slug, trackScheduleBuilds])
 
+  useEffect(() => {
+    const shareSlug = searchParams.get('share')
+    if (!shareSlug || bands.length === 0) return
+
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev)
+        next.delete('share')
+        return next
+      },
+      { replace: true }
+    )
+
+    fetch(`/api/schedule/share/${encodeURIComponent(shareSlug)}`)
+      .then(res => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then(data => {
+        const matchedIds = bands
+          .filter(band => {
+            const parts = band.id.split('-')
+            const perfId = Number(parts[parts.length - 1])
+            return data.performance_ids.includes(perfId)
+          })
+          .map(band => band.id)
+
+        if (matchedIds.length === 0) return
+
+        setPendingSharedBands(matchedIds)
+        setPendingSharedBandNames(data.band_names)
+        setSharedScheduleConfirmOpen(true)
+      })
+      .catch(err => {
+        console.warn('[App] Failed to load share link', err)
+      })
+  }, [bands, searchParams, setSearchParams])
+
   const dismissHint = () => {
     setShowHint(false)
     localStorage.setItem(HINT_DISMISSED_KEY, '1')
@@ -457,6 +493,7 @@ function App() {
     setSelectedBands(nextSelectedBands)
     setView('mine')
     setPendingSharedBands([])
+    setPendingSharedBandNames([])
     showScheduleToast({
       type: 'success',
       message:
@@ -774,6 +811,7 @@ function App() {
               nowOverride={debugTime}
               onBrowseAll={() => setView('all')}
               eventSlug={slug || eventData?.slug}
+              eventId={eventData?.id}
             />
           </Suspense>
         )}
@@ -794,6 +832,7 @@ function App() {
         onClose={() => {
           setSharedScheduleConfirmOpen(false)
           setPendingSharedBands([])
+          setPendingSharedBandNames([])
         }}
         title="Load Shared Route"
         size="sm"
@@ -804,6 +843,7 @@ function App() {
               onClick={() => {
                 setSharedScheduleConfirmOpen(false)
                 setPendingSharedBands([])
+                setPendingSharedBandNames([])
               }}
               className="min-h-[44px] rounded-lg border border-white/15 px-4 py-2 text-white/80 transition-colors hover:bg-white/10"
             >
@@ -846,6 +886,16 @@ function App() {
             <span className="font-semibold text-white">Merge</span> keeps your current route and adds only the new
             shared stops. <span className="font-semibold text-white">Replace</span> swaps your route for the shared one.
           </p>
+          {pendingSharedBandNames.length > 0 && (
+            <ul className="space-y-1 rounded-lg border border-white/10 bg-white/5 p-3 text-sm text-white/80 list-none">
+              {pendingSharedBandNames.slice(0, 5).map((name, i) => (
+                <li key={i}>{name}</li>
+              ))}
+              {pendingSharedBandNames.length > 5 && (
+                <li className="text-white/50">and {pendingSharedBandNames.length - 5} more…</li>
+              )}
+            </ul>
+          )}
         </div>
       </Modal>
       <ConfirmDialog

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -34,6 +34,7 @@ function MySchedule({
   nowOverride,
   onBrowseAll,
   eventSlug,
+  eventId,
 }) {
   const [currentTime, setCurrentTime] = useState(() => (nowOverride ? new Date(nowOverride) : new Date()))
   const [copyButtonLabel, setCopyButtonLabel] = useState('Copy Schedule')
@@ -328,15 +329,43 @@ function MySchedule({
     const performanceIds = bands
       .map(band => {
         const parts = band.id.split('-')
-        return parts[parts.length - 1]
+        return parseInt(parts[parts.length - 1], 10)
       })
-      .filter(id => /^\d+$/.test(id))
-      .join(',')
+      .filter(id => Number.isFinite(id) && id > 0)
 
-    if (!performanceIds) return
+    if (performanceIds.length === 0) return
 
-    const url = `${window.location.origin}${window.location.pathname}?s=${performanceIds}`
-    const success = await copyToClipboard(url)
+    const bandNames = bands.map(band => band.name || '')
+
+    try {
+      const res = await fetch('/api/schedule/share', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          event_id: eventId,
+          event_slug: eventSlug,
+          performance_ids: performanceIds,
+          band_names: bandNames,
+        }),
+      })
+
+      if (res.ok) {
+        const { slug } = await res.json()
+        const url = `${window.location.origin}/s/${slug}`
+        const success = await copyToClipboard(url)
+        if (success) {
+          setShareButtonLabel('Link Copied!')
+          setTimeout(() => setShareButtonLabel('Share Schedule'), 2000)
+        }
+        return
+      }
+    } catch (_err) {
+      // fall through to legacy ?s= URL
+    }
+
+    const legacyIds = performanceIds.join(',')
+    const fallbackUrl = `${window.location.origin}${window.location.pathname}?s=${legacyIds}`
+    const success = await copyToClipboard(fallbackUrl)
     if (success) {
       setShareButtonLabel('Link Copied!')
       setTimeout(() => setShareButtonLabel('Share Schedule'), 2000)

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -326,16 +326,20 @@ function MySchedule({
   }
 
   const handleShareSchedule = async () => {
-    const performanceIds = bands
-      .map(band => {
+    const { performanceIds, bandNames } = bands.reduce(
+      (acc, band) => {
         const parts = band.id.split('-')
-        return parseInt(parts[parts.length - 1], 10)
-      })
-      .filter(id => Number.isFinite(id) && id > 0)
+        const id = parseInt(parts[parts.length - 1], 10)
+        if (Number.isFinite(id) && id > 0) {
+          acc.performanceIds.push(id)
+          acc.bandNames.push(band.name || '')
+        }
+        return acc
+      },
+      { performanceIds: [], bandNames: [] }
+    )
 
     if (performanceIds.length === 0) return
-
-    const bandNames = bands.map(band => band.name || '')
 
     try {
       const res = await fetch('/api/schedule/share', {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -18,6 +18,7 @@ import './index.css'
 const AdminApp = lazy(() => import('./admin/AdminApp.jsx'))
 const BandProfilePage = lazy(() => import('./pages/BandProfilePage.jsx'))
 const EventRecapPage = lazy(() => import('./pages/EventRecapPage.jsx'))
+const SharePreviewPage = lazy(() => import('./pages/SharePreviewPage.jsx'))
 
 const hostname = typeof window !== 'undefined' ? window.location.hostname || '' : ''
 const isPreviewBuild = hostname.startsWith('dev.') || hostname.endsWith('.pages.dev')
@@ -100,6 +101,18 @@ ReactDOM.createRoot(document.getElementById('root')).render(
                 <ErrorBoundary title="Band Profile Error" message="Unable to load band profile. Please try again.">
                   <Suspense fallback={<LoadingFallback />}>
                     <BandProfilePage />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
+
+            {/* Share preview: Lazy loaded */}
+            <Route
+              path="/s/:slug"
+              element={
+                <ErrorBoundary title="Share Preview Error" message="Unable to load this shared route.">
+                  <Suspense fallback={<LoadingFallback />}>
+                    <SharePreviewPage />
                   </Suspense>
                 </ErrorBoundary>
               }

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -15,15 +15,25 @@ export default function SharePreviewPage() {
 
   useEffect(() => {
     let cancelled = false
+    setLoading(true)
+    setNotFound(false)
+    setError(false)
+    setShareData(null)
     fetchPublicJson(`/api/schedule/share/${encodeURIComponent(slug)}`)
-      .then(data => { if (!cancelled) setShareData(data) })
+      .then(data => {
+        if (!cancelled) setShareData(data)
+      })
       .catch(err => {
         if (cancelled) return
         if (err.status === 404) setNotFound(true)
         else setError(true)
       })
-      .finally(() => { if (!cancelled) setLoading(false) })
-    return () => { cancelled = true }
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [slug])
 
   const handleImport = () => {
@@ -85,18 +95,13 @@ export default function SharePreviewPage() {
         </Link>
 
         <div className="mb-6">
-          <h1 className="text-2xl font-bold text-white">
-            {shareData.band_names.length}-stop route
-          </h1>
+          <h1 className="text-2xl font-bold text-white">{shareData.band_names.length}-stop route</h1>
           <p className="mt-1 text-text-secondary">{shareData.event_name}</p>
         </div>
 
         <ul aria-label="Bands in this route" className="mb-8 list-none space-y-3 p-0">
           {shareData.band_names.map((name, i) => (
-            <li
-              key={i}
-              className="rounded-xl border border-white/10 bg-white/5 px-4 py-3"
-            >
+            <li key={i} className="rounded-xl border border-white/10 bg-white/5 px-4 py-3">
               <p className="font-semibold text-white">{name}</p>
             </li>
           ))}
@@ -107,7 +112,8 @@ export default function SharePreviewPage() {
           onClick={handleImport}
           className="w-full min-h-[48px] rounded-xl bg-accent-500 px-6 py-3 font-semibold text-bg-navy transition-colors hover:brightness-110"
         >
-          Add {shareData.band_names.length} stop{shareData.band_names.length !== 1 ? 's' : ''} to my route for {shareData.event_name}
+          Add {shareData.band_names.length} stop{shareData.band_names.length !== 1 ? 's' : ''} to my route for{' '}
+          {shareData.event_name}
         </button>
       </div>
     </div>

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -2,7 +2,7 @@ import { ArrowLeft } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { BandCardSkeleton } from '../components/ui'
+import { Alert, BandCardSkeleton } from '../components/ui'
 import { fetchPublicJson } from '../utils/publicApi'
 
 export default function SharePreviewPage() {
@@ -11,14 +11,19 @@ export default function SharePreviewPage() {
   const [shareData, setShareData] = useState(null)
   const [loading, setLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
+  const [error, setError] = useState(false)
 
   useEffect(() => {
+    let cancelled = false
     fetchPublicJson(`/api/schedule/share/${encodeURIComponent(slug)}`)
-      .then(setShareData)
+      .then(data => { if (!cancelled) setShareData(data) })
       .catch(err => {
+        if (cancelled) return
         if (err.status === 404) setNotFound(true)
+        else setError(true)
       })
-      .finally(() => setLoading(false))
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
   }, [slug])
 
   const handleImport = () => {
@@ -41,13 +46,24 @@ export default function SharePreviewPage() {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center bg-linear-to-br from-bg-navy to-bg-purple px-4 text-center">
         <Helmet>
-          <title>Route Not Found | SetTimes</title>
+          <title>Shared Route Not Found | SetTimes</title>
         </Helmet>
         <p className="text-2xl font-semibold text-white">This route has expired or doesn&apos;t exist.</p>
         <p className="mt-2 text-text-secondary">Share links are valid for 30 days.</p>
         <Link to="/" className="mt-6 text-accent-400 hover:underline">
           Browse events
         </Link>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple p-6">
+        <Helmet>
+          <title>Error | SetTimes</title>
+        </Helmet>
+        <Alert variant="error">Unable to load this shared route. Please try again later.</Alert>
       </div>
     )
   }
@@ -74,16 +90,16 @@ export default function SharePreviewPage() {
           <p className="mt-1 text-text-secondary">{shareData.event_name}</p>
         </div>
 
-        <div className="mb-8 space-y-3">
+        <ul aria-label="Bands in this route" className="mb-8 list-none space-y-3 p-0">
           {shareData.band_names.map((name, i) => (
-            <div
+            <li
               key={i}
               className="rounded-xl border border-white/10 bg-white/5 px-4 py-3"
             >
               <p className="font-semibold text-white">{name}</p>
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
 
         <button
           type="button"

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -27,6 +27,7 @@ export default function SharePreviewPage() {
   }, [slug])
 
   const handleImport = () => {
+    if (!shareData) return
     navigate(`/event/${shareData.event_slug}?share=${slug}`)
   }
 

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -1,0 +1,98 @@
+import { ArrowLeft } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Helmet } from 'react-helmet-async'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { BandCardSkeleton } from '../components/ui'
+import { fetchPublicJson } from '../utils/publicApi'
+
+export default function SharePreviewPage() {
+  const { slug } = useParams()
+  const navigate = useNavigate()
+  const [shareData, setShareData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+
+  useEffect(() => {
+    fetchPublicJson(`/api/schedule/share/${encodeURIComponent(slug)}`)
+      .then(setShareData)
+      .catch(err => {
+        if (err.status === 404) setNotFound(true)
+      })
+      .finally(() => setLoading(false))
+  }, [slug])
+
+  const handleImport = () => {
+    navigate(`/event/${shareData.event_slug}?share=${slug}`)
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple px-4 py-8">
+        <div className="mx-auto max-w-2xl space-y-4">
+          {Array.from({ length: 4 }, (_, i) => (
+            <BandCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (notFound) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-linear-to-br from-bg-navy to-bg-purple px-4 text-center">
+        <Helmet>
+          <title>Route Not Found | SetTimes</title>
+        </Helmet>
+        <p className="text-2xl font-semibold text-white">This route has expired or doesn&apos;t exist.</p>
+        <p className="mt-2 text-text-secondary">Share links are valid for 30 days.</p>
+        <Link to="/" className="mt-6 text-accent-400 hover:underline">
+          Browse events
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple">
+      <Helmet>
+        <title>Shared Route — {shareData.event_name} | SetTimes</title>
+      </Helmet>
+
+      <div className="mx-auto max-w-2xl px-4 py-8">
+        <Link
+          to={`/event/${shareData.event_slug}`}
+          className="mb-6 inline-flex items-center gap-1 text-sm text-text-secondary hover:text-white"
+        >
+          <ArrowLeft size={14} />
+          Back to {shareData.event_name}
+        </Link>
+
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-white">
+            {shareData.band_names.length}-stop route
+          </h1>
+          <p className="mt-1 text-text-secondary">{shareData.event_name}</p>
+        </div>
+
+        <div className="mb-8 space-y-3">
+          {shareData.band_names.map((name, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-white/10 bg-white/5 px-4 py-3"
+            >
+              <p className="font-semibold text-white">{name}</p>
+            </div>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={handleImport}
+          className="w-full min-h-[48px] rounded-xl bg-accent-500 px-6 py-3 font-semibold text-bg-navy transition-colors hover:brightness-110"
+        >
+          Add {shareData.band_names.length} stop{shareData.band_names.length !== 1 ? 's' : ''} to my route for {shareData.event_name}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/functions/_scheduled.js
+++ b/functions/_scheduled.js
@@ -1,5 +1,7 @@
-import { scheduled as aggregateStats } from "./scheduled/aggregate-stats.js";
+import { scheduled as aggregateStats } from './scheduled/aggregate-stats.js'
+import { expireShareLinks } from './scheduled/expire-share-links.js'
 
 export async function scheduled(event, env, ctx) {
-  return aggregateStats(event, env, ctx);
+  await aggregateStats(event, env, ctx)
+  await expireShareLinks(event, env, ctx)
 }

--- a/functions/api/schedule/__tests__/share-create.test.js
+++ b/functions/api/schedule/__tests__/share-create.test.js
@@ -131,4 +131,13 @@ describe('POST /api/schedule/share', () => {
     })
     expect(res.status).toBe(404)
   })
+
+  test('rejects null event_id', async () => {
+    const { env } = createTestEnv()
+    const res = await onRequestPost({
+      request: makeRequest({ event_id: null, event_slug: 'e', performance_ids: [1], band_names: ['B'] }),
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
 })

--- a/functions/api/schedule/__tests__/share-create.test.js
+++ b/functions/api/schedule/__tests__/share-create.test.js
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'vitest'
+import { onRequestPost } from '../share.js'
+import { createTestEnv, insertEvent, insertBand, insertVenue } from '../../test-utils.js'
+
+describe('POST /api/schedule/share', () => {
+  function makeRequest(body) {
+    return new Request('https://example.test/api/schedule/share', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  test('creates a share link and returns a slug', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { slug: 'my-event' })
+    rawDb.prepare('UPDATE events SET is_published = 1 WHERE id = ?').run(event.id)
+    const venue = insertVenue(rawDb)
+    const perf = insertBand(rawDb, { event_id: event.id, venue_id: venue.id })
+
+    const res = await onRequestPost({
+      request: makeRequest({
+        event_id: event.id,
+        event_slug: 'my-event',
+        performance_ids: [perf.id],
+        band_names: [perf.name],
+      }),
+      env,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.slug).toMatch(/^[a-zA-Z0-9]{8}$/)
+
+    const row = rawDb.prepare('SELECT * FROM share_links WHERE slug = ?').get(body.slug)
+    expect(row).not.toBeNull()
+    expect(JSON.parse(row.performance_ids)).toEqual([perf.id])
+    expect(JSON.parse(row.band_names)).toEqual([perf.name])
+    expect(row.event_slug).toBe('my-event')
+  })
+
+  test('rejects missing event_id', async () => {
+    const { env } = createTestEnv()
+    const res = await onRequestPost({
+      request: makeRequest({ event_slug: 'e', performance_ids: [1], band_names: ['B'] }),
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test('rejects invalid event_slug characters', async () => {
+    const { env } = createTestEnv()
+    const res = await onRequestPost({
+      request: makeRequest({
+        event_id: 1,
+        event_slug: '<script>',
+        performance_ids: [1],
+        band_names: ['B'],
+      }),
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test('rejects empty performance_ids', async () => {
+    const { env } = createTestEnv()
+    const res = await onRequestPost({
+      request: makeRequest({
+        event_id: 1,
+        event_slug: 'e',
+        performance_ids: [],
+        band_names: [],
+      }),
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test('rejects performance_ids exceeding 50', async () => {
+    const { env } = createTestEnv()
+    const res = await onRequestPost({
+      request: makeRequest({
+        event_id: 1,
+        event_slug: 'e',
+        performance_ids: Array.from({ length: 51 }, (_, i) => i + 1),
+        band_names: Array.from({ length: 51 }, (_, i) => `Band ${i}`),
+      }),
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test('rejects mismatched band_names length', async () => {
+    const { env } = createTestEnv()
+    const res = await onRequestPost({
+      request: makeRequest({
+        event_id: 1,
+        event_slug: 'e',
+        performance_ids: [1, 2],
+        band_names: ['Only One'],
+      }),
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test('rejects band name exceeding 100 chars', async () => {
+    const { env } = createTestEnv()
+    const res = await onRequestPost({
+      request: makeRequest({
+        event_id: 1,
+        event_slug: 'e',
+        performance_ids: [1],
+        band_names: ['x'.repeat(101)],
+      }),
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test('returns 404 for unknown event_id', async () => {
+    const { env } = createTestEnv()
+    const res = await onRequestPost({
+      request: makeRequest({
+        event_id: 9999,
+        event_slug: 'ghost',
+        performance_ids: [1],
+        band_names: ['B'],
+      }),
+      env,
+    })
+    expect(res.status).toBe(404)
+  })
+})

--- a/functions/api/schedule/__tests__/share-get.test.js
+++ b/functions/api/schedule/__tests__/share-get.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest'
+import { onRequestGet } from '../share/[slug].js'
+import { createTestEnv, insertEvent, insertShareLink } from '../../test-utils.js'
+
+describe('GET /api/schedule/share/[slug]', () => {
+  function makeRequest(slug) {
+    return new Request(`https://example.test/api/schedule/share/${slug}`)
+  }
+
+  test('returns share link data for a valid slug', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'My Fest', slug: 'my-fest' })
+    insertShareLink(rawDb, {
+      slug: 'abc12345',
+      event_id: event.id,
+      event_slug: 'my-fest',
+      performance_ids: [10, 20],
+      band_names: ['Band A', 'Band B'],
+    })
+
+    const res = await onRequestGet({
+      request: makeRequest('abc12345'),
+      params: { slug: 'abc12345' },
+      env,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.slug).toBe('abc12345')
+    expect(body.event_slug).toBe('my-fest')
+    expect(body.event_name).toBe('My Fest')
+    expect(body.performance_ids).toEqual([10, 20])
+    expect(body.band_names).toEqual(['Band A', 'Band B'])
+  })
+
+  test('returns 404 for unknown slug', async () => {
+    const { env } = createTestEnv()
+    const res = await onRequestGet({
+      request: makeRequest('notfound'),
+      params: { slug: 'notfound' },
+      env,
+    })
+    expect(res.status).toBe(404)
+  })
+
+  test('returns 404 for expired slug', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb)
+    insertShareLink(rawDb, {
+      slug: 'expired1',
+      event_id: event.id,
+      performance_ids: [1],
+      band_names: ['B'],
+      expires_at: '2000-01-01 00:00:00',
+    })
+
+    const res = await onRequestGet({
+      request: makeRequest('expired1'),
+      params: { slug: 'expired1' },
+      env,
+    })
+    expect(res.status).toBe(404)
+  })
+
+  test('returns 400 for invalid slug format', async () => {
+    const { env } = createTestEnv()
+    const res = await onRequestGet({
+      request: makeRequest('../etc/passwd'),
+      params: { slug: '../etc/passwd' },
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+})

--- a/functions/api/schedule/__tests__/share-get.test.js
+++ b/functions/api/schedule/__tests__/share-get.test.js
@@ -10,6 +10,7 @@ describe('GET /api/schedule/share/[slug]', () => {
   test('returns share link data for a valid slug', async () => {
     const { env, rawDb } = createTestEnv()
     const event = insertEvent(rawDb, { name: 'My Fest', slug: 'my-fest' })
+    rawDb.prepare('UPDATE events SET is_published = 1 WHERE id = ?').run(event.id)
     insertShareLink(rawDb, {
       slug: 'abc12345',
       event_id: event.id,

--- a/functions/api/schedule/share.js
+++ b/functions/api/schedule/share.js
@@ -19,69 +19,74 @@ function json(body, status = 200) {
 }
 
 export async function onRequestPost(context) {
-  const { request, env } = context
-  const { DB } = env
+  try {
+    const { request, env } = context
+    const { DB } = env
 
-  const body = await request.json().catch(() => ({}))
-  const { event_id, event_slug, performance_ids, band_names } = body
+    const body = await request.json().catch(() => ({}))
+    const { event_id, event_slug, performance_ids, band_names } = body
 
-  if (!Number.isFinite(Number(event_id))) {
-    return json({ error: 'Invalid event_id' }, 400)
-  }
-
-  if (typeof event_slug !== 'string' || !/^[a-z0-9-]+$/.test(event_slug)) {
-    return json({ error: 'Invalid event_slug' }, 400)
-  }
-
-  if (
-    !Array.isArray(performance_ids) ||
-    performance_ids.length === 0 ||
-    performance_ids.length > MAX_PERFORMANCE_IDS
-  ) {
-    return json(
-      { error: `performance_ids must be a non-empty array of up to ${MAX_PERFORMANCE_IDS} integers` },
-      400
-    )
-  }
-
-  if (!Array.isArray(band_names) || band_names.length !== performance_ids.length) {
-    return json({ error: 'band_names must be an array matching performance_ids length' }, 400)
-  }
-
-  const ids = performance_ids.map(Number)
-  if (ids.some(id => !Number.isFinite(id) || id <= 0)) {
-    return json({ error: 'All performance_ids must be positive integers' }, 400)
-  }
-
-  const names = band_names.map(String)
-  if (names.some(n => n.length > MAX_BAND_NAME_LENGTH)) {
-    return json({ error: `Band names must not exceed ${MAX_BAND_NAME_LENGTH} characters` }, 400)
-  }
-
-  const event = await DB.prepare('SELECT id FROM events WHERE id = ?')
-    .bind(Number(event_id))
-    .first()
-  if (!event) {
-    return json({ error: 'Event not found' }, 404)
-  }
-
-  const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .replace('T', ' ')
-    .replace(/\.\d+Z$/, '')
-
-  for (let attempt = 0; attempt < 2; attempt++) {
-    const slug = generateSlug()
-    try {
-      await DB.prepare(
-        `INSERT INTO share_links (slug, event_id, event_slug, performance_ids, band_names, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?)`
-      )
-        .bind(slug, Number(event_id), event_slug, JSON.stringify(ids), JSON.stringify(names), expiresAt)
-        .run()
-      return json({ slug })
-    } catch (err) {
-      if (attempt === 1 || !String(err).includes('UNIQUE')) throw err
+    if (typeof event_id !== 'number' || !Number.isFinite(event_id)) {
+      return json({ error: 'Invalid event_id' }, 400)
     }
+
+    if (typeof event_slug !== 'string' || !/^[a-z0-9-]+$/.test(event_slug)) {
+      return json({ error: 'Invalid event_slug' }, 400)
+    }
+
+    if (
+      !Array.isArray(performance_ids) ||
+      performance_ids.length === 0 ||
+      performance_ids.length > MAX_PERFORMANCE_IDS
+    ) {
+      return json(
+        { error: `performance_ids must be a non-empty array of up to ${MAX_PERFORMANCE_IDS} integers` },
+        400
+      )
+    }
+
+    if (!Array.isArray(band_names) || band_names.length !== performance_ids.length) {
+      return json({ error: 'band_names must be an array matching performance_ids length' }, 400)
+    }
+
+    const ids = performance_ids.map(Number)
+    if (ids.some(id => !Number.isFinite(id) || id <= 0)) {
+      return json({ error: 'All performance_ids must be positive integers' }, 400)
+    }
+
+    const names = band_names.map(String)
+    if (names.some(n => n.length > MAX_BAND_NAME_LENGTH)) {
+      return json({ error: `Band names must not exceed ${MAX_BAND_NAME_LENGTH} characters` }, 400)
+    }
+
+    const event = await DB.prepare('SELECT id FROM events WHERE id = ?')
+      .bind(Number(event_id))
+      .first()
+    if (!event) {
+      return json({ error: 'Event not found' }, 404)
+    }
+
+    const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .replace('T', ' ')
+      .replace(/\.\d+Z$/, '')
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const slug = generateSlug()
+      try {
+        await DB.prepare(
+          `INSERT INTO share_links (slug, event_id, event_slug, performance_ids, band_names, expires_at)
+           VALUES (?, ?, ?, ?, ?, ?)`
+        )
+          .bind(slug, Number(event_id), event_slug, JSON.stringify(ids), JSON.stringify(names), expiresAt)
+          .run()
+        return json({ slug })
+      } catch (err) {
+        if (attempt === 1 || !String(err).includes('UNIQUE')) throw err
+      }
+    }
+  } catch (error) {
+    console.error('Schedule share error:', error)
+    return json({ error: 'Failed to create share link' }, 500)
   }
 }

--- a/functions/api/schedule/share.js
+++ b/functions/api/schedule/share.js
@@ -1,0 +1,87 @@
+// Public API: Create a schedule share link
+// POST /api/schedule/share
+// Body: { event_id, event_slug, performance_ids[], band_names[] }
+
+const MAX_PERFORMANCE_IDS = 50
+const MAX_BAND_NAME_LENGTH = 100
+const SLUG_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+
+function generateSlug(length = 8) {
+  const bytes = crypto.getRandomValues(new Uint8Array(length))
+  return Array.from(bytes, b => SLUG_CHARS[b % SLUG_CHARS.length]).join('')
+}
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export async function onRequestPost(context) {
+  const { request, env } = context
+  const { DB } = env
+
+  const body = await request.json().catch(() => ({}))
+  const { event_id, event_slug, performance_ids, band_names } = body
+
+  if (!Number.isFinite(Number(event_id))) {
+    return json({ error: 'Invalid event_id' }, 400)
+  }
+
+  if (typeof event_slug !== 'string' || !/^[a-z0-9-]+$/.test(event_slug)) {
+    return json({ error: 'Invalid event_slug' }, 400)
+  }
+
+  if (
+    !Array.isArray(performance_ids) ||
+    performance_ids.length === 0 ||
+    performance_ids.length > MAX_PERFORMANCE_IDS
+  ) {
+    return json(
+      { error: `performance_ids must be a non-empty array of up to ${MAX_PERFORMANCE_IDS} integers` },
+      400
+    )
+  }
+
+  if (!Array.isArray(band_names) || band_names.length !== performance_ids.length) {
+    return json({ error: 'band_names must be an array matching performance_ids length' }, 400)
+  }
+
+  const ids = performance_ids.map(Number)
+  if (ids.some(id => !Number.isFinite(id) || id <= 0)) {
+    return json({ error: 'All performance_ids must be positive integers' }, 400)
+  }
+
+  const names = band_names.map(String)
+  if (names.some(n => n.length > MAX_BAND_NAME_LENGTH)) {
+    return json({ error: `Band names must not exceed ${MAX_BAND_NAME_LENGTH} characters` }, 400)
+  }
+
+  const event = await DB.prepare('SELECT id FROM events WHERE id = ?')
+    .bind(Number(event_id))
+    .first()
+  if (!event) {
+    return json({ error: 'Event not found' }, 404)
+  }
+
+  const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .replace('T', ' ')
+    .replace(/\.\d+Z$/, '')
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const slug = generateSlug()
+    try {
+      await DB.prepare(
+        `INSERT INTO share_links (slug, event_id, event_slug, performance_ids, band_names, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      )
+        .bind(slug, Number(event_id), event_slug, JSON.stringify(ids), JSON.stringify(names), expiresAt)
+        .run()
+      return json({ slug })
+    } catch (err) {
+      if (attempt === 1 || !String(err).includes('UNIQUE')) throw err
+    }
+  }
+}

--- a/functions/api/schedule/share.js
+++ b/functions/api/schedule/share.js
@@ -59,7 +59,9 @@ export async function onRequestPost(context) {
       return json({ error: `Band names must not exceed ${MAX_BAND_NAME_LENGTH} characters` }, 400)
     }
 
-    const event = await DB.prepare('SELECT id FROM events WHERE id = ?')
+    const event = await DB.prepare(
+      `SELECT id FROM events WHERE id = ? AND (is_published = 1 OR status = 'archived')`
+    )
       .bind(Number(event_id))
       .first()
     if (!event) {

--- a/functions/api/schedule/share/[slug].js
+++ b/functions/api/schedule/share/[slug].js
@@ -18,6 +18,8 @@ export async function onRequestGet(context) {
   }
 
   try {
+    // ON DELETE CASCADE on event_id means a deleted event also removes its share_links rows,
+    // so a missing event naturally produces a 404 via the INNER JOIN returning no row.
     const row = await DB.prepare(
       `SELECT sl.slug, sl.event_slug, sl.performance_ids, sl.band_names, e.name AS event_name
        FROM share_links sl
@@ -31,12 +33,21 @@ export async function onRequestGet(context) {
       return json({ error: 'Share link not found or expired' }, 404)
     }
 
+    let performance_ids, band_names
+    try {
+      performance_ids = JSON.parse(row.performance_ids)
+      band_names = JSON.parse(row.band_names)
+    } catch (_err) {
+      console.error('Share link data is corrupted:', row.slug)
+      return json({ error: 'Share link data is corrupted' }, 500)
+    }
+
     return json({
       slug: row.slug,
       event_slug: row.event_slug,
       event_name: row.event_name,
-      performance_ids: JSON.parse(row.performance_ids),
-      band_names: JSON.parse(row.band_names),
+      performance_ids,
+      band_names,
     })
   } catch (err) {
     console.error('Share link fetch error:', err)

--- a/functions/api/schedule/share/[slug].js
+++ b/functions/api/schedule/share/[slug].js
@@ -23,7 +23,7 @@ export async function onRequestGet(context) {
     const row = await DB.prepare(
       `SELECT sl.slug, sl.event_slug, sl.performance_ids, sl.band_names, e.name AS event_name
        FROM share_links sl
-       JOIN events e ON e.id = sl.event_id
+       JOIN events e ON e.id = sl.event_id AND (e.is_published = 1 OR e.status = 'archived')
        WHERE sl.slug = ? AND sl.expires_at > datetime('now')`
     )
       .bind(slug)

--- a/functions/api/schedule/share/[slug].js
+++ b/functions/api/schedule/share/[slug].js
@@ -1,0 +1,45 @@
+// Public API: Fetch a schedule share link snapshot
+// GET /api/schedule/share/[slug]
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export async function onRequestGet(context) {
+  const { params, env } = context
+  const { DB } = env
+  const { slug } = params
+
+  if (!slug || !/^[a-zA-Z0-9]{1,16}$/.test(slug)) {
+    return json({ error: 'Invalid slug' }, 400)
+  }
+
+  try {
+    const row = await DB.prepare(
+      `SELECT sl.slug, sl.event_slug, sl.performance_ids, sl.band_names, e.name AS event_name
+       FROM share_links sl
+       JOIN events e ON e.id = sl.event_id
+       WHERE sl.slug = ? AND sl.expires_at > datetime('now')`
+    )
+      .bind(slug)
+      .first()
+
+    if (!row) {
+      return json({ error: 'Share link not found or expired' }, 404)
+    }
+
+    return json({
+      slug: row.slug,
+      event_slug: row.event_slug,
+      event_name: row.event_name,
+      performance_ids: JSON.parse(row.performance_ids),
+      band_names: JSON.parse(row.band_names),
+    })
+  } catch (err) {
+    console.error('Share link fetch error:', err)
+    return json({ error: 'Failed to fetch share link' }, 500)
+  }
+}

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -301,6 +301,17 @@ export function createTestDB() {
       window_start INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
+
+    CREATE TABLE share_links (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      slug            TEXT    NOT NULL UNIQUE,
+      event_id        INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+      event_slug      TEXT    NOT NULL,
+      performance_ids TEXT    NOT NULL,
+      band_names      TEXT    NOT NULL,
+      created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+      expires_at      TEXT    NOT NULL
+    );
   `);
 
   const insertUser = db.prepare(
@@ -578,4 +589,37 @@ export function createTestEnv({ role = 'editor' } = {}) {
       Authorization: `Bearer ${sessionId}`,
     },
   };
+}
+
+export function insertShareLink(
+  db,
+  {
+    slug = 'testslug',
+    event_id,
+    event_slug = 'test-event',
+    performance_ids = [1],
+    band_names = ['Test Band'],
+    expires_at = null,
+  } = {}
+) {
+  const expiresAt =
+    expires_at ??
+    new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .replace('T', ' ')
+      .replace(/\.\d+Z$/, '')
+
+  const stmt = db.prepare(
+    `INSERT INTO share_links (slug, event_id, event_slug, performance_ids, band_names, expires_at)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  )
+  const info = stmt.run(
+    slug,
+    event_id,
+    event_slug,
+    JSON.stringify(performance_ids),
+    JSON.stringify(band_names),
+    expiresAt
+  )
+  return db.prepare('SELECT * FROM share_links WHERE id = ?').get(info.lastInsertRowid)
 }

--- a/functions/s/[slug].js
+++ b/functions/s/[slug].js
@@ -37,15 +37,26 @@ export async function onRequest(context) {
     return env.ASSETS.fetch(request)
   }
 
-  const bandNames = JSON.parse(row.band_names)
+  let bandNames
+  try {
+    bandNames = JSON.parse(row.band_names)
+  } catch (_err) {
+    console.error('Share link band_names corrupted:', row.slug)
+    return env.ASSETS.fetch(request)
+  }
+
+  if (!Array.isArray(bandNames) || bandNames.length === 0) {
+    return env.ASSETS.fetch(request)
+  }
+
   const count = bandNames.length
   const ogTitle = `${count}-stop route for ${row.event_name}`
   const featured = bandNames.slice(0, 3).join(', ')
   const remainder = count > 3 ? ` and ${count - 3} more` : ''
   const ogDescription = `Featuring ${featured}${remainder}`
-  const ogUrl = `https://settimes.ca/s/${slug}`
 
   const origin = new URL(request.url).origin
+  const ogUrl = `${origin}/s/${slug}`
   const indexResponse = await env.ASSETS.fetch(new Request(`${origin}/`))
   const html = await indexResponse.text()
 

--- a/functions/s/[slug].js
+++ b/functions/s/[slug].js
@@ -58,6 +58,9 @@ export async function onRequest(context) {
   const origin = new URL(request.url).origin
   const ogUrl = `${origin}/s/${slug}`
   const indexResponse = await env.ASSETS.fetch(new Request(`${origin}/`))
+  if (!indexResponse.ok) {
+    return env.ASSETS.fetch(request)
+  }
   const html = await indexResponse.text()
 
   const metaTags = [
@@ -72,10 +75,10 @@ export async function onRequest(context) {
 
   const injected = html.replace('</head>', `    ${metaTags}\n  </head>`)
 
-  return new Response(injected, {
-    headers: {
-      'Content-Type': 'text/html;charset=UTF-8',
-      'Cache-Control': 'public, max-age=300',
-    },
-  })
+  // Preserve original headers (CSP, ETag, etc.) and override content-type and cache
+  const headers = new Headers(indexResponse.headers)
+  headers.set('Content-Type', 'text/html;charset=UTF-8')
+  headers.set('Cache-Control', 'public, max-age=300')
+
+  return new Response(injected, { headers })
 }

--- a/functions/s/[slug].js
+++ b/functions/s/[slug].js
@@ -1,0 +1,70 @@
+// CF Pages Function: serve /s/[slug] with OG meta tags injected into index.html.
+// Social crawlers (iMessage, WhatsApp, Twitter) hit this URL and need server-rendered
+// meta tags — React Helmet only runs client-side and crawlers won't see it.
+
+function escapeAttr(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+export async function onRequest(context) {
+  const { params, env, request } = context
+  const { slug } = params
+  const { DB } = env
+
+  if (!slug || !/^[a-zA-Z0-9]{1,16}$/.test(slug)) {
+    return env.ASSETS.fetch(request)
+  }
+
+  let row = null
+  try {
+    row = await DB.prepare(
+      `SELECT sl.slug, sl.band_names, e.name AS event_name
+       FROM share_links sl
+       JOIN events e ON e.id = sl.event_id
+       WHERE sl.slug = ? AND sl.expires_at > datetime('now')`
+    )
+      .bind(slug)
+      .first()
+  } catch (_err) {
+    return env.ASSETS.fetch(request)
+  }
+
+  if (!row) {
+    return env.ASSETS.fetch(request)
+  }
+
+  const bandNames = JSON.parse(row.band_names)
+  const count = bandNames.length
+  const ogTitle = `${count}-stop route for ${row.event_name}`
+  const featured = bandNames.slice(0, 3).join(', ')
+  const remainder = count > 3 ? ` and ${count - 3} more` : ''
+  const ogDescription = `Featuring ${featured}${remainder}`
+  const ogUrl = `https://settimes.ca/s/${slug}`
+
+  const origin = new URL(request.url).origin
+  const indexResponse = await env.ASSETS.fetch(new Request(`${origin}/`))
+  const html = await indexResponse.text()
+
+  const metaTags = [
+    `<meta property="og:title" content="${escapeAttr(ogTitle)}" />`,
+    `<meta property="og:description" content="${escapeAttr(ogDescription)}" />`,
+    `<meta property="og:url" content="${escapeAttr(ogUrl)}" />`,
+    `<meta property="og:type" content="website" />`,
+    `<meta name="twitter:card" content="summary" />`,
+    `<meta name="twitter:title" content="${escapeAttr(ogTitle)}" />`,
+    `<meta name="twitter:description" content="${escapeAttr(ogDescription)}" />`,
+  ].join('\n    ')
+
+  const injected = html.replace('</head>', `    ${metaTags}\n  </head>`)
+
+  return new Response(injected, {
+    headers: {
+      'Content-Type': 'text/html;charset=UTF-8',
+      'Cache-Control': 'public, max-age=300',
+    },
+  })
+}

--- a/functions/scheduled/expire-share-links.js
+++ b/functions/scheduled/expire-share-links.js
@@ -1,0 +1,10 @@
+export async function expireShareLinks(_event, env, _ctx) {
+  const { DB } = env
+  if (!DB) return
+
+  try {
+    await DB.prepare(`DELETE FROM share_links WHERE expires_at < datetime('now')`).run()
+  } catch (err) {
+    console.error('[scheduled] Failed to clean up expired share links', err)
+  }
+}

--- a/functions/utils/rateLimit.js
+++ b/functions/utils/rateLimit.js
@@ -28,6 +28,8 @@ const RATE_LIMITS = {
 
   // Public API endpoints
   '/api/events': { requests: 60, window: 60 },
+  '/api/schedule/share/': { requests: 60, window: 60 }, // GET /api/schedule/share/[slug]
+  '/api/schedule/share':  { requests: 10, window: 60 }, // POST /api/schedule/share
   '/api/schedule': { requests: 30, window: 60 },
   '/api/feeds': { requests: 20, window: 60 },
   '/api/subscriptions': { requests: 10, window: 60 },

--- a/migrations/0037_share_links.sql
+++ b/migrations/0037_share_links.sql
@@ -1,0 +1,20 @@
+-- Migration: 0037_share_links
+-- Description: share_links table for server-side schedule snapshot sharing.
+--   Each row stores a snapshot of performance IDs and band names for a shared route,
+--   with a 30-day TTL enforced lazily on reads and cleaned up by the scheduled worker.
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+CREATE TABLE share_links (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug            TEXT    NOT NULL UNIQUE,
+  event_id        INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  event_slug      TEXT    NOT NULL,
+  performance_ids TEXT    NOT NULL,
+  band_names      TEXT    NOT NULL,
+  created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+  expires_at      TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_share_links_slug ON share_links(slug);

--- a/migrations/0037_share_links.sql
+++ b/migrations/0037_share_links.sql
@@ -17,4 +17,7 @@ CREATE TABLE share_links (
   expires_at      TEXT    NOT NULL
 );
 
+-- UNIQUE on slug already creates an implicit index; this explicit one is redundant but
+-- harmless on SQLite/D1. Added for portability and named-index visibility in tooling.
 CREATE INDEX IF NOT EXISTS idx_share_links_slug ON share_links(slug);
+CREATE INDEX IF NOT EXISTS idx_share_links_expires_at ON share_links(expires_at);


### PR DESCRIPTION
## Summary

- **Replaces `?s=` URL sharing** with server-side snapshot links at `/s/[slug]` — short URLs that never expose performance IDs
- **OG meta tag injection** via a CF Pages Function so iMessage/WhatsApp/Twitter show a real link preview with band count and names
- **Read-only preview page** at `/s/:slug` — visiting a shared link never touches the visitor's own schedule
- **Always-explicit import** — the "Add N stops to my route" button navigates to the event page where a `?share=` param triggers the merge/replace modal (with band names listed); no silent auto-apply
- **Backward compatible** — existing `?s=` links continue to work unchanged

## Files changed

| File | Change |
|---|---|
| `migrations/0037_share_links.sql` | New `share_links` D1 table (slug, event snapshot, 30-day TTL) |
| `functions/api/schedule/share.js` | `POST /api/schedule/share` — create snapshot, return slug |
| `functions/api/schedule/share/[slug].js` | `GET /api/schedule/share/[slug]` — fetch snapshot |
| `functions/s/[slug].js` | CF Pages Function — inject OG tags into `index.html` |
| `_routes.json` | Add `/s/*` to invocation include list |
| `functions/utils/rateLimit.js` | Rate limits: 10 req/min POST, 60 req/min GET |
| `functions/scheduled/expire-share-links.js` | Scheduled cleanup of expired rows |
| `functions/_scheduled.js` | Wire in cleanup task |
| `frontend/src/pages/SharePreviewPage.jsx` | New read-only preview page |
| `frontend/src/main.jsx` | Register `/s/:slug` route |
| `frontend/src/components/MySchedule.jsx` | Call share API; fallback to `?s=` on failure |
| `frontend/src/App.jsx` | `?share=` import handler; `eventId` prop; band names in modal |

## Deploy checklist

- [ ] Apply migration to prod: `npx wrangler d1 migrations apply settimes-production-db --remote`
- [ ] Smoke test: share a schedule → confirm `/s/[slug]` URL is copied
- [ ] Smoke test: paste URL in iMessage → confirm link preview renders
- [ ] Smoke test: open link in incognito → confirm preview page loads, "Add stops" triggers modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)