### PR TITLE
fix(security): drop CSP style-src 'unsafe-inline' (ZAP #314)

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -21,7 +21,7 @@
   Cross-Origin-Resource-Policy: same-origin
 
   # Content Security Policy
-  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
 
   # Permissions policy (disable unnecessary features)
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()
@@ -41,7 +41,7 @@
   ! Content-Security-Policy
   Cross-Origin-Embedder-Policy: unsafe-none
   Cross-Origin-Opener-Policy: unsafe-none
-  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-ancestors *; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-ancestors *; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
 
 # Cache control for static assets (versioned JS/CSS bundles)
 /assets/*


### PR DESCRIPTION
Addresses the `CSP: style-src unsafe-inline` finding from the ZAP baseline scan (#314) — 5 instances across `/`, `/admin`, `/embed/`.

## Why it's safe to remove
`'unsafe-inline'` was dead weight, verified empirically:
- **Build output**: `dist/index.html` has **zero** inline `<style>` / `style="`; Tailwind 4 + Vite emit external stylesheets.
- **No CSS-in-JS**: no `@emotion` / `styled-components` / etc. to inject runtime `<style>`.
- **React `style={{}}`** (7 files) sets styles via the **CSSOM** (`element.style`), which `style-src` does not govern.
- **Google Fonts** load via `<link>` from the already-allowed host (`fonts.googleapis.com`), not via inline styles.
- **Band descriptions** (`BandProfilePage`, the only `dangerouslySetInnerHTML`) are DOMPurify-sanitized to `ALLOWED_ATTR: ['href','target','rel']` — `style` attributes are stripped.

So rendered styling is unchanged; the directive only closed a CSS-injection / UI-redress vector.

## Scope
Both the default and `/embed/*` CSP blocks. Final verification is the next ZAP scan + a staging check before Aug 2.

## Not changed (intentional — see my #314 comment)
- `img-src ... https:` — band `photo_url`s can be arbitrary external HTTPS images; narrowing would break externally-hosted photos. Needs a product decision (force R2-only) first.
- `/embed/*` COOP/COEP `unsafe-none` + `frame-ancestors *` — deliberate, so the widget can be embedded in third-party iframes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
