### PR TITLE
fix(security): document accepted ZAP baseline findings (#346)

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -41,3 +41,54 @@
 
 # Session ID in URL - we use cookies, not URL params
 3	IGNORE	.*
+
+# ===========================================================================
+# Issue #346 disposition (2026-06-22) — accepted/unfixable baseline findings.
+# Sub-alert IDs (e.g. 10055-4) target one specific check so the rest of the
+# plugin keeps detecting genuine regressions. See PR for full rationale.
+# ===========================================================================
+
+# CSP: Wildcard Directive — fires on `img-src 'self' data: https: blob:`.
+# The `https:` source is intentional: band photos may be served from arbitrary
+# HTTPS hosts (admin-supplied photo_url + the R2 custom domain). img-src is
+# low risk (images can't execute script); script-src/connect-src stay 'self'.
+10055-4	IGNORE	.*
+
+# CSP: Failure to Define Directive with No Fallback (frame-ancestors).
+# Fires only on /embed/, which sets `frame-ancestors *` so third-party sites
+# can iframe the schedule widget. Required by the embed feature; embedder
+# origins are open-ended and can't be enumerated.
+10055-13	IGNORE	.*
+
+# Cross-Domain Misconfiguration (Access-Control-Allow-Origin: *).
+# Cloudflare auto-injects ACAO:* on STATIC assets (HTML/favicon/robots).
+# Our API (functions/_middleware.js) echoes a strict origin allowlist, never
+# '*'. The flagged resources are public and non-credentialed — no real exposure.
+10098	IGNORE	.*
+
+# Cross-Origin-Resource-Policy missing — only on the Cloudflare-injected
+# /cdn-cgi/ Rocket Loader script, which _headers cannot control. Our own pages
+# set CORP via the /* rule, so scope the ignore to /cdn-cgi/.
+90004-1	IGNORE	.*cdn-cgi.*
+
+# Cross-Origin-Embedder-Policy 'unsafe-none' on /embed/ — deliberate: the
+# embedded iframe must interact with its third-party parent. Normal pages set
+# require-corp via /*, so scope the ignore to /embed/.
+90004-2	IGNORE	.*embed.*
+
+# Cross-Origin-Opener-Policy 'unsafe-none' on /embed/ — deliberate (same reason
+# as COEP). Normal pages set same-origin via /*, so scope the ignore to /embed/.
+90004-3	IGNORE	.*embed.*
+
+# Permissions-Policy missing — only on the Cloudflare /cdn-cgi/ Rocket Loader
+# script. Our pages set Permissions-Policy via /* and middleware.
+10063	IGNORE	.*cdn-cgi.*
+
+# Non-Storable Content — informational. SPA HTML sets `no-store` deliberately
+# (Safari stale-HTML fix); favicon/robots inherit it via _headers merge. Not a
+# security issue.
+10049	IGNORE	.*
+
+# Re-examine Cache-control Directives — informational. Fires on sitemap.xml
+# (`public, max-age=3600`), which is the correct, intended cache policy.
+10015	IGNORE	.*


### PR DESCRIPTION
## Summary

Resolves the weekly **ZAP Baseline Scan Report** (#346). I downloaded the scan
artifact and traced every finding to its exact cause. **None is a fixable header
bug** — each is an intentional tradeoff, Cloudflare-injected, or informational —
so the resolution is to document them as accepted in `.zap/rules.tsv`, using ZAP
**sub-alert IDs** (e.g. `10055-4`) so the rest of each plugin keeps detecting
genuine regressions.

## Disposition

| Finding (alertRef) | Scope | Why accepted |
|---|---|---|
| CSP wildcard `img-src https:` (`10055-4`) | global | Band photos may come from arbitrary HTTPS hosts (admin `photo_url` + R2 custom domain). `img-src` can't execute script; `script-src`/`connect-src` stay `'self'`. |
| CSP no-fallback `frame-ancestors` (`10055-13`) | global | Fires only on `/embed/`, which sets `frame-ancestors *` so third-party sites can iframe the schedule widget. Embedder origins are open-ended. |
| Cross-Domain `ACAO: *` (`10098`) | global | Cloudflare auto-injects on public static assets (HTML/favicon/robots). Our API (`functions/_middleware.js`) echoes a strict origin allowlist, never `*`. |
| COEP/COOP `unsafe-none` (`90004-2/3`) | `.*embed.*` | Deliberate on `/embed/` so the iframe interacts with its third-party parent. Normal pages keep `require-corp`/`same-origin` via `/*` and are still scanned. |
| CORP / Permissions-Policy (`90004-1`, `10063`) | `.*cdn-cgi.*` | Only on the Cloudflare-injected `/cdn-cgi/` Rocket Loader script — unreachable from `_headers`. |
| Non-Storable Content (`10049`) | global | Informational. SPA HTML sets `no-store` deliberately (Safari stale-HTML fix). |
| Re-examine Cache-control (`10015`) | global | Informational. Fires on `sitemap.xml` (`public, max-age=3600`) — the correct, intended policy. |

## `img-src` decision

Kept the `https:` wildcard rather than narrowing it. Narrowing to
`https://band-photos.settimes.ca` would only be safe alongside locking the
`photo_url` validation to that host (otherwise admin-entered external photo URLs
silently fail CSP). That's a product decision — whether photos must be R2-only —
not a security necessity, so it's left as deliberate future hardening.

## Why sub-alert ID scoping

Scoping COEP/COOP to `.*embed.*` and CORP/Permissions-Policy to `.*cdn-cgi.*`
(rather than a blanket plugin IGNORE) means a *normal* page that ever loses its
`require-corp`/`same-origin` headers — a real regression — would still be flagged.

## Testing

Config + docs only; no app code touched, so no lint/build/test checklist applies.
`.zap/rules.tsv` validated as well-formed TSV (tab-separated `id<TAB>action<TAB>regex`).

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)