### PR TITLE
fix(ci): add .gitleaksignore for historical false-positive findings

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,11 @@
+# Acknowledged false positives — historical findings in deleted/doc files.
+# Format: commit:file:rule:line
+
+# database/production-full-sync.sql was a one-time DB export used for dev setup.
+# The file was deleted and the reset tokens it contained expired on 2026-01-30.
+1da2e683f40d7aaae16eedfe6e03e8114c271c96:database/production-full-sync.sql:generic-api-key:483
+1da2e683f40d7aaae16eedfe6e03e8114c271c96:database/production-full-sync.sql:generic-api-key:484
+
+# docs/API_DOCUMENTATION.md contains a placeholder curl example with a fictional
+# session_token value — not a real credential.
+05735d9da9763dd7d509dd75605844da7c787e3d:docs/API_DOCUMENTATION.md:curl-auth-header:150


### PR DESCRIPTION
## Summary

- Creates `.gitleaksignore` to acknowledge three false-positive findings from gitleaks secret scanning
- **`database/production-full-sync.sql` (lines 483–484)**: one-time DB export file deleted from repo; the `resetTokenId` values it contained were short-lived password-reset tokens that expired 2026-01-30
- **`docs/API_DOCUMENTATION.md` (line 150)**: fictional `session_token=abc123...` placeholder in a curl example, not a real credential

Fingerprints are pinned to exact commit SHAs — the rules remain fully active for all future commits.

## Test plan

- [ ] Merge and confirm Secret Scanning CI job passes on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)