### PR TITLE
fix(theme): light-theme sweep of remaining public pages (PR 2 of 2)

### DIFF
--- a/frontend/src/pages/ActivatePage.jsx
+++ b/frontend/src/pages/ActivatePage.jsx
@@ -46,7 +46,7 @@ export default function ActivatePage() {
   if (status === 'loading') {
     return (
       <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center">
-        <div className="text-white text-xl">Activating your account...</div>
+        <div className="text-text-primary text-xl">Activating your account...</div>
       </div>
     )
   }
@@ -54,8 +54,8 @@ export default function ActivatePage() {
   if (status === 'error') {
     return (
       <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
-        <div className="max-w-md w-full bg-white/10 backdrop-blur-lg rounded-2xl p-8 border border-white/20 text-center">
-          <h1 className="text-2xl font-bold text-white mb-4">Activation Failed</h1>
+        <div className="max-w-md w-full bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border text-center">
+          <h1 className="text-2xl font-bold text-text-primary mb-4">Activation Failed</h1>
           <p className="text-gray-300 mb-6">{message}</p>
           <button
             onClick={() => navigate('/admin/login')}
@@ -70,8 +70,8 @@ export default function ActivatePage() {
 
   return (
     <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
-      <div className="max-w-md w-full bg-white/10 backdrop-blur-lg rounded-2xl p-8 border border-white/20 text-center">
-        <h1 className="text-2xl font-bold text-white mb-4">Account Activated</h1>
+      <div className="max-w-md w-full bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border text-center">
+        <h1 className="text-2xl font-bold text-text-primary mb-4">Account Activated</h1>
         <p className="text-gray-300 mb-6">{message}</p>
         <button
           onClick={() => navigate('/admin/login')}

--- a/frontend/src/pages/EmbedPage.jsx
+++ b/frontend/src/pages/EmbedPage.jsx
@@ -79,7 +79,7 @@ export default function EmbedPage() {
     return (
       <div className="min-h-screen bg-bg-navy flex items-center justify-center p-4">
         <div className="text-center">
-          <h2 className="text-white text-xl font-bold mb-2">Event Not Found</h2>
+          <h2 className="text-text-primary text-xl font-bold mb-2">Event Not Found</h2>
           <p className="text-gray-400">{error}</p>
         </div>
       </div>

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -70,14 +70,14 @@ function groupBandsByVenue(bands) {
 
 function StatCard({ label, value }) {
   return (
-    <div className="bg-white/5 rounded-lg p-4 text-center">
+    <div className="bg-surface rounded-lg p-4 text-center">
       <div className="sr-only">
         {label}: {value ?? '—'}
       </div>
-      <div className="text-3xl font-bold text-white" aria-hidden="true">
+      <div className="text-3xl font-bold text-text-primary" aria-hidden="true">
         {value ?? '—'}
       </div>
-      <div className="text-sm text-white/60 mt-1" aria-hidden="true">
+      <div className="text-sm text-text-tertiary mt-1" aria-hidden="true">
         {label}
       </div>
     </div>
@@ -159,7 +159,7 @@ export default function EventRecapPage() {
 
       <main id="main-content" className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple px-4 py-10">
         <div className="mx-auto max-w-5xl">
-          <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur-xs">
+          <header className="mb-8 rounded-2xl border border-border bg-surface p-6 shadow-xl backdrop-blur-xs">
             <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-accent-400">
               <span className="inline-flex items-center gap-2 rounded-full border border-accent-400/20 bg-accent-400/10 px-3 py-1">
                 <Archive size={14} aria-hidden="true" />
@@ -167,8 +167,8 @@ export default function EventRecapPage() {
               </span>
               <span>Recap</span>
             </div>
-            <h1 className="mt-4 text-4xl font-bold text-white">{event.name}</h1>
-            <p className="mt-2 text-lg text-white/60">{formattedDate}</p>
+            <h1 className="mt-4 text-4xl font-bold text-text-primary">{event.name}</h1>
+            <p className="mt-2 text-lg text-text-tertiary">{formattedDate}</p>
             <div className="mt-6 flex flex-wrap gap-3">
               <Link
                 to={`/event/${event.slug}`}
@@ -179,7 +179,7 @@ export default function EventRecapPage() {
               </Link>
               <Link
                 to="/"
-                className="inline-flex min-h-[44px] items-center gap-2 rounded-lg border border-white/15 px-5 py-3 font-semibold text-white/80 transition-colors hover:bg-white/10"
+                className="inline-flex min-h-[44px] items-center gap-2 rounded-lg border border-border px-5 py-3 font-semibold text-text-secondary transition-colors hover:bg-surface"
               >
                 <ArrowLeft size={16} aria-hidden="true" />
                 Browse All Events
@@ -195,29 +195,29 @@ export default function EventRecapPage() {
             <StatCard label="Saved Route" value={savedBands.length || '—'} />
           </section>
 
-          <section aria-label="Your route recap" className="mb-10 rounded-2xl border border-white/10 bg-white/5 p-6">
+          <section aria-label="Your route recap" className="mb-10 rounded-2xl border border-border bg-surface p-6">
             <div className="mb-5 flex items-center gap-2">
               <Route size={18} className="text-accent-400" aria-hidden="true" />
-              <h2 className="text-2xl font-semibold text-white">Your Route Recap</h2>
+              <h2 className="text-2xl font-semibold text-text-primary">Your Route Recap</h2>
             </div>
 
             {savedBands.length > 0 ? (
               <div className="grid gap-6 lg:grid-cols-2">
-                <div className="rounded-xl border border-white/10 bg-bg-navy/40 p-4">
-                  <h3 className="mb-3 text-lg font-semibold text-white">Saved in your route</h3>
-                  <p className="mb-4 text-sm text-white/60">
+                <div className="rounded-xl border border-border bg-bg-navy/40 p-4">
+                  <h3 className="mb-3 text-lg font-semibold text-text-primary">Saved in your route</h3>
+                  <p className="mb-4 text-sm text-text-tertiary">
                     You saved {savedBands.length} {savedBands.length === 1 ? 'set' : 'sets'} for this event.
                   </p>
                   <ul className="space-y-3">
                     {savedBands.map(band => (
-                      <li key={band.performance_id} className="rounded-lg border border-white/10 bg-white/5 p-3">
+                      <li key={band.performance_id} className="rounded-lg border border-border bg-surface p-3">
                         <Link
                           to={buildBandProfileHref(band.name, event.slug)}
                           className="font-medium text-accent-400 hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
                         >
                           {band.name}
                         </Link>
-                        <div className="mt-1 text-sm text-white/60">
+                        <div className="mt-1 text-sm text-text-tertiary">
                           {band.venue_name || 'Unscheduled'}
                           {(band.start_time || band.end_time) &&
                             ` • ${band.start_time || 'TBD'}–${band.end_time || 'TBD'}`}
@@ -227,21 +227,21 @@ export default function EventRecapPage() {
                   </ul>
                 </div>
 
-                <div className="rounded-xl border border-white/10 bg-bg-navy/40 p-4">
-                  <h3 className="mb-3 text-lg font-semibold text-white">Bands you missed</h3>
-                  <p className="mb-4 text-sm text-white/60">
+                <div className="rounded-xl border border-border bg-bg-navy/40 p-4">
+                  <h3 className="mb-3 text-lg font-semibold text-text-primary">Bands you missed</h3>
+                  <p className="mb-4 text-sm text-text-tertiary">
                     {missedBands.length} {missedBands.length === 1 ? 'set was' : 'sets were'} outside your saved route.
                   </p>
                   <ul className="space-y-3">
                     {missedBands.slice(0, 6).map(band => (
-                      <li key={band.performance_id} className="rounded-lg border border-white/10 bg-white/5 p-3">
+                      <li key={band.performance_id} className="rounded-lg border border-border bg-surface p-3">
                         <Link
                           to={buildBandProfileHref(band.name, event.slug)}
                           className="font-medium text-accent-400 hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
                         >
                           {band.name}
                         </Link>
-                        <div className="mt-1 text-sm text-white/60">
+                        <div className="mt-1 text-sm text-text-tertiary">
                           {band.venue_name || 'Unscheduled'}
                           {(band.start_time || band.end_time) &&
                             ` • ${band.start_time || 'TBD'}–${band.end_time || 'TBD'}`}
@@ -252,25 +252,25 @@ export default function EventRecapPage() {
                 </div>
               </div>
             ) : (
-              <div className="rounded-xl border border-dashed border-white/15 bg-bg-navy/30 p-4 text-sm text-white/70">
+              <div className="rounded-xl border border-dashed border-border bg-bg-navy/30 p-4 text-sm text-text-secondary">
                 No saved route was found for this event. The archive still preserves the full lineup, venue recap, and
                 band history.
               </div>
             )}
           </section>
 
-          <section aria-label="Venue recap" className="mb-10 rounded-2xl border border-white/10 bg-white/5 p-6">
+          <section aria-label="Venue recap" className="mb-10 rounded-2xl border border-border bg-surface p-6">
             <div className="mb-5 flex items-center gap-2">
               <MapPin size={18} className="text-accent-400" aria-hidden="true" />
-              <h2 className="text-2xl font-semibold text-white">Venue Recap</h2>
+              <h2 className="text-2xl font-semibold text-text-primary">Venue Recap</h2>
             </div>
             <div className="grid gap-4 md:grid-cols-2">
               {venueRecap.map(venue => (
-                <article key={venue.id} className="rounded-xl border border-white/10 bg-bg-navy/40 p-4">
+                <article key={venue.id} className="rounded-xl border border-border bg-bg-navy/40 p-4">
                   <div className="mb-3 flex items-start justify-between gap-3">
                     <div>
-                      <h3 className="text-lg font-semibold text-white">{venue.name}</h3>
-                      <p className="text-sm text-white/60">
+                      <h3 className="text-lg font-semibold text-text-primary">{venue.name}</h3>
+                      <p className="text-sm text-text-tertiary">
                         {venue.bands.length} {venue.bands.length === 1 ? 'set' : 'sets'} on the night
                       </p>
                     </div>
@@ -281,11 +281,11 @@ export default function EventRecapPage() {
                       View schedule →
                     </Link>
                   </div>
-                  <ul className="space-y-2 text-sm text-white/70">
+                  <ul className="space-y-2 text-sm text-text-secondary">
                     {venue.bands.map(band => (
                       <li
                         key={band.performance_id}
-                        className="flex items-start justify-between gap-3 rounded-lg bg-white/5 px-3 py-2"
+                        className="flex items-start justify-between gap-3 rounded-lg bg-surface px-3 py-2"
                       >
                         <Link
                           to={buildBandProfileHref(band.name, event.slug)}
@@ -293,7 +293,7 @@ export default function EventRecapPage() {
                         >
                           {band.name}
                         </Link>
-                        <span className="shrink-0 text-white/50">
+                        <span className="shrink-0 text-text-tertiary">
                           {band.start_time || 'TBD'}–{band.end_time || 'TBD'}
                         </span>
                       </li>
@@ -305,13 +305,13 @@ export default function EventRecapPage() {
           </section>
 
           <section aria-label="Archived lineup">
-            <h2 className="mb-4 text-xl font-semibold text-white">Archived Lineup</h2>
+            <h2 className="mb-4 text-xl font-semibold text-text-primary">Archived Lineup</h2>
             <ul className="space-y-3">
               {bands.length === 0 ? (
-                <li className="text-white/50 text-sm py-4 text-center">No performers recorded for this event.</li>
+                <li className="text-text-tertiary text-sm py-4 text-center">No performers recorded for this event.</li>
               ) : (
                 bands.map(band => (
-                  <li key={band.id} className="bg-white/5 rounded-lg p-4 flex items-center justify-between gap-4">
+                  <li key={band.id} className="bg-surface rounded-lg p-4 flex items-center justify-between gap-4">
                     <div className="flex-1 min-w-0">
                       <Link
                         to={buildBandProfileHref(band.name, event.slug)}
@@ -319,8 +319,8 @@ export default function EventRecapPage() {
                       >
                         {band.name}
                       </Link>
-                      {band.genre && <span className="ml-2 text-white/50 text-sm">{band.genre}</span>}
-                      <div className="mt-0.5 text-white/50 text-sm">
+                      {band.genre && <span className="ml-2 text-text-tertiary text-sm">{band.genre}</span>}
+                      <div className="mt-0.5 text-text-tertiary text-sm">
                         {band.venue_name || 'Unscheduled'}
                         {(band.start_time || band.end_time) &&
                           ` • ${band.start_time || 'TBD'}–${band.end_time || 'TBD'}`}
@@ -339,15 +339,15 @@ export default function EventRecapPage() {
             </ul>
           </section>
 
-          <section aria-label="Archive next steps" className="mt-12 rounded-2xl bg-white/5 p-6 text-center">
-            <h2 className="mb-2 text-xl font-semibold text-white">Keep exploring the archive</h2>
-            <p className="mb-4 text-white/60">
+          <section aria-label="Archive next steps" className="mt-12 rounded-2xl bg-surface p-6 text-center">
+            <h2 className="mb-2 text-xl font-semibold text-text-primary">Keep exploring the archive</h2>
+            <p className="mb-4 text-text-tertiary">
               Revisit the archived schedule, jump into band histories, or get notified when the next lineup drops.
             </p>
             <div className="flex flex-wrap justify-center gap-3">
               <Link
                 to={`/event/${event.slug}`}
-                className="inline-flex min-h-[44px] items-center gap-2 rounded-lg border border-white/15 px-5 py-3 font-semibold text-white/80 transition-colors hover:bg-white/10"
+                className="inline-flex min-h-[44px] items-center gap-2 rounded-lg border border-border px-5 py-3 font-semibold text-text-secondary transition-colors hover:bg-surface"
               >
                 <CalendarDays size={16} aria-hidden="true" />
                 Archived Schedule

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -14,8 +14,10 @@ export default function NotFoundPage() {
           <div className="text-accent-400 mb-4" aria-hidden="true">
             <Compass size={60} />
           </div>
-          <h1 className="text-white text-3xl font-bold mb-2">Page Not Found</h1>
-          <p className="text-white/70 mb-8">The page you&apos;re looking for doesn&apos;t exist or may have moved.</p>
+          <h1 className="text-text-primary text-3xl font-bold mb-2">Page Not Found</h1>
+          <p className="text-text-secondary mb-8">
+            The page you&apos;re looking for doesn&apos;t exist or may have moved.
+          </p>
           <Link
             to="/"
             className="inline-block px-6 py-3 bg-accent-500 text-bg-navy font-semibold rounded-lg hover:brightness-110 transition-all"

--- a/frontend/src/pages/PrivacyPage.jsx
+++ b/frontend/src/pages/PrivacyPage.jsx
@@ -15,12 +15,12 @@ export default function PrivacyPage() {
           ← Back to SetTimes
         </Link>
 
-        <h1 className="text-white text-3xl font-bold mb-2">Privacy Policy</h1>
+        <h1 className="text-text-primary text-3xl font-bold mb-2">Privacy Policy</h1>
         <p className="text-text-tertiary text-sm mb-10">Last updated: April 2026</p>
 
         <div className="space-y-8 text-gray-300 leading-relaxed">
           <section>
-            <h2 className="text-white text-lg font-semibold mb-3">What SetTimes is</h2>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">What SetTimes is</h2>
             <p>
               SetTimes (settimes.ca) is a free, community-run schedule tool for Waterloo region music festivals. It
               helps festival-goers plan their evening. There is no advertising, no tracking pixels, and no third-party
@@ -29,9 +29,9 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-white text-lg font-semibold mb-3">What we collect</h2>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">What we collect</h2>
 
-            <h3 className="text-white/80 font-medium mb-2 mt-4">If you just browse</h3>
+            <h3 className="text-text-secondary font-medium mb-2 mt-4">If you just browse</h3>
             <p>
               We do not use advertising trackers, tracking pixels, or persistent cookies for public browsing. We count
               anonymous page views and artist profile visits to understand which features are useful. Limited request
@@ -39,7 +39,7 @@ export default function PrivacyPage() {
               persistent account or profiling identifier in our application data.
             </p>
 
-            <h3 className="text-white/80 font-medium mb-2 mt-4">If you subscribe to email updates</h3>
+            <h3 className="text-text-secondary font-medium mb-2 mt-4">If you subscribe to email updates</h3>
             <p>
               We store your email address, your city/genre preferences, and a verification timestamp. We do not store
               your IP address in the subscription record itself. Limited request metadata may still be processed
@@ -47,7 +47,7 @@ export default function PrivacyPage() {
               subscribed to, and the one-click unsubscribe in every email removes the active subscription immediately.
             </p>
 
-            <h3 className="text-white/80 font-medium mb-2 mt-4">If you are an organiser with admin access</h3>
+            <h3 className="text-text-secondary font-medium mb-2 mt-4">If you are an organiser with admin access</h3>
             <p>
               We store your email address, hashed password (PBKDF2-SHA256, 100,000 iterations), and session tokens.
               Login attempts and admin actions may include security metadata such as IP address and user agent for
@@ -57,7 +57,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-white text-lg font-semibold mb-3">Your browser storage</h2>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Your browser storage</h2>
             <p>
               We use <code className="text-accent-400 text-sm">localStorage</code> to remember the bands you have added
               to your personal schedule. This data never leaves your device and is not sent to our servers.
@@ -65,7 +65,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-white text-lg font-semibold mb-3">Cookies</h2>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Cookies</h2>
             <p>
               Admin accounts use a secure, HTTP-only session cookie. Public visitors receive no cookies. The privacy
               banner acknowledgement is stored in <code className="text-accent-400 text-sm">localStorage</code>, not a
@@ -74,17 +74,17 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-white text-lg font-semibold mb-3">Infrastructure and processors</h2>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Infrastructure and processors</h2>
             <p>
-              SetTimes runs on <strong className="text-white/90">Cloudflare Pages</strong> (hosting and edge functions)
-              and <strong className="text-white/90">Cloudflare D1</strong> (database). Data is processed on Cloudflare
-              infrastructure, which may include data centres outside Canada. Email notifications (if enabled) are sent
-              via a third-party transactional email provider.
+              SetTimes runs on <strong className="text-text-secondary">Cloudflare Pages</strong> (hosting and edge
+              functions) and <strong className="text-text-secondary">Cloudflare D1</strong> (database). Data is
+              processed on Cloudflare infrastructure, which may include data centres outside Canada. Email notifications
+              (if enabled) are sent via a third-party transactional email provider.
             </p>
           </section>
 
           <section>
-            <h2 className="text-white text-lg font-semibold mb-3">Your rights</h2>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Your rights</h2>
             <p className="mb-3">
               If you are an email subscriber, the unsubscribe link in every email deletes your subscription immediately.
             </p>
@@ -98,7 +98,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-white text-lg font-semibold mb-3">Changes</h2>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Changes</h2>
             <p>
               If we make material changes to this policy, we will update the date at the top of this page. We will not
               retroactively weaken privacy protections for data already collected.

--- a/frontend/src/pages/ResetPasswordPage.jsx
+++ b/frontend/src/pages/ResetPasswordPage.jsx
@@ -99,7 +99,7 @@ export default function ResetPasswordPage() {
   if (status === 'loading') {
     return (
       <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center">
-        <div className="text-white text-xl">Verifying reset token...</div>
+        <div className="text-text-primary text-xl">Verifying reset token...</div>
       </div>
     )
   }
@@ -107,8 +107,8 @@ export default function ResetPasswordPage() {
   if (status === 'error') {
     return (
       <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
-        <div className="max-w-md w-full bg-white/10 backdrop-blur-lg rounded-2xl p-8 border border-white/20 text-center">
-          <h1 className="text-2xl font-bold text-white mb-4">Reset Failed</h1>
+        <div className="max-w-md w-full bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border text-center">
+          <h1 className="text-2xl font-bold text-text-primary mb-4">Reset Failed</h1>
           <p className="text-gray-300 mb-6">{message}</p>
           <button
             onClick={() => navigate('/admin/login')}
@@ -124,8 +124,8 @@ export default function ResetPasswordPage() {
   if (status === 'success') {
     return (
       <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
-        <div className="max-w-md w-full bg-white/10 backdrop-blur-lg rounded-2xl p-8 border border-white/20 text-center">
-          <h1 className="text-2xl font-bold text-white mb-4">✓ Password Reset</h1>
+        <div className="max-w-md w-full bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border text-center">
+          <h1 className="text-2xl font-bold text-text-primary mb-4">✓ Password Reset</h1>
           <p className="text-gray-300 mb-6">{message}</p>
           <button
             onClick={() => navigate('/admin/login')}
@@ -140,9 +140,9 @@ export default function ResetPasswordPage() {
 
   return (
     <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
-      <div className="max-w-md w-full bg-white/10 backdrop-blur-lg rounded-2xl p-8 border border-white/20">
+      <div className="max-w-md w-full bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border">
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-white mb-2">Reset Password</h1>
+          <h1 className="text-3xl font-bold text-text-primary mb-2">Reset Password</h1>
           <p className="text-gray-300">
             Set a new password for <span className="font-medium">{user?.email}</span>
           </p>
@@ -150,7 +150,7 @@ export default function ResetPasswordPage() {
 
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
-            <label htmlFor="newPassword" className="block text-white font-medium mb-2">
+            <label htmlFor="newPassword" className="block text-text-primary font-medium mb-2">
               New Password
             </label>
             <input
@@ -161,14 +161,14 @@ export default function ResetPasswordPage() {
               maxLength={FIELD_LIMITS.password.max}
               value={formData.newPassword}
               onChange={e => setFormData({ ...formData, newPassword: e.target.value })}
-              className="w-full px-4 py-3 rounded-lg bg-white/10 text-white border border-white/20 focus:border-accent-500 focus:outline-hidden placeholder-gray-400"
+              className="w-full px-4 py-3 rounded-lg bg-surface text-text-primary border border-border focus:border-accent-500 focus:outline-hidden placeholder-text-tertiary"
               placeholder="Enter new password"
             />
             <PasswordStrength password={formData.newPassword} />
           </div>
 
           <div>
-            <label htmlFor="confirmPassword" className="block text-white font-medium mb-2">
+            <label htmlFor="confirmPassword" className="block text-text-primary font-medium mb-2">
               Confirm Password
             </label>
             <input
@@ -179,7 +179,7 @@ export default function ResetPasswordPage() {
               maxLength={FIELD_LIMITS.password.max}
               value={formData.confirmPassword}
               onChange={e => setFormData({ ...formData, confirmPassword: e.target.value })}
-              className="w-full px-4 py-3 rounded-lg bg-white/10 text-white border border-white/20 focus:border-accent-500 focus:outline-hidden placeholder-gray-400"
+              className="w-full px-4 py-3 rounded-lg bg-surface text-text-primary border border-border focus:border-accent-500 focus:outline-hidden placeholder-text-tertiary"
               placeholder="Confirm new password"
             />
           </div>

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -47,7 +47,7 @@ export default function SharePreviewPage() {
         <div className="mx-auto max-w-2xl">
           <Link
             to="/"
-            className="mb-6 inline-flex items-center gap-2 text-sm text-white/60 hover:text-white transition-colors"
+            className="mb-6 inline-flex items-center gap-2 text-sm text-text-tertiary hover:text-text-primary transition-colors"
           >
             <ArrowLeft size={16} aria-hidden="true" />
             Back to events
@@ -68,7 +68,7 @@ export default function SharePreviewPage() {
         <Helmet>
           <title>Shared Route Not Found | SetTimes</title>
         </Helmet>
-        <p className="text-2xl font-semibold text-white">This route has expired or doesn&apos;t exist.</p>
+        <p className="text-2xl font-semibold text-text-primary">This route has expired or doesn&apos;t exist.</p>
         <p className="mt-2 text-text-secondary">Share links are valid for 30 days.</p>
         <Link to="/" className="mt-6 text-accent-400 hover:underline">
           Browse events
@@ -97,21 +97,21 @@ export default function SharePreviewPage() {
       <div className="mx-auto max-w-2xl px-4 py-8">
         <Link
           to={`/event/${shareData.event_slug}`}
-          className="mb-6 inline-flex items-center gap-1 text-sm text-text-secondary hover:text-white"
+          className="mb-6 inline-flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary"
         >
           <ArrowLeft size={14} />
           Back to {shareData.event_name}
         </Link>
 
         <div className="mb-6">
-          <h1 className="text-2xl font-bold text-white">{shareData.band_names.length}-stop route</h1>
+          <h1 className="text-2xl font-bold text-text-primary">{shareData.band_names.length}-stop route</h1>
           <p className="mt-1 text-text-secondary">{shareData.event_name}</p>
         </div>
 
         <ul aria-label="Bands in this route" className="mb-8 list-none space-y-3 p-0">
           {shareData.band_names.map((name, i) => (
-            <li key={i} className="rounded-xl border border-white/10 bg-white/5 px-4 py-3">
-              <p className="font-semibold text-white">{name}</p>
+            <li key={i} className="rounded-xl border border-border bg-surface px-4 py-3">
+              <p className="font-semibold text-text-primary">{name}</p>
             </li>
           ))}
         </ul>

--- a/frontend/src/pages/SubscribePage.jsx
+++ b/frontend/src/pages/SubscribePage.jsx
@@ -124,18 +124,18 @@ export default function SubscribePage() {
       <div className="max-w-2xl mx-auto pt-20">
         {/* Header */}
         <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold text-white mb-4">Never Miss a Show</h1>
+          <h1 className="text-4xl font-bold text-text-primary mb-4">Never Miss a Show</h1>
           <p className="text-xl text-gray-300">
             Get weekly emails about concerts in your city. No algorithm, no ads, just shows.
           </p>
         </div>
 
         {/* Form */}
-        <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-8 border border-white/20">
+        <div className="bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border">
           <form onSubmit={handleSubmit} className="space-y-6">
             {/* Email */}
             <div>
-              <label htmlFor="email" className="block text-white font-medium mb-2">
+              <label htmlFor="email" className="block text-text-primary font-medium mb-2">
                 Email Address
               </label>
               <input
@@ -144,21 +144,21 @@ export default function SubscribePage() {
                 required
                 value={formData.email}
                 onChange={e => setFormData({ ...formData, email: e.target.value })}
-                className="w-full px-4 py-3 rounded-lg bg-white/10 text-white border border-white/20 focus:border-accent-500 focus:outline-hidden placeholder-gray-400"
+                className="w-full px-4 py-3 rounded-lg bg-surface text-text-primary border border-border focus:border-accent-500 focus:outline-hidden placeholder-text-tertiary"
                 placeholder="you@example.com"
               />
             </div>
 
             {/* City */}
             <div>
-              <label htmlFor="city" className="block text-white font-medium mb-2">
+              <label htmlFor="city" className="block text-text-primary font-medium mb-2">
                 City
               </label>
               <select
                 id="city"
                 value={formData.city}
                 onChange={e => setFormData({ ...formData, city: e.target.value })}
-                className="w-full px-4 py-3 rounded-lg bg-white/10 text-white border border-white/20 focus:border-accent-500 focus:outline-hidden"
+                className="w-full px-4 py-3 rounded-lg bg-surface text-text-primary border border-border focus:border-accent-500 focus:outline-hidden"
               >
                 <option value="kitchener">Kitchener</option>
                 <option value="waterloo">Waterloo</option>
@@ -170,14 +170,14 @@ export default function SubscribePage() {
 
             {/* Genre */}
             <div>
-              <label htmlFor="genre" className="block text-white font-medium mb-2">
+              <label htmlFor="genre" className="block text-text-primary font-medium mb-2">
                 Genre Preference
               </label>
               <select
                 id="genre"
                 value={formData.genre}
                 onChange={e => setFormData({ ...formData, genre: e.target.value })}
-                className="w-full px-4 py-3 rounded-lg bg-white/10 text-white border border-white/20 focus:border-accent-500 focus:outline-hidden"
+                className="w-full px-4 py-3 rounded-lg bg-surface text-text-primary border border-border focus:border-accent-500 focus:outline-hidden"
               >
                 <option value="all">All Genres</option>
                 <option value="punk">Punk</option>
@@ -190,14 +190,14 @@ export default function SubscribePage() {
 
             {/* Frequency */}
             <div>
-              <label htmlFor="frequency" className="block text-white font-medium mb-2">
+              <label htmlFor="frequency" className="block text-text-primary font-medium mb-2">
                 Email Frequency
               </label>
               <select
                 id="frequency"
                 value={formData.frequency}
                 onChange={e => setFormData({ ...formData, frequency: e.target.value })}
-                className="w-full px-4 py-3 rounded-lg bg-white/10 text-white border border-white/20 focus:border-accent-500 focus:outline-hidden"
+                className="w-full px-4 py-3 rounded-lg bg-surface text-text-primary border border-border focus:border-accent-500 focus:outline-hidden"
               >
                 <option value="weekly">Weekly</option>
                 <option value="monthly">Monthly</option>
@@ -227,7 +227,7 @@ export default function SubscribePage() {
           </form>
 
           {/* Privacy note */}
-          <div className="mt-8 pt-6 border-t border-white/10">
+          <div className="mt-8 pt-6 border-t border-border">
             <p className="text-sm text-gray-400 text-center">
               We respect your privacy. No tracking, no ads, no selling your data.
               <br />
@@ -238,18 +238,18 @@ export default function SubscribePage() {
 
         {/* Alternative feeds */}
         <div className="mt-12 text-center">
-          <h2 className="text-2xl font-bold text-white mb-4">Prefer RSS or Calendar Sync?</h2>
+          <h2 className="text-2xl font-bold text-text-primary mb-4">Prefer RSS or Calendar Sync?</h2>
           <div className="flex flex-wrap justify-center gap-4">
             <a
               href="/api/feeds/ical?city=portland&genre=all"
-              className="px-6 py-3 bg-white/10 hover:bg-white/20 text-white rounded-lg border border-white/20 transition"
+              className="px-6 py-3 bg-surface hover:bg-surface text-text-primary rounded-lg border border-border transition"
             >
               <CalendarDays size={16} className="mr-2 inline" aria-hidden="true" />
               Subscribe to Calendar
             </a>
             <a
               href="/api/events/public?city=portland&genre=all"
-              className="px-6 py-3 bg-white/10 hover:bg-white/20 text-white rounded-lg border border-white/20 transition"
+              className="px-6 py-3 bg-surface hover:bg-surface text-text-primary rounded-lg border border-border transition"
             >
               <Rss size={16} className="mr-2 inline" aria-hidden="true" />
               JSON Feed


### PR DESCRIPTION
## Summary

Completes the systematic light-theme contrast fix started in #356. Applies the same (now-validated) token mapping to the P1/P2 public pages not yet covered.

## Pages
`EventRecapPage`, `SubscribePage`, `ResetPasswordPage`, `ActivatePage`, `PrivacyPage`, `NotFoundPage`, `EmbedPage`, `SharePreviewPage`.

## Mapping (same as #356)
- `text-white` → `text-text-primary`
- `text-white/N` → `text-text-secondary` (/90–70) / `text-text-tertiary` (/60–50) by opacity
- `bg-white/N` → `bg-surface`, `border-white/N` → `border-border`
- `placeholder-gray-400` → `placeholder-text-tertiary` (form inputs)

`EventRecapPage`'s glassmorphism (`bg-white/5` + `backdrop-blur` over a themed gradient) is handled by the same swap — `bg-surface`/`border-border` render as a subtle light panel on light themes and ~unchanged on dark, so no bespoke rework was needed. No keep-white cases here (no `text-white` on fixed colored buttons).

## Testing
- `npm run lint` — clean (0 errors)
- `npm test -- --run` — 192 passed
- `npm run build` — succeeds

With this merged, the public surface is fully swept off hardcoded white. Remaining light-theme work is layout/visual fine-tuning caught on the deploy (the "weirdly wide / cramped" class), not contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)