### PR TITLE
feat(artists): public artist directory + search

### DIFF
--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -51,6 +51,77 @@ tags:
     description: Administrative maintenance endpoints
 
 paths:
+  /api/artists:
+    get:
+      tags:
+        - Public
+      summary: List/search the public artist directory
+      description: |
+        Returns artists (`band_profiles`) that have performed at one or more
+        published or archived events, as `{ artists, hasMore }`. Searchable by
+        name/genre and paginated. Gated by `PUBLIC_DATA_PUBLISH_ENABLED`.
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Search term matched against artist name and genre
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Page size
+          schema:
+            type: integer
+            default: 24
+            minimum: 1
+            maximum: 60
+        - name: offset
+          in: query
+          required: false
+          description: Number of results to skip
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        "200":
+          description: Artist directory page
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  artists:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        name:
+                          type: string
+                        photo_url:
+                          type: string
+                          nullable: true
+                        photo_alt_text:
+                          type: string
+                          nullable: true
+                        genre:
+                          type: string
+                          nullable: true
+                        origin:
+                          type: string
+                          nullable: true
+                        performance_count:
+                          type: integer
+                  hasMore:
+                    type: boolean
+        "503":
+          $ref: "#/components/responses/PublicDataUnavailable"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
   /api/schedule:
     get:
       tags:

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -20,6 +20,7 @@ const AdminApp = lazy(() => import('./admin/AdminApp.jsx'))
 const BandProfilePage = lazy(() => import('./pages/BandProfilePage.jsx'))
 const EventRecapPage = lazy(() => import('./pages/EventRecapPage.jsx'))
 const SharePreviewPage = lazy(() => import('./pages/SharePreviewPage.jsx'))
+const ArtistsPage = lazy(() => import('./pages/ArtistsPage.jsx'))
 
 const hostname = typeof window !== 'undefined' ? window.location.hostname || '' : ''
 const isPreviewBuild = hostname.startsWith('dev.') || hostname.endsWith('.pages.dev')
@@ -103,6 +104,18 @@ ReactDOM.createRoot(document.getElementById('root')).render(
                   <ErrorBoundary title="Band Profile Error" message="Unable to load band profile. Please try again.">
                     <Suspense fallback={<LoadingFallback />}>
                       <BandProfilePage />
+                    </Suspense>
+                  </ErrorBoundary>
+                }
+              />
+
+              {/* Artist directory: Lazy loaded */}
+              <Route
+                path="/artists"
+                element={
+                  <ErrorBoundary title="Artists Error" message="Unable to load the artist directory. Please try again.">
+                    <Suspense fallback={<LoadingFallback />}>
+                      <ArtistsPage />
                     </Suspense>
                   </ErrorBoundary>
                 }

--- a/frontend/src/pages/ArtistsPage.jsx
+++ b/frontend/src/pages/ArtistsPage.jsx
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
+import { ArrowLeft, Search } from 'lucide-react'
+import Footer from '../components/Footer'
+import ThemeToggle from '../components/ThemeToggle.jsx'
+import { fetchPublicJson } from '../utils/publicApi'
+import { trackPageView } from '../utils/metrics'
+import { buildBandProfileHref } from '../utils/bandProfileLink'
+
+const PAGE_SIZE = 24
+const PAGE_TITLE = 'Artists – SetTimes'
+
+function ArtistCard({ artist }) {
+  const meta = [artist.genre, artist.origin].filter(Boolean).join(' · ')
+  const shows = `${artist.performance_count} ${artist.performance_count === 1 ? 'show' : 'shows'}`
+
+  return (
+    <Link
+      to={buildBandProfileHref(artist.name)}
+      className="flex items-center gap-4 rounded-xl border border-white/10 bg-gradient-card p-4 transition hover:scale-[1.01] hover:border-accent-400/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+    >
+      {artist.photo_url ? (
+        <img
+          src={artist.photo_url}
+          alt=""
+          loading="lazy"
+          className="h-16 w-16 shrink-0 rounded-full object-cover ring-2 ring-white/15"
+        />
+      ) : (
+        <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-accent-500/20 text-2xl font-bold text-accent-400">
+          {(artist.name || '?').charAt(0).toUpperCase()}
+        </div>
+      )}
+      <div className="min-w-0">
+        <h2 className="truncate font-display text-lg font-bold text-text-primary">{artist.name}</h2>
+        {meta && <p className="truncate text-sm text-text-tertiary">{meta}</p>}
+        <p className="mt-0.5 text-xs text-text-tertiary">{shows}</p>
+      </div>
+    </Link>
+  )
+}
+
+export default function ArtistsPage() {
+  const [query, setQuery] = useState('')
+  const [artists, setArtists] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState(null)
+  const [hasMore, setHasMore] = useState(false)
+  const offsetRef = useRef(0)
+
+  useEffect(() => {
+    document.title = PAGE_TITLE
+    trackPageView('/artists')
+  }, [])
+
+  const load = useCallback(async (q, offset, append) => {
+    const params = new URLSearchParams()
+    if (q) params.set('q', q)
+    params.set('limit', String(PAGE_SIZE))
+    params.set('offset', String(offset))
+    const data = await fetchPublicJson(`/api/artists?${params.toString()}`, {}, 'Failed to load artists')
+    setHasMore(Boolean(data.hasMore))
+    setArtists(prev => (append ? [...prev, ...data.artists] : data.artists))
+  }, [])
+
+  // Debounced search — refetch from the start whenever the query changes.
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    setError(null)
+    offsetRef.current = 0
+    const handle = setTimeout(() => {
+      load(query.trim(), 0, false)
+        .catch(err => {
+          if (active) setError(err)
+        })
+        .finally(() => {
+          if (active) setLoading(false)
+        })
+    }, 250)
+    return () => {
+      active = false
+      clearTimeout(handle)
+    }
+  }, [query, load])
+
+  const handleLoadMore = async () => {
+    setLoadingMore(true)
+    const nextOffset = offsetRef.current + PAGE_SIZE
+    try {
+      await load(query.trim(), nextOffset, true)
+      offsetRef.current = nextOffset
+    } catch (err) {
+      setError(err)
+    } finally {
+      setLoadingMore(false)
+    }
+  }
+
+  return (
+    <main id="main-content" tabIndex={-1} className="min-h-screen bg-gradient-dark">
+      <Helmet>
+        <title>{PAGE_TITLE}</title>
+        <meta
+          name="description"
+          content="Browse and search every artist who has played a SetTimes event — explore their profiles, past sets, and upcoming shows."
+        />
+        <link rel="canonical" href="https://settimes.ca/artists" />
+        <meta property="og:title" content="Artists – SetTimes" />
+        <meta property="og:description" content="Browse and search every artist who has played a SetTimes event." />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://settimes.ca/artists" />
+      </Helmet>
+
+      <header className="border-b border-accent-500/30 px-4 py-8">
+        <div className="container mx-auto flex max-w-7xl items-start justify-between gap-4">
+          <div>
+            <Link
+              to="/"
+              className="mb-2 inline-flex items-center gap-1.5 text-sm text-accent-400 transition-colors hover:text-accent-300"
+            >
+              <ArrowLeft size={14} aria-hidden="true" /> SetTimes
+            </Link>
+            <h1 className="font-display text-4xl font-bold text-text-primary">Artists</h1>
+            <p className="mt-1 text-lg text-accent-400">Every act that&apos;s graced a SetTimes stage</p>
+          </div>
+          <ThemeToggle />
+        </div>
+      </header>
+
+      <div className="container mx-auto max-w-7xl px-4 py-8">
+        <div className="relative mb-8 max-w-md">
+          <Search
+            size={18}
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary"
+            aria-hidden="true"
+          />
+          <input
+            type="search"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search artists by name or genre…"
+            aria-label="Search artists by name or genre"
+            className="min-h-[44px] w-full rounded-full border border-white/15 bg-bg-purple/60 py-3 pl-10 pr-4 text-text-primary placeholder:text-text-tertiary focus:border-accent-400 focus:outline-hidden"
+          />
+        </div>
+
+        {error ? (
+          <p className="py-16 text-center text-text-secondary">{error.message}</p>
+        ) : loading ? (
+          <p className="py-16 text-center text-text-tertiary">Loading artists…</p>
+        ) : artists.length === 0 ? (
+          <p className="py-16 text-center text-text-secondary">
+            {query.trim() ? `No artists match “${query.trim()}”.` : 'No artists to show yet.'}
+          </p>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {artists.map(artist => (
+                <ArtistCard key={artist.id} artist={artist} />
+              ))}
+            </div>
+            {hasMore && (
+              <div className="mt-8 text-center">
+                <button
+                  type="button"
+                  onClick={handleLoadMore}
+                  disabled={loadingMore}
+                  className="min-h-[44px] rounded-full border border-accent-500/50 bg-accent-500/15 px-6 py-3 font-semibold text-accent-400 transition hover:bg-accent-500/25 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 disabled:opacity-60"
+                >
+                  {loadingMore ? 'Loading…' : 'Load more'}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <Footer />
+    </main>
+  )
+}

--- a/frontend/src/pages/EventsPage.jsx
+++ b/frontend/src/pages/EventsPage.jsx
@@ -7,7 +7,7 @@ import PrivacyBanner from '../components/PrivacyBanner'
 import ThemeToggle from '../components/ThemeToggle.jsx'
 import { trackPageView } from '../utils/metrics'
 import { hasAnySchedule, getScheduleEventSlug, SELECTED_BANDS_KEY } from '../utils/scheduleStorage'
-import { ArrowRight, CalendarDays } from 'lucide-react'
+import { ArrowRight, CalendarDays, Users } from 'lucide-react'
 
 export default function EventsPage() {
   useEffect(() => {
@@ -77,6 +77,13 @@ export default function EventsPage() {
               <span className="text-accent-500">Set</span>Times
             </h1>
             <p className="text-lg text-accent-400">Discover · Plan · Experience</p>
+            <Link
+              to="/artists"
+              className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-accent-400 transition-colors hover:text-accent-300"
+            >
+              <Users size={15} aria-hidden="true" /> Browse all artists
+              <ArrowRight size={12} aria-hidden="true" />
+            </Link>
           </div>
           <ThemeToggle />
         </div>

--- a/frontend/src/pages/__tests__/ArtistsPage.test.jsx
+++ b/frontend/src/pages/__tests__/ArtistsPage.test.jsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ArtistsPage from '../ArtistsPage.jsx'
+import { ThemeProvider } from '../../components/ThemeProvider.jsx'
+import { fetchPublicJson } from '../../utils/publicApi'
+
+vi.mock('../../utils/metrics', () => ({ trackPageView: vi.fn() }))
+vi.mock('../../utils/publicApi', () => ({ fetchPublicJson: vi.fn() }))
+
+function renderPage() {
+  return render(
+    <ThemeProvider>
+      <HelmetProvider>
+        <MemoryRouter>
+          <ArtistsPage />
+        </MemoryRouter>
+      </HelmetProvider>
+    </ThemeProvider>
+  )
+}
+
+describe('ArtistsPage', () => {
+  beforeEach(() => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      artists: [
+        {
+          id: 1,
+          name: 'The Creepshow',
+          genre: 'horror punk',
+          origin: 'Burlington, ON',
+          photo_url: null,
+          performance_count: 3,
+        },
+      ],
+      hasMore: false,
+    })
+  })
+
+  it('renders the search box and fetched artists', async () => {
+    renderPage()
+    expect(screen.getByRole('searchbox', { name: /search artists/i })).toBeInTheDocument()
+    expect(await screen.findByText('The Creepshow')).toBeInTheDocument()
+    expect(screen.getByText(/horror punk/)).toBeInTheDocument()
+    expect(screen.getByText('3 shows')).toBeInTheDocument()
+  })
+
+  it('queries the API with the search term', async () => {
+    renderPage()
+    await screen.findByText('The Creepshow')
+
+    fireEvent.change(screen.getByRole('searchbox', { name: /search artists/i }), {
+      target: { value: 'jazz' },
+    })
+
+    await waitFor(() => {
+      expect(fetchPublicJson).toHaveBeenCalledWith(
+        expect.stringContaining('q=jazz'),
+        expect.anything(),
+        expect.anything()
+      )
+    })
+  })
+})

--- a/functions/api/__tests__/artists.test.js
+++ b/functions/api/__tests__/artists.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  createTestEnv,
+  insertEvent,
+  insertBand,
+  insertVenue,
+} from "../test-utils";
+import * as artists from "../artists.js";
+
+function seedEnv() {
+  const { env, rawDb } = createTestEnv({ role: "editor" });
+  env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+  return { env, rawDb };
+}
+
+function publish(rawDb, eventId) {
+  rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(eventId);
+}
+
+async function getArtists(env, query = "") {
+  return artists.onRequestGet({
+    request: new Request(`https://example.test/api/artists${query}`),
+    env,
+  });
+}
+
+describe("Public artists directory - GET /api/artists", () => {
+  it("lists only artists who performed at a published or archived event", async () => {
+    const { env, rawDb } = seedEnv();
+    const venue = insertVenue(rawDb, { name: "Main" });
+
+    const pub = insertEvent(rawDb, { name: "Pub", slug: "pub-evt" });
+    publish(rawDb, pub.id);
+    insertBand(rawDb, {
+      name: "Published Band",
+      event_id: pub.id,
+      venue_id: venue.id,
+      genre: "punk",
+    });
+
+    const arch = insertEvent(rawDb, {
+      name: "Arch",
+      slug: "arch-evt",
+      status: "archived",
+    });
+    insertBand(rawDb, {
+      name: "Archived Band",
+      event_id: arch.id,
+      venue_id: venue.id,
+    });
+
+    // Draft event -> not published, not archived -> excluded
+    const draft = insertEvent(rawDb, {
+      name: "Draft",
+      slug: "draft-evt",
+      status: "draft",
+    });
+    insertBand(rawDb, {
+      name: "Draft Band",
+      event_id: draft.id,
+      venue_id: venue.id,
+    });
+
+    const res = await getArtists(env);
+    expect(res.status).toBe(200);
+    const { artists: list } = await res.json();
+    const names = list.map((a) => a.name);
+    expect(names).toContain("Published Band");
+    expect(names).toContain("Archived Band");
+    expect(names).not.toContain("Draft Band");
+
+    const pubBand = list.find((a) => a.name === "Published Band");
+    expect(pubBand.performance_count).toBeGreaterThanOrEqual(1);
+    expect(pubBand).toHaveProperty("photo_url");
+  });
+
+  it("filters by search query (name or genre), case-insensitive", async () => {
+    const { env, rawDb } = seedEnv();
+    const venue = insertVenue(rawDb, { name: "Main" });
+    const ev = insertEvent(rawDb, { name: "E", slug: "e-evt" });
+    publish(rawDb, ev.id);
+    insertBand(rawDb, {
+      name: "The Punks",
+      event_id: ev.id,
+      venue_id: venue.id,
+      genre: "punk",
+    });
+    insertBand(rawDb, {
+      name: "Jazz Cats",
+      event_id: ev.id,
+      venue_id: venue.id,
+      genre: "jazz",
+    });
+
+    const res = await getArtists(env, "?q=JAZZ");
+    const { artists: list } = await res.json();
+    const names = list.map((a) => a.name);
+    expect(names).toContain("Jazz Cats");
+    expect(names).not.toContain("The Punks");
+  });
+
+  it("returns 503 when public data is gated off", async () => {
+    const { env } = seedEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "false";
+    const res = await getArtists(env);
+    expect(res.status).toBe(503);
+  });
+});

--- a/functions/api/artists.js
+++ b/functions/api/artists.js
@@ -1,0 +1,103 @@
+// Public API: artist directory
+// GET /api/artists?q=<search>&limit=&offset=
+//
+// Lists band profiles that have performed at >=1 published or archived event,
+// so artists are discoverable outside of a specific event. Gated by the same
+// PUBLIC_DATA_PUBLISH_ENABLED switch as the rest of the public data.
+
+import { getPublicDataGateResponse } from "../utils/publicGate.js";
+
+const DEFAULT_LIMIT = 24;
+const MAX_LIMIT = 60;
+
+function formatOrigin(row) {
+  const parts = [row.origin_city, row.origin_region].filter(Boolean);
+  return parts.length ? parts.join(", ") : row.origin || null;
+}
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+
+  const gate = getPublicDataGateResponse(env);
+  if (gate) {
+    return gate;
+  }
+
+  const { DB } = env;
+  const url = new URL(request.url);
+  const q = (url.searchParams.get("q") || "").trim().slice(0, 100);
+
+  const parsedLimit = Number.parseInt(url.searchParams.get("limit") || "", 10);
+  const parsedOffset = Number.parseInt(
+    url.searchParams.get("offset") || "",
+    10,
+  );
+  const limit = Number.isFinite(parsedLimit)
+    ? Math.min(Math.max(parsedLimit, 1), MAX_LIMIT)
+    : DEFAULT_LIMIT;
+  const offset = Number.isFinite(parsedOffset) ? Math.max(parsedOffset, 0) : 0;
+
+  // Escape LIKE wildcards in user input so a literal % / _ isn't treated as one.
+  const like = `%${q.replace(/[%_\\]/g, (m) => `\\${m}`)}%`;
+
+  try {
+    // Fetch one extra row to compute hasMore without a separate COUNT query.
+    const rows = await DB.prepare(
+      `
+      SELECT
+        bp.id,
+        bp.name,
+        bp.photo_url,
+        bp.photo_alt_text,
+        bp.genre,
+        bp.origin,
+        bp.origin_city,
+        bp.origin_region,
+        COUNT(DISTINCT p.id) AS performance_count
+      FROM band_profiles bp
+      JOIN performances p ON p.band_profile_id = bp.id
+      JOIN events e ON e.id = p.event_id
+      WHERE (e.is_published = 1 OR e.status = 'archived')
+        AND (
+          ? = ''
+          OR bp.name LIKE ? ESCAPE '\\'
+          OR bp.genre LIKE ? ESCAPE '\\'
+        )
+      GROUP BY bp.id
+      ORDER BY bp.name COLLATE NOCASE
+      LIMIT ? OFFSET ?
+    `,
+    )
+      .bind(q, like, like, limit + 1, offset)
+      .all();
+
+    const results = rows.results || [];
+    const hasMore = results.length > limit;
+    const artists = results.slice(0, limit).map((row) => ({
+      id: row.id,
+      name: row.name,
+      photo_url: row.photo_url,
+      photo_alt_text: row.photo_alt_text,
+      genre: row.genre,
+      origin: formatOrigin(row),
+      performance_count: row.performance_count,
+    }));
+
+    return new Response(JSON.stringify({ artists, hasMore }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=300",
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching artists directory:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Database error",
+        message: "Failed to fetch artists",
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+}

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -32,6 +32,11 @@ export async function onRequestGet(context) {
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>`,
+      `  <url>
+    <loc>https://settimes.ca/artists</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>`,
     ];
 
     for (const event of events) {


### PR DESCRIPTION
Profiles were only reachable *through* an event lineup. This adds a browsable **`/artists`** directory + search so people can explore artists on their own — and since every profile already carries `MusicGroup` JSON-LD, a crawlable index is a real **SEO** win too.

## What it does
- **Backend** `GET /api/artists?q=&limit=&offset=` (public, behind the same `PUBLIC_DATA_PUBLISH_ENABLED` gate as the rest of the public data). Lists `band_profiles` with **≥1 performance at a published or archived event** — so drafts/test/never-scheduled profiles never leak. Searchable by name/genre (LIKE, wildcard-escaped), paginated with a fetch-one-extra `hasMore`.
- **Frontend** lazy `/artists` page: debounced search + responsive card grid (photo or initial-letter avatar, name, genre · origin, show count) linking to each profile. Built **theme-aware from the start** (semantic `text-text-*` tokens), so it reads on the light themes.
- **Discovery:** homepage gets a "Browse all artists" link; `/artists` added to the sitemap; endpoint documented in `api-spec.yaml`.

## Design choices (confirmed)
- Directory lists **only artists who have performed** (published/archived events).
- Entry point on the **homepage**.

## Tests
- Backend: `GET /api/artists` — includes published/archived performers, **excludes draft-only**, search filter, and the 503 gate (3 tests).
- Frontend: page renders search + fetched artists, and queries the API with the search term (2 tests).
- Backend **433** + frontend **183** green; lint, build, `validate:openapi` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)