### PR TITLE
feat(ui): add theme toggle and roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ settimes.ca is evolving into the best multi-venue/multi-artist event platform fo
 - **Single photo per band** — extends existing `photo_url` / R2 upload flow; no video embeds
 - **Design:** Fresh visual identity for Vol. 17 using Tailwind v4 `@theme`
 
+Canonical active roadmap: `docs/ROADMAP.md`. Use it for handoffs between Claude, OpenCode, and humans.
+
 ---
 
 ## Stack

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,137 @@
+# SetTimes.ca Roadmap
+
+Canonical active roadmap for SetTimes.ca. Use this file for handoffs between Claude, OpenCode, and humans.
+
+Last updated: 2026-06-19
+
+## Mission
+
+Build SetTimes.ca into the best multi-venue and multi-artist event platform for Waterloo Region, starting with Long Weekend Band Crawl Vol. 17 on August 2, 2026.
+
+## Fixed Context
+
+- Region: Waterloo Region only, with current focus on Kitchener-Waterloo.
+- Brand: SetTimes.ca. Do not rebrand.
+- Event: Long Weekend Band Crawl Vol. 17, August 2, 2026.
+- Venues: Blue Room, Princess Cafe, Prohibition Warehouse, Revive Karaoke, Room 47, Roost.
+- Lineup: 22 bands, doors 6:30 PM, show 6:45 PM, ages 19+.
+- Priority balance: fan-facing experience and admin tooling are both critical.
+- SEO: event pages, band pages, local discovery, and structured data matter.
+- Media model: one photo per band via existing `photo_url` and R2 upload flow. No video embeds.
+- Theme model: four user-selectable themes via Tailwind v4 CSS custom properties and `data-theme` on `<html>`, persisted in localStorage.
+
+## Operating Rules
+
+- Never merge with failed CI.
+- Read review comments carefully, including line-level PR comments.
+- Reply to review comments when addressed.
+- Add or update tests for behavior changes where testable.
+- Keep changes small and focused. Avoid mixing roadmap/docs, dependency work, and feature work in one PR.
+- Avoid direct writes to localStorage schedule keys; use `frontend/src/utils/scheduleStorage.js`.
+- Preserve after-midnight sorting behavior from `frontend/src/utils/bandUtils.js`.
+
+## Immediate Merge Queue
+
+1. Merge roster formatting follow-up if still open.
+   - Purpose: keep `main` format-clean after the follower count roster change.
+   - Verify: all CI green.
+
+2. Merge frontend dependency remediation if still open.
+   - Purpose: clear current frontend dependency alerts.
+   - Verify: `npm audit --audit-level=low` passes in `frontend/` and CI is green.
+
+3. Merge announcement resend/backfill work if still open.
+   - Purpose: per-follower announcement delivery tracking and resend recovery.
+   - Verify: backfill migration, resend race fix, backend tests, and CI green.
+
+## Track A: Vol. 17 Public Experience
+
+Goal: make the public event page useful before, during, and after the crawl.
+
+P0:
+
+- Redesign event page into lifecycle states: preview, live, recap, archive.
+- Build a mobile-first live schedule with Now Playing, Starting Soon, and My Next Set.
+- Rename and refine My Schedule into My Route.
+- Improve save/remove actions and overlap warnings.
+- Preserve offline-readable schedule and saved route state.
+
+P1:
+
+- Add venue-lane schedule view.
+- Add walking-time hints between King Street venues.
+- Add map-aware next-stop suggestions.
+- Improve post-event archive and recap modules.
+
+## Track B: Visual Identity And Themes
+
+Goal: deliver a fresh Vol. 17 identity while preserving readable, fast UI.
+
+Done:
+
+- Theme foundation with four palettes via `data-theme`.
+- LocalStorage persistence and FOUC prevention script.
+- Dynamic `theme-color` metadata.
+- Visible public header theme toggle.
+
+Next:
+
+- Ensure all admin and public surfaces use semantic theme tokens.
+- Tune mobile contrast for low-light event conditions.
+
+## Track C: Band And Event SEO
+
+Goal: make SetTimes.ca discoverable for local artists, venues, and event searches.
+
+P0:
+
+- Improve band profile metadata and structured data.
+- Improve event page structured data.
+- Ensure Waterloo Region language is consistent.
+- Remove or avoid non-Waterloo references in new docs/code.
+
+P1:
+
+- Add better archive pages for recurring events.
+- Add stronger internal links between bands, venues, events, and recaps.
+
+## Track D: Admin Tooling
+
+Goal: make event setup and live operations reliable and fast for organizers.
+
+Done or in flight:
+
+- Bulk band import.
+- Bulk band delete fixes.
+- Per-band verified follower counts in roster.
+- Per-follower announcement tracking with resend recovery.
+
+Next:
+
+- Improve roster mobile view and sorting quality.
+- Improve lineup management for reveal-mode events.
+- Surface follower engagement where it helps announcement planning.
+- Keep viewer/editor/admin RBAC boundaries explicit on every mutating endpoint.
+
+## Track E: Performance And Reliability
+
+Goal: keep the site fast on mobile and safe to operate under event load.
+
+P0:
+
+- Code-split `AdminApp` to reduce the large admin chunk.
+- Keep build warnings visible and actionable.
+- Re-run ZAP baseline after CSP/header changes.
+- Keep dependency alerts at zero where practical.
+
+P1:
+
+- Review caching and offline behavior for the schedule.
+- Improve observability around metrics ingestion and email delivery failures.
+
+## Reference Docs
+
+- `CLAUDE.md`: assistant context, invariants, stack, and safety rules.
+- `docs/SETTIMES_V2_UX_BRIEF.md`: UX direction and product experience details.
+- `docs/TESTING.md`: testing strategy and known test categories.
+- `docs/DATABASE.md`: schema and database implementation notes.

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import ThemeToggle from './ThemeToggle.jsx'
 
 function Header({ eventName, eventDate }) {
   const formattedDate = eventDate
@@ -57,15 +58,16 @@ function Header({ eventName, eventDate }) {
       style={headerStyle}
     >
       <div className="container mx-auto max-w-(--breakpoint-2xl) px-4">
-        <div className="flex items-center justify-center sm:justify-between min-h-[40px]">
+        <div className="flex min-h-[40px] items-center justify-between gap-3">
           <h1
-            className="font-bold text-white font-display tracking-tight text-[2rem] sm:text-3xl md:text-4xl text-center sm:text-left leading-tight transition-transform duration-300 ease-out"
+            className="font-bold text-white font-display tracking-tight text-[2rem] sm:text-3xl md:text-4xl text-left leading-tight transition-transform duration-300 ease-out"
             style={{ transform: `scale(${titleScale})` }}
           >
             <Link to="/" className="hover:opacity-80 transition-opacity">
               <span className="text-accent-500">Set</span>Times
             </Link>
           </h1>
+          <ThemeToggle />
         </div>
 
         <p className="hidden text-accent-400 text-sm font-medium text-center sm:block" style={collapseStyle}>

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,0 +1,45 @@
+import { useTheme, VALID_THEMES } from './ThemeProvider.jsx'
+
+const THEME_LABELS = {
+  'midnight-ember': 'Midnight Ember',
+  'arctic-night': 'Arctic Night',
+  'golden-hour': 'Golden Hour',
+  'silver-lining': 'Silver Lining',
+}
+
+const SWATCH_CLASSES = {
+  'midnight-ember': 'bg-orange-500',
+  'arctic-night': 'bg-sky-400',
+  'golden-hour': 'bg-amber-300',
+  'silver-lining': 'bg-slate-300',
+}
+
+export default function ThemeToggle() {
+  const { theme, cycleTheme } = useTheme()
+  const currentLabel = THEME_LABELS[theme] || 'Theme'
+
+  return (
+    <button
+      type="button"
+      onClick={cycleTheme}
+      className="group inline-flex min-h-[44px] items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-2 text-xs font-semibold text-white shadow-sm backdrop-blur-xs transition hover:border-accent-400/60 hover:bg-white/15 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-navy"
+      aria-label={`Change colour theme. Current theme: ${currentLabel}`}
+      title={`Theme: ${currentLabel}`}
+    >
+      <span className="flex items-center gap-1" aria-hidden="true">
+        {VALID_THEMES.map(name => (
+          <span
+            key={name}
+            className={`h-2.5 w-2.5 rounded-full ${SWATCH_CLASSES[name]} ${
+              name === theme
+                ? 'ring-2 ring-white ring-offset-1 ring-offset-bg-navy'
+                : 'opacity-55 group-hover:opacity-80'
+            }`}
+          />
+        ))}
+      </span>
+      <span className="hidden sm:inline">{currentLabel}</span>
+      <span className="sm:hidden">Theme</span>
+    </button>
+  )
+}

--- a/frontend/src/components/__tests__/ThemeToggle.test.jsx
+++ b/frontend/src/components/__tests__/ThemeToggle.test.jsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import ThemeToggle from '../ThemeToggle.jsx'
+import { THEME_KEY, ThemeProvider } from '../ThemeProvider.jsx'
+
+function renderThemeToggle() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>
+  )
+}
+
+describe('ThemeToggle', () => {
+  it('cycles the theme and persists the selected value', () => {
+    renderThemeToggle()
+
+    const button = screen.getByRole('button', {
+      name: /current theme: midnight ember/i,
+    })
+
+    fireEvent.click(button)
+
+    expect(document.documentElement.dataset.theme).toBe('arctic-night')
+    expect(window.localStorage.getItem(THEME_KEY)).toBe('arctic-night')
+    expect(
+      screen.getByRole('button', {
+        name: /current theme: arctic night/i,
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('uses a stored valid theme on first render', () => {
+    window.localStorage.setItem(THEME_KEY, 'golden-hour')
+
+    renderThemeToggle()
+
+    expect(document.documentElement.dataset.theme).toBe('golden-hour')
+    expect(
+      screen.getByRole('button', {
+        name: /current theme: golden hour/i,
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/a11y.test.jsx
+++ b/frontend/src/test/a11y.test.jsx
@@ -4,6 +4,7 @@ import { axe, toHaveNoViolations } from 'jest-axe'
 import { describe, expect, it, vi } from 'vitest'
 import { HelmetProvider } from 'react-helmet-async'
 import App from '../App'
+import { ThemeProvider } from '../components/ThemeProvider.jsx'
 
 expect.extend(toHaveNoViolations)
 
@@ -35,15 +36,21 @@ const waitForAppToSettle = async () => {
   })
 }
 
-describe('Accessibility Tests', () => {
-  it('App should have no accessibility violations', async () => {
-    const { container } = render(
+function renderApp() {
+  return render(
+    <ThemeProvider>
       <HelmetProvider>
         <MemoryRouter>
           <App />
         </MemoryRouter>
       </HelmetProvider>
-    )
+    </ThemeProvider>
+  )
+}
+
+describe('Accessibility Tests', () => {
+  it('App should have no accessibility violations', async () => {
+    const { container } = renderApp()
 
     // Wait for data to load
     await waitForAppToSettle()
@@ -53,13 +60,7 @@ describe('Accessibility Tests', () => {
   }, 10000) // Increase timeout for axe
 
   it('should have proper heading hierarchy', async () => {
-    const { container } = render(
-      <HelmetProvider>
-        <MemoryRouter>
-          <App />
-        </MemoryRouter>
-      </HelmetProvider>
-    )
+    const { container } = renderApp()
     await waitForAppToSettle()
 
     const headings = container.querySelectorAll('h1, h2, h3, h4, h5, h6')
@@ -67,13 +68,7 @@ describe('Accessibility Tests', () => {
   })
 
   it('should have alt text for images', async () => {
-    const { container } = render(
-      <HelmetProvider>
-        <MemoryRouter>
-          <App />
-        </MemoryRouter>
-      </HelmetProvider>
-    )
+    const { container } = renderApp()
     await waitForAppToSettle()
 
     const images = container.querySelectorAll('img')
@@ -83,13 +78,7 @@ describe('Accessibility Tests', () => {
   })
 
   it('should have accessible buttons', async () => {
-    const { container } = render(
-      <HelmetProvider>
-        <MemoryRouter>
-          <App />
-        </MemoryRouter>
-      </HelmetProvider>
-    )
+    const { container } = renderApp()
     await waitForAppToSettle()
 
     const buttons = container.querySelectorAll('button')


### PR DESCRIPTION
Adds a canonical roadmap for Claude/OpenCode/human handoffs and exposes the existing four-theme system through a public header theme toggle.\n\nChanges:\n- Add docs/ROADMAP.md as the active roadmap source of truth\n- Link the roadmap from CLAUDE.md\n- Add ThemeToggle component to the public header\n- Add tests for theme cycling, data-theme updates, and localStorage persistence\n- Update a11y tests to render with ThemeProvider, matching production\n\nVerification:\n- cd frontend && npx prettier --write "src/**/*.{js,jsx,json,css}"\n- cd frontend && npm run lint\n- cd frontend && npm run format:check\n- cd frontend && npm test -- --run\n- cd frontend && npm run build