### PR TITLE
fix(theme): light-theme WCAG AA compliance + finish contrast sweep

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -708,7 +708,7 @@ function App() {
         {/* First-time onboarding hint */}
         {!isArchived && showHint && selectedBands.length === 0 && bands.length > 0 && (
           <div className="flex items-start justify-between gap-2 rounded-lg border border-accent-500/20 bg-accent-500/10 px-3 py-2.5 text-xs sm:items-center sm:gap-3 sm:px-4 sm:py-3 sm:text-sm">
-            <p className="text-accent-300">
+            <p className="text-text-secondary">
               <span className="font-semibold">How it works:</span> Tap any performer to add them to{' '}
               <span className="font-semibold">My Route</span> — your personal lineup for the night.
             </p>
@@ -726,7 +726,7 @@ function App() {
         {!isArchived && eventData?.reveal_mode === 1 && (
           <div className="flex items-start gap-2 rounded-lg border border-accent-500/20 bg-accent-500/10 px-3 py-2.5 text-xs sm:items-center sm:gap-3 sm:px-4 sm:py-3 sm:text-sm">
             <Bell size={16} className="shrink-0 text-accent-400" aria-hidden="true" />
-            <p className="text-accent-300">
+            <p className="text-text-secondary">
               <span className="font-semibold">More bands dropping soon.</span>{' '}
               <a href="/subscribe" className="underline hover:text-accent-200 transition-colors">
                 Subscribe for updates

--- a/frontend/src/components/EventsPageSkeleton.jsx
+++ b/frontend/src/components/EventsPageSkeleton.jsx
@@ -5,8 +5,8 @@ export default function EventsPageSkeleton() {
     <div className="container mx-auto px-4 py-8 max-w-7xl">
       {/* Fake header */}
       <div className="mb-8">
-        <div className="bg-white/8 animate-shimmer h-10 w-40 mb-2 rounded" aria-hidden="true" />
-        <div className="bg-white/8 animate-shimmer h-5 w-72 rounded" aria-hidden="true" />
+        <div className="bg-surface animate-shimmer h-10 w-40 mb-2 rounded" aria-hidden="true" />
+        <div className="bg-surface animate-shimmer h-5 w-72 rounded" aria-hidden="true" />
       </div>
       <EventCardSkeletonList count={3} />
     </div>

--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -269,7 +269,7 @@ function LiveContextBar({
             aria-label={isFiltersOpen ? 'Hide filters' : 'Show filters'}
             aria-expanded={isFiltersOpen}
             aria-controls="live-filter-panel"
-            className="ml-auto inline-flex min-h-[40px] items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-2 text-xs text-text-tertiary hover:text-text-secondary transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border"
+            className="ml-auto inline-flex min-h-[40px] items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-2 text-xs text-text-tertiary hover:text-text-secondary transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
           >
             <span>Filters</span>
             <ChevronDown

--- a/frontend/src/components/ScheduleSkeleton.jsx
+++ b/frontend/src/components/ScheduleSkeleton.jsx
@@ -6,13 +6,13 @@ export default function ScheduleSkeleton() {
       <div className="w-full max-w-6xl mx-auto">
         {/* Fake section banner */}
         <div className="flex items-center mb-6">
-          <div className="bg-white/8 animate-shimmer h-10 w-36 rounded-lg" aria-hidden="true" />
-          <div className="flex-1 h-1 bg-white/10 ml-4" aria-hidden="true" />
+          <div className="bg-surface animate-shimmer h-10 w-36 rounded-lg" aria-hidden="true" />
+          <div className="flex-1 h-1 bg-surface ml-4" aria-hidden="true" />
         </div>
         {/* Fake time-group pill */}
         <div className="flex items-center mb-4">
-          <div className="bg-white/8 animate-shimmer h-9 w-28 rounded-lg" aria-hidden="true" />
-          <div className="flex-1 h-0.5 bg-white/10 ml-4" aria-hidden="true" />
+          <div className="bg-surface animate-shimmer h-9 w-28 rounded-lg" aria-hidden="true" />
+          <div className="flex-1 h-0.5 bg-surface ml-4" aria-hidden="true" />
         </div>
         {/* 5 fake band cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 ml-0 sm:ml-4">

--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -520,7 +520,7 @@ function ScheduleView({
               {pastByTime.map(({ time, bands: timeBands }) => (
                 <div key={time} className="relative ml-0 sm:ml-4 opacity-60">
                   <div className="flex items-center mb-4">
-                    <h3 className="bg-surface text-text-disabled font-mono font-semibold text-base md:text-lg px-4 py-2 rounded-lg shadow">
+                    <h3 className="bg-surface text-text-tertiary font-mono font-semibold text-base md:text-lg px-4 py-2 rounded-lg shadow">
                       {time === 'TBD' ? 'Time To Be Announced' : formatTime(time)}
                     </h3>
                     <div className="flex-1 h-0.5 bg-surface ml-4"></div>

--- a/frontend/src/components/TimeFilter.jsx
+++ b/frontend/src/components/TimeFilter.jsx
@@ -27,7 +27,7 @@ export default function TimeFilter({ selectedFilter, onFilterChange, className =
         title={selectedOption.description}
         className={`min-h-[44px] w-full appearance-none rounded-full border px-4 py-2 pr-10 text-sm font-medium transition-colors focus:border-accent-500 focus:outline-hidden ${
           selectedFilter === 'all'
-            ? 'border-white/10 bg-white/5 text-white hover:bg-white/10'
+            ? 'border-border bg-surface text-text-primary hover:bg-surface'
             : 'border-accent-500/35 bg-accent-500/10 text-accent-300'
         }`}
       >
@@ -40,7 +40,7 @@ export default function TimeFilter({ selectedFilter, onFilterChange, className =
       <ChevronDown
         size={16}
         aria-hidden="true"
-        className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-white/60"
+        className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-text-tertiary"
       />
     </div>
   )

--- a/frontend/src/components/ui/Skeleton.jsx
+++ b/frontend/src/components/ui/Skeleton.jsx
@@ -4,7 +4,7 @@ function SkeletonBlock({ className = '' }) {
 
 export function BandCardSkeleton() {
   return (
-    <div className="w-full p-4 rounded-xl bg-gradient-card border border-white/10 relative">
+    <div className="w-full p-4 rounded-xl bg-gradient-card border border-border relative">
       <SkeletonBlock className="absolute top-2 right-2 h-11 w-11 rounded-full" />
       <div className="flex flex-col items-center gap-2 pr-10">
         <SkeletonBlock className="h-6 w-32 rounded-lg" />
@@ -31,7 +31,7 @@ export function BandCardSkeletonGrid({ count = 6 }) {
 
 export function EventCardSkeleton() {
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/3 p-6" role="status" aria-label="Loading event">
+    <div className="rounded-2xl border border-border bg-surface p-6" role="status" aria-label="Loading event">
       <SkeletonBlock className="h-7 w-48 mb-3" />
       <SkeletonBlock className="h-4 w-36 mb-4" />
       <div className="flex gap-6 mb-4">
@@ -59,7 +59,7 @@ export function EventCardSkeletonList({ count = 3 }) {
 export function BandProfileSkeleton() {
   return (
     <div className="min-h-screen" role="status" aria-label="Loading band profile">
-      <div className="sticky top-0 z-50 border-b border-white/10 bg-bg-navy/95">
+      <div className="sticky top-0 z-50 border-b border-border bg-bg-navy/95">
         <div className="container mx-auto px-4 max-w-6xl">
           <div className="h-14" aria-hidden="true" />
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -225,9 +225,9 @@
   --color-primary-700: #9f1239;
 
   --color-accent-300: #fdba74;
-  --color-accent-400: #f97316;
-  --color-accent-500: #c2410c;
-  --color-accent-600: #9a3412;
+  --color-accent-400: #9a3412;
+  --color-accent-500: #7c2d12;
+  --color-accent-600: #5f2410;
 
   --color-bg-navy: #fff8f1;
   --color-bg-purple: #f3dfca;
@@ -236,12 +236,12 @@
 
   --color-text-primary: #1c1917;
   --color-text-secondary: #44403c;
-  --color-text-tertiary: #78716c;
+  --color-text-tertiary: #57534e;
   --color-text-disabled: #a8a29e;
   --color-text-inverse: #fafaf9;
 
   --color-surface: rgba(28, 25, 23, 0.04);
-  --color-border: rgba(28, 25, 23, 0.12);
+  --color-border: rgba(28, 25, 23, 0.2);
 
   --color-band-navy: #fff8f1;
   --color-band-purple: #f3dfca;
@@ -277,9 +277,9 @@
   --color-primary-700: #334155;
 
   --color-accent-300: #93c5fd;
-  --color-accent-400: #60a5fa;
-  --color-accent-500: #3b82f6;
-  --color-accent-600: #2563eb;
+  --color-accent-400: #2563eb;
+  --color-accent-500: #1d4ed8;
+  --color-accent-600: #1e3a8a;
 
   --color-bg-navy: #f8fafc;
   --color-bg-purple: #f1f5f9;
@@ -288,12 +288,12 @@
 
   --color-text-primary: #0f172a;
   --color-text-secondary: #334155;
-  --color-text-tertiary: #64748b;
+  --color-text-tertiary: #475569;
   --color-text-disabled: #94a3b8;
   --color-text-inverse: #f8fafc;
 
   --color-surface: rgba(15, 23, 42, 0.04);
-  --color-border: rgba(15, 23, 42, 0.12);
+  --color-border: rgba(15, 23, 42, 0.2);
 
   --color-band-navy: #f8fafc;
   --color-band-purple: #f1f5f9;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -73,7 +73,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <BrowserRouter>
             <a
               href="#main-content"
-              className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-9999 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:rounded focus:text-sm focus:font-medium"
+              className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[9999] focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:rounded focus:text-sm focus:font-medium"
             >
               Skip to main content
             </a>

--- a/frontend/src/pages/ArtistsPage.jsx
+++ b/frontend/src/pages/ArtistsPage.jsx
@@ -18,14 +18,14 @@ function ArtistCard({ artist }) {
   return (
     <Link
       to={buildBandProfileHref(artist.name)}
-      className="flex items-center gap-4 rounded-xl border border-white/10 bg-gradient-card p-4 transition hover:scale-[1.01] hover:border-accent-400/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+      className="flex items-center gap-4 rounded-xl border border-border bg-gradient-card p-4 transition hover:scale-[1.01] hover:border-accent-400/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
     >
       {artist.photo_url ? (
         <img
           src={artist.photo_url}
           alt=""
           loading="lazy"
-          className="h-16 w-16 shrink-0 rounded-full object-cover ring-2 ring-white/15"
+          className="h-16 w-16 shrink-0 rounded-full object-cover ring-2 ring-border"
         />
       ) : (
         <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-accent-500/20 text-2xl font-bold text-accent-400">
@@ -143,7 +143,7 @@ export default function ArtistsPage() {
             onChange={e => setQuery(e.target.value)}
             placeholder="Search artists by name or genre…"
             aria-label="Search artists by name or genre"
-            className="min-h-[44px] w-full rounded-full border border-white/15 bg-bg-purple/60 py-3 pl-10 pr-4 text-text-primary placeholder:text-text-tertiary focus:border-accent-400 focus:outline-hidden"
+            className="min-h-[44px] w-full rounded-full border border-border bg-bg-purple/60 py-3 pl-10 pr-4 text-text-primary placeholder:text-text-tertiary focus:border-accent-400 focus:outline-hidden"
           />
         </div>
 

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -904,7 +904,7 @@ export default function BandProfilePage() {
               <Card variant="elevated" className="flex items-center justify-center py-12 text-center">
                 <div>
                   <p className="text-text-tertiary text-lg mb-1">No performances on record yet.</p>
-                  <p className="text-text-disabled text-sm">Check back after the next event is announced.</p>
+                  <p className="text-text-tertiary text-sm">Check back after the next event is announced.</p>
                 </div>
               </Card>
             )}

--- a/frontend/src/pages/SubscribePage.jsx
+++ b/frontend/src/pages/SubscribePage.jsx
@@ -241,14 +241,14 @@ export default function SubscribePage() {
           <h2 className="text-2xl font-bold text-text-primary mb-4">Prefer RSS or Calendar Sync?</h2>
           <div className="flex flex-wrap justify-center gap-4">
             <a
-              href="/api/feeds/ical?city=portland&genre=all"
+              href="/api/feeds/ical?city=waterloo&genre=all"
               className="px-6 py-3 bg-surface hover:bg-surface text-text-primary rounded-lg border border-border transition"
             >
               <CalendarDays size={16} className="mr-2 inline" aria-hidden="true" />
               Subscribe to Calendar
             </a>
             <a
-              href="/api/events/public?city=portland&genre=all"
+              href="/api/events/public?city=waterloo&genre=all"
               className="px-6 py-3 bg-surface hover:bg-surface text-text-primary rounded-lg border border-border transition"
             >
               <Rss size={16} className="mr-2 inline" aria-hidden="true" />

--- a/frontend/src/pages/VenuePage.jsx
+++ b/frontend/src/pages/VenuePage.jsx
@@ -11,7 +11,7 @@ import { safeExternalHref } from '../utils/urlSafety'
 
 function PerformanceRow({ perf }) {
   return (
-    <div className="rounded-lg border border-white/10 bg-bg-purple/40 p-4">
+    <div className="rounded-lg border border-border bg-bg-purple/40 p-4">
       {perf.band_name && (
         <Link
           to={buildBandProfileHref(perf.band_name)}

--- a/frontend/src/pages/VenuesPage.jsx
+++ b/frontend/src/pages/VenuesPage.jsx
@@ -19,7 +19,7 @@ function VenueCard({ venue }) {
   return (
     <Link
       to={`/venue/${venue.id}`}
-      className="flex items-center gap-4 rounded-xl border border-white/10 bg-gradient-card p-4 transition hover:scale-[1.01] hover:border-accent-400/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+      className="flex items-center gap-4 rounded-xl border border-border bg-gradient-card p-4 transition hover:scale-[1.01] hover:border-accent-400/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
     >
       <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-accent-500/20 text-accent-400">
         <MapPin size={22} aria-hidden="true" />
@@ -134,7 +134,7 @@ export default function VenuesPage() {
             onChange={e => setQuery(e.target.value)}
             placeholder="Search venues by name or city…"
             aria-label="Search venues by name or city"
-            className="min-h-[44px] w-full rounded-full border border-white/15 bg-bg-purple/60 py-3 pl-10 pr-4 text-text-primary placeholder:text-text-tertiary focus:border-accent-400 focus:outline-hidden"
+            className="min-h-[44px] w-full rounded-full border border-border bg-bg-purple/60 py-3 pl-10 pr-4 text-text-primary placeholder:text-text-tertiary focus:border-accent-400 focus:outline-hidden"
           />
         </div>
 


### PR DESCRIPTION
## Summary
The earlier sweep routed everything through theme tokens, but the **token values themselves failed WCAG AA** on `daybreak`/`silver-lining` (a11y review). This tunes them at the source — computed, not eyeballed — and finishes the files the sweep missed.

## Token tuning (`index.css`) — verified ≥4.5:1 on the worst-case surface (`bg-purple`)
| token | before | after | result |
|---|---|---|---|
| daybreak accent-400 (text, 80 uses) | `#f97316` 2.16:1 | `#9a3412` | **5.64:1** |
| silver accent-400 | `#60a5fa` 2.32:1 | `#2563eb` | **4.72:1** |
| daybreak text-tertiary | `#78716c` 3.71:1 | `#57534e` | **5.89:1** |
| silver text-tertiary | `#64748b` 4.34:1 | `#475569` | **6.92:1** |

Accent 500/600 darkened to keep the ramp ordered; `--color-border` 0.12→0.2 alpha on light themes for visible edges. **Dark themes unchanged.**

## Finish the sweep (missed files)
`TimeFilter` (was live-unreadable in the schedule view), the three skeleton components, and `ArtistsPage`/`VenuesPage`/`VenuePage` → `bg-surface`/`border-border`/`text-text-*`.

## Targeted a11y fixes
- `text-accent-300` onboarding hints → `text-text-secondary`
- `text-text-disabled` used for real content (past-event headers, empty state) → `text-text-tertiary`
- `LiveContextBar` Filters focus ring `ring-border` (12% ink, invisible) → `ring-accent-400`
- skip-link `focus:z-9999` → `focus:z-[9999]` (invalid Tailwind v4 class)
- SubscribePage feed URLs `?city=portland` → `waterloo`

## Testing
lint clean · 192 tests · build ok · new token values confirmed in built CSS · AA re-checked from applied hexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)