### PR TITLE
fix(profile): recover mobile bio + follow-panel layout (lost post-merge)

### DIFF
--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -557,7 +557,7 @@ export default function BandProfilePage() {
 
           {/* Bio, Social Links, and Share */}
           <div className="p-6 bg-bg-purple/50 border-t border-text-primary/10">
-            <div className="mb-4 flex items-start justify-between gap-4">
+            <div className="mb-4 flex flex-col-reverse gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
               <div className="flex-1 min-w-0">
                 {profile.description ? (
                   <div
@@ -579,7 +579,7 @@ export default function BandProfilePage() {
                   )
                 )}
               </div>
-              <div className="shrink-0">
+              <div className="shrink-0 self-end sm:self-auto">
                 <ShareButton
                   url={
                     typeof window !== 'undefined' ? `${window.location.origin}${window.location.pathname}` : undefined
@@ -696,7 +696,7 @@ export default function BandProfilePage() {
 
         {/* Follow band */}
         <div className="mt-6 p-4 rounded-lg bg-text-primary/5 border border-text-primary/10">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="mx-auto flex max-w-2xl flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="sm:flex-1">
               <h3 className="text-sm font-semibold text-text-primary mb-1">Follow {profile.name}</h3>
               <p className="text-xs text-text-secondary">Get notified when they join a new lineup.</p>


### PR DESCRIPTION
## Summary

Re-lands a fix that was written but never reached `main`. PR #355 was merged when it had only its first commit; the second commit (`e7e403e`) was pushed to that branch *after* the PR merged, so it landed on a closed branch and silently never made it in. This cherry-picks it back onto `main`.

## What it fixes (both confirmed missing on main)
- **Mobile bio cramping** — the Share button shared a row with the bio on mobile, squeezing the description into a narrow, justified-looking column. Now the bio/share row is `flex-col-reverse` on mobile (Share drops to its own line, top-right; bio gets full width) and reverts to side-by-side at `sm:`.
- **Follow panel** — content is capped to `max-w-2xl` and centered so it no longer stretches edge-to-edge on desktop.

## Testing
- `npm run build` — succeeds
- `npm test -- --run` — 192 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)