### PR TITLE
fix(ci): add required third column to ZAP rules.tsv

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,43 +1,43 @@
 # ZAP Baseline Scan Rules
-# Format: rule_id	action	[regex_url]
+# Format: rule_id	action	url_regex
 # Actions: IGNORE, WARN, FAIL
 # See: https://www.zaproxy.org/docs/docker/baseline-scan/
 
 # Content Security Policy - we have CSP but ZAP may not detect it correctly
-10038	WARN
+10038	WARN	.*
 
 # X-Content-Type-Options - already set in _headers and middleware
-10021	IGNORE
+10021	IGNORE	.*
 
 # X-Frame-Options - already set as DENY
-10020	IGNORE
+10020	IGNORE	.*
 
 # Strict-Transport-Security - already set with preload
-10035	IGNORE
+10035	IGNORE	.*
 
 # Cookie without SameSite - our session cookies have SameSite=Strict
-10054	WARN
+10054	WARN	.*
 
 # Modern Web Application - informational
-10109	IGNORE
+10109	IGNORE	.*
 
 # Information Disclosure - Server header (Cloudflare sets this)
-10036	IGNORE
+10036	IGNORE	.*
 
 # Timestamp Disclosure - false positive on dates in content
-10096	IGNORE
+10096	IGNORE	.*
 
 # User Agent Fuzzer - informational only
-10104	IGNORE
+10104	IGNORE	.*
 
 # Cross-Domain JavaScript Source File Inclusion - we use CDNs intentionally
-10017	WARN
+10017	WARN	.*
 
 # Application Error Disclosure - may flag normal error messages
-90022	WARN
+90022	WARN	.*
 
 # Private IP Disclosure - may flag localhost in development
-2	WARN
+2	WARN	.*
 
 # Session ID in URL - we use cookies, not URL params
-3	IGNORE
+3	IGNORE	.*


### PR DESCRIPTION
## Summary

- Fixes malformed `.zap/rules.tsv` that caused ZAP to exit with code 3 (config error) before scanning
- ZAP requires 3 tab-separated columns: `rule_id`, `action`, `url_regex` — all entries were missing the URL column
- Added `.*` as a catch-all URL pattern to every rule

## Root cause

ZAP exit code 3 is a fatal/config error, distinct from exit 1 (WARN alerts) and exit 2 (FAIL alerts). The `fail_action: false` setting only suppresses codes 1 and 2 — a malformed config always fails regardless.

## Test plan

- [ ] Merge and rerun ZAP baseline scan — should load config successfully and complete the scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)