### PR TITLE
fix(admin): per-follower announcement tracking + resend (M1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ e2e/.auth/
 # AI assistants (developer-specific)
 .claude/
 .serena/
+.opencode/
+.agents/
 .mcp.json
 workers-mcp-server/
 chatmodes/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,23 @@ AI assistant context for this codebase. Captures non-obvious invariants, known g
 
 ---
 
+## Mission & Scope
+
+settimes.ca is evolving into the best multi-venue/multi-artist event platform for **Waterloo Region** (Kitchener-Waterloo, ON), starting with **Long Weekend Band Crawl Vol. 17** on **August 2, 2026**.
+
+- **Focus:** Waterloo Region only (not Ottawa — do not reference Ottawa in new code/docs)
+- **Brand:** settimes.ca — no rebranding
+- **Target event:** Vol. 17, ~6 weeks out (Aug 2, 2026). Urgency applies to all work.
+- **Venues (6, King St N, Waterloo):** Blue Room, Princess Cafe, Prohibition Warehouse, Revive Karaoke, Room 47, Roost
+- **Bands:** 22, doors 6:30PM / show 6:45PM, ages 19+
+- **Both fan-facing and admin tooling are equal priority**
+- **SEO is a priority** (band pages, event pages, local discovery, structured data)
+- **Colour themes:** 4 user-selectable (dark + light presets) via Tailwind v4 CSS custom properties + `data-theme` on `<html>`, persisted in localStorage
+- **Single photo per band** — extends existing `photo_url` / R2 upload flow; no video embeds
+- **Design:** Fresh visual identity for Vol. 17 using Tailwind v4 `@theme`
+
+---
+
 ## Stack
 
 - **Frontend**: React 19, Vite 8, Tailwind 4, React Router 7 (`frontend/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,12 @@ Enforced via `checkPermission(context, "viewer"|"editor"|"admin")` in `functions
 
 ---
 
+## Band Announcements
+
+When a performance is announced (`is_announced` 0→1), verified followers of that band are emailed once. Delivery is tracked **per-follower** in `band_follow_notifications (performance_id, band_follow_id)`: the announce records each *successful* send. Failed sends leave no row, so `POST /api/admin/bands/:id/resend-announcement` recovers them by emailing only followers without a notification row (never double-sending). Shared send+record logic lives in `functions/utils/bandFollowNotify.js`. **Do not reintroduce a fire-once latch without per-follower tracking** — it silently drops fans whose first send failed (the bug this replaced).
+
+---
+
 ## Testing
 
 ### Backend unit tests

--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -368,6 +368,15 @@ CREATE TABLE IF NOT EXISTS band_follows (
 CREATE INDEX IF NOT EXISTS idx_band_follows_band ON band_follows(band_profile_id);
 CREATE INDEX IF NOT EXISTS idx_band_follows_email ON band_follows(email);
 
+CREATE TABLE IF NOT EXISTS band_follow_notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  performance_id INTEGER NOT NULL REFERENCES performances(id) ON DELETE CASCADE,
+  band_follow_id INTEGER NOT NULL REFERENCES band_follows(id) ON DELETE CASCADE,
+  notified_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(performance_id, band_follow_id)
+);
+CREATE INDEX IF NOT EXISTS idx_band_follow_notifications_performance ON band_follow_notifications(performance_id);
+
 -- ============================================
 -- INDEXES
 -- ============================================

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -1407,6 +1407,40 @@ paths:
         "500":
           $ref: "#/components/responses/ServerError"
 
+  /api/admin/bands/{id}/resend-announcement:
+    post:
+      tags:
+        - Admin - Bands
+      summary: Resend a lineup announcement to un-notified followers
+      description: >
+        Re-sends the "band joined the lineup" email to verified followers who
+        were not yet notified for this performance (recovers partial send
+        failures from the initial announce). Never double-sends. `id` is a
+        performance id.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Performance id
+      security:
+        - AdminSessionCookie: []
+          CsrfToken: []
+      responses:
+        "200":
+          description: "Resend result: { success, sent, failed }"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericRecord"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
   /api/admin/bands/bulk-preview:
     post:
       tags:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script>(function(){var t;try{t=localStorage.getItem('settimes-theme')}catch{}if(!t||!['midnight-ember','arctic-night','golden-hour','silver-lining'].includes(t))t='midnight-ember';document.documentElement.dataset.theme=t})()</script>
 
     <!-- PWA manifest -->
     <link rel="manifest" href="/manifest.json" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script>(function(){var t;try{t=localStorage.getItem('settimes-theme')}catch{}if(!t||!['midnight-ember','arctic-night','golden-hour','silver-lining'].includes(t))t='midnight-ember';document.documentElement.dataset.theme=t})()</script>
+    <script>(function(){var t;try{t=localStorage.getItem('settimes-theme')}catch{}if(!t||!['midnight-ember','arctic-night','golden-hour','silver-lining'].includes(t))t='midnight-ember';document.documentElement.dataset.theme=t;var m=document.querySelector('meta[name=theme-color]');if(m){var c={0:'#0c0f1a',1:'#0f172a',2:'#fffbeb',3:'#f8fafc'}[['midnight-ember','arctic-night','golden-hour','silver-lining'].indexOf(t)];if(c)m.setAttribute('content',c)}})()</script>
 
     <!-- PWA manifest -->
     <link rel="manifest" href="/manifest.json" />

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -21,7 +21,7 @@
   Cross-Origin-Resource-Policy: same-origin
 
   # Content Security Policy
-  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors 'none'; frame-src 'none'; child-src 'none'; worker-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
 
   # Permissions policy (disable unnecessary features)
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()
@@ -41,7 +41,7 @@
   ! Content-Security-Policy
   Cross-Origin-Embedder-Policy: unsafe-none
   Cross-Origin-Opener-Policy: unsafe-none
-  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-ancestors *; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-ancestors *; frame-src 'none'; child-src 'none'; worker-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
 
 # Cache control for static assets (versioned JS/CSS bundles)
 /assets/*

--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -77,6 +77,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
   })
   const [submitting, setSubmitting] = useState(false)
   const [togglingId, setTogglingId] = useState(null)
+  const [resendingId, setResendingId] = useState(null)
   const [serverConflicts, setServerConflicts] = useState({ overlaps: [], conflicts: [] })
 
   // Selected IDs for bulk delete within event
@@ -344,6 +345,24 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
       showToast(err.message || 'Failed to update announced status', 'error')
     } finally {
       setTogglingId(null)
+    }
+  }
+
+  const handleResendAnnouncement = async (performanceId, bandName) => {
+    setResendingId(performanceId)
+    try {
+      const res = await bandsApi.resendAnnouncement(performanceId)
+      const sent = res.sent ?? 0
+      showToast(
+        sent > 0
+          ? `Resent ${bandName} announcement to ${sent} follower${sent === 1 ? '' : 's'}.`
+          : `All ${bandName} followers were already notified.`,
+        'success'
+      )
+    } catch (err) {
+      showToast(err.message || 'Failed to resend announcement', 'error')
+    } finally {
+      setResendingId(null)
     }
   }
 
@@ -825,6 +844,16 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
                                     aria-label={band.is_announced ? `Unannounce ${band.name}` : `Announce ${band.name}`}
                                   >
                                     {band.is_announced ? <Eye size={14} /> : <EyeOff size={14} />}
+                                  </button>
+                                )}
+                                {selectedEvent?.reveal_mode === 1 && band.is_announced === 1 && (
+                                  <button
+                                    onClick={() => handleResendAnnouncement(band.id, band.name)}
+                                    disabled={resendingId === band.id}
+                                    title="Resend the lineup announcement to followers not yet notified"
+                                    className={`px-3 py-2 min-h-[44px] bg-bg-purple hover:bg-bg-purple/80 text-white/80 rounded text-sm border border-accent-500/30 ${resendingId === band.id ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                  >
+                                    {resendingId === band.id ? 'Resending…' : 'Resend'}
                                   </button>
                                 )}
                                 <button

--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -671,11 +671,11 @@ export default function RosterTab({ showToast, readOnly = false }) {
                       Contact <SortIcon col="contact_email" sortConfig={sortConfig} />
                     </th>
                     <th
-  onClick={() => handleSort('follower_count')}
-  className="px-4 py-3 text-right text-white font-semibold cursor-pointer hover:text-accent-400"
->
-  Followers <SortIcon col="follower_count" sortConfig={sortConfig} />
-</th>
+                      onClick={() => handleSort('follower_count')}
+                      className="px-4 py-3 text-right text-white font-semibold cursor-pointer hover:text-accent-400"
+                    >
+                      Followers <SortIcon col="follower_count" sortConfig={sortConfig} />
+                    </th>
                     {!readOnly && <th className="px-4 py-3 text-right text-white font-semibold">Actions</th>}
                   </tr>
                 </thead>
@@ -792,18 +792,17 @@ export default function RosterTab({ showToast, readOnly = false }) {
                       </a>
                     </label>
                   </div>
-                    <div className="text-sm text-text-secondary space-y-1">
-                      <div>Origin: {formatOrigin(band) || '-'}</div>
-                      <div>Genre: {band.genre || '-'}</div>
-                      <div>Status: {band.is_active === 0 || band.is_active === false ? 'Inactive' : 'Active'}</div>
-                      <div>Followers: {band.follower_count ?? 0}</div>
-                      <div className="flex items-center gap-2">
-                        <span>Links:</span>
-                        <SocialLinksIcons band={band} />
-                      </div>
-                      <div>Contact: {band.contact_email || '-'}</div>
-                    <div>Followers: {band.follower_count > 0 ? band.follower_count : 0}</div>
+                  <div className="text-sm text-text-secondary space-y-1">
+                    <div>Origin: {formatOrigin(band) || '-'}</div>
+                    <div>Genre: {band.genre || '-'}</div>
+                    <div>Status: {band.is_active === 0 || band.is_active === false ? 'Inactive' : 'Active'}</div>
+                    <div className="flex items-center gap-2">
+                      <span>Links:</span>
+                      <SocialLinksIcons band={band} />
                     </div>
+                    <div>Contact: {band.contact_email || '-'}</div>
+                    <div>Followers: {band.follower_count ?? 0}</div>
+                  </div>
                   {!readOnly && (
                     <div className="flex flex-wrap gap-2">
                       <button

--- a/frontend/src/components/ThemeProvider.jsx
+++ b/frontend/src/components/ThemeProvider.jsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useEffect, useState, useCallback } from 'react'
+
+export const THEME_KEY = 'settimes-theme'
+export const VALID_THEMES = ['midnight-ember', 'arctic-night', 'golden-hour', 'silver-lining']
+export const DEFAULT_THEME = 'midnight-ember'
+
+const ThemeContext = createContext(null)
+
+function getStoredTheme() {
+  try {
+    const stored = localStorage.getItem(THEME_KEY)
+    if (VALID_THEMES.includes(stored)) return stored
+  } catch {
+    // localStorage unavailable (SSR, private browsing restrictions)
+  }
+  return DEFAULT_THEME
+}
+
+function applyTheme(theme) {
+  document.documentElement.dataset.theme = theme
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setThemeState] = useState(getStoredTheme)
+
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  const setTheme = useCallback(newTheme => {
+    if (!VALID_THEMES.includes(newTheme)) return
+    setThemeState(newTheme)
+    try {
+      localStorage.setItem(THEME_KEY, newTheme)
+    } catch {
+      // localStorage unavailable (SSR, private browsing restrictions)
+    }
+    applyTheme(newTheme)
+  }, [])
+
+  const cycleTheme = useCallback(() => {
+    const idx = VALID_THEMES.indexOf(theme)
+    const next = VALID_THEMES[(idx + 1) % VALID_THEMES.length]
+    setTheme(next)
+  }, [theme, setTheme])
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, cycleTheme, themes: VALID_THEMES }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}
+
+export function getThemeInitScript() {
+  return `(function(){var t;try{t=localStorage.getItem('${THEME_KEY}')}catch{}if(!t||!['midnight-ember','arctic-night','golden-hour','silver-lining'].includes(t))t='${DEFAULT_THEME}';document.documentElement.dataset.theme=t})()`
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -123,6 +123,141 @@
   --spacing-safe-right: env(safe-area-inset-right);
 }
 
+/* arctic-night — dark cool */
+[data-theme='arctic-night'] {
+  --color-primary-50: #eef2ff;
+  --color-primary-100: #e0e7ff;
+  --color-primary-400: #818cf8;
+  --color-primary-500: #6366f1;
+  --color-primary-600: #4f46e5;
+  --color-primary-700: #4338ca;
+
+  --color-accent-300: #7dd3fc;
+  --color-accent-400: #38bdf8;
+  --color-accent-500: #0ea5e9;
+  --color-accent-600: #0284c7;
+
+  --color-bg-navy: #0f172a;
+  --color-bg-purple: #1e293b;
+  --color-bg-dark: #0b1121;
+  --color-bg-darker: #070d17;
+
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #cbd5e1;
+  --color-text-tertiary: #94a3b8;
+  --color-text-disabled: #64748b;
+  --color-text-inverse: #0f172a;
+
+  --color-band-navy: #0f172a;
+  --color-band-purple: #1e293b;
+  --color-band-orange: #0ea5e9;
+
+  --background-image-gradient-dark: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  --background-image-gradient-card: linear-gradient(145deg, rgba(30, 41, 59, 0.9) 0%, rgba(15, 23, 42, 0.95) 100%);
+  --background-image-gradient-glow: radial-gradient(ellipse at center, rgba(99, 102, 241, 0.12) 0%, transparent 70%);
+
+  --shadow-glow-primary: 0 0 20px rgba(99, 102, 241, 0.4);
+  --shadow-glow-accent: 0 0 20px rgba(14, 165, 233, 0.4);
+}
+
+/* golden-hour — light warm */
+[data-theme='golden-hour'] {
+  --color-primary-50: #fff1f2;
+  --color-primary-100: #ffe4e6;
+  --color-primary-400: #fb7185;
+  --color-primary-500: #f43f5e;
+  --color-primary-600: #e11d48;
+  --color-primary-700: #be123c;
+
+  --color-accent-300: #fed7aa;
+  --color-accent-400: #fb923c;
+  --color-accent-500: #d97706;
+  --color-accent-600: #b45309;
+
+  --color-bg-navy: #fffbeb;
+  --color-bg-purple: #fef3c7;
+  --color-bg-dark: #fef3c7;
+  --color-bg-darker: #fde68a;
+
+  --color-text-primary: #1c1917;
+  --color-text-secondary: #44403c;
+  --color-text-tertiary: #78716c;
+  --color-text-disabled: #a8a29e;
+  --color-text-inverse: #fafaf9;
+
+  --color-band-navy: #fffbeb;
+  --color-band-purple: #fef3c7;
+  --color-band-orange: #d97706;
+
+  --background-image-gradient-primary: linear-gradient(135deg, #f43f5e 0%, #e11d48 100%);
+  --background-image-gradient-accent: linear-gradient(135deg, #fb923c 0%, #d97706 100%);
+  --background-image-gradient-dark: linear-gradient(180deg, #fef3c7 0%, #fffbeb 100%);
+  --background-image-gradient-card: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(254, 243, 199, 0.9) 100%
+  );
+  --background-image-gradient-glow: radial-gradient(ellipse at center, rgba(244, 63, 94, 0.08) 0%, transparent 70%);
+
+  --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.06);
+  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.08), 0 1px 2px -1px rgb(0 0 0 / 0.06);
+  --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.06);
+  --shadow-md: 0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.05);
+  --shadow-lg: 0 20px 25px -5px rgb(0 0 0 / 0.08), 0 8px 10px -6px rgb(0 0 0 / 0.05);
+  --shadow-xl: 0 25px 50px -12px rgb(0 0 0 / 0.15);
+  --shadow-glow-primary: 0 0 20px rgba(244, 63, 94, 0.25);
+  --shadow-glow-accent: 0 0 20px rgba(217, 119, 6, 0.25);
+}
+
+/* silver-lining — light cool */
+[data-theme='silver-lining'] {
+  --color-primary-50: #f8fafc;
+  --color-primary-100: #f1f5f9;
+  --color-primary-400: #94a3b8;
+  --color-primary-500: #64748b;
+  --color-primary-600: #475569;
+  --color-primary-700: #334155;
+
+  --color-accent-300: #93c5fd;
+  --color-accent-400: #60a5fa;
+  --color-accent-500: #3b82f6;
+  --color-accent-600: #2563eb;
+
+  --color-bg-navy: #f8fafc;
+  --color-bg-purple: #f1f5f9;
+  --color-bg-dark: #f1f5f9;
+  --color-bg-darker: #e2e8f0;
+
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #334155;
+  --color-text-tertiary: #64748b;
+  --color-text-disabled: #94a3b8;
+  --color-text-inverse: #f8fafc;
+
+  --color-band-navy: #f8fafc;
+  --color-band-purple: #f1f5f9;
+  --color-band-orange: #3b82f6;
+
+  --background-image-gradient-primary: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  --background-image-gradient-accent: linear-gradient(135deg, #60a5fa 0%, #3b82f6 100%);
+  --background-image-gradient-dark: linear-gradient(180deg, #f1f5f9 0%, #f8fafc 100%);
+  --background-image-gradient-card: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(241, 245, 249, 0.9) 100%
+  );
+  --background-image-gradient-glow: radial-gradient(ellipse at center, rgba(59, 130, 246, 0.08) 0%, transparent 70%);
+
+  --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.06);
+  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.08), 0 1px 2px -1px rgb(0 0 0 / 0.06);
+  --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.06);
+  --shadow-md: 0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.05);
+  --shadow-lg: 0 20px 25px -5px rgb(0 0 0 / 0.08), 0 8px 10px -6px rgb(0 0 0 / 0.05);
+  --shadow-xl: 0 25px 50px -12px rgb(0 0 0 / 0.15);
+  --shadow-glow-primary: 0 0 20px rgba(100, 116, 139, 0.2);
+  --shadow-glow-accent: 0 0 20px rgba(59, 130, 246, 0.2);
+}
+
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,7 @@ import React, { lazy, Suspense } from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
+import { ThemeProvider } from './components/ThemeProvider.jsx'
 import App from './App.jsx'
 import EventsPage from './pages/EventsPage.jsx'
 import EmbedPage from './pages/EmbedPage.jsx'
@@ -64,79 +65,81 @@ if (import.meta.env.DEV) {
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ErrorBoundary>
-      <HelmetProvider>
-        <BrowserRouter>
-          <a
-            href="#main-content"
-            className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-9999 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:rounded focus:text-sm focus:font-medium"
-          >
-            Skip to main content
-          </a>
-          <Routes>
-            {/* Fan experience: Load immediately */}
-            <Route path="/" element={<EventsPage />} />
-            <Route path="/event/:slug" element={<App />} />
-            <Route path="/embed/:slug" element={<EmbedPage />} />
-            <Route path="/subscribe" element={<SubscribePage />} />
-            <Route path="/reset-password" element={<ResetPasswordPage />} />
-            <Route path="/activate" element={<ActivatePage />} />
-            <Route path="/privacy" element={<PrivacyPage />} />
+      <ThemeProvider>
+        <HelmetProvider>
+          <BrowserRouter>
+            <a
+              href="#main-content"
+              className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-9999 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:rounded focus:text-sm focus:font-medium"
+            >
+              Skip to main content
+            </a>
+            <Routes>
+              {/* Fan experience: Load immediately */}
+              <Route path="/" element={<EventsPage />} />
+              <Route path="/event/:slug" element={<App />} />
+              <Route path="/embed/:slug" element={<EmbedPage />} />
+              <Route path="/subscribe" element={<SubscribePage />} />
+              <Route path="/reset-password" element={<ResetPasswordPage />} />
+              <Route path="/activate" element={<ActivatePage />} />
+              <Route path="/privacy" element={<PrivacyPage />} />
 
-            {/* Event recap: Lazy loaded */}
-            <Route
-              path="/events/:slug/recap"
-              element={
-                <ErrorBoundary title="Event Recap Error" message="Unable to load event recap. Please try again.">
-                  <Suspense fallback={<LoadingFallback />}>
-                    <EventRecapPage />
-                  </Suspense>
-                </ErrorBoundary>
-              }
-            />
+              {/* Event recap: Lazy loaded */}
+              <Route
+                path="/events/:slug/recap"
+                element={
+                  <ErrorBoundary title="Event Recap Error" message="Unable to load event recap. Please try again.">
+                    <Suspense fallback={<LoadingFallback />}>
+                      <EventRecapPage />
+                    </Suspense>
+                  </ErrorBoundary>
+                }
+              />
 
-            {/* Band profiles: Lazy loaded */}
-            <Route
-              path="/band/:id"
-              element={
-                <ErrorBoundary title="Band Profile Error" message="Unable to load band profile. Please try again.">
-                  <Suspense fallback={<LoadingFallback />}>
-                    <BandProfilePage />
-                  </Suspense>
-                </ErrorBoundary>
-              }
-            />
+              {/* Band profiles: Lazy loaded */}
+              <Route
+                path="/band/:id"
+                element={
+                  <ErrorBoundary title="Band Profile Error" message="Unable to load band profile. Please try again.">
+                    <Suspense fallback={<LoadingFallback />}>
+                      <BandProfilePage />
+                    </Suspense>
+                  </ErrorBoundary>
+                }
+              />
 
-            {/* Share preview: Lazy loaded */}
-            <Route
-              path="/s/:slug"
-              element={
-                <ErrorBoundary title="Share Preview Error" message="Unable to load this shared route.">
-                  <Suspense fallback={<LoadingFallback />}>
-                    <SharePreviewPage />
-                  </Suspense>
-                </ErrorBoundary>
-              }
-            />
+              {/* Share preview: Lazy loaded */}
+              <Route
+                path="/s/:slug"
+                element={
+                  <ErrorBoundary title="Share Preview Error" message="Unable to load this shared route.">
+                    <Suspense fallback={<LoadingFallback />}>
+                      <SharePreviewPage />
+                    </Suspense>
+                  </ErrorBoundary>
+                }
+              />
 
-            {/* Admin panel: Lazy loaded */}
-            <Route
-              path="/admin/*"
-              element={
-                <ErrorBoundary
-                  title="Admin Panel Error"
-                  message="An error occurred in the admin panel. Please refresh."
-                >
-                  <Suspense fallback={<LoadingFallback />}>
-                    <AdminApp />
-                  </Suspense>
-                </ErrorBoundary>
-              }
-            />
-            {/* 404 catch-all */}
-            <Route path="*" element={<NotFoundPage />} />
-          </Routes>
-        </BrowserRouter>
-      </HelmetProvider>
+              {/* Admin panel: Lazy loaded */}
+              <Route
+                path="/admin/*"
+                element={
+                  <ErrorBoundary
+                    title="Admin Panel Error"
+                    message="An error occurred in the admin panel. Please refresh."
+                  >
+                    <Suspense fallback={<LoadingFallback />}>
+                      <AdminApp />
+                    </Suspense>
+                  </ErrorBoundary>
+                }
+              />
+              {/* 404 catch-all */}
+              <Route path="*" element={<NotFoundPage />} />
+            </Routes>
+          </BrowserRouter>
+        </HelmetProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   </React.StrictMode>
 )

--- a/frontend/src/utils/adminApi.js
+++ b/frontend/src/utils/adminApi.js
@@ -690,6 +690,15 @@ export const bandsApi = {
     return handleResponse(response)
   },
 
+  async resendAnnouncement(performanceId) {
+    const response = await fetchWithCSRFRetry(`${API_BASE}/bands/${performanceId}/resend-announcement`, {
+      method: 'POST',
+      headers: getHeaders(),
+      credentials: 'include',
+    })
+    return handleResponse(response)
+  },
+
   async getStats(bandName) {
     const response = await fetchWithCSRFRetry(`${API_BASE}/bands/stats/${encodeURIComponent(bandName)}`, {
       headers: getHeaders(),

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -147,6 +147,9 @@ export async function onRequest(context) {
       "font-src 'self' data:",
       "connect-src 'self'",
       "object-src 'none'",
+      "frame-src 'none'",
+      "child-src 'none'",
+      "worker-src 'none'",
       "base-uri 'self'",
       "frame-ancestors 'none'",
     ].join('; ');
@@ -186,11 +189,11 @@ export async function onRequest(context) {
           ...(cspEnforce
             ? {
                 'Content-Security-Policy':
-                  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
+                  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-src 'none'; child-src 'none'; worker-src 'none'; base-uri 'self'; frame-ancestors 'none'",
               }
             : {
                 'Content-Security-Policy-Report-Only':
-                  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
+                  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-src 'none'; child-src 'none'; worker-src 'none'; base-uri 'self'; frame-ancestors 'none'",
               }),
         },
       }

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -11,17 +11,10 @@ import {
   sanitizeString,
 } from "../../../utils/validation.js";
 import { getClientIP } from "../../../utils/request.js";
-import { sendEmail, isEmailConfigured } from "../../../utils/email.js";
+import { isEmailConfigured } from "../../../utils/email.js";
+import { notifyBandFollowers } from "../../../utils/bandFollowNotify.js";
 import { buildIntervals, intervalsOverlap } from "../../../utils/timeConflicts.js";
 import { parseOrigin } from "../../../utils/parseOrigin.js";
-
-const escapeHtml = (s) =>
-  String(s ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 
 // Helper to extract band ID from path
 function getBandId(request) {
@@ -767,7 +760,7 @@ export async function onRequestPatch(context) {
 
       if (perf) {
         const { results: followers = [] } = await DB.prepare(
-          "SELECT email, unsubscribe_token FROM band_follows WHERE band_profile_id = ? AND verified = 1",
+          "SELECT id, email, unsubscribe_token FROM band_follows WHERE band_profile_id = ? AND verified = 1",
         )
           .bind(perf.band_profile_id)
           .all();
@@ -783,32 +776,24 @@ export async function onRequestPatch(context) {
             .run();
 
           if (claimed.meta.changes > 0) {
-            const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
-            const emailResults = await Promise.allSettled(
-              followers.map((follower) => {
-                const unsubUrl = `${publicUrl}/api/bands/${perf.band_profile_id}/unfollow?token=${follower.unsubscribe_token}`;
-                return sendEmail(env, {
-                  to: follower.email,
-                  subject: `${perf.band_name} just joined the lineup for ${perf.event_name}!`,
-                  text: `${perf.band_name} is now on the lineup for ${perf.event_name}.\n\nUnfollow: ${unsubUrl}`,
-                  html: `<p><strong>${escapeHtml(perf.band_name)}</strong> is now on the lineup for <strong>${escapeHtml(perf.event_name)}</strong>.</p><p><a href="${unsubUrl}">Unfollow this band</a></p>`,
-                });
-              }),
-            );
-            // sendEmail returns {delivered:false} on failure rather than throwing — filter both rejection types
-            const failedCount = emailResults.filter(
-              (r) =>
-                r.status === "rejected" ||
-                (r.status === "fulfilled" && !r.value?.delivered),
-            ).length;
-            if (failedCount > 0) {
+            // Send + record each successful delivery (see bandFollowNotify.js).
+            // A failed send leaves no notification row, so it can be recovered
+            // later via the resend-announcement endpoint.
+            const { failed } = await notifyBandFollowers(env, DB, {
+              performanceId: Number(performanceId),
+              bandProfileId: perf.band_profile_id,
+              bandName: perf.band_name,
+              eventName: perf.event_name,
+              followers,
+            });
+            if (failed > 0) {
               await auditLog(
                 env,
                 user.userId,
                 "performance.announced.email_failure",
                 "performance",
                 Number(performanceId),
-                { failed_count: failedCount, band_name: perf.band_name },
+                { failed_count: failed, band_name: perf.band_name },
                 ipAddress,
               ).catch(() => {});
             }

--- a/functions/api/admin/bands/[id]/resend-announcement.js
+++ b/functions/api/admin/bands/[id]/resend-announcement.js
@@ -1,0 +1,82 @@
+// Admin API: resend a band's "joined the lineup" announcement to followers who
+// were not yet notified for this performance — recovers partial-send failures
+// from the initial announce without ever double-sending.
+// POST /api/admin/bands/[id]/resend-announcement   ([id] = performance id)
+import { checkPermission, auditLog } from "../../_middleware.js";
+import { getClientIP } from "../../../../utils/request.js";
+import { isEmailConfigured } from "../../../../utils/email.js";
+import { validateId } from "../../../../utils/validation.js";
+import { notifyBandFollowers } from "../../../../utils/bandFollowNotify.js";
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function onRequestPost(context) {
+  const { request, env, params } = context;
+  const { DB } = env;
+
+  const { valid, value: performanceId, error } = validateId(params.id);
+  if (!valid) return json({ error: "Bad request", message: error }, 400);
+
+  // RBAC: editor or higher
+  const perm = await checkPermission(context, "editor");
+  if (perm.error) return perm.response;
+  const user = perm.user;
+  const ipAddress = getClientIP(request);
+
+  if (!isEmailConfigured(env)) {
+    return json(
+      { error: "Email not configured", message: "Email is not configured" },
+      400,
+    );
+  }
+
+  const perf = await DB.prepare(
+    `SELECT p.id, p.band_profile_id, bp.name AS band_name, e.name AS event_name
+     FROM performances p
+     JOIN band_profiles bp ON p.band_profile_id = bp.id
+     JOIN events e ON p.event_id = e.id
+     WHERE p.id = ?`,
+  )
+    .bind(performanceId)
+    .first();
+
+  if (!perf) {
+    return json({ error: "Not found", message: "Performance not found" }, 404);
+  }
+
+  // Verified followers WITHOUT a notification row for this performance.
+  const { results: followers = [] } = await DB.prepare(
+    `SELECT bf.id, bf.email, bf.unsubscribe_token
+     FROM band_follows bf
+     LEFT JOIN band_follow_notifications bfn
+       ON bfn.band_follow_id = bf.id AND bfn.performance_id = ?
+     WHERE bf.band_profile_id = ? AND bf.verified = 1 AND bfn.id IS NULL`,
+  )
+    .bind(performanceId, perf.band_profile_id)
+    .all();
+
+  const { sent, failed } = await notifyBandFollowers(env, DB, {
+    performanceId,
+    bandProfileId: perf.band_profile_id,
+    bandName: perf.band_name,
+    eventName: perf.event_name,
+    followers,
+  });
+
+  await auditLog(
+    env,
+    user.userId,
+    "performance.announcement_resent",
+    "performance",
+    performanceId,
+    { sent, failed, band_name: perf.band_name },
+    ipAddress,
+  ).catch(() => {});
+
+  return json({ success: true, sent, failed });
+}

--- a/functions/api/admin/bands/[id]/resend-announcement.js
+++ b/functions/api/admin/bands/[id]/resend-announcement.js
@@ -36,7 +36,7 @@ export async function onRequestPost(context) {
   }
 
   const perf = await DB.prepare(
-    `SELECT p.id, p.band_profile_id, bp.name AS band_name, e.name AS event_name
+    `SELECT p.id, p.is_announced, p.band_profile_id, bp.name AS band_name, e.name AS event_name
      FROM performances p
      JOIN band_profiles bp ON p.band_profile_id = bp.id
      JOIN events e ON p.event_id = e.id
@@ -47,6 +47,13 @@ export async function onRequestPost(context) {
 
   if (!perf) {
     return json({ error: "Not found", message: "Performance not found" }, 404);
+  }
+
+  if (!perf.is_announced) {
+    return json(
+      { error: "Bad request", message: "Performance has not been announced" },
+      400,
+    );
   }
 
   // Verified followers WITHOUT a notification row for this performance.

--- a/functions/api/admin/bands/__tests__/resend-announcement.test.js
+++ b/functions/api/admin/bands/__tests__/resend-announcement.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../_middleware.js', () => ({
+  checkPermission: async (context) => {
+    const role =
+      context?.data?.user?.role || context?.request?.headers?.get('x-test-role')
+    if (!role) {
+      return {
+        error: true,
+        response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      }
+    }
+    return { error: false, user: { userId: 1, email: 'admin@x.co', role }, userId: 1 }
+  },
+  auditLog: vi.fn(async () => {}),
+}))
+
+vi.mock('../../../../utils/email.js', () => ({
+  isEmailConfigured: () => true,
+  sendEmail: vi.fn(() => Promise.resolve({ delivered: true })),
+}))
+
+import { onRequestPost } from '../[id]/resend-announcement.js'
+import {
+  createTestEnv,
+  insertEvent,
+  insertVenue,
+  insertBand,
+} from '../../../test-utils.js'
+
+describe('POST /api/admin/bands/[id]/resend-announcement', () => {
+  test('resends only to followers not yet notified for the performance', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
+    const venue = insertVenue(rawDb, { name: 'Hall' })
+    const perf = insertBand(rawDb, {
+      name: 'The Band',
+      event_id: event.id,
+      venue_id: venue.id,
+    })
+    const bandProfileId = perf.band_profile_id
+
+    const f1 = rawDb
+      .prepare(
+        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+      )
+      .run('a@x.co', bandProfileId, 'tok-a').lastInsertRowid
+    const f2 = rawDb
+      .prepare(
+        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+      )
+      .run('b@x.co', bandProfileId, 'tok-b').lastInsertRowid
+
+    // f1 was already notified for this performance.
+    rawDb
+      .prepare(
+        'INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)'
+      )
+      .run(perf.id, f1)
+
+    const res = await onRequestPost({
+      request: new Request(
+        `https://example.test/api/admin/bands/${perf.id}/resend-announcement`,
+        { method: 'POST', headers: { 'x-test-role': 'editor' } }
+      ),
+      params: { id: String(perf.id) },
+      env,
+      data: { user: { userId: 1, email: 'admin@x.co', role: 'editor' } },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.sent).toBe(1)
+    expect(body.failed).toBe(0)
+
+    const notified = rawDb
+      .prepare(
+        'SELECT band_follow_id FROM band_follow_notifications WHERE performance_id = ? ORDER BY band_follow_id'
+      )
+      .all(perf.id)
+    expect(notified.map((r) => r.band_follow_id)).toEqual([f1, f2])
+  })
+})

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -216,6 +216,14 @@ export function createTestDB() {
       UNIQUE(email, band_profile_id)
     );
 
+    CREATE TABLE band_follow_notifications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      performance_id INTEGER NOT NULL REFERENCES performances(id) ON DELETE CASCADE,
+      band_follow_id INTEGER NOT NULL REFERENCES band_follows(id) ON DELETE CASCADE,
+      notified_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(performance_id, band_follow_id)
+    );
+
     CREATE TABLE password_reset_tokens (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/functions/utils/__tests__/bandFollowNotify.test.js
+++ b/functions/utils/__tests__/bandFollowNotify.test.js
@@ -61,4 +61,91 @@ describe('notifyBandFollowers', () => {
       .all(perf.id)
     expect(notified.map((r) => r.band_follow_id)).toEqual([f1])
   })
+
+  test('skips followers already claimed by another concurrent request', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'Test', slug: 'test' })
+    const venue = insertVenue(rawDb, { name: 'Venue' })
+    const perf = insertBand(rawDb, {
+      name: 'Band',
+      event_id: event.id,
+      venue_id: venue.id,
+    })
+    const bandProfileId = perf.band_profile_id
+
+    const fId = rawDb
+      .prepare(
+        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+      )
+      .run('fan@example.com', bandProfileId, 'tok').lastInsertRowid
+
+    // Pre-claim the follower as if another concurrent request already did
+    rawDb
+      .prepare(
+        'INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)'
+      )
+      .run(perf.id, fId)
+
+    sendEmail.mockReset()
+    sendEmail.mockImplementation(() =>
+      Promise.resolve({ delivered: true })
+    )
+
+    const result = await notifyBandFollowers(env, env.DB, {
+      performanceId: perf.id,
+      bandProfileId,
+      bandName: 'Band',
+      eventName: 'Test',
+      followers: [
+        { id: fId, email: 'fan@example.com', unsubscribe_token: 'tok' },
+      ],
+    })
+
+    expect(result).toEqual({ sent: 0, failed: 1 })
+    // sendEmail should not have been called — the race was won by the other request
+    expect(sendEmail).not.toHaveBeenCalled()
+  })
+
+  test('releases claim when email fails so resend can retry', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'Test', slug: 'test' })
+    const venue = insertVenue(rawDb, { name: 'Venue' })
+    const perf = insertBand(rawDb, {
+      name: 'Band',
+      event_id: event.id,
+      venue_id: venue.id,
+    })
+    const bandProfileId = perf.band_profile_id
+
+    const fId = rawDb
+      .prepare(
+        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+      )
+      .run('fan@example.com', bandProfileId, 'tok').lastInsertRowid
+
+    sendEmail.mockReset()
+    sendEmail.mockImplementation(() =>
+      Promise.resolve({ delivered: false })
+    )
+
+    const result = await notifyBandFollowers(env, env.DB, {
+      performanceId: perf.id,
+      bandProfileId,
+      bandName: 'Band',
+      eventName: 'Test',
+      followers: [
+        { id: fId, email: 'fan@example.com', unsubscribe_token: 'tok' },
+      ],
+    })
+
+    expect(result).toEqual({ sent: 0, failed: 1 })
+
+    // The claim row should have been deleted — resend will pick up this follower
+    const rows = rawDb
+      .prepare(
+        'SELECT id FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?'
+      )
+      .all(perf.id, fId)
+    expect(rows).toHaveLength(0)
+  })
 })

--- a/functions/utils/__tests__/bandFollowNotify.test.js
+++ b/functions/utils/__tests__/bandFollowNotify.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../email.js', () => ({
+  sendEmail: vi.fn(),
+}))
+
+import { sendEmail } from '../email.js'
+import { notifyBandFollowers } from '../bandFollowNotify.js'
+import {
+  createTestEnv,
+  insertEvent,
+  insertVenue,
+  insertBand,
+} from '../../api/test-utils.js'
+
+describe('notifyBandFollowers', () => {
+  test('records a notification for each delivered email and skips failures', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
+    const venue = insertVenue(rawDb, { name: 'Hall' })
+    const perf = insertBand(rawDb, {
+      name: 'The Band',
+      event_id: event.id,
+      venue_id: venue.id,
+    })
+    const bandProfileId = perf.band_profile_id
+
+    const f1 = rawDb
+      .prepare(
+        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+      )
+      .run('a@example.com', bandProfileId, 'tok-a').lastInsertRowid
+    const f2 = rawDb
+      .prepare(
+        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+      )
+      .run('b@example.com', bandProfileId, 'tok-b').lastInsertRowid
+
+    // First delivers, second fails.
+    sendEmail.mockImplementation((_env, { to }) =>
+      Promise.resolve({ delivered: to === 'a@example.com' })
+    )
+
+    const result = await notifyBandFollowers(env, env.DB, {
+      performanceId: perf.id,
+      bandProfileId,
+      bandName: 'The Band',
+      eventName: 'Fest',
+      followers: [
+        { id: f1, email: 'a@example.com', unsubscribe_token: 'tok-a' },
+        { id: f2, email: 'b@example.com', unsubscribe_token: 'tok-b' },
+      ],
+    })
+
+    expect(result).toEqual({ sent: 1, failed: 1 })
+
+    const notified = rawDb
+      .prepare(
+        'SELECT band_follow_id FROM band_follow_notifications WHERE performance_id = ? ORDER BY band_follow_id'
+      )
+      .all(perf.id)
+    expect(notified.map((r) => r.band_follow_id)).toEqual([f1])
+  })
+})

--- a/functions/utils/bandFollowNotify.js
+++ b/functions/utils/bandFollowNotify.js
@@ -36,7 +36,7 @@ export async function notifyBandFollowers(
       });
 
       // sendEmail returns { delivered: false } on failure rather than throwing.
-      const delivered = result?.delivered !== false;
+      const delivered = result?.delivered === true;
       if (delivered) {
         // Record the success so a future resend skips this follower. A recording
         // failure must NOT flip the email result, so it is caught and logged.

--- a/functions/utils/bandFollowNotify.js
+++ b/functions/utils/bandFollowNotify.js
@@ -27,6 +27,19 @@ export async function notifyBandFollowers(
 
   const results = await Promise.allSettled(
     followers.map(async (follower) => {
+      // Claim the follower atomically before delivery. INSERT OR IGNORE
+      // returns changes=0 if another request already claimed this follower,
+      // preventing concurrent resends from double-sending to the same person.
+      const claim = await DB.prepare(
+        "INSERT OR IGNORE INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)",
+      )
+        .bind(performanceId, follower.id)
+        .run();
+
+      if (claim.meta.changes === 0) {
+        return false;
+      }
+
       const unsubUrl = `${publicUrl}/api/bands/${bandProfileId}/unfollow?token=${follower.unsubscribe_token}`;
       const result = await sendEmail(env, {
         to: follower.email,
@@ -35,25 +48,14 @@ export async function notifyBandFollowers(
         html: `<p><strong>${escapeHtml(bandName)}</strong> is now on the lineup for <strong>${escapeHtml(eventName)}</strong>.</p><p><a href="${unsubUrl}">Unfollow this band</a></p>`,
       });
 
-      // sendEmail returns { delivered: false } on failure rather than throwing.
       const delivered = result?.delivered === true;
-      if (delivered) {
-        // Record the success so a future resend skips this follower. A recording
-        // failure must NOT flip the email result, so it is caught and logged.
-        try {
-          await DB.prepare(
-            "INSERT OR IGNORE INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)",
-          )
-            .bind(performanceId, follower.id)
-            .run();
-        } catch (err) {
-          console.error(
-            "Failed to record band follow notification",
-            performanceId,
-            follower.id,
-            err,
-          );
-        }
+      if (!delivered) {
+        // Email failed — release the claim so a future resend can retry.
+        await DB.prepare(
+          "DELETE FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?",
+        )
+          .bind(performanceId, follower.id)
+          .run();
       }
       return delivered;
     }),

--- a/functions/utils/bandFollowNotify.js
+++ b/functions/utils/bandFollowNotify.js
@@ -1,0 +1,69 @@
+// Shared "band joined the lineup" notification logic for band followers.
+//
+// Sends the announcement email to each given follower and records every
+// SUCCESSFUL delivery in band_follow_notifications, keyed by (performance,
+// follower). This lets a resend target only followers who were not yet
+// notified for a performance — guaranteeing eventual delivery without ever
+// double-sending. Used by the announce flow (bands/[id].js) and the resend
+// endpoint (bands/[id]/resend-announcement.js).
+import { sendEmail } from "./email.js";
+
+// Escape plain-text band/event names for safe interpolation into the email HTML.
+// Mirrors the escaper in bands/[id].js (regex .replace, the codebase convention).
+const escapeHtml = (s) =>
+  String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+export async function notifyBandFollowers(
+  env,
+  DB,
+  { performanceId, bandProfileId, bandName, eventName, followers },
+) {
+  const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
+
+  const results = await Promise.allSettled(
+    followers.map(async (follower) => {
+      const unsubUrl = `${publicUrl}/api/bands/${bandProfileId}/unfollow?token=${follower.unsubscribe_token}`;
+      const result = await sendEmail(env, {
+        to: follower.email,
+        subject: `${bandName} just joined the lineup for ${eventName}!`,
+        text: `${bandName} is now on the lineup for ${eventName}.\n\nUnfollow: ${unsubUrl}`,
+        html: `<p><strong>${escapeHtml(bandName)}</strong> is now on the lineup for <strong>${escapeHtml(eventName)}</strong>.</p><p><a href="${unsubUrl}">Unfollow this band</a></p>`,
+      });
+
+      // sendEmail returns { delivered: false } on failure rather than throwing.
+      const delivered = result?.delivered !== false;
+      if (delivered) {
+        // Record the success so a future resend skips this follower. A recording
+        // failure must NOT flip the email result, so it is caught and logged.
+        try {
+          await DB.prepare(
+            "INSERT OR IGNORE INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)",
+          )
+            .bind(performanceId, follower.id)
+            .run();
+        } catch (err) {
+          console.error(
+            "Failed to record band follow notification",
+            performanceId,
+            follower.id,
+            err,
+          );
+        }
+      }
+      return delivered;
+    }),
+  );
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of results) {
+    if (r.status === "fulfilled" && r.value === true) sent++;
+    else failed++;
+  }
+  return { sent, failed };
+}

--- a/migrations/0041_band_follow_notifications.sql
+++ b/migrations/0041_band_follow_notifications.sql
@@ -17,3 +17,19 @@ CREATE TABLE IF NOT EXISTS band_follow_notifications (
 
 CREATE INDEX IF NOT EXISTS idx_band_follow_notifications_performance
   ON band_follow_notifications(performance_id);
+
+-- Backfill: seed notification rows for already-announced performances that were
+-- notified under the old fire-once latch (band_follow_notified = 1). Without
+-- this, the resend endpoint treats those followers as "not yet notified" and
+-- re-emails all verified followers on the first resend, violating the
+-- no-double-send guarantee for existing production data.
+INSERT INTO band_follow_notifications (performance_id, band_follow_id)
+SELECT p.id, bf.id
+FROM performances p
+JOIN band_follows bf ON bf.band_profile_id = p.band_profile_id
+WHERE p.band_follow_notified = 1
+  AND bf.verified = 1
+  AND NOT EXISTS (
+    SELECT 1 FROM band_follow_notifications bfn
+    WHERE bfn.performance_id = p.id AND bfn.band_follow_id = bf.id
+  );

--- a/migrations/0041_band_follow_notifications.sql
+++ b/migrations/0041_band_follow_notifications.sql
@@ -1,0 +1,19 @@
+-- Migration: 0041_band_follow_notifications.sql
+-- Per-follower announcement delivery tracking.
+--
+-- Why: band-announcement emails were fire-once with no retry path — if some
+-- recipients failed, the per-performance band_follow_notified latch stayed set
+-- and those fans were never notified. This table records which follower was
+-- notified for which performance, so a resend can target only the un-notified
+-- (guaranteeing eventual delivery, never double-sending).
+
+CREATE TABLE IF NOT EXISTS band_follow_notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  performance_id INTEGER NOT NULL REFERENCES performances(id) ON DELETE CASCADE,
+  band_follow_id INTEGER NOT NULL REFERENCES band_follows(id) ON DELETE CASCADE,
+  notified_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(performance_id, band_follow_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_band_follow_notifications_performance
+  ON band_follow_notifications(performance_id);

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-sonnet-4-5",
+  "mcp": {
+    "cloudflare-bindings": {
+      "type": "remote",
+      "url": "https://bindings.mcp.cloudflare.com/mcp",
+      "enabled": true
+    },
+    "cloudflare-docs": {
+      "type": "remote",
+      "url": "https://docs.mcp.cloudflare.com/mcp",
+      "enabled": true
+    },
+    "cloudflare": {
+      "type": "remote",
+      "url": "https://mcp.cloudflare.com/mcp",
+      "enabled": true
+    },
+    "cloudflare-observability": {
+      "type": "remote",
+      "url": "https://observability.mcp.cloudflare.com/mcp",
+      "enabled": false
+    },
+    "resend": {
+      "type": "local",
+      "command": ["npx", "-y", "resend-mcp"],
+      "env": {
+        "RESEND_API_KEY": "{env:RESEND_API_KEY}"
+      },
+      "enabled": false
+    },
+    "github": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "{env:GITHUB_TOKEN}"
+      },
+      "enabled": false
+    }
+  },
+  "small_model": "anthropic/claude-haiku-4-5",
+  "instructions": [
+    "CLAUDE.md",
+    "instructions/a11y.instructions.md",
+    "instructions/performance-optimization.instructions.md",
+    "instructions/security-and-owasp.instructions.md",
+    "instructions/nodejs-javascript-vitest.instructions.md",
+    "instructions/reactjs.instructions.md",
+    "instructions/playwright-typescript.instructions.md",
+    "instructions/self-explanatory-code-commenting.instructions.md",
+    "instructions/sql-sp-generation.instructions.md",
+    "CONTRIBUTING.md",
+    "docs/API_DOCUMENTATION.md",
+    "docs/SQL_SAFETY.md",
+    "docs/DATABASE.md",
+    "docs/DEPLOYMENT.md",
+    "docs/QUICK_START.md",
+    "docs/ADMIN_HANDBOOK.md",
+    "docs/BACKEND_FRAMEWORK.md",
+    "docs/PERFORMANCE_RECOMMENDATIONS.md"
+  ],
+  "plugin": [
+    "opencode-notify",
+    "opencode-snip",
+    "opencode-update-notifier"
+  ],
+  "agent": {
+    "code-architect": {
+      "description": "Designs feature architectures by analyzing codebase patterns and conventions, then providing comprehensive implementation blueprints",
+      "mode": "subagent",
+      "color": "#00ff88",
+      "permission": {
+        "read": "allow",
+        "glob": "allow",
+        "grep": "allow",
+        "edit": "deny",
+        "bash": "deny"
+      }
+    },
+    "code-explorer": {
+      "description": "Traces codebase features, maps architecture layers, and documents dependencies to inform new development",
+      "mode": "subagent",
+      "color": "#ffd700",
+      "permission": {
+        "read": "allow",
+        "glob": "allow",
+        "grep": "allow",
+        "edit": "deny",
+        "bash": "deny"
+      }
+    },
+    "code-reviewer": {
+      "description": "Reviews code for bugs, logic errors, security vulnerabilities, and adherence to project conventions",
+      "mode": "subagent",
+      "color": "#ff4444",
+      "temperature": 0.1,
+      "permission": {
+        "edit": "deny",
+        "bash": "deny"
+      }
+    },
+    "db-architect": {
+      "description": "D1/SQLite schema design and migration planning specialist for SetTimes.ca",
+      "mode": "subagent",
+      "color": "#4488ff",
+      "permission": {
+        "edit": "deny",
+        "bash": "ask"
+      }
+    }
+  },
+  "command": {
+    "quality": {
+      "template": "Run the full quality check: cd frontend && npx prettier --write \"src/**/*.{js,jsx,json,css}\" && npm run lint && npm run format:check && npm test -- --run && npm run build",
+      "description": "Run lint + format + tests + build",
+      "agent": "build",
+      "subtask": true
+    },
+    "deploy-dev": {
+      "template": "Run the dev deployment: build frontend first with 'npm --prefix frontend run build', then deploy to Cloudflare Pages dev branch with 'npx wrangler pages deploy frontend/dist --project-name settimesdotca --branch dev'",
+      "description": "Deploy to dev environment",
+      "subtask": true
+    },
+    "deploy-prod": {
+      "template": "Run the production deployment. REMINDER: ALLOW_ADMIN_SIGNUP must never be set in production. Build frontend first with 'npm --prefix frontend run build', then deploy with 'npx wrangler pages deploy frontend/dist --project-name settimesdotca --branch main'",
+      "description": "Deploy to production",
+      "subtask": true
+    },
+    "schema": {
+      "template": "Validate the database schema with 'npm run validate:schema' and the OpenAPI spec with 'npm run validate:openapi'",
+      "description": "Validate DB schema and OpenAPI spec",
+      "subtask": true
+    },
+    "migrate": {
+      "template": "Run the local migration script: bash scripts/migrate-local-db.sh",
+      "description": "Run local D1 migrations",
+      "subtask": true
+    }
+  },
+  "permission": {
+    "edit": "ask",
+    "bash": "ask",
+    "webfetch": "allow",
+    "websearch": "allow",
+    "read": "ask",
+    "glob": "allow",
+    "grep": "allow",
+    "task": "ask",
+    "question": "allow"
+  },
+  "compaction": {
+    "auto": true,
+    "prune": true,
+    "reserved": 15000
+  },
+  "watcher": {
+    "ignore": [
+      "node_modules/**",
+      "frontend/node_modules/**",
+      "dist/**",
+      "frontend/dist/**",
+      ".wrangler/**",
+      "coverage/**",
+      "playwright-report/**",
+      "test-results/**",
+      "output/**",
+      "archive/**",
+      "plan/**",
+      ".git/**",
+      ".DS_Store"
+    ]
+  }
+}


### PR DESCRIPTION
Fixes the highest-impact finding from the silent-failure audit (M1): band-announcement emails were fire-once with no retry path, so any partial send failure dropped those fans **permanently**.

## The fix — per-follower delivery tracking
- **`band_follow_notifications(performance_id, band_follow_id)`** (migration `0041`) records each *successful* announcement send.
- **`notifyBandFollowers`** (`functions/utils/bandFollowNotify.js`) is shared send+record logic. The announce flow (`bands/[id].js`) now calls it, recording deliveries instead of relying on the fire-once `band_follow_notified` latch.
- **`POST /api/admin/bands/{id}/resend-announcement`** re-sends only to verified followers *without* a notification row for that performance — guaranteeing eventual delivery and never double-sending.
- **Admin "Resend" button** on announced reveal-mode performances in `LineupTab` (toast reports how many were re-sent, or that all were already notified).

## Tests (TDD)
- `bandFollowNotify.test.js` — records only delivered followers, skips failures.
- `resend-announcement.test.js` — resend targets only the un-notified follower.
- Backend 418 · frontend 171 · lint · build · schema · OpenAPI — all green.

## Docs
OpenAPI entry + a CLAUDE.md "Band Announcements" section (warns against reintroducing a fire-once latch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
