### PR TITLE
feat(schedule): 'By venue' lane view

### DIFF
--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -44,6 +44,7 @@ function ScheduleView({
   const [isCopyingAll, setIsCopyingAll] = useState(false)
   const [localVenueFilter, setLocalVenueFilter] = useState(null)
   const [genreFilter, setGenreFilter] = useState(null)
+  const [groupBy, setGroupBy] = useState('time')
   const venueFilter = controlledVenueFilter === undefined ? localVenueFilter : controlledVenueFilter
   const nowMs = useMemo(() => {
     const d = currentTime instanceof Date ? currentTime : new Date(currentTime)
@@ -131,6 +132,18 @@ function ScheduleView({
   const upcomingByTime = useMemo(() => groupByTime(upcomingBands), [upcomingBands])
   const pastByTime = useMemo(() => groupByTime(pastBands).reverse(), [pastBands])
 
+  // Venue-lane view: group the visible (already time-sorted) bands by venue, so
+  // each venue's sets stay in chronological order within its section.
+  const bandsByVenue = useMemo(() => {
+    const map = new Map()
+    sortedBands.forEach(band => {
+      const venue = band.venue || 'Unscheduled'
+      if (!map.has(venue)) map.set(venue, [])
+      map.get(venue).push(band)
+    })
+    return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+  }, [sortedBands])
+
   const selectedBandsSet = useMemo(() => new Set(selectedBands), [selectedBands])
   const visibleBandIds = useMemo(() => visibleBands.map(band => band.id), [visibleBands])
   const canToggleBands = typeof onToggleBand === 'function'
@@ -204,6 +217,25 @@ function ScheduleView({
           )}
         </div>
         <div className="flex justify-center sm:justify-end gap-3 flex-wrap">
+          <div
+            className="inline-flex items-center rounded-full border border-white/10 bg-white/5 p-0.5"
+            role="group"
+            aria-label="Group lineup by"
+          >
+            {['time', 'venue'].map(mode => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setGroupBy(mode)}
+                aria-pressed={groupBy === mode}
+                className={`min-h-[44px] rounded-full px-3 py-1.5 text-xs font-medium capitalize transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 ${
+                  groupBy === mode ? 'bg-accent-500/20 text-accent-400' : 'text-white/60 hover:text-white'
+                }`}
+              >
+                By {mode}
+              </button>
+            ))}
+          </div>
           {finishedCount > 0 && canTogglePast && (
             <button
               onClick={onToggleShowPast}
@@ -373,6 +405,37 @@ function ScheduleView({
             : finishedCount > 0
               ? 'All finished sets are hidden. Show them to revisit earlier performances.'
               : 'No upcoming bands at the moment.'}
+        </div>
+      ) : groupBy === 'venue' ? (
+        <div className="space-y-12">
+          {bandsByVenue.map(([venue, venueBands]) => (
+            <div key={venue}>
+              <div className="flex items-center mb-4">
+                <h2 className="bg-bg-purple text-white font-mono font-bold text-lg md:text-xl px-4 py-2 rounded-lg shadow-lg">
+                  {venue}
+                </h2>
+                <span className="ml-3 text-xs text-white/40 shrink-0">
+                  {venueBands.length} {venueBands.length === 1 ? 'set' : 'sets'}
+                </span>
+                <div className="flex-1 h-0.5 bg-bg-purple/30 ml-4"></div>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 ml-0 sm:ml-4">
+                {venueBands.map(band => (
+                  <BandCard
+                    key={band.id}
+                    band={band}
+                    isSelected={selectedBandsSet.has(band.id)}
+                    onToggle={onToggleBand}
+                    clickable={canToggleBands}
+                    showToggleButton={canToggleBands}
+                    eventSlug={eventSlug}
+                    showVenue={false}
+                    currentTime={currentTime}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
         </div>
       ) : (
         <div className="space-y-12">

--- a/frontend/src/components/__tests__/ScheduleView.test.jsx
+++ b/frontend/src/components/__tests__/ScheduleView.test.jsx
@@ -46,6 +46,37 @@ const renderView = props =>
     </MemoryRouter>
   )
 
+describe('ScheduleView — venue-lane view', () => {
+  it('groups the lineup by venue when "By venue" is selected', () => {
+    const bands = [
+      makeBand({
+        id: '1',
+        name: 'Alpha',
+        venue: 'Roost',
+        startTime: '21:00',
+        startMs: Date.parse('2024-06-01T21:00:00'),
+        endMs: Date.parse('2024-06-01T22:00:00'),
+      }),
+      makeBand({
+        id: '2',
+        name: 'Beta',
+        venue: 'Blue Room',
+        startTime: '21:30',
+        startMs: Date.parse('2024-06-01T21:30:00'),
+        endMs: Date.parse('2024-06-01T22:30:00'),
+      }),
+    ]
+    renderView({ bands })
+
+    fireEvent.click(screen.getByRole('button', { name: /by venue/i }))
+
+    expect(screen.getByRole('heading', { name: 'Roost' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Blue Room' })).toBeInTheDocument()
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+  })
+})
+
 describe('ScheduleView — Bug 4: finished sets hidden count', () => {
   it('does not count bands with no endTime as finished', () => {
     // Bands without endTime have endMs = 0; previously 0 <= NOW_MS always counted them as finished.


### PR DESCRIPTION
Roadmap Track A P1. Adds a **Time | Venue** toggle to the event schedule.

**By venue** groups the lineup into per-venue sections (each venue's sets in chronological order) — the view fans want for a 6-venue crawl ("what's on at Roost?").

- **Additive + opt-in:** default stays `time`, so existing behavior is untouched. Low blast radius.
- Reuses `BandCard` + the same responsive grid; now-playing state still shows per card; venue name moves to the section header (`showVenue={false}` on the cards).
- Grouping runs off the already time-sorted, filtered, show-past-aware band list, so time/venue/genre filters + "show finished" all keep working in venue mode.

Tested (new venue-grouping test); frontend **182** tests + lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)