### PR TITLE
feat(admin): per-band verified follower count in the roster

### DIFF
--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -665,6 +665,7 @@ export default function RosterTab({ showToast, readOnly = false }) {
                     >
                       Contact <SortIcon col="contact_email" sortConfig={sortConfig} />
                     </th>
+                    <th className="px-4 py-3 text-right text-white font-semibold">Followers</th>
                     {!readOnly && <th className="px-4 py-3 text-right text-white font-semibold">Actions</th>}
                   </tr>
                 </thead>
@@ -711,6 +712,15 @@ export default function RosterTab({ showToast, readOnly = false }) {
                         <SocialLinksIcons band={band} />
                       </td>
                       <td className="px-4 py-3 text-white/70">{band.contact_email || '-'}</td>
+                      <td className="px-4 py-3 text-right text-white/70">
+                        {band.follower_count > 0 ? (
+                          <span className="inline-flex items-center rounded-full bg-accent-500/15 px-2 py-1 text-xs font-semibold text-accent-300">
+                            {band.follower_count}
+                          </span>
+                        ) : (
+                          <span className="text-white/30">0</span>
+                        )}
+                      </td>
                       {!readOnly && (
                         <td className="px-4 py-3 flex justify-end gap-2">
                           <button

--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -802,6 +802,7 @@ export default function RosterTab({ showToast, readOnly = false }) {
                         <SocialLinksIcons band={band} />
                       </div>
                       <div>Contact: {band.contact_email || '-'}</div>
+                    <div>Followers: {band.follower_count > 0 ? band.follower_count : 0}</div>
                     </div>
                   {!readOnly && (
                     <div className="flex flex-wrap gap-2">

--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -276,6 +276,11 @@ export default function RosterTab({ showToast, readOnly = false }) {
         const bVal = formatOrigin(b).toLowerCase()
         return sortConfig.direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
       }
+      if (sortConfig.key === 'follower_count') {
+        const aVal = a.follower_count ?? 0
+        const bVal = b.follower_count ?? 0
+        return sortConfig.direction === 'asc' ? aVal - bVal : bVal - aVal
+      }
       const aVal = (a[sortConfig.key] || '').toLowerCase()
       const bVal = (b[sortConfig.key] || '').toLowerCase()
 
@@ -665,7 +670,12 @@ export default function RosterTab({ showToast, readOnly = false }) {
                     >
                       Contact <SortIcon col="contact_email" sortConfig={sortConfig} />
                     </th>
-                    <th className="px-4 py-3 text-right text-white font-semibold">Followers</th>
+                    <th
+  onClick={() => handleSort('follower_count')}
+  className="px-4 py-3 text-right text-white font-semibold cursor-pointer hover:text-accent-400"
+>
+  Followers <SortIcon col="follower_count" sortConfig={sortConfig} />
+</th>
                     {!readOnly && <th className="px-4 py-3 text-right text-white font-semibold">Actions</th>}
                   </tr>
                 </thead>
@@ -782,16 +792,17 @@ export default function RosterTab({ showToast, readOnly = false }) {
                       </a>
                     </label>
                   </div>
-                  <div className="text-sm text-text-secondary space-y-1">
-                    <div>Origin: {formatOrigin(band) || '-'}</div>
-                    <div>Genre: {band.genre || '-'}</div>
-                    <div>Status: {band.is_active === 0 || band.is_active === false ? 'Inactive' : 'Active'}</div>
-                    <div className="flex items-center gap-2">
-                      <span>Links:</span>
-                      <SocialLinksIcons band={band} />
+                    <div className="text-sm text-text-secondary space-y-1">
+                      <div>Origin: {formatOrigin(band) || '-'}</div>
+                      <div>Genre: {band.genre || '-'}</div>
+                      <div>Status: {band.is_active === 0 || band.is_active === false ? 'Inactive' : 'Active'}</div>
+                      <div>Followers: {band.follower_count ?? 0}</div>
+                      <div className="flex items-center gap-2">
+                        <span>Links:</span>
+                        <SocialLinksIcons band={band} />
+                      </div>
+                      <div>Contact: {band.contact_email || '-'}</div>
                     </div>
-                    <div>Contact: {band.contact_email || '-'}</div>
-                  </div>
                   {!readOnly && (
                     <div className="flex flex-wrap gap-2">
                       <button

--- a/functions/api/admin/__tests__/bands-follower-count.test.js
+++ b/functions/api/admin/__tests__/bands-follower-count.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../_middleware.js', () => ({
+  checkPermission: async (context) => {
+    const role =
+      context?.data?.user?.role || context?.request?.headers?.get('x-test-role')
+    if (!role) {
+      return {
+        error: true,
+        response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      }
+    }
+    return { error: false, user: { userId: 1, role }, userId: 1 }
+  },
+  auditLog: vi.fn(async () => {}),
+}))
+
+import { onRequestGet } from '../bands.js'
+import { createTestEnv } from '../../test-utils.js'
+
+describe('GET /api/admin/bands — follower_count', () => {
+  test('includes the verified follower count per band', async () => {
+    const { env, rawDb } = createTestEnv()
+    const profileId = rawDb
+      .prepare(
+        'INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)'
+      )
+      .run('The Reverbs', 'thereverbs').lastInsertRowid
+
+    // 2 verified followers + 1 unverified (should not count)
+    rawDb
+      .prepare(
+        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+      )
+      .run('a@x.co', profileId, 'tk-a')
+    rawDb
+      .prepare(
+        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+      )
+      .run('b@x.co', profileId, 'tk-b')
+    rawDb
+      .prepare(
+        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 0, ?)'
+      )
+      .run('c@x.co', profileId, 'tk-c')
+
+    const res = await onRequestGet({
+      request: new Request('https://example.test/api/admin/bands', {
+        headers: { 'x-test-role': 'viewer' },
+      }),
+      env,
+      data: { user: { userId: 1, role: 'viewer' } },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const band = (body.bands || []).find((b) => b.name === 'The Reverbs')
+    expect(band).toBeTruthy()
+    expect(band.follower_count).toBe(2)
+  })
+})

--- a/functions/api/admin/bands.js
+++ b/functions/api/admin/bands.js
@@ -153,6 +153,7 @@ export async function onRequestGet(context) {
           bp.description,
           bp.photo_url,
           bp.social_links,
+          (SELECT COUNT(*) FROM band_follows bf WHERE bf.band_profile_id = bp.id AND bf.verified = 1) AS follower_count,
           v.name as venue_name,
           e.name as event_name
         FROM performances p
@@ -190,6 +191,7 @@ export async function onRequestGet(context) {
           bp.description,
           bp.photo_url,
           bp.social_links,
+          (SELECT COUNT(*) FROM band_follows bf WHERE bf.band_profile_id = bp.id AND bf.verified = 1) AS follower_count,
           v.name as venue_name,
           e.name as event_name,
           e.date as event_date


### PR DESCRIPTION
Surfaces data we already collect in `band_follows` but never displayed. The admin bands list (`GET /api/admin/bands`) now returns `follower_count` (count of **verified** followers) per band via a subquery, and `RosterTab` shows a Followers column.

Complements the M1 resend feature (#324): admins can now see which bands have engaged fans. Answers "are we tracking which bands have followers and how many?" — the data was there; now it is visible.

TDD: `bands-follower-count.test.js` (verified followers counted, unverified excluded). Backend 417 · frontend 171 · lint · build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)