### PR TITLE
perf(api): batch timeline queries + skip FK PRAGMA on read-only requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ The bulk band import (`functions/api/admin/bands/import.js`) follows this patter
 
 ### PRAGMA `foreign_keys = ON` is enforced in production
 
-`functions/_middleware.js` runs `PRAGMA foreign_keys = ON` on every D1 session before the request handler fires. Unit test helpers (`functions/api/test-utils.js`) set it the same way via `better-sqlite3`. FK constraints are active in all environments.
+`functions/_middleware.js` runs `PRAGMA foreign_keys = ON` before the request handler fires for every **mutating** request. Read-only methods (`GET`/`HEAD`) skip it — they can't violate FK constraints, and skipping saves a D1 round-trip on hot read paths. The guard is a strict read-only allowlist, so any other method (including unknown ones) still gets FK enforcement; never widen it to skip writes. Unit test helpers (`functions/api/test-utils.js`) set the PRAGMA unconditionally via `better-sqlite3`, so FK constraints are always active under test.
 
 When recreating a table in a migration (SQLite has no ALTER COLUMN), surround the table-recreation block with `PRAGMA foreign_keys = OFF` / `PRAGMA foreign_keys = ON` as migration 0032 does — D1 will reject the DROP otherwise.
 

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -101,7 +101,16 @@ export async function onRequest(context) {
   // this must be set per-connection so it applies to every handler in this request.
   // Placed after all early returns so preflights and rejected origins don't pay
   // a D1 round-trip.
-  if (env.DB) {
+  //
+  // SECURITY: FK constraints only matter for writes (INSERT/UPDATE/DELETE). GET
+  // and HEAD are read-only by HTTP semantics and cannot violate them, so skip
+  // the PRAGMA round-trip for those to speed up read paths (e.g. the landing
+  // page). The guard is a strict allowlist of read-only methods — anything else
+  // (POST/PUT/PATCH/DELETE or an unknown method) still gets FK enforcement, so
+  // the invariant holds for every mutation. Do NOT widen this to skip writes.
+  const isReadOnlyMethod =
+    request.method === 'GET' || request.method === 'HEAD';
+  if (env.DB && !isReadOnlyMethod) {
     await env.DB.prepare('PRAGMA foreign_keys = ON').run();
   }
 

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -7,87 +7,96 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// Mock D1 Database
-const createMockDB = () => {
-  const mockPrepare = (query) => {
+// Returns the mock result set for a query string, keyed off the distinctive
+// WHERE clause for each period (now / upcoming / past).
+const resultForQuery = (query) => {
+  if (query.includes('e.date = ?')) {
+    // "Now" events query
     return {
-      bind: (...args) => ({
-        all: async () => {
-          // Mock data for different query types
-          if (query.includes('e.date = ?')) {
-            // "Now" events query
-            return {
-              results: [
-                {
-                  event_id: 1,
-                  event_name: 'Test Event Today',
-                  event_slug: 'test-event-today',
-                  event_date: '2025-11-05',
-                  band_id: 1,
-                  band_name: 'Test Band 1',
-                  start_time: '20:00',
-                  end_time: '21:00',
-                  url: 'https://testband1.com',
-                  genre: 'Rock',
-                  origin: 'Toronto',
-                  photo_url: 'https://example.com/band1.jpg',
-                  venue_id: 1,
-                  venue_name: 'Test Venue 1',
-                  venue_address: '123 Test St',
-                },
-                {
-                  event_id: 1,
-                  event_name: 'Test Event Today',
-                  event_slug: 'test-event-today',
-                  event_date: '2025-11-05',
-                  band_id: 2,
-                  band_name: 'Test Band 2',
-                  start_time: '21:00',
-                  end_time: '22:00',
-                  url: 'https://testband2.com',
-                  genre: 'Jazz',
-                  origin: 'Montreal',
-                  photo_url: 'https://example.com/band2.jpg',
-                  venue_id: 2,
-                  venue_name: 'Test Venue 2',
-                  venue_address: '456 Test Ave',
-                },
-              ],
-            };
-          } else if (query.includes('e.date > ?')) {
-            // "Upcoming" events query
-            return { results: [] };
-          } else if (query.includes('e.date < ?')) {
-            // "Past" events query
-            return {
-              results: [
-                {
-                  event_id: 2,
-                  event_name: 'Past Event',
-                  event_slug: 'past-event',
-                  event_date: '2025-11-01',
-                  band_id: 3,
-                  band_name: 'Past Band',
-                  start_time: '19:00',
-                  end_time: '20:00',
-                  url: 'https://pastband.com',
-                  genre: 'Blues',
-                  origin: 'Ottawa',
-                  photo_url: 'https://example.com/band3.jpg',
-                  venue_id: 3,
-                  venue_name: 'Past Venue',
-                  venue_address: '789 Past Rd',
-                },
-              ],
-            };
-          }
-          return { results: [] };
+      results: [
+        {
+          event_id: 1,
+          event_name: 'Test Event Today',
+          event_slug: 'test-event-today',
+          event_date: '2025-11-05',
+          band_id: 1,
+          band_name: 'Test Band 1',
+          start_time: '20:00',
+          end_time: '21:00',
+          url: 'https://testband1.com',
+          genre: 'Rock',
+          origin: 'Toronto',
+          photo_url: 'https://example.com/band1.jpg',
+          venue_id: 1,
+          venue_name: 'Test Venue 1',
+          venue_address: '123 Test St',
         },
-      }),
+        {
+          event_id: 1,
+          event_name: 'Test Event Today',
+          event_slug: 'test-event-today',
+          event_date: '2025-11-05',
+          band_id: 2,
+          band_name: 'Test Band 2',
+          start_time: '21:00',
+          end_time: '22:00',
+          url: 'https://testband2.com',
+          genre: 'Jazz',
+          origin: 'Montreal',
+          photo_url: 'https://example.com/band2.jpg',
+          venue_id: 2,
+          venue_name: 'Test Venue 2',
+          venue_address: '456 Test Ave',
+        },
+      ],
     };
-  };
+  } else if (query.includes('e.date > ?')) {
+    // "Upcoming" events query
+    return { results: [] };
+  } else if (query.includes('e.date < ?')) {
+    // "Past" events query
+    return {
+      results: [
+        {
+          event_id: 2,
+          event_name: 'Past Event',
+          event_slug: 'past-event',
+          event_date: '2025-11-01',
+          band_id: 3,
+          band_name: 'Past Band',
+          start_time: '19:00',
+          end_time: '20:00',
+          url: 'https://pastband.com',
+          genre: 'Blues',
+          origin: 'Ottawa',
+          photo_url: 'https://example.com/band3.jpg',
+          venue_id: 3,
+          venue_name: 'Past Venue',
+          venue_address: '789 Past Rd',
+        },
+      ],
+    };
+  }
+  return { results: [] };
+};
 
-  return { prepare: mockPrepare };
+// Mock D1 Database. The endpoint now batches the three period queries into a
+// single DB.batch([...]) round-trip, so the mock exposes both prepare/bind
+// (each bound statement carries its `query`) and a batch() that returns results
+// in input order.
+const createMockDB = () => {
+  const mockPrepare = (query) => ({
+    bind: () => ({
+      query,
+      all: async () => resultForQuery(query),
+    }),
+  });
+
+  return {
+    prepare: mockPrepare,
+    batch: async (statements) =>
+      statements.map((statement) => resultForQuery(statement.query)),
+  };
 };
 
 describe('Timeline API - Optimized JOIN Queries', () => {
@@ -251,10 +260,9 @@ describe('Timeline API - Optimized JOIN Queries', () => {
     it('should handle empty results', async () => {
       mockContext.env.DB = {
         prepare: () => ({
-          bind: () => ({
-            all: async () => ({ results: [] }),
-          }),
+          bind: () => ({ all: async () => ({ results: [] }) }),
         }),
+        batch: async (statements) => statements.map(() => ({ results: [] })),
       };
 
       const response = await onRequestGet(mockContext);
@@ -268,10 +276,9 @@ describe('Timeline API - Optimized JOIN Queries', () => {
     it('should handle null results', async () => {
       mockContext.env.DB = {
         prepare: () => ({
-          bind: () => ({
-            all: async () => ({ results: null }),
-          }),
+          bind: () => ({ all: async () => ({ results: null }) }),
         }),
+        batch: async (statements) => statements.map(() => ({ results: null })),
       };
 
       const response = await onRequestGet(mockContext);
@@ -300,6 +307,22 @@ describe('Timeline API - Optimized JOIN Queries', () => {
       expect(prepareCallCount.count).toBe(3);
     });
 
+    it('should run all period queries in a single batched round-trip', async () => {
+      const batchCallCount = { count: 0 };
+      const originalBatch = mockContext.env.DB.batch;
+
+      mockContext.env.DB.batch = (statements) => {
+        batchCallCount.count++;
+        return originalBatch(statements);
+      };
+
+      await onRequestGet(mockContext);
+
+      // The three period queries (now/upcoming/past) are collapsed into one
+      // DB.batch([...]) call rather than three serial awaits.
+      expect(batchCallCount.count).toBe(1);
+    });
+
     it('should group multiple bands per event without additional queries', async () => {
       // This validates that groupEventData works in-memory
       // without triggering additional database calls
@@ -314,32 +337,28 @@ describe('Timeline API - Optimized JOIN Queries', () => {
 
   describe('Edge Cases', () => {
     it('should handle events with no bands', async () => {
+      const results = [
+        {
+          event_id: 99,
+          event_name: 'Empty Event',
+          event_slug: 'empty-event',
+          event_date: '2025-11-05',
+          band_id: null,
+          band_name: null,
+          start_time: null,
+          end_time: null,
+          url: null,
+          genre: null,
+          origin: null,
+          photo_url: null,
+          venue_id: null,
+          venue_name: null,
+          venue_address: null,
+        },
+      ];
       mockContext.env.DB = {
-        prepare: () => ({
-          bind: () => ({
-            all: async () => ({
-              results: [
-                {
-                  event_id: 99,
-                  event_name: 'Empty Event',
-                  event_slug: 'empty-event',
-                  event_date: '2025-11-05',
-                  band_id: null,
-                  band_name: null,
-                  start_time: null,
-                  end_time: null,
-                  url: null,
-                  genre: null,
-                  origin: null,
-                  photo_url: null,
-                  venue_id: null,
-                  venue_name: null,
-                  venue_address: null,
-                },
-              ],
-            }),
-          }),
-        }),
+        prepare: () => ({ bind: () => ({ all: async () => ({ results }) }) }),
+        batch: async (statements) => statements.map(() => ({ results })),
       };
 
       const response = await onRequestGet(mockContext);
@@ -352,49 +371,45 @@ describe('Timeline API - Optimized JOIN Queries', () => {
     });
 
     it('should handle same venue with multiple bands', async () => {
+      const results = [
+        {
+          event_id: 1,
+          event_name: 'Multi-Band Event',
+          event_slug: 'multi-band',
+          event_date: '2025-11-05',
+          band_id: 1,
+          band_name: 'Band 1',
+          start_time: '20:00',
+          end_time: '21:00',
+          url: null,
+          genre: null,
+          origin: null,
+          photo_url: null,
+          venue_id: 1,
+          venue_name: 'Same Venue',
+          venue_address: '123 St',
+        },
+        {
+          event_id: 1,
+          event_name: 'Multi-Band Event',
+          event_slug: 'multi-band',
+          event_date: '2025-11-05',
+          band_id: 2,
+          band_name: 'Band 2',
+          start_time: '21:00',
+          end_time: '22:00',
+          url: null,
+          genre: null,
+          origin: null,
+          photo_url: null,
+          venue_id: 1,
+          venue_name: 'Same Venue',
+          venue_address: '123 St',
+        },
+      ];
       mockContext.env.DB = {
-        prepare: () => ({
-          bind: () => ({
-            all: async () => ({
-              results: [
-                {
-                  event_id: 1,
-                  event_name: 'Multi-Band Event',
-                  event_slug: 'multi-band',
-                  event_date: '2025-11-05',
-                  band_id: 1,
-                  band_name: 'Band 1',
-                  start_time: '20:00',
-                  end_time: '21:00',
-                  url: null,
-                  genre: null,
-                  origin: null,
-                  photo_url: null,
-                  venue_id: 1,
-                  venue_name: 'Same Venue',
-                  venue_address: '123 St',
-                },
-                {
-                  event_id: 1,
-                  event_name: 'Multi-Band Event',
-                  event_slug: 'multi-band',
-                  event_date: '2025-11-05',
-                  band_id: 2,
-                  band_name: 'Band 2',
-                  start_time: '21:00',
-                  end_time: '22:00',
-                  url: null,
-                  genre: null,
-                  origin: null,
-                  photo_url: null,
-                  venue_id: 1,
-                  venue_name: 'Same Venue',
-                  venue_address: '123 St',
-                },
-              ],
-            }),
-          }),
-        }),
+        prepare: () => ({ bind: () => ({ all: async () => ({ results }) }) }),
+        batch: async (statements) => statements.map(() => ({ results })),
       };
 
       const response = await onRequestGet(mockContext);

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -132,10 +132,18 @@ export async function onRequestGet(context) {
       }));
     }
 
-    // Get "Now" events (events happening today) - OPTIMIZED: Single query with JOIN
+    // Batch all timeline queries into a single D1 round-trip instead of one
+    // round-trip per period. Statements are pushed conditionally; `slots` maps
+    // each period to its index in the batch results.
+    const statements = [];
+    const slots = {};
+
+    // "Now" events (happening today) - single JOIN query
     if (includeNow) {
-      const nowResult = await DB.prepare(
-        `
+      slots.now = statements.length;
+      statements.push(
+        DB.prepare(
+          `
         SELECT
           e.id as event_id,
           e.name as event_name,
@@ -169,17 +177,16 @@ export async function onRequestGet(context) {
         AND e.date = ?
         ORDER BY e.date DESC, p.start_time, v.name
       `,
-      )
-        .bind(today)
-        .all();
-
-      response.now = groupEventData(nowResult.results || []);
+        ).bind(today),
+      );
     }
 
-    // Get "Upcoming" events (future events, next 30 days) - OPTIMIZED: Single query with JOIN
+    // "Upcoming" events (future events, next 30 days) - single JOIN query
     if (includeUpcoming) {
-      const upcomingResult = await DB.prepare(
-        `
+      slots.upcoming = statements.length;
+      statements.push(
+        DB.prepare(
+          `
         SELECT
           e.id as event_id,
           e.name as event_name,
@@ -222,17 +229,16 @@ export async function onRequestGet(context) {
         )
         ORDER BY e.date ASC, p.start_time, v.name
       `,
-      )
-        .bind(today, today, today, today)
-        .all();
-
-      response.upcoming = groupEventData(upcomingResult.results || []);
+        ).bind(today, today, today, today),
+      );
     }
 
-    // Get "Past" events (historical events) - OPTIMIZED: Single query with JOIN
+    // "Past" events (historical) - single JOIN query
     if (includePast) {
-      const pastResult = await DB.prepare(
-        `
+      slots.past = statements.length;
+      statements.push(
+        DB.prepare(
+          `
         SELECT
           e.id as event_id,
           e.name as event_name,
@@ -275,11 +281,25 @@ export async function onRequestGet(context) {
         )
         ORDER BY e.date DESC, p.start_time, v.name
       `,
-      )
-        .bind(today, today, pastLimit)
-        .all();
+        ).bind(today, today, pastLimit),
+      );
+    }
 
-      response.past = groupEventData(pastResult.results || []);
+    // Execute all timeline queries in a single batched round-trip. Results are
+    // returned in the same order statements were pushed (tracked by `slots`).
+    if (statements.length > 0) {
+      const batchResults = await DB.batch(statements);
+      if (slots.now !== undefined) {
+        response.now = groupEventData(batchResults[slots.now].results || []);
+      }
+      if (slots.upcoming !== undefined) {
+        response.upcoming = groupEventData(
+          batchResults[slots.upcoming].results || [],
+        );
+      }
+      if (slots.past !== undefined) {
+        response.past = groupEventData(batchResults[slots.past].results || []);
+      }
     }
 
     return new Response(JSON.stringify(response), {


### PR DESCRIPTION
Closes #370. Two cold-load wins surfaced by the perf review.

## 1. Batch the timeline queries (`functions/api/events/timeline.js`)
The landing page's timeline endpoint already avoids N+1 (one JOIN per period), but it ran the **now / upcoming / past** queries as three serial `await DB.prepare(...).all()` calls — three sequential network round-trips to D1. These queries are independent, so they're now collapsed into a single `DB.batch([...])` (one round-trip).

- Statements are pushed **conditionally** (each period can be disabled via `?now=false`, `?upcoming=false`, `?past=false`), and a `slots` map ties each period back to its index in the batch results.
- `DB.batch()` is the documented D1 primitive for multi-statement execution (see CLAUDE.md "D1 transactions") and returns results in input order.

## 2. Skip `PRAGMA foreign_keys = ON` on read-only requests (`functions/_middleware.js`)
The middleware set the FK PRAGMA on **every** `/api/` request, including read-only `GET`s — an extra D1 round-trip on the hottest read paths. FK constraints only matter for writes, so the PRAGMA is now skipped for `GET`/`HEAD`.

- **SECURITY:** the guard is a strict read-only **allowlist**. Anything that isn't `GET`/`HEAD` — `POST`/`PUT`/`PATCH`/`DELETE` or any unknown method — still gets FK enforcement, so the mutation invariant is fully preserved. The test harness (`functions/api/test-utils.js`) sets the PRAGMA unconditionally, so FK constraints remain active under test.

## Tests
- Timeline mock DB now exposes `batch()`; bound statements carry their `query` so the mock can map results.
- Added an assertion that all period queries run in **exactly one** batched round-trip (directly validates the perf change).
- Full backend suite passes: **449 passed, 6 todo**.
- `CLAUDE.md` PRAGMA invariant section updated to match the new GET/HEAD skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)