### PR TITLE
docs: track remaining/deferred work as GitHub issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ settimes.ca is evolving into the best multi-venue/multi-artist event platform fo
 
 Canonical active roadmap: `docs/ROADMAP.md`. Use it for handoffs between Claude, OpenCode, and humans.
 
+**Track remaining/deferred work as GitHub issues** (`gh issue create`) — not just chat threads or ad-hoc lists — so nothing is lost across sessions and contributors. Reference issues from PRs (`Closes #N`).
+
 ---
 
 ## Stack


### PR DESCRIPTION
Documents the convention (Mission & Scope) that backlog/TODOs are filed as GitHub issues — not chat threads or ad-hoc lists — so nothing is lost across sessions/contributors; PRs reference them with `Closes #N`. Also recorded in assistant memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)