### PR TITLE
feat(schedule): walk-time + buffer in My Route (walking itinerary)

### DIFF
--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -24,6 +24,25 @@ import { HIGHLIGHTED_BANDS, getHighlightMessage } from '../config/highlights.jsx
 import { copyToClipboard } from '../utils/clipboard'
 import { formatTimeRange } from '../utils/timeFormat'
 import BandCard from './BandCard'
+import { walkMinutesBetween } from '../utils/walkTime'
+
+// Label a break between two sets at the same venue.
+function formatBreakLabel(mins) {
+  if (mins >= 60) {
+    const h = Math.floor(mins / 60)
+    const m = mins % 60
+    return m > 0 ? `${h}h ${m}m break` : `${h}h break`
+  }
+  return `${mins} min break`
+}
+
+// "Buffer" = minutes of slack after walking to the next venue (gap − walk) — the
+// crawl's core decision value: can I watch this set and still make the next one?
+function bufferLabel(buffer) {
+  if (buffer < 0) return `overlaps by ${Math.abs(buffer)} min`
+  if (buffer < 3) return 'leave right after'
+  return `${buffer} min to spare`
+}
 
 function MySchedule({
   bands,
@@ -241,22 +260,6 @@ function MySchedule({
         </div>
       </div>
     )
-  }
-
-  // "Room 47" is across the street from the main venues at the specific event this app was
-  // originally built for. Warn users when consecutive bands in their schedule require crossing
-  // between Room 47 and any other venue (or vice versa).
-  const CROSS_STREET_VENUE = 'Room 47'
-  const travelWarnings = {}
-  for (let i = 0; i < visibleBands.length - 1; i++) {
-    const current = visibleBands[i]
-    const next = visibleBands[i + 1]
-    const currentIsCrossStreet = current.venue === CROSS_STREET_VENUE
-    const nextIsCrossStreet = next.venue === CROSS_STREET_VENUE
-
-    if (currentIsCrossStreet !== nextIsCrossStreet) {
-      travelWarnings[next.id] = `${next.venue} is across the street`
-    }
   }
 
   // Get contextual reminders based on schedule and time
@@ -509,32 +512,49 @@ function MySchedule({
         {visibleBands.map((band, idx) => {
           const hasConflict = conflicts.some(c => c.band1 === band.id || c.band2 === band.id)
           const hasOverlap = overlaps.some(c => c.band1 === band.id || c.band2 === band.id)
-          const travelWarning = travelWarnings[band.id]
           const showDreReminder = band.id === firstHighlightedBandId
 
-          // Calculate gap from previous band
-          let timeGap = null
+          // Walk + buffer from the previous set — the crawl's "can I make it?" math.
+          let transition = null
           if (idx > 0) {
             const prevBand = visibleBands[idx - 1]
-            const gapMs = band.startMs - prevBand.endMs
-            const gapMinutes = Math.floor(gapMs / 1000 / 60)
-
-            // Only show breaks 15+ minutes (venues are close, don't need tight warnings)
-            if (gapMinutes >= 15) {
-              if (gapMinutes >= 60) {
-                const hours = Math.floor(gapMinutes / 60)
-                const mins = gapMinutes % 60
-                timeGap = mins > 0 ? `${hours}h ${mins}m break` : `${hours}h break`
-              } else {
-                timeGap = `${gapMinutes} min break`
-              }
+            const gapMinutes = Math.floor((band.startMs - prevBand.endMs) / 1000 / 60)
+            const venueChanged = Boolean(band.venue && prevBand.venue && band.venue !== prevBand.venue)
+            const walkMin = venueChanged
+              ? walkMinutesBetween(
+                  { latitude: prevBand.venue_lat, longitude: prevBand.venue_lng },
+                  { latitude: band.venue_lat, longitude: band.venue_lng }
+                )
+              : null
+            const buffer = walkMin != null ? gapMinutes - walkMin : null
+            // Show a transition when there's a walk to make, or a notable (15+ min) break.
+            if (walkMin != null || gapMinutes >= 15) {
+              transition = { gapMinutes, walkMin, buffer, venue: band.venue }
             }
           }
 
           return (
             <div key={band.id} className="relative mb-6">
-              {/* Time gap indicator */}
-              {timeGap && <div className="text-center text-text-tertiary text-xs italic py-3">{timeGap}</div>}
+              {/* Walk / break transition from the previous set */}
+              {transition && (
+                <div className="flex flex-wrap items-center justify-center gap-1.5 py-3 text-xs">
+                  {transition.walkMin != null ? (
+                    <span className="inline-flex flex-wrap items-center justify-center gap-1.5 text-text-tertiary">
+                      <Footprints size={14} aria-hidden="true" />
+                      <span>
+                        ~{transition.walkMin} min walk to {transition.venue}
+                      </span>
+                      {transition.buffer != null && (
+                        <span className={transition.buffer < 3 ? 'font-semibold text-error-600' : 'text-text-tertiary'}>
+                          · {bufferLabel(transition.buffer)}
+                        </span>
+                      )}
+                    </span>
+                  ) : (
+                    <span className="italic text-text-tertiary">{formatBreakLabel(transition.gapMinutes)}</span>
+                  )}
+                </div>
+              )}
               {showDreReminder && (
                 <div className="text-center text-text-secondary text-xs italic pb-2 flex items-center justify-center gap-2">
                   <Smile size={14} className="text-yellow-300" aria-hidden="true" />
@@ -542,14 +562,6 @@ function MySchedule({
                 </div>
               )}
               <div className="space-y-2">
-                {/* Travel warning - appears ABOVE the band card */}
-                {travelWarning && (
-                  <div className="text-xs text-blue-300 bg-blue-900/30 px-3 py-1.5 rounded border border-blue-500/30 flex items-center gap-2">
-                    <Footprints size={14} aria-hidden="true" title="Travel time alert" />
-                    <span>Heads up, the next show at {travelWarning}</span>
-                  </div>
-                )}
-
                 <div className={getTimeStatus(band).status === 'now' ? 'playing-now rounded-xl' : ''}>
                   <BandCard
                     band={band}

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -19,9 +19,8 @@ export async function onRequestGet(context) {
       env.SCHEDULE_CACHE_TTL_SECONDS || "60",
       10,
     );
-    const cacheTtl = Number.isFinite(configuredTtl) && configuredTtl >= 0
-      ? configuredTtl
-      : 60;
+    const cacheTtl =
+      Number.isFinite(configuredTtl) && configuredTtl >= 0 ? configuredTtl : 60;
 
     let event;
 
@@ -80,7 +79,9 @@ export async function onRequestGet(context) {
         p.end_time as endTime,
         b.social_links,
         b.photo_url,
-        v.name as venue
+        v.name as venue,
+        v.latitude as venue_lat,
+        v.longitude as venue_lng
       FROM performances p
       INNER JOIN band_profiles b ON p.band_profile_id = b.id
       LEFT JOIN venues v ON p.venue_id = v.id
@@ -99,11 +100,11 @@ export async function onRequestGet(context) {
       // Extract time from datetime string or time-only format
       // Handles: "2026-01-17 20:00" -> "20:00" OR "20:00" -> "20:00"
       const extractTime = (datetime) => {
-        if (!datetime || datetime === 'TBD') return 'TBD';
+        if (!datetime || datetime === "TBD") return "TBD";
         // If it contains a space, it's a full datetime - extract time part
-        if (datetime.includes(' ')) {
-          const timePart = datetime.split(' ')[1];
-          return timePart ? timePart.substring(0, 5) : 'TBD'; // Get HH:MM
+        if (datetime.includes(" ")) {
+          const timePart = datetime.split(" ")[1];
+          return timePart ? timePart.substring(0, 5) : "TBD"; // Get HH:MM
         }
         // Otherwise, it's already in time format (HH:MM or HH:MM:SS)
         return datetime.substring(0, 5); // Get HH:MM
@@ -115,7 +116,13 @@ export async function onRequestGet(context) {
         if (band.social_links) {
           const links = JSON.parse(band.social_links);
           // Prioritize website, then bandcamp, then instagram, etc.
-          primaryUrl = links.website || links.bandcamp || links.instagram || links.facebook || links.spotify || null;
+          primaryUrl =
+            links.website ||
+            links.bandcamp ||
+            links.instagram ||
+            links.facebook ||
+            links.spotify ||
+            null;
         }
       } catch (_) {
         // Ignore JSON parse errors
@@ -128,6 +135,8 @@ export async function onRequestGet(context) {
         name: band.name,
         photo_url: band.photo_url ?? null,
         venue: band.venue ?? null,
+        venue_lat: typeof band.venue_lat === "number" ? band.venue_lat : null,
+        venue_lng: typeof band.venue_lng === "number" ? band.venue_lng : null,
         date: event.date,
         startTime: extractTime(band.startTime),
         endTime: extractTime(band.endTime),


### PR DESCRIPTION
## Summary
Brings the half-built walk-time feature to life — steps 2–3 of the walking-itinerary track (step 1 is the coords migration #360). My Route now answers the crawl's core question: *can I watch this set and still make the next one?*

## Changes
**API** (`functions/api/schedule.js`): `/api/schedule` now returns `venue_lat`/`venue_lng` per performance (additive; `null` when a venue has no coords).

**UI** (`MySchedule`): replaced the hardcoded `"Room 47 is across the street"` string with real data. Between consecutive sets at **different** venues it computes `walkMinutesBetween()` and renders:

> 🦶 ~3 min walk to Roost · **19 min to spare**

The **buffer** = `gap − walk`:
- `≥ 3 min` → neutral "N min to spare"
- `< 3 min` → red, bold "leave right after"
- negative → red, bold "overlaps by N min"

Same-venue gaps keep the "N min break" label.

## Safety / dependencies
- **Degrades gracefully**: no coords → `walkMinutesBetween` returns `null` → falls back to the break label (today's behaviour). So this is safe to merge before #360.
- **#360** (venue coords) unlocks the actual walk display.
- **Visual verification** is gated on a *published* event whose venues have coords — Vol. 16 is unpublished and Vol. 17 isn't in the DB yet, so the walk lines won't render in prod until that event data exists.

## Testing
lint clean · 192 tests · build ok. The core `walkMinutesBetween` math is already unit-tested; coords sanity-checked in #360 (adjacent rooms ~1 min, ends ~3 min). A `MySchedule` render test for the buffer thresholds is a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)