### PR TITLE
feat(ui): finish My Schedule → My Route rename

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -710,7 +710,7 @@ function App() {
           <div className="flex items-start justify-between gap-2 rounded-lg border border-accent-500/20 bg-accent-500/10 px-3 py-2.5 text-xs sm:items-center sm:gap-3 sm:px-4 sm:py-3 sm:text-sm">
             <p className="text-accent-300">
               <span className="font-semibold">How it works:</span> Tap any performer to add them to{' '}
-              <span className="font-semibold">My Schedule</span> — your personal lineup for the night.
+              <span className="font-semibold">My Route</span> — your personal lineup for the night.
             </p>
             <button
               onClick={dismissHint}

--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -53,7 +53,7 @@ function BandCard({
         : 'bg-gradient-card text-white hover:bg-bg-purple/80 hover:scale-[1.01] shadow-md border border-white/10'
   } relative`
 
-  const labelBase = isSelected ? `Remove ${band.name} from my schedule` : `Add ${band.name} to my schedule`
+  const labelBase = isSelected ? `Remove ${band.name} from my route` : `Add ${band.name} to my route`
   const bandProfileHref = band.name ? buildBandProfileHref(band.name, eventSlug) : null
 
   return (

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -382,7 +382,7 @@ function MySchedule({
       <div className="max-w-5xl mx-auto space-y-4">
         <div className="flex items-center justify-between mb-2">
           <div className="flex-1">
-            <h2 className="text-2xl font-bold text-white text-center">My Schedule</h2>
+            <h2 className="text-2xl font-bold text-white text-center">My Route</h2>
             <p className="text-center text-accent-400 text-sm">
               {showPast
                 ? `${sortedBands.length} ${sortedBands.length === 1 ? 'band' : 'bands'} selected`

--- a/frontend/src/config/highlights.jsx
+++ b/frontend/src/config/highlights.jsx
@@ -1,6 +1,6 @@
 /**
  * Configuration for highlighted bands
- * These bands will get special treatment in the My Schedule view
+ * These bands will get special treatment in the My Route view
  */
 export const HIGHLIGHTED_BANDS = ['ba-johnston', 'blackout', 'handheld']
 

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -481,7 +481,7 @@ export default function BandProfilePage() {
                 className="flex items-center gap-2 px-4 py-2 rounded-lg bg-accent-500/20 text-accent-400 hover:bg-accent-500/30 transition-colors text-sm font-medium"
               >
                 <CalendarDays size={14} />
-                {sourceEventSlug ? 'Back to Schedule' : 'My Schedule'}
+                {sourceEventSlug ? 'Back to Schedule' : 'My Route'}
               </Link>
             )}
           </div>


### PR DESCRIPTION
Completes the rename the previous AI started — `LiveContextBar`, `ScheduleLiveRow`, and `SharePreviewPage` already said "route," but `App`, `MySchedule`, `BandCard`, and `BandProfilePage` still said "schedule."

Updates the remaining personal-lineup labels (heading, homepage explainer, band add/remove aria labels, band-profile link, a config comment) to "My Route". Kept **"Back to Schedule"** — that points at the *event lineup*, which is legitimately a schedule, not the personal route.

Frontend 181 tests + lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)