### PR TITLE
feat(events): seed Vol. 17 event (unpublished, no schedule)

### DIFF
--- a/migrations/0045_seed_vol17_event.sql
+++ b/migrations/0045_seed_vol17_event.sql
@@ -1,0 +1,30 @@
+-- Migration: 0045_seed_vol17_event
+-- Description: Create the Long Weekend Band Crawl - Vol. 17 event (the target event),
+--              modeled on Vol. 16. UNPUBLISHED on purpose — the lineup (bands → venues
+--              → set times, i.e. the `performances` rows) is added later via the admin
+--              UI, and the team flips is_published when it's ready. No performances are
+--              seeded here.
+--
+-- Date/ticket URL from the official ticketscene listing (event 62461): Sunday,
+-- August 2, 2026, doors 6:30 PM / show 6:45 PM, 19+, Waterloo (6 King St N venues).
+--
+-- Idempotent: only inserts if an event with slug 'lwbc17' doesn't already exist, so
+-- re-applying (or running where it was created via the admin UI) is a no-op.
+--
+-- Numbered 0045 to sit after 0044 (venue coordinates). Apply order is by filename.
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+INSERT INTO events (name, date, slug, is_published, status, ticket_url, social_links, city, reveal_mode)
+SELECT
+  'Long Weekend Band Crawl - Vol. 17',
+  '2026-08-02',
+  'lwbc17',
+  0,        -- unpublished: do NOT surface publicly until the team publishes it
+  'draft',
+  'https://ticketscene.ca/events/62461/',
+  '{"website":null,"instagram":null,"facebook":null,"x":null,"tiktok":null,"youtube":null,"bandcamp":null}',
+  'Waterloo, ON',
+  0
+WHERE NOT EXISTS (SELECT 1 FROM events WHERE slug = 'lwbc17');


### PR DESCRIPTION
## Summary
Creates the **Long Weekend Band Crawl - Vol. 17** event, modeled on Vol. 16. **Unpublished and scheduleless on purpose** — you add the lineup and flip publish.

| field | value |
|---|---|
| name | Long Weekend Band Crawl - Vol. 17 |
| date | 2026-08-02 (Sun) |
| slug | `lwbc17` |
| city | Waterloo, ON |
| ticket_url | https://ticketscene.ca/events/62461/ |
| **is_published** | **0** (won't surface publicly) |
| status | draft |

## What's NOT here (yours to do)
- **The schedule**: `performances` rows (band → venue → set time). The 6 venues already exist (and get coords from #360); the 22 Vol. 17 bands from the ticketscene listing need profiles + assignments via the admin UI.
- **Publishing**: flip `is_published` when the lineup's ready.

## Notes
- Idempotent (guarded on `slug='lwbc17'`), so safe to merge before or after the admin team touches it.
- Numbered 0045 to sit after 0044 (venue coords, #360). Migrations apply in filename order; a gap if #360 lands later is fine.
- Merging this + #360 + #361 is what makes the **walk-time feature visible** once you add the schedule and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)