### PR TITLE
fix(security): address ZAP baseline scan findings

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -21,8 +21,7 @@
   Cross-Origin-Resource-Policy: same-origin
 
   # Content Security Policy
-  # img-src: no https: wildcard — only the R2 CDN (band-photos.settimes.ca) is an external image source
-  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: blob: https://band-photos.settimes.ca; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
 
   # Permissions policy (disable unnecessary features)
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()
@@ -42,7 +41,7 @@
   ! Content-Security-Policy
   Cross-Origin-Embedder-Policy: unsafe-none
   Cross-Origin-Opener-Policy: unsafe-none
-  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: blob: https://band-photos.settimes.ca; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors *; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors *; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
 
 # Cache control for static assets (versioned JS/CSS bundles)
 /assets/*

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -41,7 +41,7 @@
   ! Content-Security-Policy
   Cross-Origin-Embedder-Policy: unsafe-none
   Cross-Origin-Opener-Policy: unsafe-none
-  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors *; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-ancestors *; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
 
 # Cache control for static assets (versioned JS/CSS bundles)
 /assets/*

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -21,7 +21,8 @@
   Cross-Origin-Resource-Policy: same-origin
 
   # Content Security Policy
-  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  # img-src: no https: wildcard — only the R2 CDN (band-photos.settimes.ca) is an external image source
+  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: blob: https://band-photos.settimes.ca; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
 
   # Permissions policy (disable unnecessary features)
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()
@@ -41,7 +42,7 @@
   ! Content-Security-Policy
   Cross-Origin-Embedder-Policy: unsafe-none
   Cross-Origin-Opener-Policy: unsafe-none
-  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors *; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: blob: https://band-photos.settimes.ca; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors *; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
 
 # Cache control for static assets (versioned JS/CSS bundles)
 /assets/*

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -60,6 +60,9 @@ ${rows.join("\n")}
       headers: {
         "Content-Type": "application/xml; charset=UTF-8",
         "Cache-Control": "public, max-age=3600",
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "require-corp",
+        "Cross-Origin-Resource-Policy": "same-origin",
       },
     });
   } catch (error) {
@@ -75,7 +78,13 @@ ${rows.join("\n")}
 </urlset>`,
       {
         status: 500,
-        headers: { "Content-Type": "application/xml; charset=UTF-8" },
+        headers: {
+          "Content-Type": "application/xml; charset=UTF-8",
+          "Cache-Control": "no-store",
+          "Cross-Origin-Opener-Policy": "same-origin",
+          "Cross-Origin-Embedder-Policy": "require-corp",
+          "Cross-Origin-Resource-Policy": "same-origin",
+        },
       },
     );
   }


### PR DESCRIPTION
## Summary

- Add `Cross-Origin-Embedder-Policy: require-corp` to the `/*` static asset rule in `_headers`
- Add `/embed/*` override section that relaxes COEP/COOP/XFO/CSP for the iframe embed widget, using `!` unsetting to prevent Cloudflare Pages from comma-merging duplicate headers
- Add `object-src 'none'` to the embed CSP to eliminate the ZAP "Failure to Define Directive with No Fallback" alert
- Add COEP, COOP, and CORP headers directly in `sitemap.xml.js` — `_headers` rules don't apply to Pages Function responses, so they must be set inline
- Add `Cache-Control: no-store` to the sitemap error (500) path, which previously had no Cache-Control header at all

Closes #307

## Accepted risk (documented in #307)

| Alert | Justification |
|---|---|
| `style-src unsafe-inline` | Required for Tailwind 4 / React SPA static build |
| `frame-ancestors *` on `/embed/*` | Intentional — embed widget must load in any third-party site |
| `img-src https:` wildcard | Needed for band photos from R2 and external sources |
| Non-Storable Content on SPA pages | Intentional `no-store` prevents stale route shells after deploys |
| CORP/Permissions-Policy on `/cdn-cgi/` | Cloudflare Rocket Loader — not configurable from this repo |
| Cross-Domain Misconfiguration on main pages | ZAP false positive: AJAX spider attributes `ACAO: *` from the public events API to the referring page URLs |

## Test plan

- [ ] Deploy to preview and confirm ZAP scan shows no new alerts for the fixed items
- [ ] Verify embed widget (`/embed/*`) still loads inside a cross-origin iframe
- [ ] Verify `/sitemap.xml` returns COEP, COOP, CORP response headers
- [ ] Verify `/sitemap.xml` 200 path still has `Cache-Control: public, max-age=3600`

🤖 Generated with [Claude Code](https://claude.com/claude-code)