### PR TITLE
feat(venues): link venue names on band profiles to venue pages

### DIFF
--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -766,7 +766,16 @@ export default function BandProfilePage() {
                             {performance.venue_name && (
                               <span className="flex items-center gap-2">
                                 <MapPin size={14} className="text-accent-500" />
-                                {performance.venue_name}
+                                {performance.venue_id ? (
+                                  <Link
+                                    to={`/venue/${performance.venue_id}`}
+                                    className="transition-colors hover:text-accent-400 hover:underline"
+                                  >
+                                    {performance.venue_name}
+                                  </Link>
+                                ) : (
+                                  performance.venue_name
+                                )}
                               </span>
                             )}
                             {performance.start_time && performance.end_time && (
@@ -841,7 +850,16 @@ export default function BandProfilePage() {
                             {performance.venue_name && (
                               <span className="flex items-center gap-2">
                                 <MapPin size={14} className="text-text-tertiary" />
-                                {performance.venue_name}
+                                {performance.venue_id ? (
+                                  <Link
+                                    to={`/venue/${performance.venue_id}`}
+                                    className="transition-colors hover:text-accent-400 hover:underline"
+                                  >
+                                    {performance.venue_name}
+                                  </Link>
+                                ) : (
+                                  performance.venue_name
+                                )}
                               </span>
                             )}
                             {performance.start_time && performance.end_time && (


### PR DESCRIPTION
Track C internal-links follow-up. On a band profile, each performance’s **venue name** (upcoming + past) now links to its `/venue/:id` page — the `venue_id` is already in the profile API response, so no backend change. Falls back to plain text when a performance has no venue.

Completes the band ↔ venue ↔ event internal-link graph (event links already existed).

> Depends on **#344** (venue pages) for the `/venue/:id` route — merge after that.

Frontend 187 tests + lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)