### PR TITLE
feat(seo): server-render meta + JSON-LD for /band, /event, /venue

### DIFF
--- a/frontend/public/_routes.json
+++ b/frontend/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/api/*", "/s/*", "/sitemap.xml"],
-  "exclude": ["/", "/admin/*", "/band/*", "/event/*", "/privacy", "/assets/*", "/favicon.ico", "/favicon.svg", "/favicon-*.png", "/apple-touch-icon.png", "/android-chrome-*.png", "/manifest.json", "/robots.txt", "/sw.js", "/offline.html"]
+  "include": ["/api/*", "/s/*", "/sitemap.xml", "/event/*", "/band/*", "/venue/*"],
+  "exclude": ["/", "/admin/*", "/privacy", "/assets/*", "/favicon.ico", "/favicon.svg", "/favicon-*.png", "/apple-touch-icon.png", "/android-chrome-*.png", "/manifest.json", "/robots.txt", "/sw.js", "/offline.html"]
 }

--- a/functions/band/[id].js
+++ b/functions/band/[id].js
@@ -1,0 +1,71 @@
+// CF Pages Function: serve /band/[id] with server-rendered meta + MusicGroup JSON-LD
+// for crawlers. See functions/utils/ssrMeta.js for the rationale + fallback contract.
+
+import { isPublicDataEnabled } from "../utils/publicGate.js";
+import { escapeAttr, toPlainText, serveWithInjectedMeta } from "../utils/ssrMeta.js";
+
+export async function onRequest(context) {
+  const { params, env, request } = context;
+  const id = params.id;
+
+  // Only numeric band ids are server-rendered; non-numeric or gated data → plain SPA.
+  if (!/^\d+$/.test(id || "") || !isPublicDataEnabled(env)) {
+    return env.ASSETS.fetch(request);
+  }
+
+  let band = null;
+  try {
+    band = await env.DB.prepare(
+      `SELECT name, genre, origin, description, photo_url FROM band_profiles WHERE id = ?`,
+    )
+      .bind(Number(id))
+      .first();
+  } catch (err) {
+    console.error("SSR band lookup failed:", id, err);
+    return env.ASSETS.fetch(request);
+  }
+  if (!band) return env.ASSETS.fetch(request);
+
+  const origin = new URL(request.url).origin;
+  const url = `${origin}/band/${id}`;
+  const plainDesc = toPlainText(band.description, 200);
+  const tagline = [band.genre, band.origin].filter(Boolean).join(" · ");
+  const description =
+    plainDesc ||
+    `${band.name}${tagline ? ` — ${tagline}` : ""} on SetTimes, Waterloo Region's live music platform.`;
+
+  const metaTags = [
+    `<meta name="description" content="${escapeAttr(description)}" />`,
+    `<meta property="og:title" content="${escapeAttr(band.name)}" />`,
+    `<meta property="og:description" content="${escapeAttr(description)}" />`,
+    `<meta property="og:type" content="profile" />`,
+    `<meta property="og:url" content="${escapeAttr(url)}" />`,
+    `<meta name="twitter:title" content="${escapeAttr(band.name)}" />`,
+    `<meta name="twitter:description" content="${escapeAttr(description)}" />`,
+    `<link rel="canonical" href="${escapeAttr(url)}" />`,
+  ];
+  if (band.photo_url) {
+    metaTags.push(`<meta property="og:image" content="${escapeAttr(band.photo_url)}" />`);
+    metaTags.push(`<meta name="twitter:image" content="${escapeAttr(band.photo_url)}" />`);
+    metaTags.push(`<meta name="twitter:card" content="summary_large_image" />`);
+  } else {
+    metaTags.push(`<meta name="twitter:card" content="summary" />`);
+  }
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "MusicGroup",
+    name: band.name,
+    url,
+    ...(band.genre && { genre: band.genre }),
+    ...(band.origin && { foundingLocation: band.origin }),
+    ...(plainDesc && { description: plainDesc }),
+    ...(band.photo_url && { image: band.photo_url }),
+  };
+
+  return serveWithInjectedMeta(context, {
+    title: `${band.name} — Band Profile | SetTimes`,
+    metaTags,
+    jsonLd,
+  });
+}

--- a/functions/event/[slug].js
+++ b/functions/event/[slug].js
@@ -1,0 +1,62 @@
+// CF Pages Function: serve /event/[slug] with server-rendered meta + MusicEvent
+// JSON-LD for crawlers. See functions/utils/ssrMeta.js for rationale + fallback.
+
+import { isPublicDataEnabled } from "../utils/publicGate.js";
+import { escapeAttr, toPlainText, serveWithInjectedMeta, WATERLOO_ADDRESS } from "../utils/ssrMeta.js";
+
+export async function onRequest(context) {
+  const { params, env, request } = context;
+  const slug = params.slug;
+
+  if (!/^[a-z0-9-]{1,64}$/i.test(slug || "") || !isPublicDataEnabled(env)) {
+    return env.ASSETS.fetch(request);
+  }
+
+  let event = null;
+  try {
+    event = await env.DB.prepare(
+      `SELECT name, date, slug, description, city FROM events
+       WHERE slug = ? AND (is_published = 1 OR status = 'archived')`,
+    )
+      .bind(slug)
+      .first();
+  } catch (err) {
+    console.error("SSR event lookup failed:", slug, err);
+    return env.ASSETS.fetch(request);
+  }
+  if (!event) return env.ASSETS.fetch(request);
+
+  const origin = new URL(request.url).origin;
+  const url = `${origin}/event/${event.slug}`;
+  const where = event.city || "Waterloo Region";
+  const plainDesc = toPlainText(event.description, 200);
+  const description = plainDesc || `${event.name} — live music in ${where} on SetTimes.${event.date ? ` ${event.date}.` : ""}`;
+
+  const metaTags = [
+    `<meta name="description" content="${escapeAttr(description)}" />`,
+    `<meta property="og:title" content="${escapeAttr(event.name)}" />`,
+    `<meta property="og:description" content="${escapeAttr(description)}" />`,
+    `<meta property="og:type" content="website" />`,
+    `<meta property="og:url" content="${escapeAttr(url)}" />`,
+    `<meta name="twitter:card" content="summary" />`,
+    `<meta name="twitter:title" content="${escapeAttr(event.name)}" />`,
+    `<meta name="twitter:description" content="${escapeAttr(description)}" />`,
+    `<link rel="canonical" href="${escapeAttr(url)}" />`,
+  ];
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "MusicEvent",
+    name: event.name,
+    url,
+    ...(event.date && { startDate: event.date }),
+    location: {
+      "@type": "Place",
+      name: event.city || "Waterloo Region, ON",
+      address: WATERLOO_ADDRESS,
+    },
+    ...(plainDesc && { description: plainDesc }),
+  };
+
+  return serveWithInjectedMeta(context, { title: `${event.name} | SetTimes`, metaTags, jsonLd });
+}

--- a/functions/utils/__tests__/ssrMeta.test.js
+++ b/functions/utils/__tests__/ssrMeta.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeAttr, toPlainText, serveWithInjectedMeta } from "../ssrMeta.js";
+
+const DEFAULT_HTML = `<!doctype html><html><head>
+    <meta name="description" content="Homepage description" />
+    <meta property="og:title" content="SetTimes – Live Music Events" />
+    <meta property="og:description" content="Homepage og description" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="SetTimes" />
+    <title>SetTimes – Live Music Events &amp; Show Schedules</title>
+  </head><body><div id="root"></div></body></html>`;
+
+function makeContext({ url = "https://settimes.ca/band/49", assetsOk = true } = {}) {
+  return {
+    request: new Request(url),
+    env: {
+      ASSETS: {
+        fetch: async () =>
+          assetsOk
+            ? new Response(DEFAULT_HTML, { status: 200, headers: { "content-type": "text/html" } })
+            : new Response("nope", { status: 500 }),
+      },
+    },
+  };
+}
+
+describe("ssrMeta.escapeAttr", () => {
+  it("escapes &, \", <, >", () => {
+    expect(escapeAttr('Tom & "Jerry" <b>')).toBe("Tom &amp; &quot;Jerry&quot; &lt;b&gt;");
+  });
+  it("handles null/undefined", () => {
+    expect(escapeAttr(null)).toBe("");
+    expect(escapeAttr(undefined)).toBe("");
+  });
+});
+
+describe("ssrMeta.toPlainText", () => {
+  it("strips tags, decodes entities, collapses whitespace", () => {
+    expect(toPlainText("<p>Heavy   <strong>doom</strong> &amp; sludge.</p>")).toBe("Heavy doom & sludge.");
+  });
+  it("truncates with an ellipsis", () => {
+    const out = toPlainText("x".repeat(250), 50);
+    expect(out.length).toBe(50);
+    expect(out.endsWith("…")).toBe(true);
+  });
+  it("returns empty string for empty input", () => {
+    expect(toPlainText(null)).toBe("");
+  });
+});
+
+describe("ssrMeta.serveWithInjectedMeta", () => {
+  it("replaces defaults (not duplicates) and injects page meta + JSON-LD", async () => {
+    const res = await serveWithInjectedMeta(makeContext(), {
+      title: "Broadcast Zero — Band Profile | SetTimes",
+      metaTags: ['<meta property="og:title" content="Broadcast Zero" />'],
+      jsonLd: { "@type": "MusicGroup", name: "Broadcast Zero" },
+    });
+    const html = await res.text();
+    const ogTitles = html.match(/property="og:title"/g) || [];
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/html;charset=UTF-8");
+    expect(ogTitles).toHaveLength(1); // homepage default stripped
+    expect(html).toContain('content="Broadcast Zero"');
+    expect(html).not.toContain("SetTimes – Live Music Events"); // default og:title gone
+    expect(html).toContain("<title>Broadcast Zero — Band Profile | SetTimes</title>");
+    expect(html).not.toContain("Homepage description"); // default description stripped
+    expect(html).toContain("application/ld+json");
+    expect(html).toContain('id="root"'); // SPA shell intact
+  });
+
+  it("escapes </script> inside JSON-LD to prevent breakout", async () => {
+    const res = await serveWithInjectedMeta(makeContext(), {
+      jsonLd: { "@type": "MusicGroup", name: "evil </script><script>alert(1)</script>" },
+    });
+    const html = await res.text();
+    expect(html).not.toContain("</script><script>alert(1)");
+    expect(html).toContain("\\u003c/script>");
+  });
+
+  it("falls back to the raw asset when the index fetch fails", async () => {
+    const res = await serveWithInjectedMeta(makeContext({ assetsOk: false }), {
+      metaTags: ['<meta property="og:title" content="X" />'],
+    });
+    expect(res.status).toBe(500);
+  });
+});

--- a/functions/utils/ssrMeta.js
+++ b/functions/utils/ssrMeta.js
@@ -1,0 +1,82 @@
+// Shared helper for server-rendering OG/Twitter meta + JSON-LD into the SPA shell
+// for crawlers. Public pages are otherwise client-rendered, and React Helmet only
+// runs in-browser — social crawlers (iMessage, WhatsApp, Facebook, Twitter) and the
+// initial crawl pass don't execute JS, so they'd only ever see the homepage card.
+//
+// Each route function queries D1, builds its meta + JSON-LD, and calls
+// serveWithInjectedMeta(). On ANY problem (gate closed, not found, DB error, asset
+// fetch fail) the caller falls back to env.ASSETS.fetch(request) — the SPA still
+// renders client-side, just without the rich tags.
+
+export function escapeAttr(str) {
+  return String(str ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+// Strip HTML tags + collapse whitespace for a meta description, truncating to a
+// crawler-friendly length. Band/event descriptions may contain sanitized HTML.
+export function toPlainText(html, maxLength = 200) {
+  const text = String(html ?? "")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+// Default homepage meta tags baked into index.html — stripped so the page-specific
+// ones replace (not duplicate) them. Facebook often honours the FIRST og:title, so
+// appending isn't enough; the defaults must be removed.
+const DEFAULT_META_RE =
+  /[ \t]*<meta\s+(?:property="og:(?:title|description|image|type|url)"|name="(?:description|twitter:(?:card|title|description|image))")[^>]*>\r?\n?/gi;
+
+// Fetch the SPA index.html, strip the default homepage meta, swap the <title>, and
+// inject the page-specific meta tags + an optional JSON-LD block just before </head>.
+// metaTags is an array of HTML strings; jsonLd is a JS object; title sets <title>.
+// Returns the rewritten HTML Response, or falls back to the raw asset on failure.
+export async function serveWithInjectedMeta(context, { title = null, metaTags = [], jsonLd = null } = {}) {
+  const { request, env } = context;
+  try {
+    const origin = new URL(request.url).origin;
+    const indexResponse = await env.ASSETS.fetch(new Request(`${origin}/`));
+    if (!indexResponse.ok) {
+      return env.ASSETS.fetch(request);
+    }
+    let html = await indexResponse.text();
+
+    html = html.replace(DEFAULT_META_RE, "");
+    if (title) {
+      html = html.replace(/<title>[\s\S]*?<\/title>/i, `<title>${escapeAttr(title)}</title>`);
+    }
+
+    const headParts = [...metaTags];
+    if (jsonLd) {
+      // Escape "<" so a "</script>" inside any string value can't break out of the tag.
+      const json = JSON.stringify(jsonLd).replace(/</g, "\\u003c");
+      headParts.push(`<script type="application/ld+json">${json}</script>`);
+    }
+    const injected = html.replace("</head>", `    ${headParts.join("\n    ")}\n  </head>`);
+
+    // Preserve the asset's headers (CSP, etc.); override content-type + cache.
+    const headers = new Headers(indexResponse.headers);
+    headers.set("Content-Type", "text/html;charset=UTF-8");
+    headers.set("Cache-Control", "public, max-age=300");
+    return new Response(injected, { headers });
+  } catch (err) {
+    console.error("SSR meta injection failed:", err);
+    return env.ASSETS.fetch(request);
+  }
+}
+
+// Waterloo Region location block reused across event/venue structured data.
+export const WATERLOO_ADDRESS = {
+  "@type": "PostalAddress",
+  addressLocality: "Waterloo",
+  addressRegion: "ON",
+  addressCountry: "CA",
+};

--- a/functions/venue/[id].js
+++ b/functions/venue/[id].js
@@ -1,0 +1,68 @@
+// CF Pages Function: serve /venue/[id] with server-rendered meta + MusicVenue
+// JSON-LD for crawlers. See functions/utils/ssrMeta.js for rationale + fallback.
+
+import { isPublicDataEnabled } from "../utils/publicGate.js";
+import { escapeAttr, serveWithInjectedMeta } from "../utils/ssrMeta.js";
+
+export async function onRequest(context) {
+  const { params, env, request } = context;
+  const id = params.id;
+
+  if (!/^\d+$/.test(id || "") || !isPublicDataEnabled(env)) {
+    return env.ASSETS.fetch(request);
+  }
+
+  let venue = null;
+  try {
+    venue = await env.DB.prepare(
+      `SELECT name, address, address_line1, city, region, postal_code, latitude, longitude
+       FROM venues WHERE id = ?`,
+    )
+      .bind(Number(id))
+      .first();
+  } catch (err) {
+    console.error("SSR venue lookup failed:", id, err);
+    return env.ASSETS.fetch(request);
+  }
+  if (!venue) return env.ASSETS.fetch(request);
+
+  const origin = new URL(request.url).origin;
+  const url = `${origin}/venue/${id}`;
+  const locality = venue.city || "Waterloo";
+  const description =
+    [venue.name, venue.address].filter(Boolean).join(" — ") ||
+    `${venue.name} — a live music venue in ${locality}, ON on SetTimes.`;
+
+  const metaTags = [
+    `<meta name="description" content="${escapeAttr(description)}" />`,
+    `<meta property="og:title" content="${escapeAttr(venue.name)}" />`,
+    `<meta property="og:description" content="${escapeAttr(description)}" />`,
+    `<meta property="og:type" content="website" />`,
+    `<meta property="og:url" content="${escapeAttr(url)}" />`,
+    `<meta name="twitter:card" content="summary" />`,
+    `<meta name="twitter:title" content="${escapeAttr(venue.name)}" />`,
+    `<meta name="twitter:description" content="${escapeAttr(description)}" />`,
+    `<link rel="canonical" href="${escapeAttr(url)}" />`,
+  ];
+
+  const hasGeo = typeof venue.latitude === "number" && typeof venue.longitude === "number";
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "MusicVenue",
+    name: venue.name,
+    url,
+    address: {
+      "@type": "PostalAddress",
+      ...(venue.address_line1 || venue.address ? { streetAddress: venue.address_line1 || venue.address } : {}),
+      addressLocality: locality,
+      addressRegion: venue.region || "ON",
+      ...(venue.postal_code && { postalCode: venue.postal_code }),
+      addressCountry: "CA",
+    },
+    ...(hasGeo && {
+      geo: { "@type": "GeoCoordinates", latitude: venue.latitude, longitude: venue.longitude },
+    }),
+  };
+
+  return serveWithInjectedMeta(context, { title: `${venue.name} | SetTimes`, metaTags, jsonLd });
+}


### PR DESCRIPTION
## Summary
The highest-leverage SEO fix: `/band/:id`, `/event/:slug`, `/venue/:id` were pure client-rendered SPA, so crawlers and social cards (no JS) only ever saw the **homepage** card. With 17 events + ~180 bands now in the archive, that's a lot of undiscoverable/unshareable pages. This server-renders per-page meta + JSON-LD for crawlers while leaving the SPA untouched for browsers.

## How
Three CF Pages Functions (`functions/band/[id].js`, `event/[slug].js`, `venue/[id].js`) + a shared `functions/utils/ssrMeta.js`. They query D1, build meta + JSON-LD, and inject into the `index.html` shell — extending the proven `functions/s/[slug].js` pattern. `_routes.json` now **includes** `/band/*`, `/event/*`, `/venue/*` (removed from `exclude`) so those routes hit functions.

| Route | Structured data |
|---|---|
| `/band/:id` | `MusicGroup` (name, genre, foundingLocation, description, image) + `og:image` |
| `/event/:slug` | `MusicEvent` (name, startDate, Waterloo `Place`/address) |
| `/venue/:id` | `MusicVenue` (`PostalAddress` + `GeoCoordinates` from the seeded coords) |

## Correctness & safety
- **Strips the homepage default `og:`/`twitter:`/`description` tags and swaps `<title>`** rather than appending — Facebook often honours the *first* `og:title`, so a duplicate would render the homepage card. Result verified: exactly one `og:title` (the page's).
- One `<link rel=canonical>` per page (the shell has none).
- Respects the publish gate (`isPublicDataEnabled`) and **falls back to the static SPA** on any miss/error — never breaks the page.
- Escapes `</script>` inside JSON-LD (no breakout). Responses cached `max-age=300`.

## Testing
- **8 unit tests** (`functions/utils/__tests__/ssrMeta.test.js`) — pass locally (pure helper, no DLOPEN).
- End-to-end injection simulated against realistic homepage-default HTML (dup stripping, title swap, `</script>` escaping, SPA intact).
- Frontend build copies the updated `_routes.json`.

## Notes
- Every `/band`,`/event`,`/venue` request now runs a function (one indexed D1 query + cached HTML) — the intended SEO tradeoff.
- The client-side Helmet meta still runs for browsers; the server meta is for crawlers.
- There's a separate, minimal `./_routes.json` at the repo root that is **not** the deployed file (deploy uses `frontend/dist/_routes.json` ← `frontend/public/`); left as-is.

**Verify on deploy:** `curl -s https://settimes.ca/band/49 | grep -E 'og:title|ld\+json|<title>'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)