### PR TITLE
fix(build): copy .well-known/ to dist (Vite skips dot-dirs)

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,26 @@
 import react from '@vitejs/plugin-react'
+import { cpSync, existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Vite skips dot-prefixed directories when copying public/ to dist/.
+// This plugin ensures .well-known/ (and any future dot-dirs) are included.
+const copyDotDirs = {
+  name: 'copy-dot-dirs',
+  closeBundle() {
+    const dirs = ['.well-known']
+    for (const dir of dirs) {
+      const src = resolve(__dirname, `public/${dir}`)
+      if (existsSync(src)) cpSync(src, resolve(__dirname, `dist/${dir}`), { recursive: true })
+    }
+  },
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), copyDotDirs],
   build: {
     // Bundle size optimizations
     target: 'es2020',


### PR DESCRIPTION
## Summary

- Fixes `/.well-known/security.txt` returning `index.html` instead of the file — Vite silently skips directories starting with `.` when copying `public/` to `dist/`, so the file never made it into the build output
- Adds a `closeBundle` plugin hook in `vite.config.js` that explicitly copies dot-prefixed subdirectories after every build

## Test plan

- [ ] After deploy, confirm `https://settimes.ca/.well-known/security.txt` returns the file content (not HTML)
- [ ] Confirm Cloudflare security dashboard clears the `security.txt` finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)