### PR TITLE
fix(ci): opt gitleaks job into Node.js 24 before forced migration

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -21,6 +21,10 @@ jobs:
   gitleaks:
     name: Detect Secrets (gitleaks)
     runs-on: ubuntu-latest
+    env:
+      # gitleaks-action v2.3.9 declares Node 20 but runs fine on Node 24.
+      # Opt in early before GitHub forces the switch on 2026-06-02.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the gitleaks job in `secret-scan.yml`

## Context

`gitleaks/gitleaks-action v2.3.9` (the latest release, from April 2025) declares Node.js 20 as its runtime. GitHub Actions is deprecating Node 20 with a forced migration on **2026-06-02** — 2 weeks away. After that date, the gitleaks job would start emitting errors.

All other pinned actions are confirmed on their latest versions and use Node 20+ compatible runtimes already.

The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var is the migration path GitHub recommends. The action is pure JS with no native binaries and is compatible with Node 24 at runtime.

## Other deprecations found (not actionable now)

- `lucia@3.2.2` / `@lucia-auth/adapter-sqlite@3.0.2` — upstream deprecated, but this is a planned auth migration, not a CI issue
- `Buffer()` (DEP0005), `punycode` (DEP0040) — from `actions/download-artifact` and Lighthouse CI internals respectively; not our code

## Test plan

- [ ] Merge and confirm Secret Scanning job runs without the Node 20 deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)