### PR TITLE
fix(ui): show theme toggle on homepage

### DIFF
--- a/frontend/src/pages/EventsPage.jsx
+++ b/frontend/src/pages/EventsPage.jsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet-async'
 import EventTimeline from '../components/EventTimeline'
 import Footer from '../components/Footer'
 import PrivacyBanner from '../components/PrivacyBanner'
+import ThemeToggle from '../components/ThemeToggle.jsx'
 import { trackPageView } from '../utils/metrics'
 import { hasAnySchedule, getScheduleEventSlug, SELECTED_BANDS_KEY } from '../utils/scheduleStorage'
 import { ArrowRight, CalendarDays } from 'lucide-react'
@@ -69,11 +70,16 @@ export default function EventsPage() {
           })}
         </script>
       </Helmet>
-      <header className="py-8 px-4 text-center border-b border-accent-500/30">
-        <h1 className="text-4xl font-bold text-white font-display mb-2">
-          <span className="text-accent-500">Set</span>Times
-        </h1>
-        <p className="text-accent-400 text-lg">Discover · Plan · Experience</p>
+      <header className="border-b border-accent-500/30 px-4 py-8">
+        <div className="container mx-auto flex max-w-7xl items-start justify-between gap-4">
+          <div>
+            <h1 className="mb-2 text-4xl font-bold text-white font-display">
+              <span className="text-accent-500">Set</span>Times
+            </h1>
+            <p className="text-lg text-accent-400">Discover · Plan · Experience</p>
+          </div>
+          <ThemeToggle />
+        </div>
       </header>
 
       {showBanner && scheduleSlug && (

--- a/frontend/src/pages/__tests__/EventsPage.test.jsx
+++ b/frontend/src/pages/__tests__/EventsPage.test.jsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import EventsPage from '../EventsPage.jsx'
+import { THEME_KEY, ThemeProvider } from '../../components/ThemeProvider.jsx'
+
+vi.mock('../../components/EventTimeline', () => ({
+  default: () => <div>Event timeline</div>,
+}))
+
+vi.mock('../../utils/metrics', () => ({
+  trackPageView: vi.fn(),
+}))
+
+function renderEventsPage() {
+  return render(
+    <ThemeProvider>
+      <HelmetProvider>
+        <MemoryRouter>
+          <EventsPage />
+        </MemoryRouter>
+      </HelmetProvider>
+    </ThemeProvider>
+  )
+}
+
+describe('EventsPage', () => {
+  it('shows the theme toggle on the homepage', () => {
+    renderEventsPage()
+
+    const toggle = screen.getByRole('button', {
+      name: /current theme: midnight ember/i,
+    })
+
+    fireEvent.click(toggle)
+
+    expect(document.documentElement.dataset.theme).toBe('arctic-night')
+    expect(window.localStorage.getItem(THEME_KEY)).toBe('arctic-night')
+  })
+})


### PR DESCRIPTION
The theme toggle from #328 was only visible inside the event-page Header, so users landing on / could not see it.\n\nChanges:\n- Add ThemeToggle to the homepage EventsPage header\n- Add a regression test that verifies the homepage toggle is present and persists theme changes\n\nVerification:\n- cd frontend && npx prettier --write "src/**/*.{js,jsx,json,css}"\n- cd frontend && npm run lint\n- cd frontend && npm run format:check\n- cd frontend && npm test -- --run\n- cd frontend && npm run build