### PR TITLE
WS-D: Admin tooling — bulk band delete fix + bulk band import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ The Cloudflare Workers D1 binding does not support explicit `BEGIN`/`COMMIT` tra
 
 For mutations that cannot be expressed as a single batch (e.g., the event-duplication pattern in `functions/api/admin/events/[id].js`), use compensating deletes: if step N fails, manually undo steps 1…N-1.
 
+The bulk band import (`functions/api/admin/bands/import.js`) follows this pattern and is **all-or-nothing**: it validates every row first (an invalid row aborts the whole import with per-row errors, writing nothing), then find-or-creates profiles and inserts performances, rolling back everything it created if any write fails. A lineup is never left half-imported.
+
 ### PRAGMA `foreign_keys = ON` is enforced in production
 
 `functions/_middleware.js` runs `PRAGMA foreign_keys = ON` on every D1 session before the request handler fires. Unit test helpers (`functions/api/test-utils.js`) set it the same way via `better-sqlite3`. FK constraints are active in all environments.

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -1483,6 +1483,67 @@ paths:
         "500":
           $ref: "#/components/responses/ServerError"
 
+  /api/admin/bands/import:
+    post:
+      tags:
+        - Admin - Bands
+      summary: Bulk-import a lineup of bands for an event
+      description: >
+        Import many bands at once for one event. Every row is validated up front;
+        if any row is invalid nothing is written (400 with per-row errors). Valid
+        rows find-or-create band profiles by normalized name and create
+        performances. The whole import is rolled back on any write failure.
+      security:
+        - AdminSessionCookie: []
+          CsrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - event_id
+                - bands
+              properties:
+                event_id:
+                  type: integer
+                  description: Event the bands are imported into
+                bands:
+                  type: array
+                  maxItems: 200
+                  items:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        type: string
+                      start_time:
+                        type: string
+                        description: "Start time in HH:MM format"
+                      end_time:
+                        type: string
+                        description: "End time in HH:MM format"
+                      venue:
+                        type: string
+                        description: Must match an existing venue name
+                      genre:
+                        type: string
+      responses:
+        "201":
+          description: Import succeeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericRecord"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
   /api/admin/bands/photos:
     post:
       tags:

--- a/frontend/src/admin/BulkBandImport.jsx
+++ b/frontend/src/admin/BulkBandImport.jsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { bandsApi } from '../utils/adminApi'
+import { parseBandRows } from './utils/parseBandRows'
+
+// Paste-to-import UI for a lineup. One band per line:
+// name, start_time, end_time, venue, genre. Posts to the bulk-import endpoint,
+// which validates all rows atomically and returns per-row errors on failure.
+export default function BulkBandImport({ eventId, onImported }) {
+  const [text, setText] = useState('')
+  const [result, setResult] = useState('')
+  const [errors, setErrors] = useState([])
+  const [busy, setBusy] = useState(false)
+
+  const handleImport = async () => {
+    setResult('')
+    setErrors([])
+    const bands = parseBandRows(text)
+    if (bands.length === 0) {
+      setErrors(['Add at least one band — one per line: name, start, end, venue, genre'])
+      return
+    }
+    setBusy(true)
+    try {
+      const res = await bandsApi.bulkImport(eventId, bands)
+      const n = res.imported ?? 0
+      setResult(`Imported ${n} band${n === 1 ? '' : 's'}.`)
+      setText('')
+      if (onImported) onImported()
+    } catch (err) {
+      const rowErrors = err?.details?.errors
+      setErrors(Array.isArray(rowErrors) && rowErrors.length ? rowErrors : [err?.message || 'Import failed'])
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="bg-bg-purple rounded-lg p-4 space-y-3">
+      <h4 className="text-white font-semibold">Bulk import bands</h4>
+      <p className="text-gray-400 text-sm">
+        One band per line: <code>name, start, end, venue, genre</code>. Example:{' '}
+        <code>The Reverbs, 20:00, 21:00, Main Hall, rock</code>. Venues must already exist.
+      </p>
+      <textarea
+        aria-label="Bands to import"
+        value={text}
+        onChange={e => setText(e.target.value)}
+        rows={6}
+        className="w-full rounded bg-black/30 text-white p-2 text-sm font-mono"
+        placeholder="The Reverbs, 20:00, 21:00, Main Hall, rock"
+      />
+      <button
+        type="button"
+        onClick={handleImport}
+        disabled={busy}
+        className="px-4 py-2 rounded bg-white/10 hover:bg-white/20 text-white disabled:opacity-50"
+      >
+        {busy ? 'Importing…' : 'Import bands'}
+      </button>
+      {result && <p className="text-green-400 text-sm">{result}</p>}
+      {errors.length > 0 && (
+        <ul className="text-red-400 text-sm list-disc pl-5 space-y-1">
+          {errors.map((e, i) => (
+            <li key={i}>{e}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -4,6 +4,7 @@ import { bandsApi, venuesApi } from '../utils/adminApi'
 import BandForm from './BandForm'
 import BulkActionBar from './BulkActionBar'
 import BulkPreviewModal from './BulkPreviewModal'
+import BulkBandImport from './BulkBandImport'
 import ArtistPicker from './components/ArtistPicker'
 import ConfirmDialog from '../components/ui/ConfirmDialog'
 import { DEFAULT_GENRES, getNormalizedGenreSuggestions } from '../utils/genres'
@@ -552,17 +553,25 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
           <p className="text-sm text-white/70 mt-1">Manage performances, times, and venues for the selected event.</p>
         </div>
         {viewMode === 'list' && !readOnly && (
-          <button
-            onClick={() => {
-              setViewMode('picker')
-              if (!allBands.length) {
-                loadRoster()
-              }
-            }}
-            className="px-6 py-3 bg-accent-500 text-bg-navy rounded hover:bg-accent-600 transition-colors font-medium min-h-[44px]"
-          >
-            + Add to Lineup
-          </button>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => setViewMode('import')}
+              className="px-6 py-3 bg-bg-purple text-white rounded hover:bg-bg-purple/80 transition-colors font-medium min-h-[44px] border border-accent-500/30"
+            >
+              Bulk import
+            </button>
+            <button
+              onClick={() => {
+                setViewMode('picker')
+                if (!allBands.length) {
+                  loadRoster()
+                }
+              }}
+              className="px-6 py-3 bg-accent-500 text-bg-navy rounded hover:bg-accent-600 transition-colors font-medium min-h-[44px]"
+            >
+              + Add to Lineup
+            </button>
+          </div>
         )}
       </div>
 
@@ -575,6 +584,22 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
           loading={rosterLoading}
           venues={venues}
         />
+      )}
+
+      {viewMode === 'import' && !readOnly && (
+        <div className="space-y-3">
+          <button onClick={() => setViewMode('list')} className="text-sm text-white/70 hover:text-white">
+            ← Back to lineup
+          </button>
+          <BulkBandImport
+            eventId={selectedEventId}
+            onImported={() => {
+              loadData()
+              setViewMode('list')
+              if (showToast) showToast('Bands imported', 'success')
+            }}
+          />
+        </div>
       )}
 
       {viewMode === 'form' && !readOnly && (

--- a/frontend/src/admin/__tests__/BulkBandImport.test.jsx
+++ b/frontend/src/admin/__tests__/BulkBandImport.test.jsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import BulkBandImport from '../BulkBandImport'
+
+vi.mock('../../utils/adminApi', () => ({
+  bandsApi: { bulkImport: vi.fn() },
+}))
+
+import { bandsApi } from '../../utils/adminApi'
+
+describe('BulkBandImport', () => {
+  it('imports pasted bands and shows a success message', async () => {
+    bandsApi.bulkImport.mockResolvedValue({ success: true, imported: 2 })
+    render(<BulkBandImport eventId={7} />)
+
+    fireEvent.change(screen.getByLabelText(/Bands to import/i), {
+      target: {
+        value: 'Alpha, 20:00, 21:00, Hall, rock\nBeta, 21:00, 22:00, Hall, jazz',
+      },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Import bands/i }))
+
+    expect(await screen.findByText(/Imported 2 bands/i)).toBeInTheDocument()
+    expect(bandsApi.bulkImport).toHaveBeenCalledWith(7, [
+      {
+        name: 'Alpha',
+        start_time: '20:00',
+        end_time: '21:00',
+        venue: 'Hall',
+        genre: 'rock',
+      },
+      {
+        name: 'Beta',
+        start_time: '21:00',
+        end_time: '22:00',
+        venue: 'Hall',
+        genre: 'jazz',
+      },
+    ])
+  })
+
+  it('shows per-row errors when the import is rejected', async () => {
+    const err = new Error('Validation failed')
+    err.details = { errors: ['Row 2: venue "Nowhere" not found'] }
+    bandsApi.bulkImport.mockRejectedValue(err)
+    render(<BulkBandImport eventId={7} />)
+
+    fireEvent.change(screen.getByLabelText(/Bands to import/i), {
+      target: {
+        value: 'Good, 20:00, 21:00, Hall, rock\nBad, 21:00, 22:00, Nowhere, rock',
+      },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Import bands/i }))
+
+    expect(await screen.findByText(/venue "Nowhere" not found/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/admin/__tests__/parseBandRows.test.jsx
+++ b/frontend/src/admin/__tests__/parseBandRows.test.jsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { parseBandRows } from '../utils/parseBandRows'
+
+describe('parseBandRows', () => {
+  it('parses comma-separated lines into band rows', () => {
+    const rows = parseBandRows('Alpha, 20:00, 21:00, The Hall, rock\nBeta, 21:00, 22:00, The Hall, jazz')
+    expect(rows).toEqual([
+      {
+        name: 'Alpha',
+        start_time: '20:00',
+        end_time: '21:00',
+        venue: 'The Hall',
+        genre: 'rock',
+      },
+      {
+        name: 'Beta',
+        start_time: '21:00',
+        end_time: '22:00',
+        venue: 'The Hall',
+        genre: 'jazz',
+      },
+    ])
+  })
+
+  it('trims whitespace and skips blank lines', () => {
+    const rows = parseBandRows('  Solo Act , 18:00 , 19:00 , Park , folk \n\n   \n')
+    expect(rows).toEqual([
+      {
+        name: 'Solo Act',
+        start_time: '18:00',
+        end_time: '19:00',
+        venue: 'Park',
+        genre: 'folk',
+      },
+    ])
+  })
+
+  it('skips lines with no band name', () => {
+    const rows = parseBandRows(', 20:00, 21:00, Hall, rock\nReal Band, 21:00, 22:00, Hall, rock')
+    expect(rows).toEqual([
+      {
+        name: 'Real Band',
+        start_time: '21:00',
+        end_time: '22:00',
+        venue: 'Hall',
+        genre: 'rock',
+      },
+    ])
+  })
+
+  it('tolerates missing trailing fields', () => {
+    const rows = parseBandRows('Just A Name')
+    expect(rows).toEqual([
+      {
+        name: 'Just A Name',
+        start_time: '',
+        end_time: '',
+        venue: '',
+        genre: '',
+      },
+    ])
+  })
+})

--- a/frontend/src/admin/utils/parseBandRows.js
+++ b/frontend/src/admin/utils/parseBandRows.js
@@ -1,0 +1,16 @@
+// Parse pasted lineup text into band rows for bulk import.
+// One band per line, comma-separated: name, start_time, end_time, venue, genre.
+// Trailing fields may be omitted; blank lines and rows without a name are skipped.
+export function parseBandRows(text) {
+  if (typeof text !== 'string') return []
+  return text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const cells = line.split(',').map(c => c.trim())
+      const [name = '', start_time = '', end_time = '', venue = '', genre = ''] = cells
+      return { name, start_time, end_time, venue, genre }
+    })
+    .filter(row => row.name)
+}

--- a/frontend/src/utils/adminApi.js
+++ b/frontend/src/utils/adminApi.js
@@ -634,6 +634,16 @@ export const bandsApi = {
     return handleResponse(response)
   },
 
+  async bulkImport(eventId, bands) {
+    const response = await fetchWithCSRFRetry(`${API_BASE}/bands/import`, {
+      method: 'POST',
+      headers: getHeaders(),
+      credentials: 'include',
+      body: JSON.stringify({ event_id: eventId, bands }),
+    })
+    return handleResponse(response)
+  },
+
   async bulkPreview(bandIds, action, params = {}) {
     const response = await fetchWithCSRFRetry(`${API_BASE}/bands/bulk-preview`, {
       method: 'POST',

--- a/functions/api/admin/bands/__tests__/bulk.test.js
+++ b/functions/api/admin/bands/__tests__/bulk.test.js
@@ -1,0 +1,48 @@
+// Bulk band operations endpoint tests
+// DELETE /api/admin/bands/bulk
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../_middleware.js', () => ({
+  checkPermission: async (context) => {
+    const role =
+      context?.data?.user?.role || context?.request?.headers?.get('x-test-role')
+    if (!role) {
+      return {
+        error: true,
+        response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      }
+    }
+    return { error: false, user: { userId: 1, email: 'a@b.c', role }, userId: 1 }
+  },
+  auditLog: vi.fn(async () => {}),
+}))
+
+import { onRequestDelete } from '../bulk.js'
+import { createTestEnv } from '../../../test-utils.js'
+
+function deleteRequest(env, bandIds) {
+  return onRequestDelete({
+    request: new Request('https://example.test/api/admin/bands/bulk', {
+      method: 'DELETE',
+      headers: { 'x-test-role': 'editor', 'content-type': 'application/json' },
+      body: JSON.stringify({ band_ids: bandIds }),
+    }),
+    env,
+    data: { user: { userId: 1, email: 'a@b.c', role: 'editor' } },
+  })
+}
+
+describe('DELETE /api/admin/bands/bulk', () => {
+  test('reports success:false when some ids could not be deleted', async () => {
+    const { env } = createTestEnv()
+    const res = await deleteRequest(env, ['profile_abc'])
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.errors).toBeTruthy()
+    expect(body.deletedCount).toBe(0)
+  })
+})

--- a/functions/api/admin/bands/__tests__/import.test.js
+++ b/functions/api/admin/bands/__tests__/import.test.js
@@ -1,0 +1,138 @@
+// Bulk band import endpoint tests
+// POST /api/admin/bands/import
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../_middleware.js', () => ({
+  checkPermission: async (context) => {
+    const role =
+      context?.data?.user?.role || context?.request?.headers?.get('x-test-role')
+    if (!role) {
+      return {
+        error: true,
+        response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      }
+    }
+    return { error: false, user: { userId: 1, email: 'a@b.c', role }, userId: 1 }
+  },
+  auditLog: vi.fn(async () => {}),
+}))
+
+import { onRequestPost } from '../import.js'
+import {
+  createTestEnv,
+  insertBand,
+  insertEvent,
+  insertVenue,
+} from '../../../test-utils.js'
+
+function importRequest(env, payload) {
+  return onRequestPost({
+    request: new Request('https://example.test/api/admin/bands/import', {
+      method: 'POST',
+      headers: { 'x-test-role': 'editor', 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
+    env,
+    data: { user: { userId: 1, email: 'a@b.c', role: 'editor' } },
+  })
+}
+
+describe('POST /api/admin/bands/import', () => {
+  test('imports new bands as performances for the event', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
+    insertVenue(rawDb, { name: 'The Hall' })
+
+    const res = await importRequest(env, {
+      event_id: event.id,
+      bands: [
+        {
+          name: 'Alpha',
+          start_time: '20:00',
+          end_time: '21:00',
+          venue: 'The Hall',
+          genre: 'rock',
+        },
+        {
+          name: 'Beta',
+          start_time: '21:00',
+          end_time: '22:00',
+          venue: 'The Hall',
+          genre: 'jazz',
+        },
+      ],
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.imported).toBe(2)
+
+    const perfCount = rawDb
+      .prepare('SELECT COUNT(*) AS c FROM performances WHERE event_id = ?')
+      .get(event.id)
+    expect(perfCount.c).toBe(2)
+
+    const alpha = rawDb
+      .prepare("SELECT * FROM band_profiles WHERE name_normalized = 'alpha'")
+      .get()
+    expect(alpha).toBeTruthy()
+    expect(alpha.genre).toBe('rock')
+  })
+
+  test('rejects the whole import and writes nothing if any row is invalid (atomic)', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
+    insertVenue(rawDb, { name: 'The Hall' })
+
+    const res = await importRequest(env, {
+      event_id: event.id,
+      bands: [
+        { name: 'Good', start_time: '20:00', end_time: '21:00', venue: 'The Hall' },
+        { name: 'Bad', venue: 'No Such Venue' },
+      ],
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.errors.length).toBeGreaterThan(0)
+
+    const perfCount = rawDb
+      .prepare('SELECT COUNT(*) AS c FROM performances WHERE event_id = ?')
+      .get(event.id)
+    expect(perfCount.c).toBe(0)
+    const profileCount = rawDb
+      .prepare(
+        "SELECT COUNT(*) AS c FROM band_profiles WHERE name_normalized IN ('good','bad')"
+      )
+      .get()
+    expect(profileCount.c).toBe(0)
+  })
+
+  test('reuses an existing band profile instead of duplicating it', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
+    insertVenue(rawDb, { name: 'The Hall' })
+    insertBand(rawDb, { name: 'Alpha' })
+
+    const res = await importRequest(env, {
+      event_id: event.id,
+      bands: [
+        { name: 'Alpha', start_time: '20:00', end_time: '21:00', venue: 'The Hall' },
+      ],
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.createdProfiles).toBe(0)
+
+    const profiles = rawDb
+      .prepare("SELECT COUNT(*) AS c FROM band_profiles WHERE name_normalized = 'alpha'")
+      .get()
+    expect(profiles.c).toBe(1)
+  })
+})

--- a/functions/api/admin/bands/bulk.js
+++ b/functions/api/admin/bands/bulk.js
@@ -162,14 +162,14 @@ export async function onRequestDelete(context) {
             continue;
           }
 
-          await auditLog(env, user.userId, "band_profile.deleted", "band_profile", profileId, { deletedBy: user.email, bulk: true }, ipAddress);
           await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(profileId).run();
+          await auditLog(env, user.userId, "band_profile.deleted", "band_profile", profileId, { deletedBy: user.email, bulk: true }, ipAddress);
           deletedCount++;
         } else {
           const performance = performanceMap.get(Number(id));
           if (performance) {
-            await auditLog(env, user.userId, "band.deleted", "band", id, { bandName: performance.name, bulk: true }, ipAddress);
             await DB.prepare("DELETE FROM performances WHERE id = ?").bind(id).run();
+            await auditLog(env, user.userId, "band.deleted", "band", id, { bandName: performance.name, bulk: true }, ipAddress);
             deletedCount++;
           }
         }
@@ -181,7 +181,7 @@ export async function onRequestDelete(context) {
 
     return new Response(
       JSON.stringify({
-        success: true,
+        success: errors.length === 0,
         message: `Deleted ${deletedCount} bands`,
         deletedCount,
         errors: errors.length > 0 ? errors : undefined,

--- a/functions/api/admin/bands/import.js
+++ b/functions/api/admin/bands/import.js
@@ -1,0 +1,186 @@
+// Admin API: bulk-import a lineup of bands for an event.
+// POST /api/admin/bands/import
+// Body: { event_id, bands: [{ name, start_time, end_time, venue, genre, origin }] }
+//
+// Import is all-or-nothing: every row is validated up front, and if any row is
+// invalid nothing is written (400 + per-row errors). During the write phase, any
+// unexpected failure triggers a compensating delete of everything this request
+// created, so a lineup is never left half-imported.
+import { auditLog, checkPermission } from "../_middleware.js";
+import { getClientIP } from "../../../utils/request.js";
+import { isValidTime } from "../../../utils/validation.js";
+
+const MAX_IMPORT_ROWS = 200;
+const MAX_NAME_LENGTH = 200;
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function normalizeName(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const { DB } = env;
+
+  // RBAC: editor or higher
+  const permCheck = await checkPermission(context, "editor");
+  if (permCheck.error) return permCheck.response;
+  const user = permCheck.user;
+  const ipAddress = getClientIP(request);
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const eventId = Number(body.event_id);
+  const rows = Array.isArray(body.bands) ? body.bands : [];
+
+  if (!Number.isInteger(eventId) || eventId <= 0) {
+    return json({ error: "Invalid event_id" }, 400);
+  }
+  if (rows.length === 0) {
+    return json({ error: "No bands provided" }, 400);
+  }
+  if (rows.length > MAX_IMPORT_ROWS) {
+    return json({ error: `Maximum ${MAX_IMPORT_ROWS} bands per import` }, 400);
+  }
+
+  const event = await DB.prepare("SELECT id FROM events WHERE id = ?")
+    .bind(eventId)
+    .first();
+  if (!event) {
+    return json({ error: "Event not found" }, 404);
+  }
+
+  // Resolve venues by name (case-insensitive) up front.
+  const venues = await DB.prepare("SELECT id, name FROM venues").all();
+  const venueByName = new Map(
+    (venues.results || []).map((v) => [v.name.toLowerCase(), v.id]),
+  );
+
+  // Validate every row before writing anything — import is all-or-nothing.
+  const errors = [];
+  const prepared = rows.map((row, i) => {
+    const rowNum = i + 1;
+    const name = typeof row?.name === "string" ? row.name.trim() : "";
+    if (!name) {
+      errors.push(`Row ${rowNum}: name is required`);
+      return null;
+    }
+    if (name.length > MAX_NAME_LENGTH) {
+      errors.push(`Row ${rowNum}: name exceeds ${MAX_NAME_LENGTH} characters`);
+      return null;
+    }
+    const startTime = row.start_time ? String(row.start_time).trim() : null;
+    const endTime = row.end_time ? String(row.end_time).trim() : null;
+    if (startTime && !isValidTime(startTime).valid) {
+      errors.push(`Row ${rowNum}: invalid start_time "${startTime}"`);
+      return null;
+    }
+    if (endTime && !isValidTime(endTime).valid) {
+      errors.push(`Row ${rowNum}: invalid end_time "${endTime}"`);
+      return null;
+    }
+    let venueId = null;
+    if (row.venue) {
+      const key = String(row.venue).trim().toLowerCase();
+      if (!venueByName.has(key)) {
+        errors.push(`Row ${rowNum}: venue "${row.venue}" not found`);
+        return null;
+      }
+      venueId = venueByName.get(key);
+    }
+    return {
+      name,
+      nameNormalized: normalizeName(name),
+      genre: row.genre ? String(row.genre).trim() : null,
+      origin: row.origin ? String(row.origin).trim() : null,
+      startTime,
+      endTime,
+      venueId,
+    };
+  });
+
+  if (errors.length > 0) {
+    return json({ success: false, error: "Validation failed", errors }, 400);
+  }
+
+  // Write phase: find-or-create profile + insert performance per row.
+  // Track what we create so we can roll back on any failure.
+  const insertedPerformanceIds = [];
+  const createdProfileIds = [];
+  try {
+    for (const p of prepared) {
+      let profile = await DB.prepare(
+        "SELECT id FROM band_profiles WHERE name_normalized = ?",
+      )
+        .bind(p.nameNormalized)
+        .first();
+
+      if (!profile) {
+        profile = await DB.prepare(
+          `INSERT INTO band_profiles (name, name_normalized, genre, origin, is_active)
+           VALUES (?, ?, ?, ?, 1) RETURNING id`,
+        )
+          .bind(p.name, p.nameNormalized, p.genre, p.origin)
+          .first();
+        if (!profile) throw new Error("band_profiles INSERT returned null");
+        createdProfileIds.push(profile.id);
+      }
+
+      const perf = await DB.prepare(
+        `INSERT INTO performances (event_id, venue_id, band_profile_id, start_time, end_time)
+         VALUES (?, ?, ?, ?, ?) RETURNING id`,
+      )
+        .bind(eventId, p.venueId, profile.id, p.startTime, p.endTime)
+        .first();
+      if (!perf) throw new Error("performances INSERT returned null");
+      insertedPerformanceIds.push(perf.id);
+    }
+  } catch (err) {
+    // Compensating delete — undo everything this import created.
+    for (const id of insertedPerformanceIds) {
+      await DB.prepare("DELETE FROM performances WHERE id = ?").bind(id).run();
+    }
+    for (const id of createdProfileIds) {
+      await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(id).run();
+    }
+    console.error("Bulk import failed, rolled back:", err);
+    return json(
+      { error: "Import failed", message: "No bands were imported" },
+      500,
+    );
+  }
+
+  await auditLog(
+    env,
+    user.userId,
+    "bands.imported",
+    "event",
+    eventId,
+    {
+      imported: insertedPerformanceIds.length,
+      createdProfiles: createdProfileIds.length,
+    },
+    ipAddress,
+  );
+
+  return json(
+    {
+      success: true,
+      imported: insertedPerformanceIds.length,
+      createdProfiles: createdProfileIds.length,
+      performance_ids: insertedPerformanceIds,
+    },
+    201,
+  );
+}


### PR DESCRIPTION
Part of the Vol 17 readiness roadmap. Three increments.

## `fix(admin)` — bulk band delete correctness (M3)
`bands/bulk.js onRequestDelete` returned `success: true` even on partial failure (invalid ids, or profiles blocked by existing performances), misleading callers. Now returns `success: errors.length === 0`. Each `auditLog` also moved to **after** its `DELETE`, so the audit trail cannot record a deletion that then threw. (From the silent-failure audit.)

## `feat(admin)` — bulk band import
New `POST /api/admin/bands/import` imports a whole lineup in one request:
- **All-or-nothing**: every row validated up front (name required, HH:MM times, venue must resolve by name); any invalid row aborts with per-row errors, writing nothing.
- Find-or-creates band profiles by normalized name, inserts performances, **compensating-delete rollback** on any write failure.
- Editor RBAC; audited as `bands.imported`.

Frontend: a **Bulk import** mode in `LineupTab` with a paste box (`name, start, end, venue, genre` per line) → `parseBandRows` → API → shows imported count or per-row errors → reloads the lineup.

## Docs
OpenAPI entry for the new endpoint; CLAUDE.md note on the all-or-nothing semantics.

## Tests (TDD)
`bulk.test.js`, `import.test.js` (happy path + atomicity + reuse guards), `parseBandRows.test.jsx`, `BulkBandImport.test.jsx`. Backend 420 · frontend 177 · lint · build · OpenAPI — all green.

## Note
Event clone (also planned for WS-D) was found already implemented (`/duplicate` endpoint + EventsTab UI), so it is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)