### PR TITLE
feat(profiles): Share button on artist profiles

### DIFF
--- a/frontend/src/components/ShareButton.jsx
+++ b/frontend/src/components/ShareButton.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import { Check, Share2 } from 'lucide-react'
+import { copyToClipboard } from '../utils/clipboard'
+
+/**
+ * ShareButton — native share sheet (Web Share API) with a copy-link fallback.
+ *
+ * On devices that support `navigator.share` (most mobile browsers) this opens the
+ * OS share sheet. Everywhere else it copies the URL to the clipboard and shows a
+ * brief "Copied!" confirmation. Cancelling the native sheet is a no-op (we do not
+ * fall back to copying, since the user explicitly dismissed it).
+ */
+export default function ShareButton({
+  url,
+  title,
+  text,
+  label = 'Share',
+  className = 'inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-text-primary transition hover:bg-white/15 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400',
+}) {
+  const [copied, setCopied] = useState(false)
+
+  const handleShare = async () => {
+    const shareUrl = url || (typeof window !== 'undefined' ? window.location.href : '')
+
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        await navigator.share({ title, text, url: shareUrl })
+        return
+      } catch (err) {
+        // User dismissed the sheet — respect that, don't fall back to copying.
+        if (err && err.name === 'AbortError') return
+        // Any other failure falls through to the clipboard path.
+      }
+    }
+
+    const ok = await copyToClipboard(shareUrl)
+    if (ok) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      className={className}
+      aria-label={copied ? 'Link copied to clipboard' : `${label}${title ? ` ${title}` : ''}`}
+    >
+      {copied ? <Check size={16} aria-hidden="true" /> : <Share2 size={16} aria-hidden="true" />}
+      <span>{copied ? 'Copied!' : label}</span>
+    </button>
+  )
+}

--- a/frontend/src/components/__tests__/ShareButton.test.jsx
+++ b/frontend/src/components/__tests__/ShareButton.test.jsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ShareButton from '../ShareButton.jsx'
+import { copyToClipboard } from '../../utils/clipboard'
+
+vi.mock('../../utils/clipboard', () => ({ copyToClipboard: vi.fn() }))
+
+afterEach(() => {
+  vi.clearAllMocks()
+  delete navigator.share
+})
+
+describe('ShareButton', () => {
+  it('uses the native share sheet when available', async () => {
+    const share = vi.fn().mockResolvedValue(undefined)
+    navigator.share = share
+
+    render(
+      <ShareButton url="https://settimes.ca/band/the-band" title="The Band" text="Check out The Band on SetTimes" />
+    )
+    fireEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      expect(share).toHaveBeenCalledWith({
+        title: 'The Band',
+        text: 'Check out The Band on SetTimes',
+        url: 'https://settimes.ca/band/the-band',
+      })
+    })
+    expect(copyToClipboard).not.toHaveBeenCalled()
+  })
+
+  it('falls back to copying the link when native share is unavailable', async () => {
+    delete navigator.share
+    copyToClipboard.mockResolvedValue(true)
+
+    render(<ShareButton url="https://settimes.ca/band/the-band" title="The Band" />)
+    fireEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith('https://settimes.ca/band/the-band')
+    })
+    expect(await screen.findByText('Copied!')).toBeInTheDocument()
+  })
+
+  it('does not copy when the user cancels the native share sheet', async () => {
+    const abort = Object.assign(new Error('cancelled'), { name: 'AbortError' })
+    navigator.share = vi.fn().mockRejectedValue(abort)
+
+    render(<ShareButton url="https://settimes.ca/band/the-band" title="The Band" />)
+    fireEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      expect(navigator.share).toHaveBeenCalled()
+    })
+    expect(copyToClipboard).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -15,6 +15,7 @@ import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'reac
 import BandFacts from '../components/BandFacts'
 import BandStats from '../components/BandStats'
 import Breadcrumbs from '../components/Breadcrumbs'
+import ShareButton from '../components/ShareButton'
 import PrivacyBanner from '../components/PrivacyBanner'
 import { Alert, Badge, Button, Card, BandProfileSkeleton } from '../components/ui'
 import { trackArtistView, trackPageView, trackSocialClick } from '../utils/metrics'
@@ -549,6 +550,15 @@ export default function BandProfilePage() {
               </div>
             </div>
           )}
+
+          {/* Share */}
+          <div className="flex justify-end bg-bg-purple/50 px-6 pt-4">
+            <ShareButton
+              url={typeof window !== 'undefined' ? `${window.location.origin}${window.location.pathname}` : undefined}
+              title={profile.name}
+              text={`${profile.name} on SetTimes`}
+            />
+          </div>
 
           {/* Bio and Social Links */}
           <div className="p-6 bg-bg-purple/50 border-t border-white/10">


### PR DESCRIPTION
Audit #3 found artist profiles had **no share affordance** — only the schedule and `/s/<slug>` could be shared. This adds one.

## What it does
A reusable **`ShareButton`**:
- **Native share sheet** via the Web Share API where supported (the OS sheet on mobile).
- **Copy-link fallback** on desktop, with a brief "Copied!" confirmation.
- Cancelling the native sheet is a **no-op** (we don't fall back to copying when the user dismissed it).

Placed on `BandProfilePage` between the hero and bio. Profiles already carry OG/Twitter/JSON-LD, so a shared link previews richly.

## Tests
3 TDD tests — native path, copy fallback, and user-cancel. Frontend **184** tests + lint + build green.

Reusable for events/other surfaces later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)