### PR TITLE
feat(venues): walking-time foundation (coords + walk-time util)

### DIFF
--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -46,6 +46,8 @@ CREATE TABLE IF NOT EXISTS venues (
   facebook TEXT,
   phone TEXT,
   contact_email TEXT,
+  latitude REAL,
+  longitude REAL,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/frontend/src/utils/__tests__/walkTime.test.js
+++ b/frontend/src/utils/__tests__/walkTime.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { walkMinutesBetween, haversineMeters } from '../walkTime'
+
+describe('walkTime', () => {
+  it('returns null when either venue lacks usable coordinates', () => {
+    const ok = { latitude: 43.46, longitude: -80.52 }
+    expect(walkMinutesBetween(null, ok)).toBeNull()
+    expect(walkMinutesBetween(ok, {})).toBeNull()
+    expect(walkMinutesBetween({ latitude: 43.46 }, ok)).toBeNull()
+    expect(walkMinutesBetween({ latitude: 'x', longitude: 'y' }, ok)).toBeNull()
+  })
+
+  it('computes a small walk for nearby King St venues', () => {
+    // ~320 m apart (≈ 0.0029° latitude) → ~4 min at 80 m/min
+    const a = { latitude: 43.4795, longitude: -80.5235 }
+    const b = { latitude: 43.4824, longitude: -80.5235 }
+    const minutes = walkMinutesBetween(a, b)
+    expect(minutes).toBeGreaterThanOrEqual(3)
+    expect(minutes).toBeLessThanOrEqual(6)
+  })
+
+  it('haversine distance is ~0 for identical points', () => {
+    expect(haversineMeters(43.46, -80.52, 43.46, -80.52)).toBeCloseTo(0, 5)
+  })
+})

--- a/frontend/src/utils/walkTime.js
+++ b/frontend/src/utils/walkTime.js
@@ -12,9 +12,7 @@ function toRadians(deg) {
 export function haversineMeters(lat1, lng1, lat2, lng2) {
   const dLat = toRadians(lat2 - lat1)
   const dLng = toRadians(lng2 - lng1)
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) * Math.sin(dLng / 2) ** 2
+  const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) * Math.sin(dLng / 2) ** 2
   return 2 * EARTH_RADIUS_M * Math.asin(Math.min(1, Math.sqrt(a)))
 }
 

--- a/frontend/src/utils/walkTime.js
+++ b/frontend/src/utils/walkTime.js
@@ -1,0 +1,37 @@
+// Approximate walking time between two venues from their lat/lng coordinates.
+// Uses the haversine great-circle distance and a steady ~80 m/min walking pace
+// (~4.8 km/h) — a reasonable default for the compact King St venue cluster.
+
+const WALK_METERS_PER_MINUTE = 80
+const EARTH_RADIUS_M = 6371000
+
+function toRadians(deg) {
+  return (deg * Math.PI) / 180
+}
+
+export function haversineMeters(lat1, lng1, lat2, lng2) {
+  const dLat = toRadians(lat2 - lat1)
+  const dLng = toRadians(lng2 - lng1)
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) * Math.sin(dLng / 2) ** 2
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.min(1, Math.sqrt(a)))
+}
+
+function hasCoords(v) {
+  return (
+    v &&
+    typeof v.latitude === 'number' &&
+    typeof v.longitude === 'number' &&
+    !Number.isNaN(v.latitude) &&
+    !Number.isNaN(v.longitude)
+  )
+}
+
+// Approximate walking time in whole minutes between two venue-like objects
+// ({ latitude, longitude }), or null if either lacks usable coordinates.
+export function walkMinutesBetween(a, b) {
+  if (!hasCoords(a) || !hasCoords(b)) return null
+  const meters = haversineMeters(a.latitude, a.longitude, b.latitude, b.longitude)
+  return Math.max(1, Math.round(meters / WALK_METERS_PER_MINUTE))
+}

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -186,6 +186,8 @@ export function createTestDB() {
       phone TEXT,
       contact_email TEXT,
       address TEXT,
+      latitude REAL,
+      longitude REAL,
       created_by_user_id INTEGER REFERENCES users(id),
       updated_by_user_id INTEGER REFERENCES users(id),
       created_at TEXT DEFAULT (datetime('now')),

--- a/migrations/0043_add_venue_coordinates.sql
+++ b/migrations/0043_add_venue_coordinates.sql
@@ -1,0 +1,9 @@
+-- Migration: 0043_add_venue_coordinates
+-- Description: Add latitude/longitude to venues to power walking-time hints
+--              between stops on a crawl route (the King St venue cluster).
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+ALTER TABLE venues ADD COLUMN latitude REAL;
+ALTER TABLE venues ADD COLUMN longitude REAL;


### PR DESCRIPTION
First slice of walking-time hints (Track A P1), per the "data layer now, display after coords" plan.

## In this PR
- **`latitude`/`longitude` on venues** — migration `0043` + `setup-complete.sql` + test-utils, all in sync (`validate:schema` passes).
- **Walk-time util** (`frontend/src/utils/walkTime.js`) — haversine great-circle distance + a steady ~80 m/min pace; returns `null` when either venue lacks coords. **3 tests.**

## Follow-ups (not in this PR)
1. Accept lat/lng in the admin venue **POST/PUT** + a coords input in **VenuesTab** (so the 6 King St venues can be geocoded).
2. The **My-Route walk-hint display** (between consecutive different-venue stops) — deliberately deferred until coordinates exist, so it can be verified on a deploy rather than built blind.

Backend **440** + util **3/3** + `validate:schema` green.

> Note: migration `0043` auto-applies on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)