### PR TITLE
ci: bypass Cloudflare bot protection during smoke checks

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -224,7 +224,7 @@ jobs:
     if: needs.resolve-release.outputs.should_deploy == 'true'
     steps:
       - name: Bypass Cloudflare bot protection for runner IP
-        uses: xiaotianxt/bypass-cloudflare-for-github-action@v2.1.0
+        uses: xiaotianxt/bypass-cloudflare-for-github-action@0c44a8bb3b1c9d370e48be2becf88ef33de8d57e # v2.1.0
         with:
           cf_account_id: ${{ secrets.CF_ACCOUNT_ID }}
           cf_zone_id: ${{ secrets.CF_ZONE_ID }}

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -223,6 +223,13 @@ jobs:
       - resolve-release
     if: needs.resolve-release.outputs.should_deploy == 'true'
     steps:
+      - name: Bypass Cloudflare bot protection for runner IP
+        uses: xiaotianxt/bypass-cloudflare-for-github-action@v2.1.0
+        with:
+          cf_account_id: ${{ secrets.CF_ACCOUNT_ID }}
+          cf_zone_id: ${{ secrets.CF_ZONE_ID }}
+          cf_api_token: ${{ secrets.CF_WAF_API_TOKEN }}
+
       - name: Wait for deployment to become available
         env:
           SMOKE_URL: ${{ needs.resolve-release.outputs.smoke_url }}


### PR DESCRIPTION
## Summary

- Adds `xiaotianxt/bypass-cloudflare-for-github-action@v2.1.0` as the first step of the smoke job — temporarily whitelists the runner IP via a Cloudflare WAF rule, then auto-cleans up on job exit
- Fixes the smoke check getting a persistent 403 from Cloudflare bot protection when GitHub Actions runner IPs are flagged (first seen on #282 deploy, reproduced on #283)

## Prerequisites (already done)

Two secrets are set in GitHub Actions:
- `CF_ZONE_ID` — Cloudflare Zone ID for settimes.ca
- `CF_WAF_API_TOKEN` — API token with Account Filter Lists + Zone WAF Edit permissions

## Test plan

- [ ] Merge and confirm the post-deploy smoke check passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)