### PR TITLE
fix(profile): theme-safe breadcrumb + desktop follow-panel layout

### DIFF
--- a/frontend/src/components/Breadcrumbs.jsx
+++ b/frontend/src/components/Breadcrumbs.jsx
@@ -17,7 +17,10 @@ function Breadcrumbs({ items }) {
                 {item.label}
               </Link>
             ) : (
-              <span className="text-white font-medium" aria-current={index === items.length - 1 ? 'page' : undefined}>
+              <span
+                className="text-text-primary font-medium"
+                aria-current={index === items.length - 1 ? 'page' : undefined}
+              >
                 {item.label}
               </span>
             )}

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -696,39 +696,43 @@ export default function BandProfilePage() {
 
         {/* Follow band */}
         <div className="mt-6 p-4 rounded-lg bg-text-primary/5 border border-text-primary/10">
-          <h3 className="text-sm font-semibold text-text-primary mb-1">Follow {profile.name}</h3>
-          <p className="text-xs text-text-secondary mb-3">Get notified when they join a new lineup.</p>
-          {followStatus === 'success' ? (
-            <p className="text-sm text-green-400">
-              <Check size={14} className="mr-1.5" />
-              You&apos;re following {profile.name}! We&apos;ll email you when they join a lineup.
-            </p>
-          ) : (
-            <form onSubmit={submitFollow} className="flex flex-col gap-2">
-              <label htmlFor="follow-email" className="text-sm text-text-secondary">
-                Your email address
-              </label>
-              <div className="flex gap-2 max-w-md">
-                <input
-                  id="follow-email"
-                  type="email"
-                  value={followEmail}
-                  onChange={e => setFollowEmail(e.target.value)}
-                  placeholder="your@email.com"
-                  required
-                  className="flex-1 min-w-0 px-3 py-2 rounded bg-bg-navy text-text-primary border border-text-primary/20 focus:border-accent-500 focus:outline-none text-sm"
-                />
-                <Button
-                  type="submit"
-                  disabled={followStatus === 'loading' || (turnstileEnabled && !turnstileToken)}
-                  size="sm"
-                >
-                  {followStatus === 'loading' ? 'Saving…' : 'Follow'}
-                </Button>
-              </div>
-              {turnstileEnabled && <div ref={turnstileContainerRef} className="mt-2" />}
-            </form>
-          )}
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="sm:flex-1">
+              <h3 className="text-sm font-semibold text-text-primary mb-1">Follow {profile.name}</h3>
+              <p className="text-xs text-text-secondary">Get notified when they join a new lineup.</p>
+            </div>
+            {followStatus === 'success' ? (
+              <p className="text-sm text-green-400 sm:max-w-sm">
+                <Check size={14} className="mr-1.5" />
+                You&apos;re following {profile.name}! We&apos;ll email you when they join a lineup.
+              </p>
+            ) : (
+              <form onSubmit={submitFollow} className="w-full sm:w-auto">
+                <label htmlFor="follow-email" className="sr-only">
+                  Your email address
+                </label>
+                <div className="flex gap-2 sm:w-80">
+                  <input
+                    id="follow-email"
+                    type="email"
+                    value={followEmail}
+                    onChange={e => setFollowEmail(e.target.value)}
+                    placeholder="your@email.com"
+                    required
+                    className="flex-1 min-w-0 px-3 py-2 rounded bg-bg-navy text-text-primary border border-text-primary/20 focus:border-accent-500 focus:outline-none text-sm"
+                  />
+                  <Button
+                    type="submit"
+                    disabled={followStatus === 'loading' || (turnstileEnabled && !turnstileToken)}
+                    size="sm"
+                  >
+                    {followStatus === 'loading' ? 'Saving…' : 'Follow'}
+                  </Button>
+                </div>
+                {turnstileEnabled && <div ref={turnstileContainerRef} className="mt-2" />}
+              </form>
+            )}
+          </div>
           {followStatus === 'error' && <p className="text-xs text-red-400 mt-1">{followError}</p>}
         </div>
 


### PR DESCRIPTION
## Summary

Two follow-ups from the light-theme review of band profile pages (after #354).

### 1. Breadcrumb band name invisible on light themes
The current-page item in the shared `Breadcrumbs` component was hardcoded `text-white`, so the band name (e.g. "AAWKS") rendered white-on-cream. Swapped to `text-text-primary`, which flips correctly (dark ink on light, white on dark). This component is only used on public, theme-following pages (event pages via `App.jsx` + band profiles); the admin panel has its own separate breadcrumb, so admin is unaffected.

### 2. Follow panel dead space on desktop
After constraining the email input, the form sat at the far left of a full-width panel, leaving the right ~60% blank on desktop. Restructured the panel into a proper signup bar: heading/subtext on the left, email form on the right (`sm:justify-between`), stacking vertically on mobile. The now-redundant visible label becomes `sr-only` (the placeholder conveys it), keeping accessibility intact.

## Testing
- `npm run lint` — clean (0 errors)
- `npm test -- --run` — 192 passed
- `npm run build` — succeeds

Mobile-first preserved; the desktop bar is purely an `sm:`-and-up enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)