### PR TITLE
fix(ci): enable disable_bot_fight_mode on Cloudflare bypass action

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -229,6 +229,7 @@ jobs:
           cf_account_id: ${{ secrets.CF_ACCOUNT_ID }}
           cf_zone_id: ${{ secrets.CF_ZONE_ID }}
           cf_api_token: ${{ secrets.CF_WAF_API_TOKEN }}
+          disable_bot_fight_mode: true
 
       - name: Wait for deployment to become available
         env:

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -218,6 +218,11 @@ jobs:
     name: Post-deploy smoke checks
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Serialize across all branches: disable_bot_fight_mode operates at zone
+    # level, so concurrent smoke jobs from main+dev would race to restore it.
+    concurrency:
+      group: cloudflare-zone-smoke
+      cancel-in-progress: false
     needs:
       - deploy
       - resolve-release

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -55,8 +55,8 @@ jobs:
             echo "url=https://settimes.ca" >> $GITHUB_OUTPUT
             echo "Scheduled scan of production: https://settimes.ca"
           else
-            echo "url=https://dev.settimesdotca.pages.dev" >> $GITHUB_OUTPUT
-            echo "Post-deployment scan of dev: https://dev.settimesdotca.pages.dev"
+            echo "url=https://dev.settimes.ca" >> $GITHUB_OUTPUT
+            echo "Post-deployment scan of dev: https://dev.settimes.ca"
           fi
 
       - name: Bypass Cloudflare bot protection for runner IP

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -65,6 +65,7 @@ jobs:
           fi
 
       - name: Bypass Cloudflare bot protection for runner IP
+        if: contains(steps.target.outputs.url, 'settimes.ca')
         uses: xiaotianxt/bypass-cloudflare-for-github-action@0c44a8bb3b1c9d370e48be2becf88ef33de8d57e # v2.1.0
         with:
           cf_account_id: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -30,6 +30,11 @@ jobs:
   zap-baseline:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Serialize with smoke checks: both disable BFM at zone level and must not
+    # run concurrently or one will restore BFM while the other still needs it.
+    concurrency:
+      group: cloudflare-zone-smoke
+      cancel-in-progress: false
     # Only run if deployment succeeded (for workflow_run trigger)
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -59,6 +59,14 @@ jobs:
             echo "Post-deployment scan of dev: https://dev.settimesdotca.pages.dev"
           fi
 
+      - name: Bypass Cloudflare bot protection for runner IP
+        uses: xiaotianxt/bypass-cloudflare-for-github-action@0c44a8bb3b1c9d370e48be2becf88ef33de8d57e # v2.1.0
+        with:
+          cf_account_id: ${{ secrets.CF_ACCOUNT_ID }}
+          cf_zone_id: ${{ secrets.CF_ZONE_ID }}
+          cf_api_token: ${{ secrets.CF_WAF_API_TOKEN }}
+          disable_bot_fight_mode: true
+
       - name: Wait for deployment to be ready
         run: |
           TARGET="${{ steps.target.outputs.url }}"


### PR DESCRIPTION
## Summary

- Adds `disable_bot_fight_mode: true` to the Cloudflare bypass action in both `cloudflare-pages.yml` (smoke checks) and `zap-baseline.yml` (DAST scans)

## Root cause

The WAF custom skip rule (`ip.src in $bypass_cloudflare_for_github_action_list → Skip`) is evaluated **after** Bot Fight Mode on Cloudflare's Free plan. BFM blocks GitHub Actions runner IPs before the custom rule ever fires, causing the smoke check curl calls to get 403s.

`disable_bot_fight_mode: true` uses the Cloudflare API to temporarily disable BFM at job start and restores it at job teardown.

## Token permission required

`CF_WAF_API_TOKEN` must include **Zone > Zone Settings > Edit** for the BFM toggle to work. Update the token in the Cloudflare dashboard if it doesn't already have this permission.

## Test plan

- [ ] Merge and verify smoke check step in next deploy to `main` or `dev` passes (no more 403)
- [ ] Verify ZAP baseline scan passes on next scheduled Monday run

🤖 Generated with [Claude Code](https://claude.com/claude-code)