### PR TITLE
feat(ui): minimal swatch theme picker (no names) + golden-hour→daybreak rename

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script>(function(){var t;try{t=localStorage.getItem('settimes-theme')}catch{}if(!t||!['midnight-ember','arctic-night','golden-hour','silver-lining'].includes(t))t='midnight-ember';document.documentElement.dataset.theme=t;var m=document.querySelector('meta[name=theme-color]');if(m){var c={0:'#0c0f1a',1:'#0f172a',2:'#fffbeb',3:'#f8fafc'}[['midnight-ember','arctic-night','golden-hour','silver-lining'].indexOf(t)];if(c)m.setAttribute('content',c)}})()</script>
+    <script>(function(){var t;try{t=localStorage.getItem('settimes-theme')}catch{}if(!t||!['midnight-ember','arctic-night','daybreak','silver-lining'].includes(t))t='midnight-ember';document.documentElement.dataset.theme=t;var m=document.querySelector('meta[name=theme-color]');if(m){var c={0:'#0c0f1a',1:'#0f172a',2:'#fffbeb',3:'#f8fafc'}[['midnight-ember','arctic-night','daybreak','silver-lining'].indexOf(t)];if(c)m.setAttribute('content',c)}})()</script>
 
     <!-- PWA manifest -->
     <link rel="manifest" href="/manifest.json" />

--- a/frontend/src/components/ThemeProvider.jsx
+++ b/frontend/src/components/ThemeProvider.jsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState, useCallback } from 'react'
 
 export const THEME_KEY = 'settimes-theme'
-export const VALID_THEMES = ['midnight-ember', 'arctic-night', 'golden-hour', 'silver-lining']
+export const VALID_THEMES = ['midnight-ember', 'arctic-night', 'daybreak', 'silver-lining']
 export const DEFAULT_THEME = 'midnight-ember'
 
 const ThemeContext = createContext(null)
@@ -58,5 +58,5 @@ export function useTheme() {
 }
 
 export function getThemeInitScript() {
-  return `(function(){var t;try{t=localStorage.getItem('${THEME_KEY}')}catch{}if(!t||!['midnight-ember','arctic-night','golden-hour','silver-lining'].includes(t))t='${DEFAULT_THEME}';document.documentElement.dataset.theme=t})()`
+  return `(function(){var t;try{t=localStorage.getItem('${THEME_KEY}')}catch{}if(!t||!['midnight-ember','arctic-night','daybreak','silver-lining'].includes(t))t='${DEFAULT_THEME}';document.documentElement.dataset.theme=t})()`
 }

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,45 +1,92 @@
+import { useState, useRef, useEffect } from 'react'
 import { useTheme, VALID_THEMES } from './ThemeProvider.jsx'
 
+// Functional descriptions for accessibility only — theme names are intentionally
+// NOT surfaced in the UI. The swatches are the affordance.
 const THEME_LABELS = {
-  'midnight-ember': 'Midnight Ember',
-  'arctic-night': 'Arctic Night',
-  'golden-hour': 'Golden Hour',
-  'silver-lining': 'Silver Lining',
+  'midnight-ember': 'warm dark',
+  'arctic-night': 'cool dark',
+  daybreak: 'warm light',
+  'silver-lining': 'cool light',
 }
 
 const SWATCH_CLASSES = {
   'midnight-ember': 'bg-orange-500',
   'arctic-night': 'bg-sky-400',
-  'golden-hour': 'bg-amber-300',
+  daybreak: 'bg-amber-300',
   'silver-lining': 'bg-slate-300',
 }
 
+// Minimal theme picker: a single current-theme dot that expands to the four
+// swatches on tap (a small popover). One small element in the header — especially
+// on mobile — and direct pick when opened.
 export default function ThemeToggle() {
-  const { theme, cycleTheme } = useTheme()
-  const currentLabel = THEME_LABELS[theme] || 'Theme'
+  const { theme, setTheme } = useTheme()
+  const [open, setOpen] = useState(false)
+  const ref = useRef(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = e => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false)
+    }
+    const onKeyDown = e => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
 
   return (
-    <button
-      type="button"
-      onClick={cycleTheme}
-      className="group inline-flex min-h-[44px] items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-2 text-xs font-semibold text-white shadow-sm backdrop-blur-xs transition hover:border-accent-400/60 hover:bg-white/15 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-navy"
-      aria-label={`Change colour theme. Current theme: ${currentLabel}`}
-      title={`Theme: ${currentLabel}`}
-    >
-      <span className="flex items-center gap-1" aria-hidden="true">
-        {VALID_THEMES.map(name => (
-          <span
-            key={name}
-            className={`h-2.5 w-2.5 rounded-full ${SWATCH_CLASSES[name]} ${
-              name === theme
-                ? 'ring-2 ring-white ring-offset-1 ring-offset-bg-navy'
-                : 'opacity-55 group-hover:opacity-80'
-            }`}
-          />
-        ))}
-      </span>
-      <span className="hidden sm:inline">{currentLabel}</span>
-      <span className="sm:hidden">Theme</span>
-    </button>
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-label={`Colour theme: ${THEME_LABELS[theme] || theme}. Activate to change.`}
+        title="Colour theme"
+        className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+      >
+        <span aria-hidden="true" className={`h-5 w-5 rounded-full ${SWATCH_CLASSES[theme]} ring-1 ring-white/40`} />
+      </button>
+      {open && (
+        <div
+          role="group"
+          aria-label="Colour theme"
+          className="absolute right-0 top-full z-50 mt-1 flex items-center gap-1 rounded-full border border-white/10 bg-bg-purple/95 px-1.5 py-1 shadow-lg backdrop-blur-xs"
+        >
+          {VALID_THEMES.map(name => {
+            const isActive = name === theme
+            const label = `${THEME_LABELS[name] || name} theme`
+            return (
+              <button
+                key={name}
+                type="button"
+                onClick={() => {
+                  setTheme(name)
+                  setOpen(false)
+                }}
+                aria-pressed={isActive}
+                aria-label={label}
+                title={label}
+                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+              >
+                <span
+                  aria-hidden="true"
+                  className={`h-5 w-5 rounded-full ${SWATCH_CLASSES[name]} ${
+                    isActive ? 'ring-2 ring-white ring-offset-1 ring-offset-bg-purple' : 'opacity-60'
+                  }`}
+                />
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
   )
 }

--- a/frontend/src/components/__tests__/ThemeToggle.test.jsx
+++ b/frontend/src/components/__tests__/ThemeToggle.test.jsx
@@ -11,35 +11,28 @@ function renderThemeToggle() {
   )
 }
 
+function openPicker() {
+  fireEvent.click(screen.getByRole('button', { name: /activate to change/i }))
+}
+
 describe('ThemeToggle', () => {
-  it('cycles the theme and persists the selected value', () => {
+  it('applies and persists the selected theme', () => {
     renderThemeToggle()
+    openPicker()
 
-    const button = screen.getByRole('button', {
-      name: /current theme: midnight ember/i,
-    })
-
-    fireEvent.click(button)
+    fireEvent.click(screen.getByRole('button', { name: /cool dark theme/i }))
 
     expect(document.documentElement.dataset.theme).toBe('arctic-night')
     expect(window.localStorage.getItem(THEME_KEY)).toBe('arctic-night')
-    expect(
-      screen.getByRole('button', {
-        name: /current theme: arctic night/i,
-      })
-    ).toBeInTheDocument()
   })
 
-  it('uses a stored valid theme on first render', () => {
-    window.localStorage.setItem(THEME_KEY, 'golden-hour')
-
+  it('marks the stored theme as active on first render', () => {
+    window.localStorage.setItem(THEME_KEY, 'daybreak')
     renderThemeToggle()
 
-    expect(document.documentElement.dataset.theme).toBe('golden-hour')
-    expect(
-      screen.getByRole('button', {
-        name: /current theme: golden hour/i,
-      })
-    ).toBeInTheDocument()
+    expect(document.documentElement.dataset.theme).toBe('daybreak')
+
+    openPicker()
+    expect(screen.getByRole('button', { name: /warm light theme/i })).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -160,8 +160,8 @@
   --shadow-glow-accent: 0 0 20px rgba(14, 165, 233, 0.4);
 }
 
-/* golden-hour — light warm */
-[data-theme='golden-hour'] {
+/* daybreak — light warm (slug renamed from golden-hour; not surfaced in the UI) */
+[data-theme='daybreak'] {
   --color-primary-50: #fff7ed;
   --color-primary-100: #ffedd5;
   --color-primary-400: #fb7185;

--- a/frontend/src/pages/__tests__/EventsPage.test.jsx
+++ b/frontend/src/pages/__tests__/EventsPage.test.jsx
@@ -30,11 +30,9 @@ describe('EventsPage', () => {
   it('shows the theme toggle on the homepage', () => {
     renderEventsPage()
 
-    const toggle = screen.getByRole('button', {
-      name: /current theme: midnight ember/i,
-    })
-
-    fireEvent.click(toggle)
+    // Open the minimal swatch picker, then pick the cool-dark (arctic-night) theme.
+    fireEvent.click(screen.getByRole('button', { name: /colour theme/i }))
+    fireEvent.click(screen.getByRole('button', { name: /cool dark theme/i }))
 
     expect(document.documentElement.dataset.theme).toBe('arctic-night')
     expect(window.localStorage.getItem(THEME_KEY)).toBe('arctic-night')


### PR DESCRIPTION
Redesigns the public theme picker based on feedback.

## What changed
- **No surfaced theme names** — they read as corny. The picker is now pure swatches; theme names demote to internal slugs.
- **Minimal, especially on mobile** — a single current-theme dot that expands to a small 4-swatch popover on tap. One tiny element in the header until you interact with it.
- **Direct pick** — tap any swatch to apply (44px touch targets, `aria-pressed`, click-outside + Escape to close). Functional aria labels ("warm light" / "cool dark") for screen readers, never branded names.
- **Renamed** the `golden-hour` slug → `daybreak` everywhere (CSS `[data-theme]`, ThemeProvider, FOUC script, swatch map). No longer surfaced, but cleans up the code/aria.

## Tests
`ThemeToggle.test.jsx` + the homepage `EventsPage.test.jsx` updated for the popover behavior. Frontend 181 tests · lint · build — all green.

## Follow-up (separate PR)
Pin admin to the dark theme (it should not follow the fan's pick) + migrate public surfaces from hardcoded `text-white` to semantic tokens so `daybreak`/`silver-lining` are actually readable. That is the larger foundation change; this PR is just the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
