### PR TITLE
docs: fix auth/session inaccuracies + document MFA, photos, public features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Canonical active roadmap: `docs/ROADMAP.md`. Use it for handoffs between Claude,
 
 - **Frontend**: React 19, Vite 8, Tailwind 4, React Router 7 (`frontend/`)
 - **Backend**: Cloudflare Pages Functions (edge serverless, `functions/`)
-- **Database**: Cloudflare D1 (SQLite-compatible), 38 migrations in `migrations/`
+- **Database**: Cloudflare D1 (SQLite-compatible), numbered migrations in `migrations/`
 - **Auth**: Direct D1 session manager (`functions/utils/auth.js`), CSRF double-submit, TOTP MFA, trusted devices, RBAC
 - **Storage**: Cloudflare R2 (band photos)
 - **Email**: Postmark/Resend/MailChannels

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SetTimes.ca is a Cloudflare Pages application for managing and publishing multi-
 - Frontend: React 19, Vite 8, Tailwind CSS 4, React Router 7
 - Backend: Cloudflare Pages Functions with `nodejs_compat`
 - Data: Cloudflare D1 and optional R2 photo storage
-- Auth: Lucia-backed server-side sessions with HttpOnly cookies and CSRF protection
+- Auth: Direct D1 server-side session manager with HttpOnly cookies and CSRF protection
 - Testing: Vitest for unit/integration coverage and Playwright for end-to-end coverage
 
 ## What The App Supports

--- a/docs/ADMIN_HANDBOOK.md
+++ b/docs/ADMIN_HANDBOOK.md
@@ -591,7 +591,7 @@ CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs(user_id);
 
 ```sql
 -- Remove old sessions
-DELETE FROM sessions WHERE expires_at < datetime('now', '-7 days');
+DELETE FROM lucia_sessions WHERE expires_at < unixepoch('now', '-7 days');
 
 -- Archive old audit logs
 INSERT INTO audit_logs_archive SELECT * FROM audit_logs

--- a/docs/ADMIN_HANDBOOK.md
+++ b/docs/ADMIN_HANDBOOK.md
@@ -44,10 +44,10 @@ This handbook is for system administrators managing the SetTimes platform. It co
 
 **Frontend:**
 
-- React 18 with Vite 5
+- React 19 with Vite 8
 - React Router v7
-- Tailwind CSS 3
-- Font Awesome icons
+- Tailwind CSS 4
+- lucide-react icons
 - Cloudflare Pages (hosting)
 
 **Backend:**
@@ -207,14 +207,15 @@ POST /api/admin/users
 **Tables:**
 
 - `users` - User accounts
-- `sessions` - Active user sessions
+- `lucia_sessions` - Active server-side sessions
 - `events` - Event definitions
 - `venues` - Performance venues
-- `bands` - Band profiles
+- `band_profiles` - Artist/band profiles
+- `performances` - Links a band profile to an event, venue, and set time
 - `audit_logs` - Security audit trail
 - `invite_codes` - User invite system
 
-**Schema Location:** `migrations/schema.sql`
+**Schema Location:** numbered migrations in `migrations/` (with `database/setup-complete.sql` as the consolidated reference)
 
 ### Accessing the Database
 
@@ -225,16 +226,16 @@ POST /api/admin/users
 wrangler d1 list
 
 # Execute query
-wrangler d1 execute settimes-db --command="SELECT * FROM users LIMIT 10"
+wrangler d1 execute settimes-production-db --command="SELECT * FROM users LIMIT 10"
 
 # Run migration
-wrangler d1 execute settimes-db --file=./migrations/001_initial_schema.sql
+wrangler d1 execute settimes-production-db --file=./migrations/001_initial_schema.sql
 ```
 
 **Via Cloudflare Dashboard:**
 
 1. Workers & Pages → D1
-2. Select database: `settimes-db`
+2. Select database: `settimes-production-db`
 3. Console tab → Run queries
 
 ### Common Database Queries
@@ -242,11 +243,11 @@ wrangler d1 execute settimes-db --file=./migrations/001_initial_schema.sql
 **Check User Sessions:**
 
 ```sql
-SELECT u.email, s.created_at, s.last_activity_at, s.ip_address
-FROM sessions s
+SELECT u.email, s.expires_at
+FROM lucia_sessions s
 JOIN users u ON s.user_id = u.id
-WHERE s.expires_at > datetime('now')
-ORDER BY s.last_activity_at DESC;
+WHERE s.expires_at > unixepoch()
+ORDER BY s.expires_at DESC;
 ```
 
 **Event Statistics:**
@@ -255,11 +256,10 @@ ORDER BY s.last_activity_at DESC;
 SELECT
   e.name,
   e.date,
-  COUNT(DISTINCT b.id) as band_count,
-  COUNT(DISTINCT v.id) as venue_count
+  COUNT(DISTINCT p.band_profile_id) as band_count,
+  COUNT(DISTINCT p.venue_id) as venue_count
 FROM events e
-LEFT JOIN bands b ON e.id = b.event_id
-LEFT JOIN venues v ON b.venue_id = v.id
+LEFT JOIN performances p ON e.id = p.event_id
 GROUP BY e.id
 ORDER BY e.date DESC;
 ```
@@ -291,14 +291,14 @@ LIMIT 100;
 
 ```bash
 # Export entire database
-wrangler d1 export settimes-db --output=backup-$(date +%Y%m%d).sql
+wrangler d1 export settimes-production-db --output=backup-$(date +%Y%m%d).sql
 ```
 
 **Restore from Backup:**
 
 ```bash
 # Restore database
-wrangler d1 execute settimes-db --file=backup-20251119.sql
+wrangler d1 execute settimes-production-db --file=backup-20251119.sql
 ```
 
 **Backup Schedule:**
@@ -500,7 +500,7 @@ wrangler tail --status error
 
 ```bash
 # Create backup
-wrangler d1 export settimes-db --output=backups/settimes-$(date +%Y%m%d-%H%M%S).sql
+wrangler d1 export settimes-production-db --output=backups/settimes-$(date +%Y%m%d-%H%M%S).sql
 
 # Compress backup
 gzip backups/settimes-*.sql
@@ -511,7 +511,7 @@ gzip backups/settimes-*.sql
 ```bash
 # Restore from backup
 gunzip backups/settimes-20251119.sql.gz
-wrangler d1 execute settimes-db --file=backups/settimes-20251119.sql
+wrangler d1 execute settimes-production-db --file=backups/settimes-20251119.sql
 ```
 
 ### Disaster Recovery Plan
@@ -662,7 +662,7 @@ SELECT COUNT(*) FROM bands WHERE event_id = <event_id>;
 wrangler tail --status slow
 
 # Check query performance
-wrangler d1 execute settimes-db --command="EXPLAIN QUERY PLAN <your_query>"
+wrangler d1 execute settimes-production-db --command="EXPLAIN QUERY PLAN <your_query>"
 ```
 
 **Solutions:**
@@ -754,13 +754,13 @@ cd frontend && npm run deploy:dev
 wrangler d1 migrations apply settimes-production-db
 
 # Check database size
-wrangler d1 info settimes-db
+wrangler d1 info settimes-production-db
 
 # List all users
-wrangler d1 execute settimes-db --command="SELECT email, role FROM users"
+wrangler d1 execute settimes-production-db --command="SELECT email, role FROM users"
 
 # Force logout all users
-wrangler d1 execute settimes-db --command="DELETE FROM sessions"
+wrangler d1 execute settimes-production-db --command="DELETE FROM lucia_sessions"
 ```
 
 ### Environment Variables

--- a/docs/ADMIN_HANDBOOK.md
+++ b/docs/ADMIN_HANDBOOK.md
@@ -196,7 +196,7 @@ POST /api/admin/users
 
 - Minimum 8 characters
 - Must include: uppercase, lowercase, number
-- Hashed using bcrypt (cost factor: 10)
+- Hashed using PBKDF2-SHA256 via the Web Crypto API (not bcrypt — Workers cannot run native bcrypt)
 
 ---
 
@@ -314,17 +314,26 @@ wrangler d1 execute settimes-db --file=backup-20251119.sql
 ### Authentication Flow
 
 1. User submits email + password to `/api/admin/auth/login`
-2. Backend verifies credentials (bcrypt)
-3. Session created in `sessions` table
+2. Backend verifies credentials (PBKDF2-SHA256 via Web Crypto)
+3. Session created in `lucia_sessions` table
 4. Session token returned in HTTPOnly cookie
 5. All subsequent requests include cookie
 6. Middleware validates session + checks RBAC
+
+### Multi-Factor Authentication (MFA)
+
+Admins can enable TOTP-based two-factor authentication on their accounts:
+
+- **Setup:** In account settings, scan the QR code (or enter the secret) into an authenticator app (Google Authenticator, Authy, 1Password, etc.) and confirm with a 6-digit code. TOTP is HMAC-SHA1 over a 30-second window, computed via the Web Crypto API (`functions/utils/totp.js`) — no third-party crypto library.
+- **Backup codes:** Enabling MFA reveals one-time backup codes — store them securely. Each works once if the authenticator is unavailable.
+- **Trusted devices:** A device can be marked trusted to skip the MFA prompt there for a limited period; trusted devices can be revoked at any time.
+- **Enforcement:** With MFA enabled, login requires the password **and** a valid TOTP (or backup) code before a session is issued. On any successful re-authentication, the user's prior sessions are invalidated.
 
 ### Session Management
 
 **Session Configuration:**
 
-- Storage: Lucia-backed `lucia_sessions` rows in D1
+- Storage: `lucia_sessions` rows in D1 (direct D1 session manager; `expires_at` is INTEGER Unix-epoch seconds)
 - Admin idle timeout: 15 minutes
 - Admin absolute lifetime: 8 hours
 - Cookie transport: HttpOnly session cookie (`__Host-session_token` in production)
@@ -742,7 +751,7 @@ cd frontend && npm run deploy:prod
 cd frontend && npm run deploy:dev
 
 # Run migrations
-wrangler d1 migrations apply settimes-db
+wrangler d1 migrations apply settimes-production-db
 
 # Check database size
 wrangler d1 info settimes-db

--- a/docs/SESSION_MANAGEMENT.md
+++ b/docs/SESSION_MANAGEMENT.md
@@ -4,7 +4,7 @@ This document describes the current session model used by the SetTimes admin exp
 
 ## Current Session Architecture
 
-SetTimes uses Lucia-backed server-side sessions stored in D1.
+SetTimes uses server-side sessions stored in D1, managed by a direct session manager in `functions/utils/auth.js`. (The Lucia dependency was removed in PR #290; the table is still named `lucia_sessions` for historical/compatibility reasons.)
 
 - Server-side session store: `lucia_sessions`
 - Session cookie: `__Host-session_token` in production, `session_token` in local development

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -335,11 +335,22 @@ settimes.ca/bands/[event-slug]/[band-name]
 1. Go to **🎸 Performers** tab
 2. Find the band and click "Edit"
 3. Update the **Description** field (supports markdown)
-4. Add or update social media links
-5. Upload a photo (if photo support is enabled)
-6. Click "Save"
+4. Upload a photo — drag-and-drop or click to browse (JPG/PNG/WebP, up to 5 MB). It is stored in Cloudflare R2 and appears on the public profile, the schedule-card thumbnail, and link previews.
+5. (Recommended) Fill in **Photo alt text** — a short description of the image for screen readers and for when the image fails to load. Defaults to the band name if left blank.
+6. Add or update social media links
+7. Click "Save"
 
 **Tip:** Write compelling descriptions that fans will want to read and share!
+
+---
+
+## Public-Facing Features
+
+Beyond the schedule itself, fans get a few experience features worth knowing about:
+
+- **Themes** — four selectable colour themes (two dark, two light) via the swatch picker in the public header; the choice persists per browser. The admin panel always stays on the dark theme regardless of the visitor's pick.
+- **My Route** — a fan's personal lineup (formerly "My Schedule"). Fans tap performers to add them; the route is saved in their browser and can be shared as a `/s/<code>` link with rich social previews.
+- **Artist Directory** — a public, searchable index of every artist who has performed at a SetTimes event, at `/artists` (linked from the homepage). Each card links to that artist's profile.
 
 ---
 


### PR DESCRIPTION
From the docs audit. Two buckets — accuracy and completeness.

## Accuracy fixes (living docs)
- **Passwords were documented as bcrypt** (`ADMIN_HANDBOOK`) — they are **PBKDF2-SHA256** via Web Crypto. Corrected (login flow + password policy).
- **"Lucia-backed sessions"** in `README`, `SESSION_MANAGEMENT`, `ADMIN_HANDBOOK` — Lucia was removed in #290; now a **direct D1 session manager** (`functions/utils/auth.js`); table still named `lucia_sessions`. Corrected.
- `CLAUDE.md` said **"38 migrations"** (actually 42) → de-hardcoded to avoid re-staleness.
- `ADMIN_HANDBOOK` migration command used DB name `settimes-db` → `settimes-production-db`.
- *Left as-is:* the ADRs and `docs/code-review/*` keep their Lucia/bcrypt mentions — dated point-in-time records.

## Completeness additions
- **`ADMIN_HANDBOOK`:** new **MFA / two-factor** section (TOTP setup, backup codes, trusted devices, enforcement) — it was entirely undocumented.
- **`USER_GUIDE`:** concrete **band-photo upload** steps + **photo alt text**; new **Public-Facing Features** section (themes, My Route, artist directory).

Docs-only; no code/tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)