### PR TITLE
fix(observability): surface two swallowed errors (audit M2, L2)

### DIFF
--- a/functions/api/auth/resend-activation.js
+++ b/functions/api/auth/resend-activation.js
@@ -1,6 +1,6 @@
-import { isValidEmail } from '../../utils/validation.js';
-import { isEmailConfigured, sendEmail } from '../../utils/email.js';
-import { buildActivationEmail } from '../../utils/emailTemplates.js';
+import { isValidEmail } from "../../utils/validation.js";
+import { isEmailConfigured, sendEmail } from "../../utils/email.js";
+import { buildActivationEmail } from "../../utils/emailTemplates.js";
 
 export async function onRequestPost(context) {
   const { request, env } = context;
@@ -14,29 +14,29 @@ export async function onRequestPost(context) {
     email = null;
   }
 
-  if (!email || typeof email !== 'string') {
+  if (!email || typeof email !== "string") {
     return new Response(
       JSON.stringify({
-        error: 'Validation error',
-        message: 'Email is required',
+        error: "Validation error",
+        message: "Email is required",
       }),
       {
         status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   }
 
   if (!isValidEmail(email)) {
     return new Response(
       JSON.stringify({
-        error: 'Validation error',
-        message: 'Invalid email format',
+        error: "Validation error",
+        message: "Invalid email format",
       }),
       {
         status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   }
 
@@ -44,12 +44,12 @@ export async function onRequestPost(context) {
     JSON.stringify({
       success: true,
       message:
-        'If an inactive account exists with this email, an activation link has been sent.',
+        "If an inactive account exists with this email, an activation link has been sent.",
     }),
     {
       status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    }
+      headers: { "Content-Type": "application/json" },
+    },
   );
 
   try {
@@ -58,7 +58,7 @@ export async function onRequestPost(context) {
       SELECT id, first_name, last_name, is_active, activated_at
       FROM users
       WHERE email = ?
-    `
+    `,
     )
       .bind(email)
       .first();
@@ -72,30 +72,42 @@ export async function onRequestPost(context) {
     }
 
     const activationToken =
-      crypto.randomUUID() + crypto.randomUUID().replace(/-/g, '');
+      crypto.randomUUID() + crypto.randomUUID().replace(/-/g, "");
     const activationExpires = new Date(
-      Date.now() + 24 * 60 * 60 * 1000
+      Date.now() + 24 * 60 * 60 * 1000,
     ).toISOString();
 
-    await DB.prepare(
-      `
+    try {
+      await DB.prepare(
+        `
       UPDATE users
       SET activation_token = ?,
           activation_token_expires_at = ?
       WHERE id = ?
-    `
-    )
-      .bind(activationToken, activationExpires, user.id)
-      .run();
+    `,
+      )
+        .bind(activationToken, activationExpires, user.id)
+        .run();
+    } catch (writeErr) {
+      // The generic response is intentionally returned for all paths (user
+      // enumeration resistance), but a failed token write is infrastructural,
+      // not a benign not-found/already-active branch — log it distinctly so it
+      // is alertable rather than hidden behind the generic 200.
+      console.error(
+        "[ResendActivation] activation token write failed:",
+        writeErr,
+      );
+      return genericResponse;
+    }
 
     const baseUrl = env.PUBLIC_URL || new URL(request.url).origin;
-    const activationUrl = new URL('/activate', baseUrl);
-    activationUrl.searchParams.set('token', activationToken);
+    const activationUrl = new URL("/activate", baseUrl);
+    activationUrl.searchParams.set("token", activationToken);
 
     if (isEmailConfigured(env)) {
       const fullName = [user.first_name, user.last_name]
         .filter(Boolean)
-        .join(' ')
+        .join(" ")
         .trim();
       const emailPayload = buildActivationEmail({
         activationUrl: activationUrl.toString(),
@@ -109,18 +121,18 @@ export async function onRequestPost(context) {
         html: emailPayload.html,
       });
       console.log(
-        '[ResendActivation] Activation email delivery attempted:',
-        emailResult.reason || 'delivered'
+        "[ResendActivation] Activation email delivery attempted:",
+        emailResult.reason || "delivered",
       );
     } else {
       console.warn(
-        '[ResendActivation] Email not configured; activation email was not sent.'
+        "[ResendActivation] Email not configured; activation email was not sent.",
       );
     }
 
     return genericResponse;
   } catch (error) {
-    console.error('Resend activation error:', error);
+    console.error("Resend activation error:", error);
     return genericResponse;
   }
 }

--- a/functions/s/[slug].js
+++ b/functions/s/[slug].js
@@ -4,64 +4,68 @@
 
 function escapeAttr(str) {
   return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 export async function onRequest(context) {
-  const { params, env, request } = context
-  const { slug } = params
-  const { DB } = env
+  const { params, env, request } = context;
+  const { slug } = params;
+  const { DB } = env;
 
   if (!slug || !/^[a-zA-Z0-9]{1,16}$/.test(slug)) {
-    return env.ASSETS.fetch(request)
+    return env.ASSETS.fetch(request);
   }
 
-  let row = null
+  let row = null;
   try {
     row = await DB.prepare(
       `SELECT sl.slug, sl.band_names, e.name AS event_name
        FROM share_links sl
        JOIN events e ON e.id = sl.event_id
-       WHERE sl.slug = ? AND sl.expires_at > datetime('now')`
+       WHERE sl.slug = ? AND sl.expires_at > datetime('now')`,
     )
       .bind(slug)
-      .first()
-  } catch (_err) {
-    return env.ASSETS.fetch(request)
+      .first();
+  } catch (err) {
+    // A DB error here is indistinguishable from "link not found" to the visitor
+    // (the SPA still renders without rich OG tags), so log it to keep transient
+    // failures visible rather than silently degrading.
+    console.error("Share-link OG lookup failed:", slug, err);
+    return env.ASSETS.fetch(request);
   }
 
   if (!row) {
-    return env.ASSETS.fetch(request)
+    return env.ASSETS.fetch(request);
   }
 
-  let bandNames
+  let bandNames;
   try {
-    bandNames = JSON.parse(row.band_names)
+    bandNames = JSON.parse(row.band_names);
   } catch (_err) {
-    console.error('Share link band_names corrupted:', row.slug)
-    return env.ASSETS.fetch(request)
+    console.error("Share link band_names corrupted:", row.slug);
+    return env.ASSETS.fetch(request);
   }
 
   if (!Array.isArray(bandNames) || bandNames.length === 0) {
-    return env.ASSETS.fetch(request)
+    return env.ASSETS.fetch(request);
   }
 
-  const count = bandNames.length
-  const ogTitle = `${count}-stop route for ${row.event_name}`
-  const featured = bandNames.slice(0, 3).join(', ')
-  const remainder = count > 3 ? ` and ${count - 3} more` : ''
-  const ogDescription = `Featuring ${featured}${remainder}`
+  const count = bandNames.length;
+  const ogTitle = `${count}-stop route for ${row.event_name}`;
+  const featured = bandNames.slice(0, 3).join(", ");
+  const remainder = count > 3 ? ` and ${count - 3} more` : "";
+  const ogDescription = `Featuring ${featured}${remainder}`;
 
-  const origin = new URL(request.url).origin
-  const ogUrl = `${origin}/s/${slug}`
-  const indexResponse = await env.ASSETS.fetch(new Request(`${origin}/`))
+  const origin = new URL(request.url).origin;
+  const ogUrl = `${origin}/s/${slug}`;
+  const indexResponse = await env.ASSETS.fetch(new Request(`${origin}/`));
   if (!indexResponse.ok) {
-    return env.ASSETS.fetch(request)
+    return env.ASSETS.fetch(request);
   }
-  const html = await indexResponse.text()
+  const html = await indexResponse.text();
 
   const metaTags = [
     `<meta property="og:title" content="${escapeAttr(ogTitle)}" />`,
@@ -71,14 +75,14 @@ export async function onRequest(context) {
     `<meta name="twitter:card" content="summary" />`,
     `<meta name="twitter:title" content="${escapeAttr(ogTitle)}" />`,
     `<meta name="twitter:description" content="${escapeAttr(ogDescription)}" />`,
-  ].join('\n    ')
+  ].join("\n    ");
 
-  const injected = html.replace('</head>', `    ${metaTags}\n  </head>`)
+  const injected = html.replace("</head>", `    ${metaTags}\n  </head>`);
 
   // Preserve original headers (CSP, ETag, etc.) and override content-type and cache
-  const headers = new Headers(indexResponse.headers)
-  headers.set('Content-Type', 'text/html;charset=UTF-8')
-  headers.set('Cache-Control', 'public, max-age=300')
+  const headers = new Headers(indexResponse.headers);
+  headers.set("Content-Type", "text/html;charset=UTF-8");
+  headers.set("Cache-Control", "public, max-age=300");
 
-  return new Response(injected, { headers })
+  return new Response(injected, { headers });
 }


### PR DESCRIPTION
Two small observability fixes from the silent-failure audit — no behavior change.

- **L2** `functions/s/[slug].js`: the share-link OG-preview DB lookup `catch` now logs. It was indistinguishable from "link not found" (both serve the plain SPA), so transient DB errors degraded the rich preview silently.
- **M2** `functions/api/auth/resend-activation.js`: a failed activation-token `UPDATE` is now logged distinctly. The generic 200 is intentionally kept (user-enumeration resistance), but an infrastructure write failure should be alertable, not hidden behind the 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)