### PR TITLE
fix(auth): trust device when IP changes but UA matches

### DIFF
--- a/functions/utils/__tests__/trustedDevice.test.js
+++ b/functions/utils/__tests__/trustedDevice.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { createTestEnv, mockUsers } from "../../api/test-utils.js";
+import { createTrustedDevice, validateTrustedDevice } from "../trustedDevice.js";
+
+const IP_A = "1.2.3.4";
+const IP_B = "5.6.7.8";
+const UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Test";
+const UA_OTHER = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Other";
+
+async function seedDevice(DB, userId, ip = IP_A, ua = UA) {
+  const { token } = await createTrustedDevice(DB, userId, ip, ua);
+  return token;
+}
+
+describe("validateTrustedDevice", () => {
+  it("returns user_id when IP and UA both match", async () => {
+    const { env } = createTestEnv();
+    const token = await seedDevice(env.DB, mockUsers.editor.id);
+    const result = await validateTrustedDevice(env.DB, token, IP_A, UA);
+    expect(result).toBe(mockUsers.editor.id);
+  });
+
+  it("returns user_id and refreshes fingerprint when UA matches but IP changed", async () => {
+    const { env, rawDb } = createTestEnv();
+    const token = await seedDevice(env.DB, mockUsers.editor.id, IP_A, UA);
+
+    const result = await validateTrustedDevice(env.DB, token, IP_B, UA);
+    expect(result).toBe(mockUsers.editor.id);
+
+    // Fingerprint in DB should now reflect the new IP
+    const row = rawDb
+      .prepare("SELECT ip_address FROM trusted_devices WHERE user_id = ?")
+      .get(mockUsers.editor.id);
+    expect(row.ip_address).toBe(IP_B);
+  });
+
+  it("returns null when UA mismatches even if IP matches", async () => {
+    const { env } = createTestEnv();
+    const token = await seedDevice(env.DB, mockUsers.editor.id, IP_A, UA);
+    const result = await validateTrustedDevice(env.DB, token, IP_A, UA_OTHER);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when both IP and UA mismatch", async () => {
+    const { env } = createTestEnv();
+    const token = await seedDevice(env.DB, mockUsers.editor.id, IP_A, UA);
+    const result = await validateTrustedDevice(env.DB, token, IP_B, UA_OTHER);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for an expired device", async () => {
+    const { env, rawDb } = createTestEnv();
+    const token = await seedDevice(env.DB, mockUsers.editor.id);
+    rawDb
+      .prepare("UPDATE trusted_devices SET expires_at = datetime('now', '-1 second') WHERE user_id = ?")
+      .run(mockUsers.editor.id);
+
+    const result = await validateTrustedDevice(env.DB, token, IP_A, UA);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a missing or invalid token", async () => {
+    const { env } = createTestEnv();
+    expect(await validateTrustedDevice(env.DB, null, IP_A, UA)).toBeNull();
+    expect(await validateTrustedDevice(env.DB, "not-a-real-token", IP_A, UA)).toBeNull();
+  });
+
+  describe("legacy rows (no ua_hash)", () => {
+    async function seedLegacyDevice(rawDb, DB, userId, ip = IP_A, ua = UA) {
+      // createTrustedDevice writes ua_hash; we clear it to simulate pre-migration rows
+      const { token } = await createTrustedDevice(DB, userId, ip, ua);
+      rawDb.prepare("UPDATE trusted_devices SET ua_hash = NULL WHERE user_id = ?").run(userId);
+      return token;
+    }
+
+    it("returns user_id when full fingerprint matches", async () => {
+      const { env, rawDb } = createTestEnv();
+      const token = await seedLegacyDevice(rawDb, env.DB, mockUsers.editor.id);
+      const result = await validateTrustedDevice(env.DB, token, IP_A, UA);
+      expect(result).toBe(mockUsers.editor.id);
+    });
+
+    it("returns null when IP changes (no ua_hash to fall back on)", async () => {
+      const { env, rawDb } = createTestEnv();
+      const token = await seedLegacyDevice(rawDb, env.DB, mockUsers.editor.id, IP_A, UA);
+      const result = await validateTrustedDevice(env.DB, token, IP_B, UA);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/functions/utils/__tests__/trustedDevice.test.js
+++ b/functions/utils/__tests__/trustedDevice.test.js
@@ -27,11 +27,18 @@ describe("validateTrustedDevice", () => {
     const result = await validateTrustedDevice(env.DB, token, IP_B, UA);
     expect(result).toBe(mockUsers.editor.id);
 
-    // Fingerprint in DB should now reflect the new IP
-    const row = rawDb
-      .prepare("SELECT ip_address FROM trusted_devices WHERE user_id = ?")
+    // Both ip_address and device_fingerprint should reflect the new IP
+    const updated = rawDb
+      .prepare("SELECT ip_address, device_fingerprint FROM trusted_devices WHERE user_id = ?")
       .get(mockUsers.editor.id);
-    expect(row.ip_address).toBe(IP_B);
+    expect(updated.ip_address).toBe(IP_B);
+    // Fingerprint is SHA-256(IP_B:UA) — must differ from original SHA-256(IP_A:UA).
+    // Seed a reference device with IP_A to get its fingerprint for comparison.
+    await createTrustedDevice(env.DB, mockUsers.admin.id, IP_A, UA);
+    const ipARow = rawDb
+      .prepare("SELECT device_fingerprint FROM trusted_devices WHERE user_id = ?")
+      .get(mockUsers.admin.id);
+    expect(updated.device_fingerprint).not.toBe(ipARow.device_fingerprint);
   });
 
   it("returns null when UA mismatches even if IP matches", async () => {

--- a/functions/utils/trustedDevice.js
+++ b/functions/utils/trustedDevice.js
@@ -122,19 +122,20 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
       return null;
     }
     if (!fingerprintMatch) {
-      console.log("[TrustedDevice] Fingerprint mismatch, MFA required");
-      return null;
+      // UA matches but IP changed — normal for DHCP, mobile, VPN users.
+      // Fingerprint is refreshed in the update below.
+      console.log("[TrustedDevice] IP changed for known UA, refreshing fingerprint");
     }
   } else if (!fingerprintMatch) {
     console.log("[TrustedDevice] Fingerprint mismatch, device not trusted");
     return null;
   }
 
-  // Update last_used_at and current IP
+  // Update last_used_at, current IP, and fingerprint (no-op if IP unchanged)
   await DB.prepare(
-    `UPDATE trusted_devices SET last_used_at = datetime('now'), ip_address = ? WHERE id = ?`
+    `UPDATE trusted_devices SET last_used_at = datetime('now'), ip_address = ?, device_fingerprint = ? WHERE id = ?`
   )
-    .bind(ipAddress, device.id)
+    .bind(ipAddress, currentFingerprint, device.id)
     .run();
 
   return device.user_id;

--- a/functions/utils/trustedDevice.js
+++ b/functions/utils/trustedDevice.js
@@ -104,7 +104,9 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
 
   if (!device) return null;
 
-  // Validate IP and UA independently using constant-time comparison
+  // Trust policy:
+  //   New rows (ua_hash present): UA must match; IP change is tolerated (DHCP, mobile, VPN).
+  //   Legacy rows (no ua_hash):   full IP+UA fingerprint must match.
   const currentFingerprint = await generateDeviceFingerprint(ipAddress, userAgent);
   const currentUaHash = await generateUaHash(userAgent);
 
@@ -113,8 +115,6 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
     currentFingerprint,
   );
 
-  // If stored ua_hash exists, validate UA independently (new schema)
-  // Otherwise fall back to full fingerprint check (pre-migration rows)
   if (device.ua_hash) {
     const uaMatch = timingSafeStringEqual(device.ua_hash, currentUaHash);
     if (!uaMatch) {

--- a/functions/utils/trustedDevice.js
+++ b/functions/utils/trustedDevice.js
@@ -131,7 +131,7 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
     return null;
   }
 
-  // Update last_used_at, current IP, and fingerprint (no-op if IP unchanged)
+  // Always refresh last_used_at; also refresh IP and fingerprint so they stay current
   await DB.prepare(
     `UPDATE trusted_devices SET last_used_at = datetime('now'), ip_address = ?, device_fingerprint = ? WHERE id = ?`
   )


### PR DESCRIPTION
## Problem

The "Remember this device for 30 days" feature was requiring MFA on every login for users with dynamic IPs (DHCP renewals, mobile networks, VPNs). When the IP changed, the stored device fingerprint (SHA-256 of `ip:ua`) no longer matched — even though the User-Agent was identical — so the device was rejected as untrusted.

## Fix

When the stored `ua_hash` matches but the full fingerprint doesn't, the device is still trusted (IP changed for a known UA). The stored fingerprint and IP are refreshed atomically in the existing `last_used_at` update — no extra query.

**Before:**
```
ua_hash check ✓ → fingerprint check ✗ → return null (MFA required)
```

**After:**
```
ua_hash check ✓ → fingerprint check ✗ → log "IP changed" → refresh fingerprint → return user_id
```

The pre-`ua_hash` path (legacy rows without `ua_hash`) is unchanged — those still require full fingerprint match.

## Security

- UA-only match is sufficient here because `ua_hash` is stored independently and validated with constant-time comparison
- Full fingerprint (IP+UA) is updated on each successful login, so the next request will match normally
- If both UA and fingerprint mismatch, the device is still rejected as untrusted

## Test plan

- [ ] Log in on a trusted device, then change IP (simulate with a VPN toggle) — should skip MFA
- [ ] Fresh device (no cookie) still requires MFA
- [ ] UA mismatch (different browser) still requires MFA
- [ ] CI trusted-devices test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)