### PR TITLE
feat(schedule): show start time in soon pill alongside countdown

### DIFF
--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -3,6 +3,7 @@ import { memo } from 'react'
 import { Link } from 'react-router-dom'
 import { buildBandProfileHref } from '../utils/bandProfileLink'
 import { getTimeDescription, isHappeningNow, isStartingSoon } from '../utils/timeFilter'
+import { formatTime } from '../utils/timeFormat'
 
 function BandCard({
   band,
@@ -83,9 +84,9 @@ function BandCard({
         {startingSoon && (
           <span
             className="soon-pill"
-            aria-label={`Starts in ${minutesUntil} ${minutesUntil === 1 ? 'minute' : 'minutes'}`}
+            aria-label={`Starts in ${minutesUntil} ${minutesUntil === 1 ? 'minute' : 'minutes'} at ${formatTime(band.startTime)}`}
           >
-            Starts in {minutesUntil}m
+            Starts in {minutesUntil}m · {formatTime(band.startTime)}
           </span>
         )}
         <div className={`inline-block px-3 py-1.5 rounded-lg mb-1 ${isSelected ? 'bg-white/20' : 'bg-bg-navy/60'}`}>


### PR DESCRIPTION
## Summary
- Adds the actual start time (e.g. "11:10 PM") to the \"Starts in Xm\" pill on band cards
- Pill now reads `Starts in 19m · 11:10 PM` — compact, one-line, uses the existing `formatTime` utility
- `aria-label` updated to match (e.g. "Starts in 19 minutes at 11:10 PM")

## Test plan
- [ ] Find a band starting within the next 30 minutes and confirm the pill shows both the countdown and the clock time
- [ ] Verify after-midnight bands (e.g. 1:30 AM) display the correct clock time, not an offset time

🤖 Generated with [Claude Code](https://claude.com/claude-code)