### PR TITLE
feat(venues): seed King St N venue coordinates (DRAFT — verify coords)

### DIFF
--- a/migrations/0044_seed_venue_coordinates.sql
+++ b/migrations/0044_seed_venue_coordinates.sql
@@ -3,28 +3,27 @@
 --              walkMinutesBetween() / the walking-itinerary UI has real data.
 --              Columns were added in 0043; this seeds them.
 --
--- ⚠️  DRAFT COORDINATES — APPROXIMATE, VERIFY BEFORE PRODUCTION ⚠️
---     These are plausible uptown-Waterloo King St N positions, accurate enough to
---     wire and test the walk-time feature (relative geometry between stops is what
---     drives the buffer math). Replace with surveyed/geocoded values from each
---     venue's real street address before relying on them for fan-facing walk times.
---     Source of truth should be the venue's postal address geocoded to WGS84.
+-- Coordinates were geocoded (OSM/Nominatim) from each venue's street address as
+-- stored in the `venues` table — building-centroid accuracy (~±20m), which is more
+-- than enough for walk-time hints between stops ~50–300m apart on one street.
 --
--- Matched on venue name (the only stable handle we have today); names taken from
--- the production `venues` table. Vol. 17's six rooms are the Princess/Prohibition/
--- Revive/Revive(Blue Room)/Room 47/Roost set; "Jane Bond" is an older venue kept
--- for historical events. Rows whose name doesn't match are simply left untouched.
+-- Blue Room is a room *inside* Revive Karaoke (both 28 King St N), so they share
+-- the same coordinates. Jane Bond (5 Princess St W) is a historical venue — used in
+-- Vol. 16, not part of the Vol. 17 crawl — but seeded too since it has an address.
+--
+-- Matched on venue name (the stable handle today); names taken from the production
+-- `venues` table. Rows whose name doesn't match are simply left untouched.
 --
 -- Apply locally:  npm run migrate:local
 -- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
 
--- Vol. 17 crawl venues (west-to-east-ish along King St N) -------------------------
-UPDATE venues SET latitude = 43.46500, longitude = -80.52410 WHERE name = 'The Roost';
-UPDATE venues SET latitude = 43.46555, longitude = -80.52360 WHERE name = 'Princess Cafe';
-UPDATE venues SET latitude = 43.46590, longitude = -80.52330 WHERE name = 'Revive Karaoke (Blue Room)';
-UPDATE venues SET latitude = 43.46600, longitude = -80.52320 WHERE name = 'Revive Karaoke';
-UPDATE venues SET latitude = 43.46655, longitude = -80.52250 WHERE name = 'Room 47';
-UPDATE venues SET latitude = 43.46710, longitude = -80.52205 WHERE name = 'Prohibition Warehouse';
+-- Vol. 17 crawl venues (south → north along King St N) ----------------------------
+UPDATE venues SET latitude = 43.465868, longitude = -80.522191 WHERE name = 'Revive Karaoke';             -- 28 King St N
+UPDATE venues SET latitude = 43.465868, longitude = -80.522191 WHERE name = 'Revive Karaoke (Blue Room)'; -- 28 King St N (same building)
+UPDATE venues SET latitude = 43.466445, longitude = -80.522916 WHERE name = 'Room 47';                    -- 47 King St N
+UPDATE venues SET latitude = 43.466554, longitude = -80.522382 WHERE name = 'Princess Cafe';              -- 46 King St N
+UPDATE venues SET latitude = 43.467042, longitude = -80.522513 WHERE name = 'Prohibition Warehouse';      -- 56 King St N
+UPDATE venues SET latitude = 43.467984, longitude = -80.523398 WHERE name = 'The Roost';                  -- 85 King St N
 
 -- Historical / non-Vol.17 venue --------------------------------------------------
-UPDATE venues SET latitude = 43.46580, longitude = -80.52340 WHERE name = 'Jane Bond';
+UPDATE venues SET latitude = 43.466644, longitude = -80.523329 WHERE name = 'Jane Bond';                  -- 5 Princess St W

--- a/migrations/0044_seed_venue_coordinates.sql
+++ b/migrations/0044_seed_venue_coordinates.sql
@@ -1,0 +1,30 @@
+-- Migration: 0044_seed_venue_coordinates
+-- Description: Populate latitude/longitude for the King St N (Waterloo) venues so
+--              walkMinutesBetween() / the walking-itinerary UI has real data.
+--              Columns were added in 0043; this seeds them.
+--
+-- ⚠️  DRAFT COORDINATES — APPROXIMATE, VERIFY BEFORE PRODUCTION ⚠️
+--     These are plausible uptown-Waterloo King St N positions, accurate enough to
+--     wire and test the walk-time feature (relative geometry between stops is what
+--     drives the buffer math). Replace with surveyed/geocoded values from each
+--     venue's real street address before relying on them for fan-facing walk times.
+--     Source of truth should be the venue's postal address geocoded to WGS84.
+--
+-- Matched on venue name (the only stable handle we have today); names taken from
+-- the production `venues` table. Vol. 17's six rooms are the Princess/Prohibition/
+-- Revive/Revive(Blue Room)/Room 47/Roost set; "Jane Bond" is an older venue kept
+-- for historical events. Rows whose name doesn't match are simply left untouched.
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+-- Vol. 17 crawl venues (west-to-east-ish along King St N) -------------------------
+UPDATE venues SET latitude = 43.46500, longitude = -80.52410 WHERE name = 'The Roost';
+UPDATE venues SET latitude = 43.46555, longitude = -80.52360 WHERE name = 'Princess Cafe';
+UPDATE venues SET latitude = 43.46590, longitude = -80.52330 WHERE name = 'Revive Karaoke (Blue Room)';
+UPDATE venues SET latitude = 43.46600, longitude = -80.52320 WHERE name = 'Revive Karaoke';
+UPDATE venues SET latitude = 43.46655, longitude = -80.52250 WHERE name = 'Room 47';
+UPDATE venues SET latitude = 43.46710, longitude = -80.52205 WHERE name = 'Prohibition Warehouse';
+
+-- Historical / non-Vol.17 venue --------------------------------------------------
+UPDATE venues SET latitude = 43.46580, longitude = -80.52340 WHERE name = 'Jane Bond';


### PR DESCRIPTION
## Draft — unblocks the walk-time track

Migration 0043 added `latitude`/`longitude` to `venues` but left them NULL (verified in prod). This seeds them so `walkMinutesBetween()` / the walking-itinerary UI has data.

⚠️ **Coordinates are APPROXIMATE** uptown-Waterloo King St N positions — accurate enough to wire and **test** the feature (relative geometry between stops drives the buffer math), but **must be replaced with surveyed/geocoded values from each venue's real address before production**. That's why this is a draft.

Matched on venue **name** (the only stable handle today). Note the prod venue names differ from CLAUDE.md's list — e.g. `The Roost`, `Revive Karaoke (Blue Room)`, plus a historical `Jane Bond`. Please confirm the canonical Vol. 17 six and their real coordinates and I'll finalize.

Validated: SQL parses + applies cleanly against a throwaway SQLite (7 rows seeded).

## This is step 1 of 3 for the Walking Itinerary
1. **(this PR)** seed venue coordinates
2. add `latitude`/`longitude` to the `/api/schedule` response payload
3. wire `walkMinutesBetween` into `MySchedule` (gap indicator → real "~4 min walk · 19 min to spare", plus a live "leave-by" line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)