### PR TITLE
chore(auth): replace deprecated Lucia v3 with direct D1 session manager

### DIFF
--- a/functions/utils/__tests__/auth.test.js
+++ b/functions/utils/__tests__/auth.test.js
@@ -106,7 +106,7 @@ describe('initializeLucia / session manager', () => {
 
       expect(session).not.toBeNull();
       expect(session.id).toBe(sessionId);
-      expect(session.userId).toBe(1);
+      expect(session.userId).toBe(mockUsers.admin.id);
       expect(session.fresh).toBe(false);
       expect(session.expiresAt).toBeInstanceOf(Date);
       expect(user).not.toBeNull();

--- a/functions/utils/__tests__/auth.test.js
+++ b/functions/utils/__tests__/auth.test.js
@@ -1,0 +1,243 @@
+// functions/utils/__tests__/auth.test.js
+import { describe, test, expect, beforeEach } from 'vitest';
+import { createTestDB, createDBEnv, mockUsers } from '../../api/test-utils.js';
+import { initializeLucia } from '../auth.js';
+
+function makeEnv(rawDb, opts = {}) {
+  return {
+    DB: createDBEnv(rawDb),
+    ENVIRONMENT: opts.env ?? 'test',
+  };
+}
+
+function makeRequest(opts = {}) {
+  return new Request('https://example.test/api/admin/me', {
+    headers: opts.headers ?? {},
+  });
+}
+
+describe('initializeLucia / session manager', () => {
+  let rawDb;
+
+  beforeEach(() => {
+    rawDb = createTestDB();
+  });
+
+  // ── readSessionCookie ─────────────────────────────────────────────────────
+
+  describe('readSessionCookie', () => {
+    test('returns session ID from session_token cookie in dev/test', () => {
+      const env = makeEnv(rawDb, { env: 'test' });
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      const id = manager.readSessionCookie('session_token=abc123; other=x');
+      expect(id).toBe('abc123');
+    });
+
+    test('returns null when session cookie is absent', () => {
+      const env = makeEnv(rawDb, { env: 'test' });
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      expect(manager.readSessionCookie('other=x')).toBeNull();
+    });
+
+    test('returns session ID from __Host-session_token in production', () => {
+      const env = makeEnv(rawDb, { env: 'production' });
+      const req = makeRequest({ headers: { Host: 'settimes.ca' } });
+      const manager = initializeLucia(env.DB, req, env);
+      const id = manager.readSessionCookie('__Host-session_token=prodid; other=x');
+      expect(id).toBe('prodid');
+    });
+  });
+
+  // ── createSession ─────────────────────────────────────────────────────────
+
+  describe('createSession', () => {
+    test('returns a session object with fresh:true and a string id', async () => {
+      const env = makeEnv(rawDb);
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      const session = await manager.createSession(mockUsers.admin.id, {});
+
+      expect(typeof session.id).toBe('string');
+      expect(session.id.length).toBeGreaterThan(8);
+      expect(session.userId).toBe(mockUsers.admin.id);
+      expect(session.fresh).toBe(true);
+      expect(session.expiresAt).toBeInstanceOf(Date);
+    });
+
+    test('stores the session in lucia_sessions with expires_at ~30 days out', async () => {
+      const env = makeEnv(rawDb);
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      const before = Math.floor(Date.now() / 1000);
+      const session = await manager.createSession(mockUsers.admin.id, {});
+      const after = Math.floor(Date.now() / 1000);
+
+      const row = rawDb
+        .prepare('SELECT * FROM lucia_sessions WHERE id = ?')
+        .get(session.id);
+
+      expect(row).not.toBeNull();
+      expect(row.user_id).toBe(mockUsers.admin.id);
+      // expires_at must be approximately now + 30 days (unix seconds)
+      const thirtyDays = 30 * 24 * 3600;
+      expect(row.expires_at).toBeGreaterThanOrEqual(before + thirtyDays);
+      expect(row.expires_at).toBeLessThanOrEqual(after + thirtyDays + 5);
+    });
+  });
+
+  // ── validateSession ───────────────────────────────────────────────────────
+
+  describe('validateSession', () => {
+    async function seedSession(rawDb, userId = 1, offsetSeconds = 20 * 86400) {
+      const id = crypto.randomUUID();
+      const expiresAt = Math.floor(Date.now() / 1000) + offsetSeconds;
+      rawDb
+        .prepare(
+          "INSERT INTO lucia_sessions (id, user_id, expires_at, created_at, last_activity_at) VALUES (?, ?, ?, datetime('now'), datetime('now'))"
+        )
+        .run(id, userId, expiresAt);
+      return id;
+    }
+
+    test('returns session and user for a valid session', async () => {
+      const env = makeEnv(rawDb);
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      const sessionId = await seedSession(rawDb, mockUsers.admin.id);
+
+      const { session, user } = await manager.validateSession(sessionId);
+
+      expect(session).not.toBeNull();
+      expect(session.id).toBe(sessionId);
+      expect(session.userId).toBe(1);
+      expect(session.fresh).toBe(false);
+      expect(session.expiresAt).toBeInstanceOf(Date);
+      expect(user).not.toBeNull();
+      expect(user.email).toBe('admin@test');
+      expect(user.role).toBe('admin');
+    });
+
+    test('returns nulls for a non-existent session', async () => {
+      const env = makeEnv(rawDb);
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      const { session, user } = await manager.validateSession('no-such-id');
+      expect(session).toBeNull();
+      expect(user).toBeNull();
+    });
+
+    test('returns nulls and deletes an expired session', async () => {
+      const env = makeEnv(rawDb);
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      // expires_at in the past
+      const id = await seedSession(rawDb, mockUsers.admin.id, -10);
+
+      const { session, user } = await manager.validateSession(id);
+      expect(session).toBeNull();
+      expect(user).toBeNull();
+
+      const row = rawDb.prepare('SELECT id FROM lucia_sessions WHERE id = ?').get(id);
+      expect(row).toBeUndefined();
+    });
+  });
+
+  // ── invalidateSession ─────────────────────────────────────────────────────
+
+  describe('invalidateSession', () => {
+    test('removes the session row', async () => {
+      const env = makeEnv(rawDb);
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      const session = await manager.createSession(mockUsers.admin.id, {});
+
+      await manager.invalidateSession(session.id);
+
+      const row = rawDb
+        .prepare('SELECT id FROM lucia_sessions WHERE id = ?')
+        .get(session.id);
+      expect(row).toBeUndefined();
+    });
+  });
+
+  // ── invalidateUserSessions ────────────────────────────────────────────────
+
+  describe('invalidateUserSessions', () => {
+    test('removes all sessions for a user', async () => {
+      const env = makeEnv(rawDb);
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      await manager.createSession(mockUsers.admin.id, {});
+      await manager.createSession(mockUsers.admin.id, {});
+      await manager.createSession(mockUsers.editor.id, {}); // different user — must survive
+
+      await manager.invalidateUserSessions(mockUsers.admin.id);
+
+      const user1Rows = rawDb
+        .prepare('SELECT id FROM lucia_sessions WHERE user_id = ?')
+        .all(mockUsers.admin.id);
+      expect(user1Rows).toHaveLength(0);
+
+      const user2Rows = rawDb
+        .prepare('SELECT id FROM lucia_sessions WHERE user_id = ?')
+        .all(mockUsers.editor.id);
+      expect(user2Rows).toHaveLength(1);
+    });
+  });
+
+  // ── cookie serialization ──────────────────────────────────────────────────
+
+  describe('createSessionCookie', () => {
+    test('dev: serializes with session_token name, no Secure flag, SameSite=Lax', () => {
+      const env = makeEnv(rawDb, { env: 'test' });
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      const cookie = manager.createSessionCookie('test-session-id').serialize();
+
+      expect(cookie).toContain('session_token=test-session-id');
+      expect(cookie).toContain('HttpOnly');
+      expect(cookie).toContain('Path=/');
+      // Lucia sets expires:false → uses 400-day cookie lifetime (34560000 s)
+      expect(cookie).toContain('Max-Age=34560000');
+      // Lucia's serializeCookie only matches lowercase sameSite values;
+      // auth.js passes "Lax" (titlecase) so no SameSite header is emitted.
+      // The replacement will fix this — update this assertion to .toContain('SameSite=Lax') in Task 2.
+      expect(cookie).not.toContain('SameSite');
+      expect(cookie.toLowerCase()).not.toContain('secure');
+      expect(cookie).not.toContain('__Host-');
+    });
+
+    test('prod: serializes with __Host-session_token, Secure, SameSite=Strict', () => {
+      const env = makeEnv(rawDb, { env: 'production' });
+      const req = makeRequest({ headers: { Host: 'settimes.ca' } });
+      const manager = initializeLucia(env.DB, req, env);
+      const cookie = manager.createSessionCookie('prod-session-id').serialize();
+
+      expect(cookie).toContain('__Host-session_token=prod-session-id');
+      expect(cookie).toContain('HttpOnly');
+      expect(cookie).toContain('Path=/');
+      // Lucia sets expires:false → uses 400-day cookie lifetime (34560000 s)
+      expect(cookie).toContain('Max-Age=34560000');
+      // Lucia's serializeCookie only matches lowercase sameSite values;
+      // auth.js passes "Strict" (titlecase) so no SameSite header is emitted.
+      // The replacement will fix this — update this assertion to .toContain('SameSite=Strict') in Task 2.
+      expect(cookie).not.toContain('SameSite');
+      expect(cookie).toContain('Secure');
+    });
+  });
+
+  describe('createBlankSessionCookie', () => {
+    test('dev: serializes with Max-Age=0 to clear the cookie', () => {
+      const env = makeEnv(rawDb, { env: 'test' });
+      const manager = initializeLucia(env.DB, makeRequest(), env);
+      const cookie = manager.createBlankSessionCookie().serialize();
+
+      expect(cookie).toContain('session_token=');
+      expect(cookie).toContain('Max-Age=0');
+      expect(cookie).toContain('HttpOnly');
+    });
+
+    test('prod: serializes with __Host-session_token and Max-Age=0', () => {
+      const env = makeEnv(rawDb, { env: 'production' });
+      const req = makeRequest({ headers: { Host: 'settimes.ca' } });
+      const manager = initializeLucia(env.DB, req, env);
+      const cookie = manager.createBlankSessionCookie().serialize();
+
+      expect(cookie).toContain('__Host-session_token=');
+      expect(cookie).toContain('Max-Age=0');
+      expect(cookie).toContain('Secure');
+    });
+  });
+});

--- a/functions/utils/__tests__/auth.test.js
+++ b/functions/utils/__tests__/auth.test.js
@@ -189,12 +189,8 @@ describe('initializeLucia / session manager', () => {
       expect(cookie).toContain('session_token=test-session-id');
       expect(cookie).toContain('HttpOnly');
       expect(cookie).toContain('Path=/');
-      // Lucia sets expires:false → uses 400-day cookie lifetime (34560000 s)
-      expect(cookie).toContain('Max-Age=34560000');
-      // Lucia's serializeCookie only matches lowercase sameSite values;
-      // auth.js passes "Lax" (titlecase) so no SameSite header is emitted.
-      // The replacement will fix this — update this assertion to .toContain('SameSite=Lax') in Task 2.
-      expect(cookie).not.toContain('SameSite');
+      expect(cookie).toContain('Max-Age=2592000');
+      expect(cookie).toContain('SameSite=Lax');
       expect(cookie.toLowerCase()).not.toContain('secure');
       expect(cookie).not.toContain('__Host-');
     });
@@ -208,12 +204,8 @@ describe('initializeLucia / session manager', () => {
       expect(cookie).toContain('__Host-session_token=prod-session-id');
       expect(cookie).toContain('HttpOnly');
       expect(cookie).toContain('Path=/');
-      // Lucia sets expires:false → uses 400-day cookie lifetime (34560000 s)
-      expect(cookie).toContain('Max-Age=34560000');
-      // Lucia's serializeCookie only matches lowercase sameSite values;
-      // auth.js passes "Strict" (titlecase) so no SameSite header is emitted.
-      // The replacement will fix this — update this assertion to .toContain('SameSite=Strict') in Task 2.
-      expect(cookie).not.toContain('SameSite');
+      expect(cookie).toContain('Max-Age=2592000');
+      expect(cookie).toContain('SameSite=Strict');
       expect(cookie).toContain('Secure');
     });
   });

--- a/functions/utils/auth.js
+++ b/functions/utils/auth.js
@@ -1,7 +1,6 @@
 export const SESSION_CONFIG = {
   absoluteTimeout: 30 * 24 * 60 * 60 * 1000,
   idleTimeout: 30 * 60 * 1000,
-  refreshThreshold: 15 * 60 * 1000,
   adminIdleTimeout: 15 * 60 * 1000,
   adminAbsoluteTimeout: 8 * 60 * 60 * 1000,
 };

--- a/functions/utils/auth.js
+++ b/functions/utils/auth.js
@@ -1,65 +1,113 @@
-import { Lucia, TimeSpan } from "lucia";
-import { D1Adapter } from "@lucia-auth/adapter-sqlite";
-
 export const SESSION_CONFIG = {
-  // Absolute maximum session lifetime
   absoluteTimeout: 30 * 24 * 60 * 60 * 1000,
-
-  // Idle timeout (no activity)
   idleTimeout: 30 * 60 * 1000,
-
-  // Refresh threshold (extend session if within this time of expiry)
   refreshThreshold: 15 * 60 * 1000,
-
-  // Admin sessions have shorter timeouts
   adminIdleTimeout: 15 * 60 * 1000,
   adminAbsoluteTimeout: 8 * 60 * 60 * 1000,
 };
 
 export function isDevRequest(request, env = null) {
-  // SECURITY: Trust env.ENVIRONMENT over request headers — the Origin header
-  // is attacker-controlled and must not influence security-sensitive decisions.
-  if (env?.ENVIRONMENT === "production") return false;
-  if (env?.ENVIRONMENT && env.ENVIRONMENT !== "production") return true;
-  // Fallback for local dev without ENVIRONMENT set: check server-controlled headers only.
+  if (env?.ENVIRONMENT === 'production') return false;
+  if (env?.ENVIRONMENT && env.ENVIRONMENT !== 'production') return true;
   if (!request) return false;
-  const host = request.headers.get("Host") || "";
-  const url = request.url || "";
-  return host.includes("localhost") || url.includes("localhost");
+  const host = request.headers.get('Host') || '';
+  const url = request.url || '';
+  return host.includes('localhost') || url.includes('localhost');
+}
+
+const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+function serializeCookie(name, value, { secure, sameSite, maxAge }) {
+  const parts = [`${name}=${value}`, 'Path=/', 'HttpOnly', `SameSite=${sameSite}`, `Max-Age=${maxAge}`];
+  if (secure) parts.push('Secure');
+  return parts.join('; ');
 }
 
 export function initializeLucia(DB, request = null, env = null) {
   const isDev = request ? isDevRequest(request, env) : false;
-  const adapter = new D1Adapter(DB, {
-    user: "users",
-    session: "lucia_sessions",
-  });
+  const cookieName = isDev ? 'session_token' : '__Host-session_token';
+  const cookieOpts = {
+    secure: !isDev,
+    sameSite: isDev ? 'Lax' : 'Strict',
+  };
 
-  return new Lucia(adapter, {
-    sessionCookie: {
-      // __Host- prefix enforces Secure + Path=/ + no Domain at the browser level,
-      // preventing subdomain cookie injection. Not valid for HTTP (dev).
-      name: isDev ? "session_token" : "__Host-session_token",
-      expires: false,
-      attributes: {
-        secure: !isDev,
-        sameSite: isDev ? "Lax" : "Strict",
-        path: "/",
-        httpOnly: true,
-        // Explicit Max-Age keeps the cookie aligned with the DB session lifetime
-        // so browsers don't discard it on close while the server-side session
-        // remains valid, which would leave orphaned rows in lucia_sessions.
-        maxAge: 30 * 24 * 60 * 60, // 30 days, matches sessionExpiresIn below
-      },
+  return {
+    readSessionCookie(cookieHeader) {
+      if (!cookieHeader) return null;
+      for (const part of cookieHeader.split(';')) {
+        const [k, ...rest] = part.trim().split('=');
+        if (k.trim() === cookieName) return rest.join('=').trim() || null;
+      }
+      return null;
     },
-    sessionExpiresIn: new TimeSpan(30, "d"),
-    getUserAttributes: (attributes) => ({
-      email: attributes.email,
-      role: attributes.role,
-      name: attributes.name,
-      firstName: attributes.first_name,
-      lastName: attributes.last_name,
-      isActive: attributes.is_active,
-    }),
-  });
+
+    async validateSession(sessionId) {
+      const row = await DB.prepare(
+        `SELECT s.id, s.user_id, s.expires_at,
+                u.email, u.role, u.name, u.first_name, u.last_name, u.is_active
+         FROM lucia_sessions s
+         JOIN users u ON u.id = s.user_id
+         WHERE s.id = ?`
+      )
+        .bind(sessionId)
+        .first();
+
+      if (!row) return { session: null, user: null };
+
+      if (row.expires_at * 1000 < Date.now()) {
+        await DB.prepare('DELETE FROM lucia_sessions WHERE id = ?').bind(sessionId).run();
+        return { session: null, user: null };
+      }
+
+      return {
+        session: {
+          id: row.id,
+          userId: row.user_id,
+          fresh: false,
+          expiresAt: new Date(row.expires_at * 1000),
+        },
+        user: {
+          id: row.user_id,
+          email: row.email,
+          role: row.role,
+          name: row.name,
+          firstName: row.first_name,
+          lastName: row.last_name,
+          isActive: row.is_active,
+        },
+      };
+    },
+
+    async createSession(userId, _attributes = {}) {
+      const id = crypto.randomUUID();
+      const expiresAt = Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS;
+      await DB.prepare(
+        `INSERT INTO lucia_sessions (id, user_id, expires_at, created_at, last_activity_at)
+         VALUES (?, ?, ?, datetime('now'), datetime('now'))`
+      )
+        .bind(id, userId, expiresAt)
+        .run();
+      return { id, userId, fresh: true, expiresAt: new Date(expiresAt * 1000) };
+    },
+
+    async invalidateSession(sessionId) {
+      await DB.prepare('DELETE FROM lucia_sessions WHERE id = ?').bind(sessionId).run();
+    },
+
+    async invalidateUserSessions(userId) {
+      await DB.prepare('DELETE FROM lucia_sessions WHERE user_id = ?').bind(userId).run();
+    },
+
+    createSessionCookie(sessionId) {
+      return {
+        serialize: () => serializeCookie(cookieName, sessionId, { ...cookieOpts, maxAge: SESSION_TTL_SECONDS }),
+      };
+    },
+
+    createBlankSessionCookie() {
+      return {
+        serialize: () => serializeCookie(cookieName, '', { ...cookieOpts, maxAge: 0 }),
+      };
+    },
+  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,8 @@
       "name": "settimes",
       "version": "1.0.0",
       "dependencies": {
-        "@lucia-auth/adapter-sqlite": "^3.0.2",
         "csrf-csrf": "^4.0.3",
         "email-validator": "^2.0.4",
-        "lucia": "^3.2.2",
         "otplib": "^13.4.0"
       },
       "devDependencies": {
@@ -212,26 +210,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@lucia-auth/adapter-sqlite": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@lucia-auth/adapter-sqlite/-/adapter-sqlite-3.0.2.tgz",
-      "integrity": "sha512-UlXpF+2UoFEdm1AsriJii5BOARwqko6SX29rQ8T8Za7rnjj9KLXLaRVQUgBhGmggAyvzCtguJ2+XOZDsfWm6Sw==",
-      "deprecated": "This package has been deprecated. Please see https://lucia-auth.com/lucia-v3/migrate.",
-      "license": "MIT",
-      "peerDependencies": {
-        "@libsql/client": "^0.3.0",
-        "better-sqlite3": "8.x - 11.x",
-        "lucia": "3.x"
-      },
-      "peerDependenciesMeta": {
-        "@libsql/client": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -262,37 +240,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@oslojs/asn1": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
-      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@oslojs/binary": "1.0.0"
-      }
-    },
-    "node_modules/@oslojs/binary": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
-      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
-      "license": "MIT"
-    },
-    "node_modules/@oslojs/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@oslojs/asn1": "1.0.0",
-        "@oslojs/binary": "1.0.0"
-      }
-    },
-    "node_modules/@oslojs/encoding": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
-      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
-      "license": "MIT"
     },
     "node_modules/@otplib/core": {
       "version": "13.4.0",
@@ -1624,17 +1571,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lucia": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/lucia/-/lucia-3.2.2.tgz",
-      "integrity": "sha512-P1FlFBGCMPMXu+EGdVD9W4Mjm0DqsusmKgO7Xc33mI5X1bklmsQb0hfzPhXomQr9waWIBDsiOjvr1e6BTaUqpA==",
-      "deprecated": "This package has been deprecated. Please see https://lucia-auth.com/lucia-v3/migrate.",
-      "license": "MIT",
-      "dependencies": {
-        "@oslojs/crypto": "^1.0.1",
-        "@oslojs/encoding": "^1.1.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
     "vitest": "^4.1.6"
   },
   "dependencies": {
-    "@lucia-auth/adapter-sqlite": "^3.0.2",
     "csrf-csrf": "^4.0.3",
     "email-validator": "^2.0.4",
-    "lucia": "^3.2.2",
     "otplib": "^13.4.0"
   }
 }


### PR DESCRIPTION
## Summary

Removes `lucia@3.2.2` and `@lucia-auth/adapter-sqlite@3.0.2` (both deprecated upstream) and replaces them with a drop-in session manager that calls D1 directly.

- `initializeLucia()` keeps its exact name and return shape — zero changes to any caller
- `lucia_sessions` table schema is unchanged — no DB migration
- 7 Lucia methods replaced with equivalent D1 queries and `crypto.randomUUID()`
- `session.fresh` contract preserved: `true` on `createSession`, `false` on `validateSession`
- Cookie names and attributes corrected: `Max-Age=2592000` (was 400-day due to `expires: false`), `SameSite=Lax/Strict` now emitted (was silently dropped by Lucia due to titlecase mismatch)
- `createSession(userId, _attributes = {})` signature preserved for call-site compatibility

## Validation

- [x] Backend unit tests pass (`npm test` — 416 tests)
- [ ] Manual smoke: login → reload → logout in `wrangler dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)