### PR TITLE
chore(theme): finish Tier 0 — hover token, status-color tokens, theming docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,24 @@ Example: `frontend/src/pages/BandProfilePage.jsx` — uses both `<Helmet>` (for 
 
 ---
 
+## Theming
+
+Four user-selectable colour themes, set as `data-theme` on `<html>` by `frontend/src/components/ThemeProvider.jsx` and persisted in localStorage: `midnight-ember` (warm dark, default), `arctic-night` (cool dark), `daybreak` (warm light), `silver-lining` (cool light). All theme colours are CSS custom properties defined per `[data-theme]` block in `frontend/src/index.css`, exposed as Tailwind v4 utilities via `@theme`.
+
+**On public / theme-following surfaces, use semantic tokens — never hardcoded white.** This is the recurring bug class (white text/surfaces invisible on the light themes):
+
+- **Text:** `text-text-primary` / `-secondary` / `-tertiary` / `-disabled`. When converting opacity'd whites, map by weight: `text-white/90–70` → `secondary`, `/60–40` → `tertiary`, `/30–20` → `disabled`.
+- **Surfaces / borders:** `bg-surface` (faint card/input fill), `bg-surface-hover` (hover state), `border-border` / `ring-border` (subtle edges/dividers). Never `bg-white/N` or `border-white/N`.
+- **Status colours:** `success` / `warning` / `error` / `info` (e.g. `bg-warning-500/20 border-warning-500/50`) with `text-text-primary` for the label so it reads on both light and dark.
+
+**Light-theme token values are WCAG-AA tuned** (accent ramp, `text-tertiary`, etc. clear 4.5:1 on the darker `bg-purple` surface). If you change a light-theme colour, verify contrast — don't just pick a lighter shade.
+
+**Keep `text-white` only where it is theme-independent:** on a fixed colour (coloured/gradient buttons, brand/social buttons) or over a dark photo scrim.
+
+**Admin is dark-pinned:** `frontend/src/admin/AdminApp.jsx` wraps the admin surface in `<div data-theme="midnight-ember">`, so hardcoded `text-white` inside `frontend/src/admin/` is correct and intentional — do not migrate it.
+
+---
+
 ## Schedule Storage (localStorage)
 
 Band selections are stored under the `selectedBandsByEvent` key as `{ [eventSlug]: [bandId, ...], __dates__: { [eventSlug]: "YYYY-MM-DD" } }`.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -774,7 +774,7 @@ function App() {
                 <button
                   type="button"
                   onClick={() => setDebugTime(null)}
-                  className="px-3 py-2 rounded bg-surface border border-border text-text-secondary text-sm hover:bg-surface"
+                  className="px-3 py-2 rounded bg-surface border border-border text-text-secondary text-sm hover:bg-surface-hover"
                 >
                   Clear override
                 </button>
@@ -848,7 +848,7 @@ function App() {
                 setPendingSharedBands([])
                 setPendingSharedBandNames([])
               }}
-              className="min-h-[44px] rounded-lg border border-border px-4 py-2 text-text-secondary transition-colors hover:bg-surface"
+              className="min-h-[44px] rounded-lg border border-border px-4 py-2 text-text-secondary transition-colors hover:bg-surface-hover"
             >
               Cancel
             </button>

--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -74,7 +74,7 @@ function BandCard({
           className={`absolute top-2 right-2 h-11 w-11 flex items-center justify-center text-lg font-bold rounded-full transition-all duration-150 z-10 ${
             onAmber
               ? 'bg-bg-navy/20 hover:bg-bg-navy/30 text-bg-navy'
-              : 'bg-surface hover:bg-surface text-text-secondary hover:text-text-primary'
+              : 'bg-surface hover:bg-surface-hover text-text-secondary hover:text-text-primary'
           } focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500`}
           aria-label={labelBase}
           title={labelBase}

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -119,7 +119,7 @@ function MySchedule({
         status: 'now',
         icon: Guitar,
         text: `Playing now - ${minutesLeft} min left`,
-        color: 'bg-green-500/20 border-green-500/50 text-green-200',
+        color: 'bg-success-500/20 border-success-500/50 text-text-primary',
       }
     }
 
@@ -129,7 +129,7 @@ function MySchedule({
         status: 'past',
         icon: Check,
         text: 'Finished',
-        color: 'bg-gray-500/20 border-gray-500/50 text-gray-400',
+        color: 'bg-surface border-border text-text-tertiary',
       }
     }
 
@@ -140,14 +140,14 @@ function MySchedule({
         status: 'soon',
         icon: Bell,
         text: 'Starting soon!',
-        color: 'bg-yellow-500/20 border-yellow-500/50 text-yellow-200',
+        color: 'bg-warning-500/20 border-warning-500/50 text-text-primary',
       }
     } else if (minutesUntil <= 60) {
       return {
         status: 'upcoming',
         icon: Clock,
         text: `In ${minutesUntil} min`,
-        color: 'bg-blue-500/20 border-blue-500/50 text-blue-200',
+        color: 'bg-info-500/20 border-info-500/50 text-text-primary',
       }
     } else if (minutesUntil >= 1440) {
       const days = Math.floor(minutesUntil / 1440)
@@ -161,7 +161,7 @@ function MySchedule({
         status: 'later',
         icon: Hourglass,
         text: `In ${parts.join(' ')}`,
-        color: 'bg-blue-500/20 border-blue-500/50 text-blue-200',
+        color: 'bg-info-500/20 border-info-500/50 text-text-primary',
       }
     } else {
       const hours = Math.floor(minutesUntil / 60)
@@ -171,7 +171,7 @@ function MySchedule({
         status: 'later',
         icon: Hourglass,
         text: `In ${timeLabel}`,
-        color: 'bg-blue-500/20 border-blue-500/50 text-blue-200',
+        color: 'bg-info-500/20 border-info-500/50 text-text-primary',
       }
     }
   }
@@ -457,7 +457,7 @@ function MySchedule({
               )}
               <button
                 onClick={onClearSchedule}
-                className="text-xs px-3 py-1.5 rounded bg-red-500/20 border border-red-500/50 text-red-200 flex items-center gap-2 transition-transform duration-150 hover:bg-red-500/30 hover:brightness-110 active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-300"
+                className="text-xs px-3 py-1.5 rounded bg-error-500/20 border border-error-500/50 text-text-primary flex items-center gap-2 transition-transform duration-150 hover:bg-error-500/30 hover:brightness-110 active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-error-400"
                 title="Clear all selected bands"
               >
                 <Trash2 size={14} aria-hidden="true" />
@@ -484,9 +484,9 @@ function MySchedule({
       {(conflicts.length > 0 || overlaps.length > 0) && (
         <div className="space-y-4 max-w-5xl mx-auto">
           {conflicts.length > 0 && (
-            <div className="bg-red-500/20 border border-red-500/50 rounded-lg p-4 leading-normal">
-              <div className="flex items-center gap-3 text-red-200 font-semibold">
-                <TriangleAlert size={20} className="text-red-300 shrink-0" aria-hidden="true" />
+            <div className="bg-error-500/20 border border-error-500/50 rounded-lg p-4 leading-normal">
+              <div className="flex items-center gap-3 text-text-primary font-semibold">
+                <TriangleAlert size={20} className="text-error-400 shrink-0" aria-hidden="true" />
                 <p className="text-sm sm:text-base leading-normal">
                   {conflictCount} band{conflictCount !== 1 ? 's' : ''} happening at the same time — you&apos;ll need to
                   choose!
@@ -495,9 +495,9 @@ function MySchedule({
             </div>
           )}
           {overlaps.length > 0 && (
-            <div className="bg-yellow-500/20 border border-yellow-500/50 rounded-lg p-4 leading-normal">
-              <div className="flex items-center gap-3 text-yellow-200 font-semibold">
-                <Zap size={20} className="text-yellow-300 shrink-0" aria-hidden="true" />
+            <div className="bg-warning-500/20 border border-warning-500/50 rounded-lg p-4 leading-normal">
+              <div className="flex items-center gap-3 text-text-primary font-semibold">
+                <Zap size={20} className="text-warning-400 shrink-0" aria-hidden="true" />
                 <p className="text-sm sm:text-base leading-normal">
                   {overlapCount} band{overlapCount !== 1 ? 's' : ''} with overlapping set{overlapCount !== 1 ? 's' : ''}{' '}
                   — you may not catch every full set.

--- a/frontend/src/components/ScheduleLiveRow.jsx
+++ b/frontend/src/components/ScheduleLiveRow.jsx
@@ -66,7 +66,7 @@ function ScheduleLiveRow({ band, variant, isSelected, onToggle, currentTime }) {
               className={`inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full border transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-navy ${
                 isSelected
                   ? 'border-accent-500/50 bg-accent-500/20 text-accent-400 hover:bg-accent-500/30'
-                  : 'border-border bg-surface text-text-secondary hover:bg-surface'
+                  : 'border-border bg-surface text-text-secondary hover:bg-surface-hover'
               }`}
               aria-label={toggleLabel}
               title={toggleLabel}

--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -352,7 +352,7 @@ function ScheduleView({
                       className={`text-xs px-3 py-1.5 min-h-[44px] rounded-full border whitespace-nowrap transition-colors ${
                         venueFilter === venue
                           ? 'bg-accent-500/20 border-accent-500/50 text-accent-400'
-                          : 'bg-surface border-border text-text-tertiary hover:bg-surface'
+                          : 'bg-surface border-border text-text-tertiary hover:bg-surface-hover'
                       }`}
                     >
                       {venue}
@@ -365,7 +365,7 @@ function ScheduleView({
                       className={`text-xs px-3 py-1.5 min-h-[44px] rounded-full border whitespace-nowrap transition-colors ${
                         venueFilter === UNSCHEDULED
                           ? 'bg-accent-500/20 border-accent-500/50 text-accent-400'
-                          : 'bg-surface border-border text-text-tertiary hover:bg-surface'
+                          : 'bg-surface border-border text-text-tertiary hover:bg-surface-hover'
                       }`}
                     >
                       Unscheduled
@@ -386,7 +386,7 @@ function ScheduleView({
                       className={`text-xs px-3 py-1.5 min-h-[44px] rounded-full border whitespace-nowrap transition-colors ${
                         genreFilter === genre
                           ? 'bg-accent-500/20 border-accent-500/50 text-accent-400'
-                          : 'bg-surface border-border text-text-tertiary hover:bg-surface'
+                          : 'bg-surface border-border text-text-tertiary hover:bg-surface-hover'
                       }`}
                     >
                       {genre}

--- a/frontend/src/components/ShareButton.jsx
+++ b/frontend/src/components/ShareButton.jsx
@@ -15,7 +15,7 @@ export default function ShareButton({
   title,
   text,
   label = 'Share',
-  className = 'inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400',
+  className = 'inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-hover focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400',
 }) {
   const [copied, setCopied] = useState(false)
 

--- a/frontend/src/components/TimeFilter.jsx
+++ b/frontend/src/components/TimeFilter.jsx
@@ -27,7 +27,7 @@ export default function TimeFilter({ selectedFilter, onFilterChange, className =
         title={selectedOption.description}
         className={`min-h-[44px] w-full appearance-none rounded-full border px-4 py-2 pr-10 text-sm font-medium transition-colors focus:border-accent-500 focus:outline-hidden ${
           selectedFilter === 'all'
-            ? 'border-border bg-surface text-text-primary hover:bg-surface'
+            ? 'border-border bg-surface text-text-primary hover:bg-surface-hover'
             : 'border-accent-500/35 bg-accent-500/10 text-accent-300'
         }`}
       >

--- a/frontend/src/components/ui/Alert.jsx
+++ b/frontend/src/components/ui/Alert.jsx
@@ -59,7 +59,7 @@ export default function Alert({
       {dismissible && onClose && (
         <button
           onClick={onClose}
-          className="shrink-0 p-1 hover:bg-surface rounded transition-colors"
+          className="shrink-0 p-1 hover:bg-surface-hover rounded transition-colors"
           aria-label="Dismiss alert"
         >
           <X size={18} />

--- a/frontend/src/components/ui/Button.jsx
+++ b/frontend/src/components/ui/Button.jsx
@@ -35,9 +35,9 @@ export default function Button({
       'bg-accent-500 text-bg-navy font-semibold hover:bg-accent-400 focus:ring-accent-500 shadow-xs hover:shadow-md active:scale-95',
     'primary-gradient':
       'bg-gradient-accent text-bg-navy font-semibold hover:brightness-110 focus:ring-accent-500 shadow-xs hover:shadow-md active:scale-95',
-    secondary: 'border-2 border-text-secondary text-text-primary hover:bg-surface focus:ring-primary-500',
+    secondary: 'border-2 border-text-secondary text-text-primary hover:bg-surface-hover focus:ring-primary-500',
     danger: 'bg-error-500 text-white hover:bg-error-600 focus:ring-error-500 shadow-xs hover:shadow-md active:scale-95',
-    ghost: 'text-text-primary hover:bg-surface focus:ring-primary-500',
+    ghost: 'text-text-primary hover:bg-surface-hover focus:ring-primary-500',
     success: 'bg-success-500 text-white hover:bg-success-600 focus:ring-success-500 shadow-xs hover:shadow-md',
     warning: 'bg-warning-500 text-white hover:bg-warning-600 focus:ring-warning-500 shadow-xs hover:shadow-md',
     link: 'text-accent-500 hover:text-accent-400 underline-offset-4 hover:underline focus:ring-accent-500 p-0',

--- a/frontend/src/components/ui/Combobox.jsx
+++ b/frontend/src/components/ui/Combobox.jsx
@@ -138,7 +138,7 @@ export default function Combobox({
               onMouseDown={() => pick(opt)}
               onMouseEnter={() => setActiveIndex(i)}
               className={`px-4 py-2 text-sm cursor-pointer select-none ${
-                i === activeIndex ? 'bg-accent-500/20 text-accent-300' : 'text-text-primary hover:bg-surface'
+                i === activeIndex ? 'bg-accent-500/20 text-accent-300' : 'text-text-primary hover:bg-surface-hover'
               }`}
             >
               {opt}

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -202,7 +202,7 @@ export default function Modal({
             {showCloseButton && (
               <button
                 onClick={onClose}
-                className="p-2 hover:bg-surface rounded-lg transition-colors"
+                className="p-2 hover:bg-surface-hover rounded-lg transition-colors"
                 aria-label="Close modal"
               >
                 <X size={20} className="text-text-secondary" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -47,6 +47,7 @@
      Defined here so Tailwind generates bg-surface / border-border utilities;
      each [data-theme] block below overrides the values. */
   --color-surface: rgba(255, 255, 255, 0.05);
+  --color-surface-hover: rgba(255, 255, 255, 0.1);
   --color-border: rgba(255, 255, 255, 0.1);
 
   --color-band-navy: #0c0f1a;
@@ -159,6 +160,7 @@
   --color-text-inverse: #111827;
 
   --color-surface: rgba(255, 255, 255, 0.05);
+  --color-surface-hover: rgba(255, 255, 255, 0.1);
   --color-border: rgba(255, 255, 255, 0.1);
 
   --color-band-navy: #0c0f1a;
@@ -201,6 +203,7 @@
   --color-text-inverse: #0f172a;
 
   --color-surface: rgba(255, 255, 255, 0.05);
+  --color-surface-hover: rgba(255, 255, 255, 0.1);
   --color-border: rgba(255, 255, 255, 0.1);
 
   --color-band-navy: #0f172a;
@@ -241,6 +244,7 @@
   --color-text-inverse: #fafaf9;
 
   --color-surface: rgba(28, 25, 23, 0.04);
+  --color-surface-hover: rgba(28, 25, 23, 0.08);
   --color-border: rgba(28, 25, 23, 0.2);
 
   --color-band-navy: #fff8f1;
@@ -293,6 +297,7 @@
   --color-text-inverse: #f8fafc;
 
   --color-surface: rgba(15, 23, 42, 0.04);
+  --color-surface-hover: rgba(15, 23, 42, 0.08);
   --color-border: rgba(15, 23, 42, 0.2);
 
   --color-band-navy: #f8fafc;

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -179,7 +179,7 @@ export default function EventRecapPage() {
               </Link>
               <Link
                 to="/"
-                className="inline-flex min-h-[44px] items-center gap-2 rounded-lg border border-border px-5 py-3 font-semibold text-text-secondary transition-colors hover:bg-surface"
+                className="inline-flex min-h-[44px] items-center gap-2 rounded-lg border border-border px-5 py-3 font-semibold text-text-secondary transition-colors hover:bg-surface-hover"
               >
                 <ArrowLeft size={16} aria-hidden="true" />
                 Browse All Events
@@ -347,7 +347,7 @@ export default function EventRecapPage() {
             <div className="flex flex-wrap justify-center gap-3">
               <Link
                 to={`/event/${event.slug}`}
-                className="inline-flex min-h-[44px] items-center gap-2 rounded-lg border border-border px-5 py-3 font-semibold text-text-secondary transition-colors hover:bg-surface"
+                className="inline-flex min-h-[44px] items-center gap-2 rounded-lg border border-border px-5 py-3 font-semibold text-text-secondary transition-colors hover:bg-surface-hover"
               >
                 <CalendarDays size={16} aria-hidden="true" />
                 Archived Schedule

--- a/frontend/src/pages/SubscribePage.jsx
+++ b/frontend/src/pages/SubscribePage.jsx
@@ -242,14 +242,14 @@ export default function SubscribePage() {
           <div className="flex flex-wrap justify-center gap-4">
             <a
               href="/api/feeds/ical?city=waterloo&genre=all"
-              className="px-6 py-3 bg-surface hover:bg-surface text-text-primary rounded-lg border border-border transition"
+              className="px-6 py-3 bg-surface hover:bg-surface-hover text-text-primary rounded-lg border border-border transition"
             >
               <CalendarDays size={16} className="mr-2 inline" aria-hidden="true" />
               Subscribe to Calendar
             </a>
             <a
               href="/api/events/public?city=waterloo&genre=all"
-              className="px-6 py-3 bg-surface hover:bg-surface text-text-primary rounded-lg border border-border transition"
+              className="px-6 py-3 bg-surface hover:bg-surface-hover text-text-primary rounded-lg border border-border transition"
             >
               <Rss size={16} className="mr-2 inline" aria-hidden="true" />
               JSON Feed


### PR DESCRIPTION
## Summary
Wraps up the Tier 0 cleanup from the review — three clean items. (DOMPurify split **deferred to its own PR**: the functions form an internal chain — `validateUrl`→`sanitizeUrl`, `validateAddress`→`sanitizeString` — so it's a real refactor-vs-delete call that deserves a before/after bundle check, not a rushed swap.)

### 1. Hover-affordance regression → `--color-surface-hover`
The earlier token sweep collapsed `bg-surface … hover:bg-surface` into a no-op hover. Added a per-theme `--color-surface-hover` token and made `hover:bg-surface-hover` the consistent hover state app-wide (also makes the working hovers a touch more noticeable). Verified in built CSS: `#ffffff1a` dark / `#1c191714` daybreak / `#0f172a14` silver.

### 2. MySchedule status colours → semantic tokens
The now/soon/upcoming/finished pills **and** the conflict/overlap banners + remove button used hardcoded `green`/`yellow`/`blue`/`red` with `text-*-200` labels that washed out on light themes. Now `success`/`warning`/`error`/`info` for tint+border with `text-text-primary` labels (readable on both themes). Decorative accent icon left.

### 3. CLAUDE.md "Theming" section
Documents the token conventions (`text-text-*`, `bg-surface`/`bg-surface-hover`, `border-border`, `success`/`warning`/etc.), the no-hardcoded-white rule, the AA-tuned light values, the `text-white`-on-fixed-colour exception, and the admin dark-pin — the doc audit's #1 gap.

## Testing
lint clean · 192 tests · build ok · `hover:bg-surface-hover` utility + per-theme token values confirmed in built CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)