### PR TITLE
security: low-severity hardening — Turnstile fail-closed, follow double opt-in, trusted-device doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,11 @@ Enforced via `checkPermission(context, "viewer"|"editor"|"admin")` in `functions
 
 ## Band Announcements
 
+Band follows are **double opt-in**: `POST /api/bands/:name/follow` creates the row `verified = 0` with a `verification_token` and sends only a confirmation email. Clicking the link hits `GET /api/bands/:name/confirm-follow?token=…`, which sets `verified = 1` and clears the token (idempotent). Announcement emails target `verified = 1` followers **only** (the `WHERE … verified = 1` filter in `admin/bands/[id].js` and `resend-announcement.js`), so an address the submitter doesn't control can never be enrolled in the announcement stream — it receives at most one confirmation email. **Do not revert follow to auto-verify (`verified = 1` on insert)** — it reopens the email-bombing vector.
+
 When a performance is announced (`is_announced` 0→1), verified followers of that band are emailed once. Delivery is tracked **per-follower** in `band_follow_notifications (performance_id, band_follow_id)`: the announce records each *successful* send. Failed sends leave no row, so `POST /api/admin/bands/:id/resend-announcement` recovers them by emailing only followers without a notification row (never double-sending). Shared send+record logic lives in `functions/utils/bandFollowNotify.js`. **Do not reintroduce a fire-once latch without per-follower tracking** — it silently drops fans whose first send failed (the bug this replaced).
+
+Bot protection on the public email-input endpoints (follow, subscribe) goes through `verifyTurnstile()` in `functions/utils/turnstile.js`, which **fails closed in production**: if `TURNSTILE_SECRET_KEY` is unset it allows only local-dev requests and rejects everything else (mirrors `CSRF_SECRET`). The secret **must** be configured in the production Pages project.
 
 ---
 

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -702,7 +702,7 @@ export default function BandProfilePage() {
             {followStatus === 'success' ? (
               <p className="inline-flex items-start gap-1.5 text-sm text-green-400 sm:max-w-sm">
                 <Check size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
-                You&apos;re following {profile.name}! We&apos;ll email you when they join a lineup.
+                Almost there — check your email to confirm your follow of {profile.name}.
               </p>
             ) : (
               <form onSubmit={submitFollow} className="w-full sm:w-auto">

--- a/functions/api/bands/[name]/confirm-follow.js
+++ b/functions/api/bands/[name]/confirm-follow.js
@@ -1,0 +1,76 @@
+// GET /api/bands/:name/confirm-follow?token=...
+// Confirms a pending (double opt-in) band follow: sets verified=1 and clears the
+// one-time verification token. Only verified follows receive announcement emails
+// (see admin/bands/[id].js + resend-announcement.js). Returns a friendly HTML
+// page; messaging is generic to avoid leaking whether a given token was valid.
+
+const escapeHtml = (s) =>
+  String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const htmlPage = (heading, body) =>
+  new Response(
+    `<html><body style="font-family:sans-serif;padding:2rem"><h2>${heading}</h2><p>${body}</p></body></html>`,
+    {
+      status: 200,
+      headers: { "Content-Type": "text/html", "Cache-Control": "no-store" },
+    },
+  );
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+  const { DB } = env;
+
+  try {
+    const url = new URL(request.url);
+    const token = url.searchParams.get("token");
+
+    if (!token || token.length > 256) {
+      return new Response("Invalid token.", {
+        status: 400,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+
+    // Resolve the pending follow by its one-time verification token.
+    const row = await DB.prepare(
+      `SELECT bf.id, bp.name AS band_name
+       FROM band_follows bf
+       JOIN band_profiles bp ON bp.id = bf.band_profile_id
+       WHERE bf.verification_token = ?`,
+    )
+      .bind(token)
+      .first();
+
+    if (!row) {
+      // Token invalid, already used, or expired — keep it generic.
+      return htmlPage(
+        "Link expired",
+        "This confirmation link is invalid or has already been used. If you already confirmed, you're all set.",
+      );
+    }
+
+    // Verify and clear the one-time token in one statement. This is idempotent:
+    // a second click finds no matching token (already NULL) and changes nothing.
+    await DB.prepare(
+      "UPDATE band_follows SET verified = 1, verification_token = NULL WHERE id = ?",
+    )
+      .bind(row.id)
+      .run();
+
+    return htmlPage(
+      `You're following ${escapeHtml(row.band_name)}`,
+      "We'll email you when they join a lineup. You can unsubscribe anytime from those emails.",
+    );
+  } catch (err) {
+    console.error("[band-confirm-follow] Error:", err);
+    return new Response("An error occurred.", {
+      status: 500,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+}

--- a/functions/api/bands/[name]/follow.js
+++ b/functions/api/bands/[name]/follow.js
@@ -1,6 +1,7 @@
 import { isValidEmail } from "../../../utils/validation.js";
 import { generateToken } from "../../../utils/tokens.js";
 import { sendEmail, isEmailConfigured } from "../../../utils/email.js";
+import { verifyTurnstile } from "../../../utils/turnstile.js";
 
 const escapeHtml = (s) =>
   String(s ?? "")
@@ -11,41 +12,6 @@ const escapeHtml = (s) =>
     .replace(/'/g, "&#39;");
 
 const MAX_EMAIL_LENGTH = 320;
-
-async function verifyTurnstile(request, env, token) {
-  const secret = env?.TURNSTILE_SECRET_KEY;
-  if (!secret) {
-    return true;
-  }
-
-  if (!token || typeof token !== "string") {
-    return false;
-  }
-
-  const ip = request.headers.get("CF-Connecting-IP") || "";
-  const formData = new URLSearchParams();
-  formData.set("secret", secret);
-  formData.set("response", token);
-  if (ip) {
-    formData.set("remoteip", ip);
-  }
-
-  try {
-    const response = await fetch(
-      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: formData,
-      },
-    );
-
-    const result = await response.json().catch(() => ({}));
-    return Boolean(result?.success);
-  } catch (_error) {
-    return false;
-  }
-}
 
 export async function onRequestPost(context) {
   const { request, env, params, waitUntil } = context;
@@ -97,28 +63,38 @@ export async function onRequestPost(context) {
 
     // Atomic upsert — INSERT OR IGNORE avoids the SELECT-then-INSERT race where two
     // concurrent requests both pass the existence check and one hits the UNIQUE constraint.
+    //
+    // Double opt-in: the follow is created UNVERIFIED (verified=0) and only a
+    // confirmation email is sent. Announcement emails go to verified=1 followers
+    // only (see admin/bands/[id].js + resend-announcement.js), so an address the
+    // submitter doesn't control can never be enrolled in the announcement stream
+    // — it receives at most this single confirmation email it can ignore.
     const unsubscribeToken = generateToken();
+    const verificationToken = generateToken();
     const result = await DB.prepare(
-      `INSERT OR IGNORE INTO band_follows (email, band_profile_id, verified, unsubscribe_token)
-       VALUES (?, ?, 1, ?)`,
+      `INSERT OR IGNORE INTO band_follows (email, band_profile_id, verified, verification_token, unsubscribe_token)
+       VALUES (?, ?, 0, ?, ?)`,
     )
-      .bind(email, band.id, unsubscribeToken)
+      .bind(email, band.id, verificationToken, unsubscribeToken)
       .run();
 
-    // Only send confirmation when a new row was actually inserted (changes=0 → already followed)
-    if (result.meta.changes > 0 && isEmailConfigured(env)) {
-      const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
-      const unsubUrl = `${publicUrl}/api/bands/${band.id}/unfollow?token=${unsubscribeToken}`;
+    // changes=0 → this email already follows the band (verified or pending). Say
+    // nothing further: don't leak follow state and don't re-send on every POST.
+    const isNewFollow = result.meta.changes > 0;
+    const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
+    const confirmUrl = `${publicUrl}/api/bands/${band.id}/confirm-follow?token=${verificationToken}`;
+
+    if (isNewFollow && isEmailConfigured(env)) {
       // Use waitUntil so the Worker stays alive for the email after the response is returned.
       waitUntil(
         sendEmail(env, {
           to: email,
-          subject: `You're following ${band.name} on SetTimes`,
-          text: `You'll be notified when ${band.name} joins a lineup.\n\nUnfollow: ${unsubUrl}`,
-          html: `<p>You'll be notified when <strong>${escapeHtml(band.name)}</strong> joins a lineup.</p><p><a href="${unsubUrl}">Unfollow</a></p>`,
-        }).then(result => {
-          if (!result?.delivered) {
-            console.warn("[band-follow] Confirmation email not delivered:", result?.reason);
+          subject: `Confirm your follow of ${band.name} on SetTimes`,
+          text: `Someone (hopefully you) asked to follow ${band.name} on SetTimes.\n\nConfirm to be notified when they join a lineup:\n${confirmUrl}\n\nIf this wasn't you, ignore this email — you won't be subscribed.`,
+          html: `<p>Someone (hopefully you) asked to follow <strong>${escapeHtml(band.name)}</strong> on SetTimes.</p><p><a href="${confirmUrl}">Confirm your follow</a> to be notified when they join a lineup.</p><p>If this wasn't you, just ignore this email — you won't be subscribed.</p>`,
+        }).then(emailResult => {
+          if (!emailResult?.delivered) {
+            console.warn("[band-follow] Confirmation email not delivered:", emailResult?.reason);
           }
         }).catch(err => {
           console.error("[band-follow] Failed to send confirmation email:", err);
@@ -126,7 +102,15 @@ export async function onRequestPost(context) {
       );
     }
 
-    return new Response(JSON.stringify({ success: true }), {
+    // When email delivery isn't configured (local/dev), surface the confirm URL
+    // so the follow can still be verified — mirrors the subscriptions endpoint.
+    // In production email IS configured, so the token is never returned here.
+    const responseBody = { success: true };
+    if (isNewFollow && !isEmailConfigured(env)) {
+      responseBody.confirmUrl = confirmUrl;
+    }
+
+    return new Response(JSON.stringify(responseBody), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });

--- a/functions/api/bands/__tests__/confirm-follow.test.js
+++ b/functions/api/bands/__tests__/confirm-follow.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
+import * as followHandler from '../[name]/follow.js'
+import * as confirmHandler from '../[name]/confirm-follow.js'
+
+const waitUntil = () => {}
+
+describe('GET /api/bands/:name/confirm-follow', () => {
+  it('verifies a pending follow and clears the one-time token', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-confirm' })
+    const band = insertBand(rawDb, { name: 'Confirm Band', event_id: ev.id })
+
+    // Create the pending (verified=0) follow via the follow endpoint.
+    const followReq = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com' }),
+    })
+    await followHandler.onRequestPost({ request: followReq, env, params: { name: String(band.band_profile_id) }, waitUntil })
+
+    const pending = rawDb
+      .prepare('SELECT verified, verification_token FROM band_follows WHERE email=? AND band_profile_id=?')
+      .get('fan@example.com', band.band_profile_id)
+    expect(pending.verified).toBe(0)
+    expect(pending.verification_token).toBeTruthy()
+
+    // Confirm via the verification token.
+    const confirmReq = new Request(
+      `https://example.test/api/bands/${band.band_profile_id}/confirm-follow?token=${pending.verification_token}`
+    )
+    const res = await confirmHandler.onRequestGet({ request: confirmReq, env, params: { name: String(band.band_profile_id) } })
+    expect(res.status).toBe(200)
+
+    const confirmed = rawDb
+      .prepare('SELECT verified, verification_token FROM band_follows WHERE email=? AND band_profile_id=?')
+      .get('fan@example.com', band.band_profile_id)
+    expect(confirmed.verified).toBe(1)
+    expect(confirmed.verification_token).toBeNull()
+  })
+
+  it('is idempotent — a second click on a used token changes nothing', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-confirm-twice' })
+    const band = insertBand(rawDb, { name: 'Twice Band', event_id: ev.id })
+
+    const followReq = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com' }),
+    })
+    await followHandler.onRequestPost({ request: followReq, env, params: { name: String(band.band_profile_id) }, waitUntil })
+
+    const { verification_token: token } = rawDb
+      .prepare('SELECT verification_token FROM band_follows WHERE email=? AND band_profile_id=?')
+      .get('fan@example.com', band.band_profile_id)
+
+    const url = `https://example.test/api/bands/${band.band_profile_id}/confirm-follow?token=${token}`
+    const params = { name: String(band.band_profile_id) }
+    const first = await confirmHandler.onRequestGet({ request: new Request(url), env, params })
+    const second = await confirmHandler.onRequestGet({ request: new Request(url), env, params })
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200) // generic "link expired" page, still verified=1
+    const row = rawDb
+      .prepare('SELECT verified FROM band_follows WHERE email=? AND band_profile_id=?')
+      .get('fan@example.com', band.band_profile_id)
+    expect(row.verified).toBe(1)
+  })
+
+  it('returns 400 for a missing token', async () => {
+    const { env } = createTestEnv()
+    const req = new Request('https://example.test/api/bands/1/confirm-follow')
+    const res = await confirmHandler.onRequestGet({ request: req, env, params: { name: '1' } })
+    expect(res.status).toBe(400)
+  })
+
+  it('shows a generic page for an unknown token (no enumeration)', async () => {
+    const { env } = createTestEnv()
+    const req = new Request('https://example.test/api/bands/1/confirm-follow?token=nonexistent-token')
+    const res = await confirmHandler.onRequestGet({ request: req, env, params: { name: '1' } })
+    expect(res.status).toBe(200)
+  })
+})

--- a/functions/api/bands/__tests__/follow.test.js
+++ b/functions/api/bands/__tests__/follow.test.js
@@ -24,7 +24,10 @@ describe('POST /api/bands/:name/follow', () => {
     const row = rawDb.prepare('SELECT * FROM band_follows WHERE email=? AND band_profile_id=?')
       .get('fan@example.com', band.band_profile_id)
     expect(row).toBeTruthy()
-    expect(row.verified).toBe(1)
+    // Double opt-in: a new follow is created UNVERIFIED with a pending
+    // verification token; it only becomes verified=1 after confirm-follow.
+    expect(row.verified).toBe(0)
+    expect(row.verification_token).toBeTruthy()
     expect(row.unsubscribe_token).toBeTruthy()
   })
 

--- a/functions/api/subscriptions/subscribe.js
+++ b/functions/api/subscriptions/subscribe.js
@@ -4,6 +4,7 @@
 import { generateToken } from '../../utils/tokens.js';
 import { sendEmail, isEmailConfigured } from '../../utils/email.js';
 import { isValidEmail } from '../../utils/validation.js';
+import { verifyTurnstile } from '../../utils/turnstile.js';
 
 const FREQUENCY_OPTIONS = new Set(['daily', 'weekly', 'monthly']);
 const MAX_EMAIL_LENGTH = 320;
@@ -18,41 +19,6 @@ function escapeHtml(value) {
     .replace(/>/g, '&gt;')
     .replace(/\"/g, '&quot;')
     .replace(/'/g, '&#39;');
-}
-
-async function verifyTurnstile(request, env, token) {
-  const secret = env?.TURNSTILE_SECRET_KEY;
-  if (!secret) {
-    return true;
-  }
-
-  if (!token || typeof token !== 'string') {
-    return false;
-  }
-
-  const ip = request.headers.get('CF-Connecting-IP') || '';
-  const formData = new URLSearchParams();
-  formData.set('secret', secret);
-  formData.set('response', token);
-  if (ip) {
-    formData.set('remoteip', ip);
-  }
-
-  try {
-    const response = await fetch(
-      'https://challenges.cloudflare.com/turnstile/v0/siteverify',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: formData,
-      }
-    );
-
-    const result = await response.json().catch(() => ({}));
-    return Boolean(result?.success);
-  } catch (_error) {
-    return false;
-  }
 }
 
 // Build a JSON Response, merging an optional verificationUrl when email

--- a/functions/utils/trustedDevice.js
+++ b/functions/utils/trustedDevice.js
@@ -107,6 +107,21 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
   // Trust policy:
   //   New rows (ua_hash present): UA must match; IP change is tolerated (DHCP, mobile, VPN).
   //   Legacy rows (no ua_hash):   full IP+UA fingerprint must match.
+  //
+  // ACCEPTED RISK (conscious tradeoff): tolerating IP changes means a stolen
+  // trusted-device token replayed from a different network still validates, as
+  // long as the attacker also presents the same User-Agent string. We accept
+  // this because:
+  //   1. The token is the primary factor — a 256-bit secret, hashed at rest
+  //      (hashTrustedDeviceToken), delivered over a Secure/HttpOnly cookie and
+  //      expiring after a bounded window. IP/UA are only weak secondary signals.
+  //   2. Pinning to IP would reject a large fraction of legitimate logins
+  //      (mobile handoff, CGNAT/DHCP churn, corporate VPNs), pushing users back
+  //      through full MFA constantly and eroding the feature's value.
+  //   3. Trusted-device only skips the MFA *second factor* on an already
+  //      password-authenticated login — it is not a standalone credential.
+  // If the threat model tightens (e.g. admin-only high-value accounts), revisit
+  // by adding IP-range/ASN checks rather than exact-IP pinning.
   const currentFingerprint = await generateDeviceFingerprint(ipAddress, userAgent);
   const currentUaHash = await generateUaHash(userAgent);
 

--- a/functions/utils/turnstile.js
+++ b/functions/utils/turnstile.js
@@ -1,0 +1,56 @@
+// Cloudflare Turnstile server-side verification.
+//
+// Shared by the public POST endpoints that accept anonymous email input
+// (subscriptions/subscribe.js, bands/[name]/follow.js) so the bot-gate logic
+// — and especially its fail-closed posture — lives in exactly one place.
+//
+// SECURITY: when TURNSTILE_SECRET_KEY is unset we fail OPEN only in local dev
+// and fail CLOSED in production. A missing or misconfigured secret must never
+// silently disable bot protection in prod (mirrors the CSRF_SECRET handling in
+// utils/csrf.js). NOTE: this means TURNSTILE_SECRET_KEY MUST be configured in
+// the production Pages project, or these endpoints will reject every request.
+import { isDevRequest } from "./auth.js";
+
+const SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+export async function verifyTurnstile(request, env, token) {
+  const secret = env?.TURNSTILE_SECRET_KEY;
+  if (!secret) {
+    if (isDevRequest(request, env)) {
+      console.warn(
+        "[Turnstile] TURNSTILE_SECRET_KEY not set — skipping bot verification (local dev only).",
+      );
+      return true;
+    }
+    console.error(
+      "[Turnstile] TURNSTILE_SECRET_KEY is required in production; rejecting request.",
+    );
+    return false;
+  }
+
+  if (!token || typeof token !== "string") {
+    return false;
+  }
+
+  const ip = request.headers.get("CF-Connecting-IP") || "";
+  const formData = new URLSearchParams();
+  formData.set("secret", secret);
+  formData.set("response", token);
+  if (ip) {
+    formData.set("remoteip", ip);
+  }
+
+  try {
+    const response = await fetch(SITEVERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formData,
+    });
+
+    const result = await response.json().catch(() => ({}));
+    return Boolean(result?.success);
+  } catch (_error) {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #371. The three Low-severity items from the security audit.

> [!IMPORTANT]
> **Action required before/after merge:** `TURNSTILE_SECRET_KEY` **must** be set in the production Pages project. With this change, an unset secret makes the follow/subscribe endpoints reject every request in production (fail-closed). Please confirm the secret is configured.

## 1. Turnstile: fail-open → fail-closed
`verifyTurnstile()` was duplicated in `subscribe.js` and `follow.js` and returned `true` when `TURNSTILE_SECRET_KEY` was unset — silently disabling bot protection. Consolidated into **`functions/utils/turnstile.js`**, which now:
- allows the no-secret path **only** for local-dev requests (`isDevRequest`), and
- **fails closed** otherwise — the same posture as `CSRF_SECRET` (`utils/csrf.js`).

Both endpoints keep their existing response codes; only the no-secret behaviour changed. Single source of truth removes future drift.

## 2. Band follow: double opt-in (email-bombing fix)
`follow.js` inserted `verified = 1` (auto-verify), so anyone could enroll a victim's address into a band's announcement stream. Now:
- follow creates the row `verified = 0` with a `verification_token` and sends **only** a confirmation email;
- new **`GET /api/bands/:name/confirm-follow?token=…`** sets `verified = 1` and clears the token (idempotent, generic messaging to avoid enumeration);
- announcement emails already filter `verified = 1` (`admin/bands/[id].js`, `resend-announcement.js`), so an unconfirmed/unowned address receives **at most one** confirmation email it can ignore.

**No migration** — `band_follows.verification_token` already exists (migration 0035); it was designed for this and never wired up. Frontend success copy updated to "check your email to confirm". When email delivery isn't configured (local/dev only) the confirm URL is returned in the response, mirroring the subscriptions endpoint — never in production.

## 3. Trusted-device IP tolerance: documented accepted risk
Added an explicit **ACCEPTED RISK** note in `functions/utils/trustedDevice.js` explaining why IP changes are tolerated (token is the primary 256-bit factor; exact-IP pinning would reject legitimate mobile/DHCP/VPN logins) and how to revisit (IP-range/ASN, not exact-IP) if the threat model tightens.

## Tests
- `follow.test.js` updated: a new follow is now `verified = 0` with a pending token.
- New `confirm-follow.test.js`: verify-and-clear, idempotency on second click, missing token (400), unknown token (generic 200).
- Full backend suite: **452 passed, 6 todo**. Frontend lint/format/build clean.
- `CLAUDE.md` Band Announcements section updated (double opt-in + Turnstile fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)