### PR TITLE
fix(timeline): show full crawl history on the landing page

### DIFF
--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -41,7 +41,7 @@ export default function EventTimeline() {
         }
         setError(null)
 
-        const data = await fetchPublicJson('/api/events/timeline', {}, 'Failed to fetch events timeline')
+        const data = await fetchPublicJson('/api/events/timeline?pastLimit=50', {}, 'Failed to fetch events timeline')
         setTimeline(data)
       } catch (err) {
         console.error('Error fetching timeline:', err)

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -44,7 +44,7 @@ describe('EventTimeline', () => {
     })
 
     global.fetch = vi.fn(url => {
-      if (url === '/api/events/timeline') {
+      if (url.startsWith('/api/events/timeline')) {
         return Promise.resolve(jsonResponse(timelineData))
       }
 


### PR DESCRIPTION
The landing page fetched `/api/events/timeline` with no `pastLimit`, defaulting to 10 past events. After the historical backfill (Vols 3–16 now past), that cut the timeline off at Vol 7. Now requests `pastLimit=50` (API caps at 100) so the whole ~3/year history shows. Test updated to prefix-match. lint clean · 192 tests · build ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)