### PR TITLE
fix(embed): point embed iframe at canonical settimes.ca domain

### DIFF
--- a/frontend/src/admin/EmbedCodeGenerator.jsx
+++ b/frontend/src/admin/EmbedCodeGenerator.jsx
@@ -1,7 +1,7 @@
 export default function EmbedCodeGenerator({ event }) {
   const embedCode = `
 <iframe
-  src="https://setplan.app/embed/${event.slug}"
+  src="https://settimes.ca/embed/${event.slug}"
   width="100%"
   height="600"
   frameborder="0"


### PR DESCRIPTION
## Summary

`EmbedCodeGenerator.jsx` generated copy-paste iframe code with
`src="https://setplan.app/embed/${event.slug}"` — a **stale, pre-rebrand domain**
that appears nowhere else in the codebase (everything else uses `settimes.ca`, and
the embed widget is actually served from `settimes.ca/embed/`). Admins copying the
embed code onto their sites got a widget pointed at the wrong host.

Fixed to the canonical `https://settimes.ca` domain.

## Why hardcode `settimes.ca` (not `window.location.origin`)

The frontend uses two URL conventions: `window.location.origin` for
environment-relative links (share/copy buttons), and hardcoded `https://settimes.ca`
for canonical/SEO URLs (`App.jsx`, `BandProfilePage.jsx`, etc.). Embed code is
**copied onto third-party sites**, so it must be an absolute *production* URL —
`window.location.origin` would incorrectly bake in `dev.settimes.ca`/`localhost`
when generated from a non-prod admin session. The canonical-hardcode convention is
the correct one here.

## Testing

- `npm run lint` — clean (0 errors)
- `npm run format:check` — clean
- `npm test -- --run` — 192 passed
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)