### PR TITLE
test(e2e): harden flaky mobile band-profile check

### DIFF
--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -188,11 +188,20 @@ test.describe('Band Profile Viewing', () => {
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
     if (await bandLink.isVisible()) {
-      const bandName = await bandLink.textContent();
+      const bandName = (await bandLink.textContent())?.trim() || '';
       await bandLink.click();
+      await page.waitForURL(/\/band(s)?\//);
 
-      // Verify band profile is visible on mobile
-      await expect(page.getByRole('heading', { name: new RegExp(bandName || '', 'i') })).toBeVisible();
+      // Verify the band profile heading renders on mobile. Wait generously: the
+      // profile route is lazy-loaded and fetches its data, which can exceed the
+      // default 5s timeout on a cold CI mobile run. Match the band name robustly
+      // (regex-escaped), and allow multiple headings via .first().
+      const headingName = bandName
+        ? new RegExp(bandName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i')
+        : /.+/;
+      await expect(page.getByRole('heading', { name: headingName }).first()).toBeVisible({
+        timeout: 15000,
+      });
 
       // Verify content is readable on mobile
       const contentArea = page.locator('main, [role="main"], article').first();


### PR DESCRIPTION
The `band-profile-viewing.spec.js` "responsive on mobile viewport" test failed on `main` (all 3 retries) — `getByRole(heading, /The Time Travellers/i)` not visible within the default 5s.

**Cause (not a code regression):** the test clicks a homepage band link, then immediately asserts the heading. The `/band/:id` route is **lazy-loaded + fetches data**, which can exceed 5s on a cold CI mobile run. Desktop band-profile tests pass (they navigate differently), and the profile heading renders fine.

**Fix:** wait for the `/band/` URL after the click, give the heading a 15s timeout, and match the name robustly (trimmed + regex-escaped, `.first()`). It still asserts the heading **is** visible, so a real missing-heading regression would still fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)