### PR TITLE
fix: admin UX — reliable autocomplete, new social icons on roster

### DIFF
--- a/frontend/src/admin/BandForm.jsx
+++ b/frontend/src/admin/BandForm.jsx
@@ -184,7 +184,6 @@ export default function BandForm({
                     options={mergedOriginCitySuggestions}
                     maxLength={FIELD_LIMITS.bandOriginCity.max}
                     placeholder="City"
-                    fullWidth
                   />
                 </div>
                 <div>
@@ -196,7 +195,6 @@ export default function BandForm({
                     options={mergedOriginRegionSuggestions}
                     maxLength={FIELD_LIMITS.bandOriginRegion.max}
                     placeholder="Province/State"
-                    fullWidth
                   />
                 </div>
               </div>
@@ -219,7 +217,6 @@ export default function BandForm({
                 options={mergedGenreSuggestions}
                 maxLength={FIELD_LIMITS.bandGenre.max}
                 placeholder="punk, indie rock, etc."
-                fullWidth
               />
             </div>
 

--- a/frontend/src/admin/BandForm.jsx
+++ b/frontend/src/admin/BandForm.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import PhotoUpload from './components/PhotoUpload'
 import RichTextEditor from './components/RichTextEditor'
 import { Input, Button, Tooltip } from '../components/ui'
+import Combobox from '../components/ui/Combobox'
 import { Info } from 'lucide-react'
 import { FIELD_LIMITS } from '../utils/validation'
 import { DEFAULT_GENRES, getNormalizedGenreSuggestions } from '../utils/genres'
@@ -175,42 +176,30 @@ export default function BandForm({
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
-                  <Input
+                  <Combobox
                     id="band-origin-city"
-                    type="text"
                     name="origin_city"
                     value={formData.origin_city || ''}
                     onChange={onChange}
+                    options={mergedOriginCitySuggestions}
                     maxLength={FIELD_LIMITS.bandOriginCity.max}
                     placeholder="City"
-                    list="band-origin-city-list"
                     fullWidth
                   />
                 </div>
                 <div>
-                  <Input
+                  <Combobox
                     id="band-origin-region"
-                    type="text"
                     name="origin_region"
                     value={formData.origin_region || ''}
                     onChange={onChange}
+                    options={mergedOriginRegionSuggestions}
                     maxLength={FIELD_LIMITS.bandOriginRegion.max}
                     placeholder="Province/State"
-                    list="band-origin-region-list"
                     fullWidth
                   />
                 </div>
               </div>
-              <datalist id="band-origin-city-list">
-                {mergedOriginCitySuggestions.map(city => (
-                  <option key={city} value={city} />
-                ))}
-              </datalist>
-              <datalist id="band-origin-region-list">
-                {mergedOriginRegionSuggestions.map(region => (
-                  <option key={region} value={region} />
-                ))}
-              </datalist>
             </fieldset>
 
             <div className="sm:col-span-2">
@@ -222,22 +211,16 @@ export default function BandForm({
                   <Info size={14} className="text-text-tertiary cursor-help" />
                 </Tooltip>
               </div>
-              <Input
+              <Combobox
                 id="band-genre"
-                type="text"
                 name="genre"
                 value={formData.genre || ''}
                 onChange={onChange}
+                options={mergedGenreSuggestions}
                 maxLength={FIELD_LIMITS.bandGenre.max}
                 placeholder="punk, indie rock, etc."
-                list="band-genre-list"
                 fullWidth
               />
-              <datalist id="band-genre-list">
-                {mergedGenreSuggestions.map(genre => (
-                  <option key={genre} value={genre} />
-                ))}
-              </datalist>
             </div>
 
             <div className="sm:col-span-2">

--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -5,7 +5,15 @@ import { DEFAULT_GENRES, getNormalizedGenreSuggestions } from '../utils/genres'
 import { safeExternalHref, safeHttpsFallbackHref, safeInstagramHref } from '../utils/urlSafety'
 import { Globe } from 'lucide-react'
 import { parseOrigin } from '../utils/parseOrigin'
-import { BandcampIcon, FacebookIcon, InstagramIcon } from '../components/ui/SocialIcons'
+import {
+  AppleMusicIcon,
+  BandcampIcon,
+  FacebookIcon,
+  InstagramIcon,
+  LinktreeIcon,
+  SpotifyIcon,
+  YouTubeIcon,
+} from '../components/ui/SocialIcons'
 
 function parseSocialLinks(band) {
   let links = {}
@@ -23,12 +31,25 @@ function SocialLinksIcons({ band }) {
   const instagramHref = safeInstagramHref(links.instagram)
   const bandcampHref = safeHttpsFallbackHref(links.bandcamp)
   const facebookHref = safeExternalHref(links.facebook)
-  const hasAnyLink = [websiteHref, instagramHref, bandcampHref, facebookHref].some(href => href !== '#')
+  const youtubeHref = safeExternalHref(links.youtube)
+  const spotifyHref = safeExternalHref(links.spotify)
+  const appleMusicHref = safeExternalHref(links.apple_music)
+  const linktreeHref = safeExternalHref(links.linktree)
+  const hasAnyLink = [
+    websiteHref,
+    instagramHref,
+    bandcampHref,
+    facebookHref,
+    youtubeHref,
+    spotifyHref,
+    appleMusicHref,
+    linktreeHref,
+  ].some(href => href !== '#')
 
   if (!hasAnyLink) return <span className="text-white/30">-</span>
 
   return (
-    <div className="flex gap-2">
+    <div className="flex gap-2 flex-wrap">
       {websiteHref !== '#' && (
         <a
           href={websiteHref}
@@ -75,6 +96,54 @@ function SocialLinksIcons({ band }) {
           aria-label={`Open Facebook for ${band.name}`}
         >
           <FacebookIcon size={14} />
+        </a>
+      )}
+      {youtubeHref !== '#' && (
+        <a
+          href={youtubeHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-white/70 hover:text-red-500 transition-colors focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500"
+          title="YouTube"
+          aria-label={`Open YouTube for ${band.name}`}
+        >
+          <YouTubeIcon size={14} />
+        </a>
+      )}
+      {spotifyHref !== '#' && (
+        <a
+          href={spotifyHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-white/70 hover:text-green-400 transition-colors focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-400"
+          title="Spotify"
+          aria-label={`Open Spotify for ${band.name}`}
+        >
+          <SpotifyIcon size={14} />
+        </a>
+      )}
+      {appleMusicHref !== '#' && (
+        <a
+          href={appleMusicHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-white/70 hover:text-rose-400 transition-colors focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400"
+          title="Apple Music"
+          aria-label={`Open Apple Music for ${band.name}`}
+        >
+          <AppleMusicIcon size={14} />
+        </a>
+      )}
+      {linktreeHref !== '#' && (
+        <a
+          href={linktreeHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-white/70 hover:text-lime-400 transition-colors focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime-400"
+          title="Linktree"
+          aria-label={`Open Linktree for ${band.name}`}
+        >
+          <LinktreeIcon size={14} />
         </a>
       )}
     </div>
@@ -127,6 +196,10 @@ export default function RosterTab({ showToast, readOnly = false }) {
     instagram: '',
     bandcamp: '',
     facebook: '',
+    youtube: '',
+    spotify: '',
+    apple_music: '',
+    linktree: '',
   })
   const [submitting, setSubmitting] = useState(false)
 

--- a/frontend/src/components/ui/Combobox.jsx
+++ b/frontend/src/components/ui/Combobox.jsx
@@ -73,7 +73,7 @@ export default function Combobox({
         e.preventDefault()
         break
       case 'Enter':
-        if (activeIndex >= 0) {
+        if (activeIndex >= 0 && activeIndex < filtered.length) {
           pick(filtered[activeIndex])
           e.preventDefault()
         }

--- a/frontend/src/components/ui/Combobox.jsx
+++ b/frontend/src/components/ui/Combobox.jsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Combobox — free-text input with filtered suggestion dropdown.
+ * Replaces native <datalist> for reliable cross-browser behaviour (Safari < 16 has broken datalist).
+ *
+ * Props mirror a plain <input> where possible so callers can swap in place.
+ */
+export default function Combobox({
+  id,
+  name,
+  value = '',
+  onChange,
+  options = [],
+  placeholder = '',
+  maxLength,
+  className = '',
+  disabled = false,
+  fullWidth,
+}) {
+  const [open, setOpen] = useState(false)
+  const [focused, setFocused] = useState(false)
+  const containerRef = useRef(null)
+  const inputRef = useRef(null)
+  const listRef = useRef(null)
+  const [activeIndex, setActiveIndex] = useState(-1)
+
+  const filtered = options
+    .filter(opt => !value || opt.toLowerCase().includes(value.toLowerCase()))
+    .slice(0, 12)
+
+  const shouldShow = open && focused && filtered.length > 0
+
+  // Close on outside click
+  useEffect(() => {
+    if (!shouldShow) return
+    function handleDown(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleDown)
+    return () => document.removeEventListener('mousedown', handleDown)
+  }, [shouldShow])
+
+  const pick = useCallback(
+    opt => {
+      onChange({ target: { name, value: opt } })
+      setOpen(false)
+      inputRef.current?.focus()
+    },
+    [name, onChange]
+  )
+
+  const handleKeyDown = e => {
+    if (!shouldShow) {
+      if (e.key === 'ArrowDown' && filtered.length > 0) {
+        setOpen(true)
+        setActiveIndex(0)
+        e.preventDefault()
+      }
+      return
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        setActiveIndex(i => Math.min(i + 1, filtered.length - 1))
+        e.preventDefault()
+        break
+      case 'ArrowUp':
+        setActiveIndex(i => Math.max(i - 1, 0))
+        e.preventDefault()
+        break
+      case 'Enter':
+        if (activeIndex >= 0) {
+          pick(filtered[activeIndex])
+          e.preventDefault()
+        }
+        break
+      case 'Escape':
+        setOpen(false)
+        break
+    }
+  }
+
+  const baseClass = `w-full px-4 py-2.5 min-h-[44px] bg-white/5 border rounded-lg text-text-primary placeholder-text-tertiary transition-colors duration-base focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg-navy border-white/10 focus:border-primary-500 focus:ring-primary-500/50 disabled:opacity-50 disabled:cursor-not-allowed ${className}`
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        ref={inputRef}
+        id={id}
+        name={name}
+        type="text"
+        value={value}
+        onChange={e => {
+          onChange(e)
+          setOpen(true)
+          setActiveIndex(-1)
+        }}
+        onFocus={() => {
+          setFocused(true)
+          setOpen(true)
+          setActiveIndex(-1)
+        }}
+        onBlur={() => {
+          setFocused(false)
+          // delay so click on option registers first
+          setTimeout(() => setOpen(false), 150)
+        }}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        disabled={disabled}
+        autoComplete="off"
+        aria-autocomplete="list"
+        aria-expanded={shouldShow}
+        aria-haspopup="listbox"
+        aria-controls={shouldShow ? `${id}-listbox` : undefined}
+        aria-activedescendant={activeIndex >= 0 ? `${id}-opt-${activeIndex}` : undefined}
+        className={baseClass}
+      />
+      {shouldShow && (
+        <ul
+          ref={listRef}
+          id={`${id}-listbox`}
+          role="listbox"
+          className="absolute z-50 mt-1 w-full rounded-lg border border-white/10 bg-bg-navy shadow-lg max-h-52 overflow-y-auto"
+        >
+          {filtered.map((opt, i) => (
+            <li
+              key={opt}
+              id={`${id}-opt-${i}`}
+              role="option"
+              aria-selected={i === activeIndex}
+              onMouseDown={() => pick(opt)}
+              onMouseEnter={() => setActiveIndex(i)}
+              className={`px-4 py-2 text-sm cursor-pointer select-none ${
+                i === activeIndex
+                  ? 'bg-accent-500/20 text-accent-300'
+                  : 'text-text-primary hover:bg-white/5'
+              }`}
+            >
+              {opt}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/Combobox.jsx
+++ b/frontend/src/components/ui/Combobox.jsx
@@ -16,18 +16,20 @@ export default function Combobox({
   maxLength,
   className = '',
   disabled = false,
-  fullWidth,
 }) {
   const [open, setOpen] = useState(false)
   const [focused, setFocused] = useState(false)
   const containerRef = useRef(null)
   const inputRef = useRef(null)
   const listRef = useRef(null)
+  const blurTimerRef = useRef(null)
   const [activeIndex, setActiveIndex] = useState(-1)
 
-  const filtered = options
-    .filter(opt => !value || opt.toLowerCase().includes(value.toLowerCase()))
-    .slice(0, 12)
+  useEffect(() => {
+    return () => clearTimeout(blurTimerRef.current)
+  }, [])
+
+  const filtered = options.filter(opt => !value || opt.toLowerCase().includes(value.toLowerCase())).slice(0, 12)
 
   const shouldShow = open && focused && filtered.length > 0
 
@@ -98,19 +100,20 @@ export default function Combobox({
           setActiveIndex(-1)
         }}
         onFocus={() => {
+          clearTimeout(blurTimerRef.current)
           setFocused(true)
           setOpen(true)
           setActiveIndex(-1)
         }}
         onBlur={() => {
           setFocused(false)
-          // delay so click on option registers first
-          setTimeout(() => setOpen(false), 150)
+          blurTimerRef.current = setTimeout(() => setOpen(false), 150)
         }}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         maxLength={maxLength}
         disabled={disabled}
+        role="combobox"
         autoComplete="off"
         aria-autocomplete="list"
         aria-expanded={shouldShow}
@@ -135,9 +138,7 @@ export default function Combobox({
               onMouseDown={() => pick(opt)}
               onMouseEnter={() => setActiveIndex(i)}
               className={`px-4 py-2 text-sm cursor-pointer select-none ${
-                i === activeIndex
-                  ? 'bg-accent-500/20 text-accent-300'
-                  : 'text-text-primary hover:bg-white/5'
+                i === activeIndex ? 'bg-accent-500/20 text-accent-300' : 'text-text-primary hover:bg-white/5'
               }`}
             >
               {opt}

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -420,42 +420,54 @@ export default function BandProfilePage() {
   }
 
   if (loading) {
-    return <BandProfileSkeleton />
+    return (
+      <>
+        <Helmet>
+          <title>Band Profile | SetTimes</title>
+        </Helmet>
+        <BandProfileSkeleton />
+      </>
+    )
   }
 
   if (error || !profile) {
     return (
-      <div className="min-h-screen bg-bg-navy">
-        <div className="container mx-auto px-4 py-12 max-w-2xl">
-          <Alert variant="error" className="mb-6">
-            <h2 className="text-xl font-bold mb-2">
-              {isPublishGateError
-                ? 'Band Profiles Unavailable'
-                : isNotFoundError
-                  ? 'Band Not Found'
-                  : 'Failed to load band profile'}
-            </h2>
-            <p>
-              {isPublishGateError
-                ? error.message
-                : isNotFoundError
-                  ? `We couldn't find a profile for this band.${error ? ` Error: ${error.message}` : ''}`
-                  : error?.message || "We couldn't load this band profile right now."}
-            </p>
-          </Alert>
-          <div className="text-center">
-            <Button
-              as={Link}
-              to={returnEventPath}
-              variant="secondary"
-              icon={<ArrowLeft size={14} />}
-              iconPosition="left"
-            >
-              Back to Schedule
-            </Button>
+      <>
+        <Helmet>
+          <title>{isNotFoundError ? 'Band Not Found | SetTimes' : 'Band Profile | SetTimes'}</title>
+        </Helmet>
+        <div className="min-h-screen bg-bg-navy">
+          <div className="container mx-auto px-4 py-12 max-w-2xl">
+            <Alert variant="error" className="mb-6">
+              <h2 className="text-xl font-bold mb-2">
+                {isPublishGateError
+                  ? 'Band Profiles Unavailable'
+                  : isNotFoundError
+                    ? 'Band Not Found'
+                    : 'Failed to load band profile'}
+              </h2>
+              <p>
+                {isPublishGateError
+                  ? error.message
+                  : isNotFoundError
+                    ? `We couldn't find a profile for this band.${error ? ` Error: ${error.message}` : ''}`
+                    : error?.message || "We couldn't load this band profile right now."}
+              </p>
+            </Alert>
+            <div className="text-center">
+              <Button
+                as={Link}
+                to={returnEventPath}
+                variant="secondary"
+                icon={<ArrowLeft size={14} />}
+                iconPosition="left"
+              >
+                Back to Schedule
+              </Button>
+            </div>
           </div>
         </div>
-      </div>
+      </>
     )
   }
 


### PR DESCRIPTION
## Summary

- **Band profile tab title fix**: All early return branches (loading skeleton, error/not-found) now render a `<Helmet>` with a placeholder title. Previously, \`react-helmet-async\` had no active Helmet during loading, so it cleared the document title entirely — causing browsers to show the URL in the tab instead of a name. The title now always resolves to something: "Band Profile | SetTimes" while loading, "Band Not Found | SetTimes" on 404, and the artist name once data loads.
- **Autocomplete fix**: Replaced native \`<datalist>\` with a custom \`Combobox\` component for city, province/state, and genre fields. \`<datalist>\` is unreliable in Safari < 16 and inconsistent with React controlled inputs. The new \`Combobox\` shows a filtered suggestion dropdown that works in all browsers, with keyboard navigation (↑↓ Enter Escape) and full ARIA support.
- **Roster social icons**: Added YouTube, Spotify, Apple Music, and Linktree icons to the \`SocialLinksIcons\` component in the roster table — these were missing after the social links expansion in #267.
- **Roster formData fix**: The initial \`useState\` in \`RosterTab\` was missing the 4 new social link keys; they're now included so the form starts with clean values.

## Test plan

- [ ] Navigate directly to a band profile page (e.g. settimes.ca/band/44) — tab should show "Band Profile | SetTimes" while loading, then "Mr Hands - Band Profile | SetTimes" once loaded
- [ ] Open admin → band form (lineup or roster) → type in City field → confirm suggestions dropdown appears and clicking one fills the field
- [ ] Same for Province/State (should show pre-populated list like ON, QC, BC…)
- [ ] Same for Genre
- [ ] Open admin → Roster tab → find a band with YouTube/Spotify/Apple Music/Linktree links → confirm icons appear in the Links column
- [ ] All 387 tests pass (\`npm test\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)