### PR TITLE
WS-B/WS-C: Metrics reliability + share analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,14 @@ All interactions go through `frontend/src/utils/scheduleStorage.js`. Do not writ
 
 ---
 
+## Metrics & Analytics
+
+Metrics write to D1 daily-aggregate tables (`page_views_daily`, `artist_daily_stats`) via `POST /api/metrics`, plus an optional Cloudflare Analytics Engine sink (`env.ANALYTICS`, configured in `wrangler.toml`). Ingestion is best-effort and fire-and-forget; failures must not surface to users.
+
+**Share metrics come from `share_links`, not telemetry.** A share *create* is a `share_links` row; a *view* increments `share_links.view_count` (best-effort, in the `GET /api/schedule/share/[slug]` handler). The admin event metrics endpoint reads these directly. Do **not** wire the allowlisted-but-unused `share_event` / `filter_use` events into `/api/metrics` for share counts — they would be redundant with `share_links`.
+
+---
+
 ## RBAC Roles
 
 Three roles in ascending order: `viewer` → `editor` → `admin`.

--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -412,7 +412,8 @@ CREATE TABLE IF NOT EXISTS share_links (
   performance_ids TEXT    NOT NULL,
   band_names      TEXT    NOT NULL,
   created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
-  expires_at      TEXT    NOT NULL
+  expires_at      TEXT    NOT NULL,
+  view_count      INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_share_links_slug ON share_links(slug);
 CREATE INDEX IF NOT EXISTS idx_share_links_expires_at ON share_links(expires_at);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -432,7 +432,9 @@ function App() {
       { replace: true }
     )
 
-    fetch(`/api/schedule/share/${encodeURIComponent(shareSlug)}`)
+    // ?import=1 — this is the apply-the-route refetch after the preview already
+    // counted the view, so it must not inflate share view_count (see share/[slug].js).
+    fetch(`/api/schedule/share/${encodeURIComponent(shareSlug)}?import=1`)
       .then(res => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then(data => {
         const matchedBands = bands.filter(band => {

--- a/frontend/src/admin/MetricsDashboard.jsx
+++ b/frontend/src/admin/MetricsDashboard.jsx
@@ -46,6 +46,18 @@ export default function MetricsDashboard({ eventId }) {
             {metrics.lastUpdated ? new Date(metrics.lastUpdated).toLocaleDateString() : 'Never'}
           </div>
         </div>
+
+        {/* Shares Created */}
+        <div className="bg-bg-purple rounded-lg p-4">
+          <div className="text-gray-400 text-sm">Shares Created</div>
+          <div className="text-3xl font-bold text-white mt-2">{metrics.totalShares ?? 0}</div>
+        </div>
+
+        {/* Share Views */}
+        <div className="bg-bg-purple rounded-lg p-4">
+          <div className="text-gray-400 text-sm">Share Views</div>
+          <div className="text-3xl font-bold text-white mt-2">{metrics.totalShareViews ?? 0}</div>
+        </div>
       </div>
 
       {/* Popular Bands */}
@@ -63,6 +75,25 @@ export default function MetricsDashboard({ eventId }) {
             ))
           ) : (
             <p className="text-gray-400 text-sm">No data available yet</p>
+          )}
+        </div>
+      </div>
+
+      {/* Most-Viewed Shared Routes */}
+      <div className="bg-bg-purple rounded-lg p-4">
+        <h4 className="text-white font-semibold mb-3">Most-Viewed Shared Routes</h4>
+        <div className="space-y-2">
+          {(metrics.topSharedRoutes || []).length > 0 ? (
+            (metrics.topSharedRoutes || []).map((route, idx) => (
+              <div key={route.slug} className="flex justify-between text-sm">
+                <span className="text-white">
+                  {idx + 1}. /s/{route.slug}
+                </span>
+                <span className="text-gray-400">{route.view_count} views</span>
+              </div>
+            ))
+          ) : (
+            <p className="text-gray-400 text-sm">No shared routes yet</p>
           )}
         </div>
       </div>

--- a/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
+++ b/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import MetricsDashboard from '../MetricsDashboard'
+
+vi.mock('../../utils/adminApi', () => ({
+  eventsApi: {
+    getMetrics: vi.fn(),
+  },
+}))
+
+import { eventsApi } from '../../utils/adminApi'
+
+describe('MetricsDashboard', () => {
+  it('displays share analytics: shares created, share views, and top routes', async () => {
+    eventsApi.getMetrics.mockResolvedValue({
+      metrics: {
+        totalScheduleBuilds: 10,
+        uniqueVisitors: 7,
+        lastUpdated: '2026-06-18 12:00:00',
+        popularBands: [],
+        totalShares: 3,
+        totalShareViews: 42,
+        topSharedRoutes: [
+          { slug: 'abc123', view_count: 30 },
+          { slug: 'def456', view_count: 12 },
+        ],
+      },
+    })
+
+    render(<MetricsDashboard eventId={1} />)
+
+    expect(await screen.findByText('Shares Created')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('Share Views')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('Most-Viewed Shared Routes')).toBeInTheDocument()
+    expect(screen.getByText(/abc123/)).toBeInTheDocument()
+    expect(screen.getByText('30 views')).toBeInTheDocument()
+  })
+})

--- a/functions/api/admin/events/[id]/metrics.js
+++ b/functions/api/admin/events/[id]/metrics.js
@@ -58,6 +58,27 @@ export async function onRequestGet(context) {
       popularBands = { results: [] };
     }
 
+    // Share-link analytics: shares created + total views + top routes by views.
+    // Derived directly from share_links (creates are rows; views are view_count),
+    // so no separate share telemetry path is needed.
+    const shareStats = await DB.prepare(
+      `SELECT COUNT(*) AS total_shares,
+              COALESCE(SUM(view_count), 0) AS total_share_views
+       FROM share_links WHERE event_id = ?`,
+    )
+      .bind(eventId)
+      .first();
+
+    const topSharedRoutes = await DB.prepare(
+      `SELECT slug, view_count
+       FROM share_links
+       WHERE event_id = ?
+       ORDER BY view_count DESC, created_at DESC
+       LIMIT 10`,
+    )
+      .bind(eventId)
+      .all();
+
     return new Response(
       JSON.stringify({
         success: true,
@@ -66,6 +87,9 @@ export async function onRequestGet(context) {
           uniqueVisitors: metrics?.unique_visitors || 0,
           lastUpdated: metrics?.last_updated,
           popularBands: popularBands.results || [],
+          totalShares: shareStats?.total_shares || 0,
+          totalShareViews: shareStats?.total_share_views || 0,
+          topSharedRoutes: topSharedRoutes.results || [],
         },
       }),
       {

--- a/functions/api/admin/events/__tests__/metrics.test.js
+++ b/functions/api/admin/events/__tests__/metrics.test.js
@@ -1,0 +1,72 @@
+// Admin event metrics endpoint tests
+// GET /api/admin/events/[id]/metrics
+import { describe, expect, test, vi } from 'vitest'
+
+// Mock RBAC middleware: authenticate via context.data.user.role or x-test-role header
+vi.mock('../../_middleware.js', () => ({
+  checkPermission: async (context) => {
+    const role =
+      context?.data?.user?.role || context?.request?.headers?.get('x-test-role')
+    if (!role) {
+      return {
+        error: true,
+        response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      }
+    }
+    return { error: false, user: { userId: 1, role }, userId: 1 }
+  },
+  auditLog: async () => {},
+}))
+
+import { onRequestGet } from '../[id]/metrics.js'
+import { createTestEnv, insertEvent, insertShareLink } from '../../../test-utils.js'
+
+describe('GET /api/admin/events/[id]/metrics', () => {
+  function call(env, eventId) {
+    return onRequestGet({
+      request: new Request(
+        `https://example.test/api/admin/events/${eventId}/metrics`,
+        { headers: { 'x-test-role': 'viewer' } }
+      ),
+      params: { id: String(eventId) },
+      env,
+      data: { user: { userId: 1, role: 'viewer' } },
+    })
+  }
+
+  test('includes share analytics: count, total views, and top routes by views', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
+    insertShareLink(rawDb, {
+      slug: 'routeaaa',
+      event_id: event.id,
+      event_slug: 'fest',
+      performance_ids: [1],
+      band_names: ['A'],
+    })
+    insertShareLink(rawDb, {
+      slug: 'routebbb',
+      event_id: event.id,
+      event_slug: 'fest',
+      performance_ids: [1, 2],
+      band_names: ['A', 'B'],
+    })
+    rawDb
+      .prepare('UPDATE share_links SET view_count = ? WHERE slug = ?')
+      .run(5, 'routeaaa')
+    rawDb
+      .prepare('UPDATE share_links SET view_count = ? WHERE slug = ?')
+      .run(2, 'routebbb')
+
+    const res = await call(env, event.id)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.metrics.totalShares).toBe(2)
+    expect(body.metrics.totalShareViews).toBe(7)
+    expect(body.metrics.topSharedRoutes[0].slug).toBe('routeaaa')
+    expect(body.metrics.topSharedRoutes[0].view_count).toBe(5)
+  })
+})

--- a/functions/api/schedule/__tests__/share-get.test.js
+++ b/functions/api/schedule/__tests__/share-get.test.js
@@ -100,4 +100,34 @@ describe('GET /api/schedule/share/[slug]', () => {
       .get('view1234')
     expect(row.view_count).toBe(2)
   })
+
+  test('does not increment view_count for an import refetch (?import=1)', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'My Fest', slug: 'my-fest' })
+    rawDb.prepare('UPDATE events SET is_published = 1 WHERE id = ?').run(event.id)
+    insertShareLink(rawDb, {
+      slug: 'import12',
+      event_id: event.id,
+      event_slug: 'my-fest',
+      performance_ids: [10],
+      band_names: ['Band A'],
+    })
+
+    const importFetch = () =>
+      onRequestGet({
+        request: new Request(
+          'https://example.test/api/schedule/share/import12?import=1'
+        ),
+        params: { slug: 'import12' },
+        env,
+      })
+
+    await importFetch()
+    await importFetch()
+
+    const row = rawDb
+      .prepare('SELECT view_count FROM share_links WHERE slug = ?')
+      .get('import12')
+    expect(row.view_count).toBe(0)
+  })
 })

--- a/functions/api/schedule/__tests__/share-get.test.js
+++ b/functions/api/schedule/__tests__/share-get.test.js
@@ -72,4 +72,32 @@ describe('GET /api/schedule/share/[slug]', () => {
     })
     expect(res.status).toBe(400)
   })
+
+  test('increments view_count each time the share link is fetched', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'My Fest', slug: 'my-fest' })
+    rawDb.prepare('UPDATE events SET is_published = 1 WHERE id = ?').run(event.id)
+    insertShareLink(rawDb, {
+      slug: 'view1234',
+      event_id: event.id,
+      event_slug: 'my-fest',
+      performance_ids: [10],
+      band_names: ['Band A'],
+    })
+
+    const call = () =>
+      onRequestGet({
+        request: makeRequest('view1234'),
+        params: { slug: 'view1234' },
+        env,
+      })
+
+    await call()
+    await call()
+
+    const row = rawDb
+      .prepare('SELECT view_count FROM share_links WHERE slug = ?')
+      .get('view1234')
+    expect(row.view_count).toBe(2)
+  })
 })

--- a/functions/api/schedule/share/[slug].js
+++ b/functions/api/schedule/share/[slug].js
@@ -9,7 +9,7 @@ function json(body, status = 200) {
 }
 
 export async function onRequestGet(context) {
-  const { params, env } = context
+  const { params, env, request } = context
   const { DB } = env
   const { slug } = params
 
@@ -35,14 +35,21 @@ export async function onRequestGet(context) {
 
     // Best-effort view counter — a counter failure must never break share
     // retrieval, but we log (not silently swallow) so write failures stay visible.
-    try {
-      await DB.prepare(
-        'UPDATE share_links SET view_count = view_count + 1 WHERE slug = ?'
-      )
-        .bind(slug)
-        .run()
-    } catch (err) {
-      console.error('Share link view-count increment failed:', slug, err)
+    // The import refetch (App.jsx adds ?import=1) re-fetches the same snapshot to
+    // apply it after the preview already counted, so it must NOT count again —
+    // only genuine preview views (SharePreviewPage, no flag) increment.
+    const isImportRefetch =
+      new URL(request.url).searchParams.get('import') === '1'
+    if (!isImportRefetch) {
+      try {
+        await DB.prepare(
+          'UPDATE share_links SET view_count = view_count + 1 WHERE slug = ?'
+        )
+          .bind(slug)
+          .run()
+      } catch (err) {
+        console.error('Share link view-count increment failed:', slug, err)
+      }
     }
 
     let performance_ids, band_names

--- a/functions/api/schedule/share/[slug].js
+++ b/functions/api/schedule/share/[slug].js
@@ -33,6 +33,18 @@ export async function onRequestGet(context) {
       return json({ error: 'Share link not found or expired' }, 404)
     }
 
+    // Best-effort view counter — a counter failure must never break share
+    // retrieval, but we log (not silently swallow) so write failures stay visible.
+    try {
+      await DB.prepare(
+        'UPDATE share_links SET view_count = view_count + 1 WHERE slug = ?'
+      )
+        .bind(slug)
+        .run()
+    } catch (err) {
+      console.error('Share link view-count increment failed:', slug, err)
+    }
+
     let performance_ids, band_names
     try {
       performance_ids = JSON.parse(row.performance_ids)

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -311,7 +311,8 @@ export function createTestDB() {
       performance_ids TEXT    NOT NULL,
       band_names      TEXT    NOT NULL,
       created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
-      expires_at      TEXT    NOT NULL
+      expires_at      TEXT    NOT NULL,
+      view_count      INTEGER NOT NULL DEFAULT 0
     );
   `);
 

--- a/migrations/0039_add_page_views_daily.sql
+++ b/migrations/0039_add_page_views_daily.sql
@@ -1,0 +1,20 @@
+-- Migration: 0039_add_page_views_daily.sql
+-- Backfills the numbered migration sequence with page_views_daily.
+--
+-- Why: this table is written by functions/api/metrics.js (page_view + event_view
+-- daily aggregation) and already exists in production and in
+-- database/setup-complete.sql, but was never added to the numbered migrations/
+-- sequence tracked in d1_migrations. That drift meant a database built purely from
+-- numbered migrations (fresh dev/CI/replica) would lack the table, and the INSERT in
+-- metrics.js is wrapped in a try/catch that silently no-ops when the table is absent
+-- -- masking the loss. IF NOT EXISTS makes applying this to production a safe no-op.
+
+CREATE TABLE IF NOT EXISTS page_views_daily (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  page TEXT NOT NULL,
+  date TEXT NOT NULL,
+  views INTEGER DEFAULT 0,
+  UNIQUE(page, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_page_views_date ON page_views_daily(date);

--- a/migrations/0040_share_links_view_count.sql
+++ b/migrations/0040_share_links_view_count.sql
@@ -1,0 +1,8 @@
+-- Migration: 0040_share_links_view_count.sql
+-- Adds a view counter to share_links for share-virality metrics.
+--
+-- Incremented (best-effort) by functions/api/schedule/share/[slug].js on each
+-- successful fetch of a shared route. Powers "most-viewed shared routes" and the
+-- share segment of the engagement funnel. Existing rows default to 0.
+
+ALTER TABLE share_links ADD COLUMN view_count INTEGER NOT NULL DEFAULT 0;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -30,12 +30,18 @@ binding = "DB"
 database_name = "settimes-production-db"
 database_id = "c6c8b4a6-f951-47c1-a787-aab0a61ca09b" # binding reference only — not a credential; D1 access still requires Cloudflare API token auth
 
-# Analytics Engine binding (privacy-first metrics)
-# Requires Analytics Engine to be enabled in Cloudflare dashboard
-# Enable at: https://dash.cloudflare.com/YOUR_ACCOUNT/workers/analytics-engine
-# [[analytics_engine_datasets]]
-# binding = "ANALYTICS"
-# dataset = "settimes_metrics"
+# Analytics Engine binding (privacy-first metrics) — secondary, queryable sink
+# read by functions/api/metrics.js (env.ANALYTICS.writeDataPoint). The D1 daily
+# aggregate tables remain the primary store; this adds fast, queryable analytics
+# for the event-day dashboard. The metrics handler guards on `if (env.ANALYTICS)`,
+# so this is a no-op until the binding resolves.
+#
+# Production (Pages): also add the binding in the Cloudflare dashboard under
+# Settings > Functions > Analytics Engine bindings (Variable name: ANALYTICS),
+# mirroring the R2 binding below. Requires Analytics Engine enabled on the account.
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "settimes_metrics"
 
 # Cron triggers are not supported for Cloudflare Pages
 # Use a separate Worker if scheduled tasks are needed


### PR DESCRIPTION
Part of the Vol 17 readiness roadmap. Makes site metrics solid and adds the missing share analytics.

## `feat(metrics)` — share view tracking + share analytics
Verified first via prod queries: page-view metrics are *flowing* (no data-loss fire), and the unique-visitor id is already a full UUID — so this PR targets the real gap, **comprehensiveness**, not reliability theatre.

- **Share view tracking**: new `view_count` on `share_links`, incremented best-effort (fail-open + logged) in the `GET /api/schedule/share/[slug]` handler. Closes the dark share-view segment of the engagement funnel.
- **Share analytics surfaced**: the admin event metrics endpoint now returns `totalShares`, `totalShareViews`, and `topSharedRoutes` (derived directly from `share_links` — no new telemetry). `MetricsDashboard` renders them as Shares Created / Share Views cards plus a Most-Viewed Shared Routes list.

## `fix(metrics)` — schema drift + Analytics Engine
- **`0039` migration** backfills `page_views_daily` into the numbered `migrations/` sequence (it existed only in `setup-complete.sql`, so a DB built from numbered migrations would silently drop page/event views).
- **`0040` migration** adds `share_links.view_count`.
- Enables the **Analytics Engine** binding in `wrangler.toml` (secondary queryable sink). Needs a matching `ANALYTICS` binding added in the Pages dashboard.

## Docs
CLAUDE.md note on the share-metrics-from-`share_links` (not telemetry) convention.

## Tests (TDD)
`share-get.test.js` (view-count increment), `metrics.test.js` (share analytics), `MetricsDashboard.test.jsx`. Backend 420 · frontend · schema validate — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)