### PR TITLE
fix(seo): finish per-page meta — SubscribePage, document.title, event h1

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -294,6 +294,12 @@ function App() {
     saveSelectedBands(slug || 'default', selectedBands, eventData?.date)
   }, [selectedBands, slug, eventData?.date])
 
+  // react-helmet-async does not reliably set document.title in React 19 — set it
+  // directly. Mirrors the <Helmet> <title> below. See BandProfilePage.jsx.
+  useEffect(() => {
+    document.title = eventData?.name ? `${eventData.name} | SetTimes` : 'SetTimes'
+  }, [eventData?.name])
+
   const clearScheduleToast = useCallback(({ clearUndoState = false } = {}) => {
     if (scheduleToastTimeoutRef.current) {
       window.clearTimeout(scheduleToastTimeoutRef.current)
@@ -690,6 +696,10 @@ function App() {
         id="main-content"
         className="container mx-auto px-4 max-w-(--breakpoint-2xl) mt-3 sm:mt-6 space-y-6 sm:space-y-8"
       >
+        {/* Primary page heading for SEO/a11y. The event name is shown visually in
+            the LiveContextBar (as h2); this gives the <main> landmark a correct h1
+            naming the page topic without duplicating it on screen. */}
+        <h1 className="sr-only">{eventData?.name ? `${eventData.name} — set times & schedule` : 'Event schedule'}</h1>
         <div className="hidden sm:block">
           <Breadcrumbs items={breadcrumbs} />
         </div>

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -118,6 +118,12 @@ export default function EventRecapPage() {
     }
   }, [slug])
 
+  // react-helmet-async does not reliably set document.title in React 19 — set it
+  // directly to match the <Helmet> title below. See BandProfilePage.jsx.
+  useEffect(() => {
+    document.title = event ? `${event.name} — Event Recap | SetTimes.ca` : 'Event Recap | SetTimes.ca'
+  }, [event])
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen bg-linear-to-br from-bg-navy to-bg-purple">

--- a/frontend/src/pages/EventsPage.jsx
+++ b/frontend/src/pages/EventsPage.jsx
@@ -11,6 +11,9 @@ import { ArrowRight, CalendarDays, MapPin, Users } from 'lucide-react'
 
 export default function EventsPage() {
   useEffect(() => {
+    // react-helmet-async does not reliably set document.title in React 19 — set it
+    // directly to match the <Helmet> title below. See BandProfilePage.jsx.
+    document.title = 'SetTimes – Live Music Events & Show Schedules'
     trackPageView('/')
   }, [])
 

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -36,6 +36,20 @@ export default function SharePreviewPage() {
     }
   }, [slug])
 
+  const pageTitle = notFound
+    ? 'Shared Route Not Found | SetTimes'
+    : error
+      ? 'Error | SetTimes'
+      : shareData
+        ? `Shared Route — ${shareData.event_name} | SetTimes`
+        : 'Shared Route | SetTimes'
+
+  // react-helmet-async does not reliably set document.title in React 19 — set it
+  // directly to match the <Helmet> titles below. See BandProfilePage.jsx.
+  useEffect(() => {
+    document.title = pageTitle
+  }, [pageTitle])
+
   const handleImport = () => {
     if (!shareData) return
     navigate(`/event/${shareData.event_slug}?share=${slug}`)

--- a/frontend/src/pages/SubscribePage.jsx
+++ b/frontend/src/pages/SubscribePage.jsx
@@ -1,7 +1,12 @@
 import { CalendarDays, Rss } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { Helmet } from 'react-helmet-async'
 
 const TURNSTILE_SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+
+const PAGE_TITLE = 'Subscribe — Never Miss a Show | SetTimes'
+const PAGE_DESCRIPTION =
+  'Get notified about new live music events and lineup announcements in Waterloo Region. Subscribe for show alerts from SetTimes.'
 
 export default function SubscribePage() {
   const turnstileContainerRef = useRef(null)
@@ -18,6 +23,12 @@ export default function SubscribePage() {
   const [turnstileToken, setTurnstileToken] = useState('')
   const [status, setStatus] = useState('idle') // idle, submitting, success, error
   const [message, setMessage] = useState('')
+
+  // react-helmet-async does not reliably set document.title in React 19 — set it
+  // directly to match the <Helmet> title below. See BandProfilePage.jsx.
+  useEffect(() => {
+    document.title = PAGE_TITLE
+  }, [])
 
   useEffect(() => {
     if (!turnstileEnabled) {
@@ -121,6 +132,19 @@ export default function SubscribePage() {
 
   return (
     <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple p-4">
+      <Helmet>
+        <title>{PAGE_TITLE}</title>
+        <meta name="description" content={PAGE_DESCRIPTION} />
+        <link rel="canonical" href="https://settimes.ca/subscribe" />
+        <meta property="og:title" content={PAGE_TITLE} />
+        <meta property="og:description" content={PAGE_DESCRIPTION} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://settimes.ca/subscribe" />
+        <meta property="og:site_name" content="SetTimes" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content={PAGE_TITLE} />
+        <meta name="twitter:description" content={PAGE_DESCRIPTION} />
+      </Helmet>
       <div className="max-w-2xl mx-auto pt-20">
         {/* Header */}
         <div className="text-center mb-12">


### PR DESCRIPTION
Closes #369. Complements the SSR meta from #366 by closing the remaining **client-side** rendering gaps surfaced in the a11y/SEO review.

## Why
`react-helmet-async`'s `<Helmet>` does not reliably set `document.title` under React 19 (documented in `CLAUDE.md`). Several public pages therefore ended up with a stale/blank tab title once client-rendered. The established workaround is a direct `document.title = …` assignment in a `useEffect`, mirroring the page's `<Helmet>` title (see `BandProfilePage.jsx`).

## Changes
- **`document.title` direct-assignment** added to: event page (`App.jsx`), `EventsPage`, `EventRecapPage`, `SubscribePage`, `SharePreviewPage`. Each mirrors that page's existing `<Helmet>` `<title>` (state-derived where the page has loading/not-found/error branches).
- **`SubscribePage`** had no `<Helmet>` at all → added title / description / canonical / OG / Twitter meta.
- **Event `<h1>`**: `/event/:slug` had no `<h1>` for the event. `Header.jsx` renders the brand "SetTimes" as the only `<h1>`, demoting the event (which is only an `<h2>` in `LiveContextBar`). Added an `sr-only` `<h1>` with the event name inside the `<main>` landmark — gives crawlers and screen-reader users a correct page heading without duplicating the name visually (it's already shown in the context bar).

## Verification
- `npm run lint` — clean (only pre-existing admin warnings)
- `npm run format:check` — clean
- `npm test -- --run` — 192 passed
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)