### PR TITLE
design(profile): redesign band profile page — grids, alignment, no bad wraps

### DIFF
--- a/frontend/src/components/BandFacts.jsx
+++ b/frontend/src/components/BandFacts.jsx
@@ -47,15 +47,15 @@ export default function BandFacts({ band, stats }) {
 
   return (
     <Card variant="elevated">
-      <h3 className="text-lg font-semibold text-text-primary mb-3 flex items-center gap-2">
-        <Lightbulb size={18} className="text-accent-500" />
+      <h3 className="mb-3 flex items-center gap-2 text-lg font-semibold text-text-primary">
+        <Lightbulb size={18} className="text-accent-500" aria-hidden="true" />
         Fast Facts
       </h3>
-      <ul className="space-y-2">
+      <ul className="space-y-2.5">
         {facts.map((fact, index) => (
-          <li key={index} className="text-text-secondary text-sm leading-relaxed flex items-center gap-2">
-            <span className="text-accent-500">•</span>
-            <span>{fact}</span>
+          <li key={index} className="flex items-start gap-2.5 text-sm leading-relaxed text-text-secondary">
+            <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-accent-500" aria-hidden="true" />
+            <span className="break-words">{fact}</span>
           </li>
         ))}
       </ul>

--- a/frontend/src/components/BandStats.jsx
+++ b/frontend/src/components/BandStats.jsx
@@ -1,6 +1,7 @@
-import { TrendingUp } from 'lucide-react'
+import { CalendarRange, MapPin, Music2, TrendingUp } from 'lucide-react'
 import PropTypes from 'prop-types'
 import { Card } from './ui'
+import { parseLocalDate } from '../utils/timeFormat'
 
 const LABELS = {
   total_performances: 'Shows listed',
@@ -9,44 +10,32 @@ const LABELS = {
   debut_date: 'First listed show',
   latest_date: 'Latest listed show',
   signature_venue: 'Most played venue',
-  average_set_minutes: 'Avg set (min)',
+  average_set_minutes: 'Avg set',
 }
 
-const ORDER = [
-  'total_performances',
-  'unique_venues',
-  'unique_events',
-  'debut_date',
-  'latest_date',
-  'signature_venue',
-  'average_set_minutes',
-]
+// Compact numeric metrics render two-up in a tight grid. The "wide" keys hold
+// longer values (formatted dates, venue names) that wrap badly in a narrow
+// half-width cell, so they each get a full-width row of their own.
+const COMPACT_ORDER = ['total_performances', 'unique_venues', 'unique_events', 'average_set_minutes']
+const WIDE_ORDER = ['debut_date', 'latest_date', 'signature_venue']
+
+const DATE_KEYS = new Set(['debut_date', 'latest_date'])
 
 function formatLabel(key) {
   return LABELS[key] || key.replace(/_/g, ' ').replace(/\b\w/g, letter => letter.toUpperCase())
 }
 
-function formatValue(value) {
-  if (value === null || value === undefined) {
-    return '—'
-  }
+// Compact, non-wrapping date: "Aug 4, 2024" instead of the raw "2024-08-04",
+// which the browser would otherwise break across two lines in a narrow card.
+function formatStatDate(value) {
+  const parsed = parseLocalDate(value) || new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return parsed.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
 
-  if (typeof value === 'number') {
-    const isInteger = Number.isInteger(value)
-    return isInteger ? value.toLocaleString() : value.toFixed(1)
-  }
-
-  if (typeof value === 'object') {
-    if (value.name && value.count !== undefined) {
-      return `${value.name} (${value.count}x)`
-    }
-    if (value.name) {
-      return value.name
-    }
-    return '—'
-  }
-
-  return value
+function formatNumber(value) {
+  if (Number.isInteger(value)) return value.toLocaleString()
+  return value.toFixed(1)
 }
 
 export default function BandStats({ stats }) {
@@ -58,34 +47,85 @@ export default function BandStats({ stats }) {
     return null
   }
 
-  const entries = ORDER.map(key => [key, stats?.[key]])
-    .filter(([, value]) => value !== null && value !== undefined)
-    .filter(([key]) => {
-      if (key === 'average_set_minutes' && totalShows < 3) return false
-      if ((key === 'debut_date' || key === 'latest_date' || key === 'signature_venue') && uniqueEvents < 2) {
-        return false
-      }
-      return true
-    })
+  const has = key => {
+    const value = stats?.[key]
+    if (value === null || value === undefined) return false
+    if (key === 'average_set_minutes' && totalShows < 3) return false
+    if ((key === 'debut_date' || key === 'latest_date' || key === 'signature_venue') && uniqueEvents < 2) {
+      return false
+    }
+    return true
+  }
 
-  if (entries.length === 0) {
+  const compact = COMPACT_ORDER.filter(has)
+  const wide = WIDE_ORDER.filter(has)
+
+  if (compact.length === 0 && wide.length === 0) {
     return null
   }
 
   return (
     <Card variant="elevated">
-      <h3 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
-        <TrendingUp size={18} className="text-accent-500" />
+      <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold text-text-primary">
+        <TrendingUp size={18} className="text-accent-500" aria-hidden="true" />
         Performance Snapshot
       </h3>
-      <div className="grid grid-cols-2 gap-3">
-        {entries.map(([key, value]) => (
-          <Card key={key} padding="sm" variant="outline" className="text-center">
-            <p className="text-xs uppercase tracking-wide text-text-secondary mb-1">{formatLabel(key)}</p>
-            <p className="text-2xl font-bold text-text-primary">{formatValue(value)}</p>
-          </Card>
-        ))}
-      </div>
+
+      <dl className="space-y-3">
+        {compact.length > 0 && (
+          <div className="grid grid-cols-2 gap-3">
+            {compact.map(key => {
+              const value = stats[key]
+              const display =
+                key === 'average_set_minutes' ? `${Math.round(Number(value))} min` : formatNumber(Number(value))
+              return (
+                <Card key={key} padding="none" variant="outline" className="flex flex-col justify-between gap-1 p-3">
+                  <dt className="text-[0.7rem] font-medium uppercase tracking-wide text-text-tertiary">
+                    {formatLabel(key)}
+                  </dt>
+                  <dd className="text-2xl font-bold tabular-nums leading-none text-text-primary">{display}</dd>
+                </Card>
+              )
+            })}
+          </div>
+        )}
+
+        {wide.length > 0 && (
+          <div className="space-y-2">
+            {wide.map(key => {
+              const value = stats[key]
+              const isDate = DATE_KEYS.has(key)
+              const isVenue = key === 'signature_venue'
+              const Icon = isVenue ? MapPin : key === 'debut_date' ? Music2 : CalendarRange
+
+              return (
+                <Card
+                  key={key}
+                  padding="none"
+                  variant="outline"
+                  className="flex items-center justify-between gap-3 p-3"
+                >
+                  <dt className="flex items-center gap-2 text-[0.7rem] font-medium uppercase tracking-wide text-text-tertiary">
+                    <Icon size={13} className="shrink-0 text-accent-500" aria-hidden="true" />
+                    {formatLabel(key)}
+                  </dt>
+                  <dd
+                    className={`min-w-0 text-right text-sm font-semibold text-text-primary ${
+                      isDate ? 'whitespace-nowrap tabular-nums' : 'break-words'
+                    }`}
+                  >
+                    {isDate
+                      ? formatStatDate(value)
+                      : isVenue && value?.name
+                        ? `${value.name}${value.count !== undefined ? ` · ${value.count}×` : ''}`
+                        : '—'}
+                  </dd>
+                </Card>
+              )
+            })}
+          </div>
+        )}
+      </dl>
     </Card>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -559,6 +559,19 @@ body {
   animation-delay: 250ms;
 }
 
+/* Band-profile bio: long URLs / unbroken slugs (e.g. "have-you-lost-your-mind")
+   must wrap at any point rather than overflow or hyphenate mid-word. */
+.band-bio {
+  overflow-wrap: anywhere;
+  word-break: normal;
+  hyphens: none;
+}
+
+.band-bio a {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .rich-text-content p {
   margin-bottom: 0.75rem;
 }

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -509,26 +509,28 @@ export default function BandProfilePage() {
         <div className="bg-bg-purple rounded-xl border-2 border-accent-500/30 overflow-hidden mb-6 shadow-xl">
           {/* Band Photo with Overlay */}
           {profile.photo_url ? (
-            <div className="relative h-80 bg-linear-to-b from-bg-navy via-bg-purple to-bg-navy overflow-hidden">
+            <div className="relative h-72 overflow-hidden bg-linear-to-b from-bg-navy via-bg-purple to-bg-navy sm:h-80">
               <img
                 src={profile.photo_url}
                 alt={profile.photo_alt_text || profile.name}
                 loading="lazy"
-                className="w-full h-full object-cover opacity-60"
+                className="h-full w-full object-cover opacity-60"
               />
-              <div className="absolute inset-0 bg-linear-to-t from-black/80 via-black/30 to-transparent" />
-              <div className="absolute bottom-0 left-0 right-0 p-6">
-                <h1 className="text-5xl font-bold text-white drop-shadow-lg mb-3">{profile.name}</h1>
-                <div className="flex flex-wrap gap-3">
+              <div className="absolute inset-0 bg-linear-to-t from-black/85 via-black/35 to-transparent" />
+              <div className="absolute inset-x-0 bottom-0 p-6">
+                <h1 className="mb-3 text-4xl font-bold leading-tight text-white drop-shadow-lg sm:text-5xl">
+                  {profile.name}
+                </h1>
+                <div className="flex flex-wrap gap-2.5">
                   {profile.genre && (
-                    <span className="px-4 py-2 bg-accent-500 text-bg-navy rounded-lg font-bold text-sm shadow-lg">
-                      <Guitar size={14} className="mr-2" aria-hidden="true" />
+                    <span className="inline-flex items-center gap-1.5 rounded-lg bg-accent-500 px-3.5 py-2 text-sm font-bold text-bg-navy shadow-lg">
+                      <Guitar size={14} className="shrink-0" aria-hidden="true" />
                       {profile.genre}
                     </span>
                   )}
                   {profile.origin && (
-                    <span className="px-4 py-2 bg-black/40 border-2 border-white/40 text-white rounded-lg font-bold text-sm shadow-lg">
-                      <MapPin size={14} className="mr-2" aria-hidden="true" />
+                    <span className="inline-flex items-center gap-1.5 rounded-lg border-2 border-white/40 bg-black/40 px-3.5 py-2 text-sm font-bold text-white shadow-lg backdrop-blur-xs">
+                      <MapPin size={14} className="shrink-0" aria-hidden="true" />
                       {profile.origin}
                     </span>
                   )}
@@ -536,18 +538,18 @@ export default function BandProfilePage() {
               </div>
             </div>
           ) : (
-            <div className="p-8 bg-linear-to-br from-bg-purple to-bg-navy">
-              <h1 className="text-5xl font-bold text-text-primary mb-3">{profile.name}</h1>
-              <div className="flex flex-wrap gap-3">
+            <div className="bg-linear-to-br from-bg-purple to-bg-navy p-6 sm:p-8">
+              <h1 className="mb-3 text-4xl font-bold leading-tight text-text-primary sm:text-5xl">{profile.name}</h1>
+              <div className="flex flex-wrap gap-2.5">
                 {profile.genre && (
-                  <span className="px-4 py-2 bg-accent-500 text-bg-navy rounded-lg font-bold text-sm">
-                    <Guitar size={14} className="mr-2 inline" aria-hidden="true" />
+                  <span className="inline-flex items-center gap-1.5 rounded-lg bg-accent-500 px-3.5 py-2 text-sm font-bold text-bg-navy">
+                    <Guitar size={14} className="shrink-0" aria-hidden="true" />
                     {profile.genre}
                   </span>
                 )}
                 {profile.origin && (
-                  <span className="px-4 py-2 bg-bg-navy border-2 border-text-primary/30 text-text-primary rounded-lg font-bold text-sm">
-                    <MapPin size={14} className="mr-2 inline" aria-hidden="true" />
+                  <span className="inline-flex items-center gap-1.5 rounded-lg border-2 border-text-primary/30 bg-bg-navy px-3.5 py-2 text-sm font-bold text-text-primary">
+                    <MapPin size={14} className="shrink-0" aria-hidden="true" />
                     {profile.origin}
                   </span>
                 )}
@@ -556,26 +558,17 @@ export default function BandProfilePage() {
           )}
 
           {/* Bio, Social Links, and Share */}
-          <div className="p-6 bg-bg-purple/50 border-t border-text-primary/10">
-            <div className="mb-4 flex flex-col-reverse gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-              <div className="flex-1 min-w-0">
+          <div className="border-t border-text-primary/10 bg-bg-purple/50 p-6">
+            <div className="flex flex-col-reverse gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0 flex-1">
                 {profile.description ? (
                   <div
-                    className="text-text-secondary text-sm leading-relaxed [&_p]:my-2 [&_a]:text-accent-500 [&_a:hover]:underline"
-                    style={{
-                      wordBreak: 'normal',
-                      overflowWrap: 'break-word',
-                      whiteSpace: 'normal',
-                      hyphens: 'none',
-                      WebkitHyphens: 'none',
-                      MozHyphens: 'none',
-                      msHyphens: 'none',
-                    }}
+                    className="band-bio max-w-prose text-sm leading-relaxed text-text-secondary [&_a:hover]:underline [&_a]:text-accent-500 [&_p]:my-2"
                     dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
                   />
                 ) : (
                   !hasAnySocial(profile.social) && (
-                    <p className="text-text-tertiary text-sm italic">No bio added yet.</p>
+                    <p className="text-sm italic text-text-tertiary">No bio added yet.</p>
                   )
                 )}
               </div>
@@ -590,120 +583,125 @@ export default function BandProfilePage() {
               </div>
             </div>
             {hasAnySocial(profile.social) ? (
-              <div className="flex flex-wrap gap-3">
-                {safeExternalHref(profile.social.website) !== '#' && (
-                  <a
-                    href={safeExternalHref(profile.social.website)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="px-4 py-2 bg-accent-500 text-bg-navy rounded hover:bg-accent-600 transition-colors text-sm font-medium inline-flex items-center gap-2"
-                    onClick={() => trackSocialClick(profile.id, 'website')}
-                  >
-                    <Globe size={16} />
-                    Website
-                  </a>
-                )}
-                {safeInstagramHref(profile.social.instagram) !== '#' && (
-                  <a
-                    href={safeInstagramHref(profile.social.instagram)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="px-4 py-2 bg-linear-to-br from-purple-500 to-pink-500 text-white rounded hover:opacity-90 transition-colors text-sm font-medium inline-flex items-center gap-2"
-                    onClick={() => trackSocialClick(profile.id, 'instagram')}
-                  >
-                    <InstagramIcon size={16} />
-                    Instagram
-                  </a>
-                )}
-                {safeExternalHref(profile.social.bandcamp) !== '#' && (
-                  <a
-                    href={safeExternalHref(profile.social.bandcamp)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors text-sm font-medium inline-flex items-center gap-2"
-                    onClick={() => trackSocialClick(profile.id, 'bandcamp')}
-                  >
-                    <BandcampIcon size={16} />
-                    Bandcamp
-                  </a>
-                )}
-                {safeExternalHref(profile.social.facebook) !== '#' && (
-                  <a
-                    href={safeExternalHref(profile.social.facebook)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors text-sm font-medium inline-flex items-center gap-2"
-                    onClick={() => trackSocialClick(profile.id, 'facebook')}
-                  >
-                    <FacebookIcon size={16} />
-                    Facebook
-                  </a>
-                )}
-                {safeExternalHref(profile.social.youtube) !== '#' && (
-                  <a
-                    href={safeExternalHref(profile.social.youtube)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition-colors text-sm font-medium inline-flex items-center gap-2"
-                    onClick={() => trackSocialClick(profile.id, 'youtube')}
-                  >
-                    <YouTubeIcon size={16} />
-                    YouTube
-                  </a>
-                )}
-                {safeExternalHref(profile.social.spotify) !== '#' && (
-                  <a
-                    href={safeExternalHref(profile.social.spotify)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 transition-colors text-sm font-medium inline-flex items-center gap-2"
-                    onClick={() => trackSocialClick(profile.id, 'spotify')}
-                  >
-                    <SpotifyIcon size={16} />
-                    Spotify
-                  </a>
-                )}
-                {safeExternalHref(profile.social.apple_music) !== '#' && (
-                  <a
-                    href={safeExternalHref(profile.social.apple_music)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="px-4 py-2 bg-linear-to-br from-pink-500 to-red-600 text-white rounded hover:opacity-90 transition-colors text-sm font-medium inline-flex items-center gap-2"
-                    onClick={() => trackSocialClick(profile.id, 'apple_music')}
-                  >
-                    <AppleMusicIcon size={16} />
-                    Apple Music
-                  </a>
-                )}
-                {safeExternalHref(profile.social.linktree) !== '#' && (
-                  <a
-                    href={safeExternalHref(profile.social.linktree)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="px-4 py-2 bg-lime-500 text-white rounded hover:bg-lime-600 transition-colors text-sm font-medium inline-flex items-center gap-2"
-                    onClick={() => trackSocialClick(profile.id, 'linktree')}
-                  >
-                    <LinktreeIcon size={16} />
-                    Linktree
-                  </a>
-                )}
+              <div className="mt-5 border-t border-text-primary/10 pt-5">
+                <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-tertiary">
+                  Listen &amp; follow
+                </h2>
+                <div className="grid grid-cols-[repeat(auto-fit,minmax(9.5rem,1fr))] gap-2.5">
+                  {safeExternalHref(profile.social.website) !== '#' && (
+                    <a
+                      href={safeExternalHref(profile.social.website)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-accent-500 px-4 py-2.5 text-sm font-semibold text-bg-navy transition-colors hover:bg-accent-600 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                      onClick={() => trackSocialClick(profile.id, 'website')}
+                    >
+                      <Globe size={16} className="shrink-0" />
+                      Website
+                    </a>
+                  )}
+                  {safeInstagramHref(profile.social.instagram) !== '#' && (
+                    <a
+                      href={safeInstagramHref(profile.social.instagram)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-linear-to-br from-purple-500 to-pink-500 px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-pink-300 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                      onClick={() => trackSocialClick(profile.id, 'instagram')}
+                    >
+                      <InstagramIcon size={16} className="shrink-0" />
+                      Instagram
+                    </a>
+                  )}
+                  {safeExternalHref(profile.social.bandcamp) !== '#' && (
+                    <a
+                      href={safeExternalHref(profile.social.bandcamp)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-green-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-green-700 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                      onClick={() => trackSocialClick(profile.id, 'bandcamp')}
+                    >
+                      <BandcampIcon size={16} className="shrink-0" />
+                      Bandcamp
+                    </a>
+                  )}
+                  {safeExternalHref(profile.social.facebook) !== '#' && (
+                    <a
+                      href={safeExternalHref(profile.social.facebook)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                      onClick={() => trackSocialClick(profile.id, 'facebook')}
+                    >
+                      <FacebookIcon size={16} className="shrink-0" />
+                      Facebook
+                    </a>
+                  )}
+                  {safeExternalHref(profile.social.youtube) !== '#' && (
+                    <a
+                      href={safeExternalHref(profile.social.youtube)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-red-300 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                      onClick={() => trackSocialClick(profile.id, 'youtube')}
+                    >
+                      <YouTubeIcon size={16} className="shrink-0" />
+                      YouTube
+                    </a>
+                  )}
+                  {safeExternalHref(profile.social.spotify) !== '#' && (
+                    <a
+                      href={safeExternalHref(profile.social.spotify)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-green-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-green-600 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                      onClick={() => trackSocialClick(profile.id, 'spotify')}
+                    >
+                      <SpotifyIcon size={16} className="shrink-0" />
+                      Spotify
+                    </a>
+                  )}
+                  {safeExternalHref(profile.social.apple_music) !== '#' && (
+                    <a
+                      href={safeExternalHref(profile.social.apple_music)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-linear-to-br from-pink-500 to-red-600 px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-pink-300 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                      onClick={() => trackSocialClick(profile.id, 'apple_music')}
+                    >
+                      <AppleMusicIcon size={16} className="shrink-0" />
+                      Apple Music
+                    </a>
+                  )}
+                  {safeExternalHref(profile.social.linktree) !== '#' && (
+                    <a
+                      href={safeExternalHref(profile.social.linktree)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-lime-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-lime-600 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-300 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple"
+                      onClick={() => trackSocialClick(profile.id, 'linktree')}
+                    >
+                      <LinktreeIcon size={16} className="shrink-0" />
+                      Linktree
+                    </a>
+                  )}
+                </div>
               </div>
             ) : (
-              !profile.description && <p className="text-text-tertiary text-sm italic">No links added yet.</p>
+              !profile.description && <p className="mt-5 text-sm italic text-text-tertiary">No links added yet.</p>
             )}
           </div>
         </div>
 
         {/* Follow band */}
-        <div className="mt-6 p-4 rounded-lg bg-text-primary/5 border border-text-primary/10">
+        <div className="mb-6 rounded-xl border border-text-primary/10 bg-text-primary/5 p-5">
           <div className="mx-auto flex max-w-2xl flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="sm:flex-1">
-              <h3 className="text-sm font-semibold text-text-primary mb-1">Follow {profile.name}</h3>
+              <h2 className="mb-1 text-sm font-semibold text-text-primary">Follow {profile.name}</h2>
               <p className="text-xs text-text-secondary">Get notified when they join a new lineup.</p>
             </div>
             {followStatus === 'success' ? (
-              <p className="text-sm text-green-400 sm:max-w-sm">
-                <Check size={14} className="mr-1.5" />
+              <p className="inline-flex items-start gap-1.5 text-sm text-green-400 sm:max-w-sm">
+                <Check size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
                 You&apos;re following {profile.name}! We&apos;ll email you when they join a lineup.
               </p>
             ) : (
@@ -733,12 +731,12 @@ export default function BandProfilePage() {
               </form>
             )}
           </div>
-          {followStatus === 'error' && <p className="text-xs text-red-400 mt-1">{followError}</p>}
+          {followStatus === 'error' && <p className="mt-2 text-xs text-red-400">{followError}</p>}
         </div>
 
         {/* Stats/Facts (left) + Shows (right). When a band has no stats, the shows
             column spans full width so the empty state stays aligned with the page. */}
-        <div className={`mt-6 mb-6 ${profile.stats ? 'grid grid-cols-1 gap-6 lg:grid-cols-3' : ''}`}>
+        <div className={`mb-6 ${profile.stats ? 'grid grid-cols-1 gap-6 lg:grid-cols-3' : ''}`}>
           {/* Left Column - Stats & Facts */}
           {profile.stats && (
             <div className="lg:col-span-1 space-y-6">
@@ -752,11 +750,13 @@ export default function BandProfilePage() {
             {/* Upcoming Shows */}
             {profile.upcoming && profile.upcoming.length > 0 && (
               <Card variant="elevated" className="border-2 border-accent-500/30">
-                <div className="pb-4 mb-4 border-b border-text-primary/10">
-                  <h2 className="text-2xl font-bold text-accent-500 flex items-center gap-2">
-                    <CalendarDays size={14} />
-                    <span>Upcoming Shows</span>
-                    <Badge variant="primary" className="ml-2">
+                <div className="mb-5 flex items-center gap-3 border-b border-text-primary/10 pb-4">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-500/15 text-accent-500">
+                    <CalendarDays size={18} aria-hidden="true" />
+                  </span>
+                  <h2 className="flex flex-1 items-center gap-2 text-xl font-bold text-accent-500 sm:text-2xl">
+                    Upcoming Shows
+                    <Badge variant="primary" className="ml-1">
                       {profile.upcoming.length}
                     </Badge>
                   </h2>
@@ -828,11 +828,13 @@ export default function BandProfilePage() {
             {/* Past Performance History */}
             {profile.past && profile.past.length > 0 && (
               <Card variant="elevated">
-                <div className="pb-4 mb-4 border-b border-text-primary/10">
-                  <h2 className="text-2xl font-bold text-text-primary flex items-center gap-2">
-                    <TrendingUp size={14} />
-                    <span>Performance History</span>
-                    <Badge variant="secondary" className="ml-2">
+                <div className="mb-5 flex items-center gap-3 border-b border-text-primary/10 pb-4">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-text-primary/10 text-text-tertiary">
+                    <TrendingUp size={18} aria-hidden="true" />
+                  </span>
+                  <h2 className="flex flex-1 items-center gap-2 text-xl font-bold text-text-primary sm:text-2xl">
+                    Performance History
+                    <Badge variant="secondary" className="ml-1">
                       {profile.past.length}
                     </Badge>
                   </h2>
@@ -912,7 +914,7 @@ export default function BandProfilePage() {
         </div>
 
         {/* Back to Events */}
-        <div className="mt-6 text-center">
+        <div className="pt-2 text-center">
           <Button as={Link} to={returnEventPath} variant="secondary" icon={<ArrowLeft size={14} />} iconPosition="left">
             {returnEventSlug ? 'Back to Schedule' : 'Back to Events'}
           </Button>


### PR DESCRIPTION
Closes #367. Presentation-only redesign of the band profile page (no data/props/API changes); all functionality preserved (SEO Helmet+JSON-LD, breadcrumbs, sticky header, both hero branches, Share, Follow form + Turnstile, every social link, BandStats/BandFacts, upcoming/past history, empty states).

## Fixes for the reported problems
1. **Stat cards wrapping mid-value** (`2024-08-\n04`, `The Roost (1x)`) — `BandStats` is now a 2-up grid of compact numeric cards + full-width rows for long values; dates reformatted (`Aug 4, 2024`) with `whitespace-nowrap tabular-nums` (never break a date); long venue names wrap gracefully on their own row.
2. **Uneven social grid** (orphaned Linktree) — `grid-cols-[repeat(auto-fit,minmax(9.5rem,1fr))]` fills every row evenly at any count; 44px targets + focus rings.
3. **Bio link wrapping mid-word** — `.band-bio` rule (`overflow-wrap:anywhere`) replaces the brittle inline style; bio capped to `max-w-prose`.
4. **Polish** — fixed pill-badge icon spacing, unified `mb-6` section rhythm (was compounding to 48px gaps), responsive hero + section headers, Follow → `h2`.

## Design-system compliance
Theme-aware tokens throughout — light themes unaffected. Only `text-white` left is on the fixed-dark photo scrim and the fixed-color social buttons (both intended). 44px touch targets, `focus-visible` rings, reduced-motion already global.

## Testing
lint clean (0 errors) · 192/192 tests · build ok · no hardcoded white on theme surfaces.

**Review on deploy:** visual confirmation of the stats stack + social grid on a real mobile viewport across light/dark themes (couldn't be confirmed in-browser locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)