### PR TITLE
fix(db): enable PRAGMA foreign_keys = ON for every D1 session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,11 @@ The Cloudflare Workers D1 binding does not support explicit `BEGIN`/`COMMIT` tra
 
 For mutations that cannot be expressed as a single batch (e.g., the event-duplication pattern in `functions/api/admin/events/[id].js`), use compensating deletes: if step N fails, manually undo steps 1…N-1.
 
-### PRAGMA `foreign_keys = ON` is NOT set in production
+### PRAGMA `foreign_keys = ON` is enforced in production
 
-SQLite foreign keys are disabled by default. They're enabled in test helpers but not in the production wrangler config (`wrangler.toml`). This is a known open issue (DB-F1). Do not silently assume FK constraints are enforced — application-level checks are required.
+`functions/_middleware.js` runs `PRAGMA foreign_keys = ON` on every D1 session before the request handler fires. Unit test helpers (`functions/api/test-utils.js`) set it the same way via `better-sqlite3`. FK constraints are active in all environments.
+
+When recreating a table in a migration (SQLite has no ALTER COLUMN), surround the table-recreation block with `PRAGMA foreign_keys = OFF` / `PRAGMA foreign_keys = ON` as migration 0032 does — D1 will reject the DROP otherwise.
 
 ### `ALLOW_ADMIN_SIGNUP` is test-only
 

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -19,6 +19,12 @@ export async function onRequest(context) {
 
   const log = createRequestLogger(context);
 
+  // Enable FK enforcement for this D1 session. SQLite disables it by default;
+  // this must be set per-connection so it applies to every handler in this request.
+  if (env.DB) {
+    await env.DB.prepare('PRAGMA foreign_keys = ON').run();
+  }
+
   // Allowed origins for CORS (production and development)
   const baseAllowedOrigins = [
     'https://settimes.ca',

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -19,12 +19,6 @@ export async function onRequest(context) {
 
   const log = createRequestLogger(context);
 
-  // Enable FK enforcement for this D1 session. SQLite disables it by default;
-  // this must be set per-connection so it applies to every handler in this request.
-  if (env.DB) {
-    await env.DB.prepare('PRAGMA foreign_keys = ON').run();
-  }
-
   // Allowed origins for CORS (production and development)
   const baseAllowedOrigins = [
     'https://settimes.ca',
@@ -102,6 +96,14 @@ export async function onRequest(context) {
     env?.CSP_ENFORCE !== undefined && env?.CSP_ENFORCE !== null
       ? env?.CSP_ENFORCE === 'true'
       : env?.ENVIRONMENT === 'production';
+
+  // Enable FK enforcement for this D1 session. SQLite disables it by default;
+  // this must be set per-connection so it applies to every handler in this request.
+  // Placed after all early returns so preflights and rejected origins don't pay
+  // a D1 round-trip.
+  if (env.DB) {
+    await env.DB.prepare('PRAGMA foreign_keys = ON').run();
+  }
 
   try {
     const startTime = Date.now();


### PR DESCRIPTION
## Summary

- Adds `await env.DB.prepare('PRAGMA foreign_keys = ON').run()` to `functions/_middleware.js` before each request handler fires
- This is a per-session SQLite setting — it must be set on every connection; it cannot be stored in the schema
- Activates all 20+ FK declarations in the schema (CASCADE, SET NULL, RESTRICT) in production and wrangler dev
- Unit test helpers (`functions/api/test-utils.js`) already set it via `better-sqlite3.pragma()` — no test changes needed
- Retires DB-F1 known-issue in CLAUDE.md and adds a migration reminder about PRAGMA OFF/ON when recreating tables

## Why this works

D1 gives each Worker invocation its own SQLite session. All `env.DB` calls within a single request share that session, so setting the PRAGMA once in the outermost middleware applies to every query in every handler for that request.

## Test plan

- [ ] CI passes (unit + E2E)
- [ ] Verify FK violations are now rejected: delete a band that has performances → should return an error (RESTRICT), not silently succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)