### PR TITLE
feat(venues): public venue directory + detail pages

### DIFF
--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -122,6 +122,110 @@ paths:
         "500":
           $ref: "#/components/responses/ServerError"
 
+  /api/venues:
+    get:
+      tags:
+        - Public
+      summary: List/search the public venue directory
+      description: |
+        Venues that have hosted one or more performances at a published or
+        archived event, as `{ venues, hasMore }`. Searchable by name/city and
+        paginated. Gated by `PUBLIC_DATA_PUBLISH_ENABLED`.
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Search term matched against venue name and city
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 24
+            minimum: 1
+            maximum: 60
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        "200":
+          description: Venue directory page
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  venues:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        name:
+                          type: string
+                        location:
+                          type: string
+                          nullable: true
+                        performance_count:
+                          type: integer
+                        event_count:
+                          type: integer
+                  hasMore:
+                    type: boolean
+        "503":
+          $ref: "#/components/responses/PublicDataUnavailable"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /api/venues/{id}:
+    get:
+      tags:
+        - Public
+      summary: Get a venue with its lineup
+      description: |
+        Returns a venue plus its upcoming and past performances at published or
+        archived events. Gated by `PUBLIC_DATA_PUBLISH_ENABLED`.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Venue id
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Venue detail with lineup
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  venue:
+                    type: object
+                  upcoming:
+                    type: array
+                    items:
+                      type: object
+                  past:
+                    type: array
+                    items:
+                      type: object
+        "400":
+          description: Invalid venue id
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/PublicDataUnavailable"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
   /api/schedule:
     get:
       tags:

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -21,6 +21,8 @@ const BandProfilePage = lazy(() => import('./pages/BandProfilePage.jsx'))
 const EventRecapPage = lazy(() => import('./pages/EventRecapPage.jsx'))
 const SharePreviewPage = lazy(() => import('./pages/SharePreviewPage.jsx'))
 const ArtistsPage = lazy(() => import('./pages/ArtistsPage.jsx'))
+const VenuesPage = lazy(() => import('./pages/VenuesPage.jsx'))
+const VenuePage = lazy(() => import('./pages/VenuePage.jsx'))
 
 const hostname = typeof window !== 'undefined' ? window.location.hostname || '' : ''
 const isPreviewBuild = hostname.startsWith('dev.') || hostname.endsWith('.pages.dev')
@@ -116,6 +118,28 @@ ReactDOM.createRoot(document.getElementById('root')).render(
                   <ErrorBoundary title="Artists Error" message="Unable to load the artist directory. Please try again.">
                     <Suspense fallback={<LoadingFallback />}>
                       <ArtistsPage />
+                    </Suspense>
+                  </ErrorBoundary>
+                }
+              />
+
+              {/* Venues: Lazy loaded */}
+              <Route
+                path="/venues"
+                element={
+                  <ErrorBoundary title="Venues Error" message="Unable to load venues. Please try again.">
+                    <Suspense fallback={<LoadingFallback />}>
+                      <VenuesPage />
+                    </Suspense>
+                  </ErrorBoundary>
+                }
+              />
+              <Route
+                path="/venue/:id"
+                element={
+                  <ErrorBoundary title="Venue Error" message="Unable to load this venue. Please try again.">
+                    <Suspense fallback={<LoadingFallback />}>
+                      <VenuePage />
                     </Suspense>
                   </ErrorBoundary>
                 }

--- a/frontend/src/pages/EventsPage.jsx
+++ b/frontend/src/pages/EventsPage.jsx
@@ -7,7 +7,7 @@ import PrivacyBanner from '../components/PrivacyBanner'
 import ThemeToggle from '../components/ThemeToggle.jsx'
 import { trackPageView } from '../utils/metrics'
 import { hasAnySchedule, getScheduleEventSlug, SELECTED_BANDS_KEY } from '../utils/scheduleStorage'
-import { ArrowRight, CalendarDays, Users } from 'lucide-react'
+import { ArrowRight, CalendarDays, MapPin, Users } from 'lucide-react'
 
 export default function EventsPage() {
   useEffect(() => {
@@ -82,6 +82,13 @@ export default function EventsPage() {
               className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-accent-400 transition-colors hover:text-accent-300"
             >
               <Users size={15} aria-hidden="true" /> Browse all artists
+              <ArrowRight size={12} aria-hidden="true" />
+            </Link>
+            <Link
+              to="/venues"
+              className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-accent-400 transition-colors hover:text-accent-300"
+            >
+              <MapPin size={15} aria-hidden="true" /> Browse venues
               <ArrowRight size={12} aria-hidden="true" />
             </Link>
           </div>

--- a/frontend/src/pages/VenuePage.jsx
+++ b/frontend/src/pages/VenuePage.jsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
+import { ArrowLeft, CalendarDays, Globe, MapPin } from 'lucide-react'
+import Footer from '../components/Footer'
+import ThemeToggle from '../components/ThemeToggle.jsx'
+import { fetchPublicJson } from '../utils/publicApi'
+import { trackPageView } from '../utils/metrics'
+import { buildBandProfileHref } from '../utils/bandProfileLink'
+import { safeExternalHref } from '../utils/urlSafety'
+
+function PerformanceRow({ perf }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-bg-purple/40 p-4">
+      {perf.band_name && (
+        <Link
+          to={buildBandProfileHref(perf.band_name)}
+          className="font-display text-lg font-semibold text-text-primary transition-colors hover:text-accent-400"
+        >
+          {perf.band_name}
+        </Link>
+      )}
+      <p className="mt-1 flex flex-wrap items-center gap-2 text-sm text-text-tertiary">
+        {perf.event_slug ? (
+          <Link to={`/event/${perf.event_slug}`} className="hover:text-accent-400">
+            {perf.event_name}
+          </Link>
+        ) : (
+          <span>{perf.event_name}</span>
+        )}
+        {perf.event_date && (
+          <span className="inline-flex items-center gap-1">
+            <CalendarDays size={13} aria-hidden="true" />
+            {perf.event_date}
+          </span>
+        )}
+      </p>
+    </div>
+  )
+}
+
+function Section({ title, items }) {
+  if (!items.length) return null
+  return (
+    <section className="mt-8">
+      <h2 className="mb-3 font-display text-xl font-bold text-text-primary">{title}</h2>
+      <div className="space-y-3">
+        {items.map(perf => (
+          <PerformanceRow key={perf.performance_id} perf={perf} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default function VenuePage() {
+  const { id } = useParams()
+  const [venue, setVenue] = useState(null)
+  const [upcoming, setUpcoming] = useState([])
+  const [past, setPast] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    setError(null)
+    trackPageView(`/venue/${id}`)
+    fetchPublicJson(`/api/venues/${id}`, {}, 'Failed to load venue')
+      .then(data => {
+        if (!active) return
+        setVenue(data.venue)
+        setUpcoming(data.upcoming || [])
+        setPast(data.past || [])
+        document.title = `${data.venue?.name || 'Venue'} – SetTimes`
+      })
+      .catch(err => {
+        if (active) setError(err)
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [id])
+
+  const website = venue ? safeExternalHref(venue.website) : '#'
+
+  return (
+    <main id="main-content" tabIndex={-1} className="min-h-screen bg-gradient-dark">
+      <Helmet>
+        <title>{venue ? `${venue.name} – SetTimes` : 'Venue – SetTimes'}</title>
+        {venue && (
+          <meta
+            name="description"
+            content={`${venue.name}${venue.location ? ` in ${venue.location}` : ''} — events and lineups on SetTimes.`}
+          />
+        )}
+        {venue && <link rel="canonical" href={`https://settimes.ca/venue/${venue.id}`} />}
+        {venue && (
+          <script type="application/ld+json">
+            {JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'MusicVenue',
+              name: venue.name,
+              url: `https://settimes.ca/venue/${venue.id}`,
+              ...(venue.address && { address: venue.address }),
+              ...(safeExternalHref(venue.website) !== '#' && { sameAs: [venue.website] }),
+            })}
+          </script>
+        )}
+      </Helmet>
+
+      <header className="border-b border-accent-500/30 px-4 py-6">
+        <div className="container mx-auto flex max-w-5xl items-center justify-between gap-4">
+          <Link
+            to="/venues"
+            className="inline-flex items-center gap-1.5 text-sm text-accent-400 transition-colors hover:text-accent-300"
+          >
+            <ArrowLeft size={14} aria-hidden="true" /> All venues
+          </Link>
+          <ThemeToggle />
+        </div>
+      </header>
+
+      <div className="container mx-auto max-w-5xl px-4 py-8">
+        {loading ? (
+          <p className="py-16 text-center text-text-tertiary">Loading venue…</p>
+        ) : error ? (
+          <p className="py-16 text-center text-text-secondary">{error.message}</p>
+        ) : venue ? (
+          <>
+            <h1 className="font-display text-4xl font-bold text-text-primary">{venue.name}</h1>
+            <div className="mt-2 flex flex-wrap items-center gap-4 text-text-secondary">
+              {venue.location && (
+                <span className="inline-flex items-center gap-1.5">
+                  <MapPin size={15} aria-hidden="true" /> {venue.location}
+                </span>
+              )}
+              {website !== '#' && (
+                <a
+                  href={website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-accent-400 hover:text-accent-300"
+                >
+                  <Globe size={15} aria-hidden="true" /> Website
+                </a>
+              )}
+            </div>
+            {venue.address && <p className="mt-1 text-sm text-text-tertiary">{venue.address}</p>}
+
+            <Section title="Upcoming" items={upcoming} />
+            <Section title="Past shows" items={past} />
+
+            {upcoming.length === 0 && past.length === 0 && (
+              <p className="py-16 text-center text-text-secondary">No published performances at this venue yet.</p>
+            )}
+          </>
+        ) : null}
+      </div>
+
+      <Footer />
+    </main>
+  )
+}

--- a/frontend/src/pages/VenuesPage.jsx
+++ b/frontend/src/pages/VenuesPage.jsx
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
+import { ArrowLeft, MapPin, Search } from 'lucide-react'
+import Footer from '../components/Footer'
+import ThemeToggle from '../components/ThemeToggle.jsx'
+import { fetchPublicJson } from '../utils/publicApi'
+import { trackPageView } from '../utils/metrics'
+
+const PAGE_SIZE = 24
+const PAGE_TITLE = 'Venues – SetTimes'
+
+function VenueCard({ venue }) {
+  const counts = [
+    `${venue.performance_count} ${venue.performance_count === 1 ? 'set' : 'sets'}`,
+    `${venue.event_count} ${venue.event_count === 1 ? 'event' : 'events'}`,
+  ].join(' · ')
+
+  return (
+    <Link
+      to={`/venue/${venue.id}`}
+      className="flex items-center gap-4 rounded-xl border border-white/10 bg-gradient-card p-4 transition hover:scale-[1.01] hover:border-accent-400/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+    >
+      <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-accent-500/20 text-accent-400">
+        <MapPin size={22} aria-hidden="true" />
+      </div>
+      <div className="min-w-0">
+        <h2 className="truncate font-display text-lg font-bold text-text-primary">{venue.name}</h2>
+        {venue.location && <p className="truncate text-sm text-text-tertiary">{venue.location}</p>}
+        <p className="mt-0.5 text-xs text-text-tertiary">{counts}</p>
+      </div>
+    </Link>
+  )
+}
+
+export default function VenuesPage() {
+  const [query, setQuery] = useState('')
+  const [venues, setVenues] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState(null)
+  const [hasMore, setHasMore] = useState(false)
+  const offsetRef = useRef(0)
+
+  useEffect(() => {
+    document.title = PAGE_TITLE
+    trackPageView('/venues')
+  }, [])
+
+  const load = useCallback(async (q, offset, append) => {
+    const params = new URLSearchParams()
+    if (q) params.set('q', q)
+    params.set('limit', String(PAGE_SIZE))
+    params.set('offset', String(offset))
+    const data = await fetchPublicJson(`/api/venues?${params.toString()}`, {}, 'Failed to load venues')
+    setHasMore(Boolean(data.hasMore))
+    setVenues(prev => (append ? [...prev, ...data.venues] : data.venues))
+  }, [])
+
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    setError(null)
+    offsetRef.current = 0
+    const handle = setTimeout(() => {
+      load(query.trim(), 0, false)
+        .catch(err => {
+          if (active) setError(err)
+        })
+        .finally(() => {
+          if (active) setLoading(false)
+        })
+    }, 250)
+    return () => {
+      active = false
+      clearTimeout(handle)
+    }
+  }, [query, load])
+
+  const handleLoadMore = async () => {
+    setLoadingMore(true)
+    const nextOffset = offsetRef.current + PAGE_SIZE
+    try {
+      await load(query.trim(), nextOffset, true)
+      offsetRef.current = nextOffset
+    } catch (err) {
+      setError(err)
+    } finally {
+      setLoadingMore(false)
+    }
+  }
+
+  return (
+    <main id="main-content" tabIndex={-1} className="min-h-screen bg-gradient-dark">
+      <Helmet>
+        <title>{PAGE_TITLE}</title>
+        <meta
+          name="description"
+          content="Browse every venue that has hosted a SetTimes event — explore their lineups, past shows, and upcoming performances."
+        />
+        <link rel="canonical" href="https://settimes.ca/venues" />
+        <meta property="og:title" content="Venues – SetTimes" />
+        <meta property="og:description" content="Browse every venue that has hosted a SetTimes event." />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://settimes.ca/venues" />
+      </Helmet>
+
+      <header className="border-b border-accent-500/30 px-4 py-8">
+        <div className="container mx-auto flex max-w-7xl items-start justify-between gap-4">
+          <div>
+            <Link
+              to="/"
+              className="mb-2 inline-flex items-center gap-1.5 text-sm text-accent-400 transition-colors hover:text-accent-300"
+            >
+              <ArrowLeft size={14} aria-hidden="true" /> SetTimes
+            </Link>
+            <h1 className="font-display text-4xl font-bold text-text-primary">Venues</h1>
+            <p className="mt-1 text-lg text-accent-400">Every stage that&apos;s hosted a SetTimes event</p>
+          </div>
+          <ThemeToggle />
+        </div>
+      </header>
+
+      <div className="container mx-auto max-w-7xl px-4 py-8">
+        <div className="relative mb-8 max-w-md">
+          <Search
+            size={18}
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary"
+            aria-hidden="true"
+          />
+          <input
+            type="search"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search venues by name or city…"
+            aria-label="Search venues by name or city"
+            className="min-h-[44px] w-full rounded-full border border-white/15 bg-bg-purple/60 py-3 pl-10 pr-4 text-text-primary placeholder:text-text-tertiary focus:border-accent-400 focus:outline-hidden"
+          />
+        </div>
+
+        {error ? (
+          <p className="py-16 text-center text-text-secondary">{error.message}</p>
+        ) : loading ? (
+          <p className="py-16 text-center text-text-tertiary">Loading venues…</p>
+        ) : venues.length === 0 ? (
+          <p className="py-16 text-center text-text-secondary">
+            {query.trim() ? `No venues match “${query.trim()}”.` : 'No venues to show yet.'}
+          </p>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {venues.map(venue => (
+                <VenueCard key={venue.id} venue={venue} />
+              ))}
+            </div>
+            {hasMore && (
+              <div className="mt-8 text-center">
+                <button
+                  type="button"
+                  onClick={handleLoadMore}
+                  disabled={loadingMore}
+                  className="min-h-[44px] rounded-full border border-accent-500/50 bg-accent-500/15 px-6 py-3 font-semibold text-accent-400 transition hover:bg-accent-500/25 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 disabled:opacity-60"
+                >
+                  {loadingMore ? 'Loading…' : 'Load more'}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <Footer />
+    </main>
+  )
+}

--- a/frontend/src/pages/__tests__/VenuesPage.test.jsx
+++ b/frontend/src/pages/__tests__/VenuesPage.test.jsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import VenuesPage from '../VenuesPage.jsx'
+import { ThemeProvider } from '../../components/ThemeProvider.jsx'
+import { fetchPublicJson } from '../../utils/publicApi'
+
+vi.mock('../../utils/metrics', () => ({ trackPageView: vi.fn() }))
+vi.mock('../../utils/publicApi', () => ({ fetchPublicJson: vi.fn() }))
+
+function renderPage() {
+  return render(
+    <ThemeProvider>
+      <HelmetProvider>
+        <MemoryRouter>
+          <VenuesPage />
+        </MemoryRouter>
+      </HelmetProvider>
+    </ThemeProvider>
+  )
+}
+
+describe('VenuesPage', () => {
+  beforeEach(() => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venues: [
+        {
+          id: 7,
+          name: 'Roost',
+          location: 'Waterloo, ON',
+          performance_count: 5,
+          event_count: 2,
+        },
+      ],
+      hasMore: false,
+    })
+  })
+
+  it('renders the search box and fetched venues', async () => {
+    renderPage()
+    expect(screen.getByRole('searchbox', { name: /search venues/i })).toBeInTheDocument()
+    expect(await screen.findByText('Roost')).toBeInTheDocument()
+    expect(screen.getByText(/Waterloo, ON/)).toBeInTheDocument()
+    expect(screen.getByText(/5 sets · 2 events/)).toBeInTheDocument()
+  })
+
+  it('queries the API with the search term', async () => {
+    renderPage()
+    await screen.findByText('Roost')
+
+    fireEvent.change(screen.getByRole('searchbox', { name: /search venues/i }), {
+      target: { value: 'kitchener' },
+    })
+
+    await waitFor(() => {
+      expect(fetchPublicJson).toHaveBeenCalledWith(
+        expect.stringContaining('q=kitchener'),
+        expect.anything(),
+        expect.anything()
+      )
+    })
+  })
+})

--- a/functions/api/__tests__/venues.test.js
+++ b/functions/api/__tests__/venues.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  createTestEnv,
+  insertEvent,
+  insertBand,
+  insertVenue,
+} from "../test-utils";
+import * as venues from "../venues.js";
+import * as venueDetail from "../venues/[id].js";
+
+function seedEnv() {
+  const { env, rawDb } = createTestEnv({ role: "editor" });
+  env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+  return { env, rawDb };
+}
+
+function publish(rawDb, eventId) {
+  rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(eventId);
+}
+
+async function getVenues(env, query = "") {
+  return venues.onRequestGet({
+    request: new Request(`https://example.test/api/venues${query}`),
+    env,
+  });
+}
+
+describe("Public venue directory - GET /api/venues", () => {
+  it("lists only venues that hosted a performance at a published or archived event", async () => {
+    const { env, rawDb } = seedEnv();
+
+    const pub = insertEvent(rawDb, { name: "Pub", slug: "pub-evt" });
+    publish(rawDb, pub.id);
+    const roost = insertVenue(rawDb, { name: "Roost", city: "Waterloo" });
+    insertBand(rawDb, { name: "B1", event_id: pub.id, venue_id: roost.id });
+
+    const arch = insertEvent(rawDb, {
+      name: "Arch",
+      slug: "arch-evt",
+      status: "archived",
+    });
+    const blue = insertVenue(rawDb, { name: "Blue Room", city: "Waterloo" });
+    insertBand(rawDb, { name: "B2", event_id: arch.id, venue_id: blue.id });
+
+    // Draft event venue -> excluded
+    const draft = insertEvent(rawDb, {
+      name: "Draft",
+      slug: "draft-evt",
+      status: "draft",
+    });
+    const secret = insertVenue(rawDb, {
+      name: "Secret Venue",
+      city: "Waterloo",
+    });
+    insertBand(rawDb, { name: "B3", event_id: draft.id, venue_id: secret.id });
+
+    const res = await getVenues(env);
+    expect(res.status).toBe(200);
+    const { venues: list } = await res.json();
+    const names = list.map((v) => v.name);
+    expect(names).toContain("Roost");
+    expect(names).toContain("Blue Room");
+    expect(names).not.toContain("Secret Venue");
+
+    const roostRow = list.find((v) => v.name === "Roost");
+    expect(roostRow.performance_count).toBeGreaterThanOrEqual(1);
+    expect(roostRow.location).toBe("Waterloo");
+  });
+
+  it("filters by search (name or city)", async () => {
+    const { env, rawDb } = seedEnv();
+    const ev = insertEvent(rawDb, { name: "E", slug: "e-evt" });
+    publish(rawDb, ev.id);
+    const a = insertVenue(rawDb, { name: "The Roost", city: "Waterloo" });
+    const b = insertVenue(rawDb, { name: "Jazz Hall", city: "Kitchener" });
+    insertBand(rawDb, { name: "X", event_id: ev.id, venue_id: a.id });
+    insertBand(rawDb, { name: "Y", event_id: ev.id, venue_id: b.id });
+
+    const res = await getVenues(env, "?q=kitchener");
+    const { venues: list } = await res.json();
+    const names = list.map((v) => v.name);
+    expect(names).toContain("Jazz Hall");
+    expect(names).not.toContain("The Roost");
+  });
+
+  it("returns 503 when public data is gated off", async () => {
+    const { env } = seedEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "false";
+    const res = await getVenues(env);
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("Public venue detail - GET /api/venues/:id", () => {
+  it("returns the venue with its lineup", async () => {
+    const { env, rawDb } = seedEnv();
+    const ev = insertEvent(rawDb, { name: "Crawl", slug: "crawl-evt" });
+    publish(rawDb, ev.id);
+    const roost = insertVenue(rawDb, { name: "Roost", city: "Waterloo" });
+    insertBand(rawDb, {
+      name: "Alpha",
+      event_id: ev.id,
+      venue_id: roost.id,
+      start_time: "21:00",
+      end_time: "22:00",
+    });
+
+    const res = await venueDetail.onRequestGet({
+      params: { id: String(roost.id) },
+      env,
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.venue.name).toBe("Roost");
+    expect(data.venue.location).toBe("Waterloo");
+    expect(data.venue.performance_count).toBeGreaterThanOrEqual(1);
+    const lineup = [...data.upcoming, ...data.past].map((p) => p.band_name);
+    expect(lineup).toContain("Alpha");
+  });
+
+  it("returns 404 for an unknown venue", async () => {
+    const { env } = seedEnv();
+    const res = await venueDetail.onRequestGet({
+      params: { id: "99999" },
+      env,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for an invalid id", async () => {
+    const { env } = seedEnv();
+    const res = await venueDetail.onRequestGet({ params: { id: "abc" }, env });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 503 when gated off", async () => {
+    const { env } = seedEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "false";
+    const res = await venueDetail.onRequestGet({ params: { id: "1" }, env });
+    expect(res.status).toBe(503);
+  });
+});

--- a/functions/api/venues.js
+++ b/functions/api/venues.js
@@ -1,0 +1,95 @@
+// Public API: venue directory
+// GET /api/venues?q=<search>&limit=&offset=
+//
+// Lists venues that have hosted >=1 performance at a published or archived event,
+// so venues are discoverable. Gated by PUBLIC_DATA_PUBLISH_ENABLED.
+
+import { getPublicDataGateResponse } from "../utils/publicGate.js";
+
+const DEFAULT_LIMIT = 24;
+const MAX_LIMIT = 60;
+
+function formatLocation(row) {
+  const parts = [row.city, row.region].filter(Boolean);
+  return parts.length ? parts.join(", ") : null;
+}
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+
+  const gate = getPublicDataGateResponse(env);
+  if (gate) {
+    return gate;
+  }
+
+  const { DB } = env;
+  const url = new URL(request.url);
+  const q = (url.searchParams.get("q") || "").trim().slice(0, 100);
+
+  const parsedLimit = Number.parseInt(url.searchParams.get("limit") || "", 10);
+  const parsedOffset = Number.parseInt(
+    url.searchParams.get("offset") || "",
+    10,
+  );
+  const limit = Number.isFinite(parsedLimit)
+    ? Math.min(Math.max(parsedLimit, 1), MAX_LIMIT)
+    : DEFAULT_LIMIT;
+  const offset = Number.isFinite(parsedOffset) ? Math.max(parsedOffset, 0) : 0;
+
+  const like = `%${q.replace(/[%_\\]/g, (m) => `\\${m}`)}%`;
+
+  try {
+    const rows = await DB.prepare(
+      `
+      SELECT
+        v.id,
+        v.name,
+        v.city,
+        v.region,
+        COUNT(DISTINCT p.id) AS performance_count,
+        COUNT(DISTINCT e.id) AS event_count
+      FROM venues v
+      JOIN performances p ON p.venue_id = v.id
+      JOIN events e ON e.id = p.event_id
+      WHERE (e.is_published = 1 OR e.status = 'archived')
+        AND (
+          ? = ''
+          OR v.name LIKE ? ESCAPE '\\'
+          OR v.city LIKE ? ESCAPE '\\'
+        )
+      GROUP BY v.id
+      ORDER BY v.name COLLATE NOCASE
+      LIMIT ? OFFSET ?
+    `,
+    )
+      .bind(q, like, like, limit + 1, offset)
+      .all();
+
+    const results = rows.results || [];
+    const hasMore = results.length > limit;
+    const venues = results.slice(0, limit).map((row) => ({
+      id: row.id,
+      name: row.name,
+      location: formatLocation(row),
+      performance_count: row.performance_count,
+      event_count: row.event_count,
+    }));
+
+    return new Response(JSON.stringify({ venues, hasMore }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=300",
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching venue directory:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Database error",
+        message: "Failed to fetch venues",
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+}

--- a/functions/api/venues/[id].js
+++ b/functions/api/venues/[id].js
@@ -1,0 +1,121 @@
+// Public API: venue detail
+// GET /api/venues/:id
+//
+// Returns a venue plus its lineup (upcoming/past performances at published or
+// archived events). Gated by PUBLIC_DATA_PUBLISH_ENABLED.
+
+import { getPublicDataGateResponse } from "../../utils/publicGate.js";
+import { validateId } from "../../utils/validation.js";
+
+function json(body, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...extraHeaders },
+  });
+}
+
+function formatLocation(v) {
+  const parts = [v.city, v.region].filter(Boolean);
+  return parts.length ? parts.join(", ") : null;
+}
+
+function formatAddress(v) {
+  const cityRegion = [v.city, v.region].filter(Boolean).join(", ");
+  const parts = [
+    v.address_line1,
+    v.address_line2,
+    cityRegion,
+    v.postal_code,
+  ].filter(Boolean);
+  return parts.length ? parts.join(", ") : v.address || null;
+}
+
+export async function onRequestGet(context) {
+  const { params, env } = context;
+
+  const gate = getPublicDataGateResponse(env);
+  if (gate) {
+    return gate;
+  }
+
+  const { DB } = env;
+  const { valid, value: id } = validateId(params.id);
+  if (!valid) {
+    return json({ error: "Invalid venue id" }, 400);
+  }
+
+  try {
+    const venue = await DB.prepare("SELECT * FROM venues WHERE id = ?")
+      .bind(id)
+      .first();
+    if (!venue) {
+      return json({ error: "Venue not found" }, 404);
+    }
+
+    const perfs = await DB.prepare(
+      `
+      SELECT
+        p.id AS performance_id,
+        p.start_time,
+        p.end_time,
+        e.id AS event_id,
+        e.name AS event_name,
+        e.slug AS event_slug,
+        e.date AS event_date,
+        e.status AS event_status,
+        bp.id AS band_id,
+        bp.name AS band_name
+      FROM performances p
+      JOIN events e ON e.id = p.event_id
+      JOIN band_profiles bp ON bp.id = p.band_profile_id
+      WHERE p.venue_id = ?
+        AND (e.is_published = 1 OR e.status = 'archived')
+      ORDER BY e.date DESC, p.start_time
+    `,
+    )
+      .bind(id)
+      .all();
+
+    const all = perfs.results || [];
+    const today = new Date().toISOString().split("T")[0];
+    const isPast = (p) => p.event_date < today || p.event_status === "archived";
+
+    const mapPerf = (p) => ({
+      performance_id: p.performance_id,
+      start_time: p.start_time,
+      end_time: p.end_time,
+      event_id: p.event_id,
+      event_name: p.event_name,
+      event_slug: p.event_slug,
+      event_date: p.event_date,
+      band_id: p.band_id,
+      band_name: p.band_name,
+    });
+
+    return json(
+      {
+        venue: {
+          id: venue.id,
+          name: venue.name,
+          location: formatLocation(venue),
+          address: formatAddress(venue),
+          website: venue.website || null,
+          instagram: venue.instagram || null,
+          facebook: venue.facebook || null,
+          performance_count: all.length,
+          event_count: new Set(all.map((p) => p.event_id)).size,
+        },
+        upcoming: all.filter((p) => !isPast(p)).map(mapPerf),
+        past: all.filter(isPast).map(mapPerf),
+      },
+      200,
+      { "Cache-Control": "public, max-age=300" },
+    );
+  } catch (error) {
+    console.error("Error fetching venue:", error);
+    return json(
+      { error: "Database error", message: "Failed to fetch venue" },
+      500,
+    );
+  }
+}

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -13,18 +13,26 @@ export async function onRequestGet(context) {
   }
 
   try {
-    const [{ results: events }, { results: bands }] = await Promise.all([
-      env.DB.prepare(
-        `SELECT slug, date FROM events WHERE is_published = 1 ORDER BY date DESC`,
-      ).all(),
-      env.DB.prepare(
-        `SELECT DISTINCT bp.id
+    const [{ results: events }, { results: bands }, { results: venues }] =
+      await Promise.all([
+        env.DB.prepare(
+          `SELECT slug, date FROM events WHERE is_published = 1 ORDER BY date DESC`,
+        ).all(),
+        env.DB.prepare(
+          `SELECT DISTINCT bp.id
          FROM band_profiles bp
          INNER JOIN performances p ON p.band_profile_id = bp.id
          INNER JOIN events e ON e.id = p.event_id
          WHERE e.is_published = 1`,
-      ).all(),
-    ]);
+        ).all(),
+        env.DB.prepare(
+          `SELECT DISTINCT v.id
+         FROM venues v
+         INNER JOIN performances p ON p.venue_id = v.id
+         INNER JOIN events e ON e.id = p.event_id
+         WHERE e.is_published = 1`,
+        ).all(),
+      ]);
 
     const rows = [
       `  <url>
@@ -34,6 +42,11 @@ export async function onRequestGet(context) {
   </url>`,
       `  <url>
     <loc>https://settimes.ca/artists</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>`,
+      `  <url>
+    <loc>https://settimes.ca/venues</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>`,
@@ -53,6 +66,14 @@ export async function onRequestGet(context) {
     <loc>https://settimes.ca/band/${band.id}</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
+  </url>`);
+    }
+
+    for (const venue of venues) {
+      rows.push(`  <url>
+    <loc>https://settimes.ca/venue/${venue.id}</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>`);
     }
 


### PR DESCRIPTION
Roadmap Track C P1 (venue discovery + SEO). A full venue feature, mirroring the artist directory.

## Backend (committed first)
- `GET /api/venues` — venues that hosted ≥1 performance at a published/archived event; searchable by name/city, paginated. (`{ venues, hasMore }`)
- `GET /api/venues/:id` — venue + its lineup (upcoming/past performances). Both gated by `PUBLIC_DATA_PUBLISH_ENABLED`. **7 tests.**

## Frontend
- **`/venues`** directory — debounced search + responsive grid of venue cards (name, location, set/event counts).
- **`/venue/[id]`** detail — info (location, address, website) + lineup, with each performance linking to its **event** and **band**. `MusicVenue` JSON-LD for SEO.
- Lazy routes; **"Browse venues"** link on the homepage; `/venues` + venue URLs added to the **sitemap**; both endpoints in **OpenAPI**.
- Built **theme-aware** (semantic tokens), so the light themes read.

## Verification
Backend **437** + frontend **183** tests; `validate:openapi` + `validate:schema` pass; lint + build green.

Follow-up: linking venue *names* from the schedule + band profiles into these pages (needs `venue_id` threaded into those responses) — a focused next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)