### PR TITLE
feat: add security.txt for vulnerability disclosure (RFC 9116)

### DIFF
--- a/frontend/public/.well-known/security.txt
+++ b/frontend/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:settimes@dredre.net
+Expires: 2027-05-17T00:00:00.000Z
+Preferred-Languages: en, fr
+Canonical: https://settimes.ca/.well-known/security.txt

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -123,3 +123,7 @@
 
 /sitemap.xml
   Cache-Control: public, max-age=3600
+
+/.well-known/security.txt
+  Cache-Control: public, max-age=86400
+  Content-Type: text/plain; charset=utf-8


### PR DESCRIPTION
## Summary

- Adds `/.well-known/security.txt` with contact address `settimes@dredre.net`, expiry date, and canonical URL — satisfies RFC 9116 and resolves the Cloudflare security dashboard recommendation
- Adds a `_headers` override for `/.well-known/security.txt` so the global `no-cache, no-store` catch-all rule doesn't apply to this static file

## Test plan

- [ ] After deploy, confirm `https://settimes.ca/.well-known/security.txt` returns the file with `Content-Type: text/plain`
- [ ] Confirm Cloudflare security dashboard no longer flags the missing security.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)