### PR TITLE
feat(live): "Next Move" live-event companion card

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,10 @@
 import { Archive, Bell, CircleAlert, X } from 'lucide-react'
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
 import Breadcrumbs from './components/Breadcrumbs'
 import ComingUp from './components/ComingUp'
+import NextMove from './components/NextMove'
 import Footer from './components/Footer'
 import Header from './components/Header'
 import OfflineIndicator from './components/OfflineIndicator'
@@ -14,6 +15,7 @@ import ScheduleSkeleton from './components/ScheduleSkeleton'
 import { ConfirmDialog, Modal } from './components/ui'
 import { trackEventView, trackPageView } from './utils/metrics'
 import { getTimeFilterOptions } from './utils/timeFilter'
+import { computeNextMove } from './utils/nextMove'
 import { validateBandsData } from './utils/validation'
 import { prepareBands } from './utils/bandUtils'
 import { saveSelectedBands } from './utils/scheduleStorage'
@@ -575,6 +577,10 @@ function App() {
   const toggleShowPast = () => setShowPast(prev => !prev)
   const shouldShowLoading = loading && bands.length === 0
   const effectiveNow = debugTime || currentTime
+  // "Next Move" live companion: the single glanceable action for right now,
+  // derived from the user's route + current time (see utils/nextMove.js). When
+  // active (event is live/near), it supersedes the simpler ComingUp banner.
+  const nextMoveState = useMemo(() => computeNextMove(myBands, effectiveNow), [myBands, effectiveNow])
   const debugEnabled = (() => {
     if (typeof window === 'undefined') return false
     const hostname = window.location.hostname || ''
@@ -677,7 +683,12 @@ function App() {
       ) : (
         <Header eventName={eventData?.name} eventDate={eventData?.date} />
       )}
-      {!isArchived && <ComingUp bands={myBands} currentTime={effectiveNow} />}
+      {!isArchived &&
+        (nextMoveState.kind ? (
+          <NextMove state={nextMoveState} onDecide={() => setView('mine')} />
+        ) : (
+          <ComingUp bands={myBands} currentTime={effectiveNow} />
+        ))}
       {!isArchived && (
         <LiveContextBar
           eventData={eventData}

--- a/frontend/src/components/NextMove.jsx
+++ b/frontend/src/components/NextMove.jsx
@@ -1,0 +1,155 @@
+import { ArrowRight, CircleAlert, Clock, Footprints, Guitar, Navigation } from 'lucide-react'
+import { directionsHref } from '../utils/nextMove'
+
+// Glanceable live-event companion. Renders the single "what do I do right now"
+// answer produced by computeNextMove() — see utils/nextMove.js. Purely
+// presentational: all decisions live in the state machine, this just paints it.
+
+const formatMins = mins => {
+  if (mins == null) return ''
+  if (mins < 60) return `${mins} min`
+  const h = Math.floor(mins / 60)
+  const m = mins % 60
+  return m ? `${h}h ${m}m` : `${h}h`
+}
+
+const KIND_META = {
+  watching: { eyebrow: 'Now playing', Icon: Guitar, accent: 'border-success-500/50 bg-success-500/10' },
+  move: { eyebrow: 'Time to move', Icon: Footprints, accent: 'border-warning-500/50 bg-warning-500/10' },
+  decide: { eyebrow: 'Sets clash', Icon: CircleAlert, accent: 'border-error-500/50 bg-error-500/10' },
+  upnext: { eyebrow: 'Up next', Icon: Clock, accent: 'border-info-500/50 bg-info-500/10' },
+}
+
+function DirectionsButton({ band }) {
+  const href = directionsHref(band)
+  if (!href) return null
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1.5 rounded-lg bg-accent-500 px-3 py-2 text-sm font-semibold text-bg-navy transition-colors hover:bg-accent-400 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-300"
+      aria-label={`Directions to ${band.venue || 'the venue'}`}
+    >
+      <Navigation size={15} aria-hidden="true" />
+      Directions
+    </a>
+  )
+}
+
+function Body({ state }) {
+  const titleClass = 'truncate text-lg font-bold leading-tight text-text-primary sm:text-xl'
+  const subClass = 'mt-0.5 text-sm text-text-secondary'
+
+  if (state.kind === 'watching') {
+    const { nowBand, minutesLeft, nextBand, minutesToNext } = state
+    return (
+      <>
+        <p className={titleClass}>{nowBand.name}</p>
+        <p className={subClass}>
+          {nowBand.venue ? `${nowBand.venue} · ` : ''}
+          {minutesLeft} min left
+        </p>
+        {nextBand && (
+          <p className="mt-1 truncate text-xs text-text-tertiary">
+            Then {nextBand.name} in {formatMins(minutesToNext)}
+          </p>
+        )}
+      </>
+    )
+  }
+
+  if (state.kind === 'move') {
+    const { nextBand, minutesToNext, walkMin, slackMin } = state
+    let walkLine
+    if (walkMin == null) {
+      walkLine = `Starts in ${formatMins(minutesToNext)}`
+    } else if (slackMin != null && slackMin <= 0) {
+      walkLine = `~${walkMin} min walk · leave now`
+    } else {
+      walkLine = `~${walkMin} min walk · ${formatMins(slackMin)} to spare`
+    }
+    return (
+      <>
+        <p className={titleClass}>Head to {nextBand.venue || 'the next venue'}</p>
+        <p className={subClass}>
+          {nextBand.name} · {walkLine}
+        </p>
+      </>
+    )
+  }
+
+  if (state.kind === 'decide') {
+    const [a, b] = state.conflict
+    return (
+      <>
+        <p className={titleClass}>
+          {a.name} <span className="text-text-tertiary">vs</span> {b.name}
+        </p>
+        <p className={subClass}>
+          {a.venue && b.venue ? `${a.venue} & ${b.venue} overlap — pick one` : 'Two saved sets overlap — pick one'}
+        </p>
+      </>
+    )
+  }
+
+  // upnext
+  const { nextBand, minutesToNext } = state
+  return (
+    <>
+      <p className={titleClass}>{nextBand.name}</p>
+      <p className={subClass}>
+        {nextBand.venue ? `${nextBand.venue} · ` : ''}in {formatMins(minutesToNext)}
+      </p>
+    </>
+  )
+}
+
+function Action({ state, onDecide }) {
+  if (state.kind === 'decide') {
+    return (
+      <button
+        type="button"
+        onClick={onDecide}
+        className="inline-flex items-center gap-1.5 rounded-lg bg-accent-500 px-3 py-2 text-sm font-semibold text-bg-navy transition-colors hover:bg-accent-400 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-300"
+      >
+        Choose in My Route
+        <ArrowRight size={15} aria-hidden="true" />
+      </button>
+    )
+  }
+  if (state.kind === 'move' || state.kind === 'upnext') {
+    return <DirectionsButton band={state.nextBand} />
+  }
+  return null
+}
+
+export default function NextMove({ state, onDecide }) {
+  if (!state || !state.kind) return null
+  const meta = KIND_META[state.kind]
+  if (!meta) return null
+  const { Icon, eyebrow, accent } = meta
+
+  return (
+    <div className="container mx-auto max-w-(--breakpoint-2xl) px-4">
+      <div
+        role="status"
+        aria-live="polite"
+        className={`flex flex-col gap-3 rounded-xl border p-4 shadow-lg sm:flex-row sm:items-center sm:justify-between ${accent}`}
+      >
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="mt-0.5 shrink-0 rounded-lg bg-bg-navy/20 p-2 text-text-primary">
+            <Icon size={20} aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-text-secondary">{eyebrow}</p>
+            <Body state={state} />
+          </div>
+        </div>
+        <div className="shrink-0 sm:pl-3">
+          <Action state={state} onDecide={onDecide} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/utils/__tests__/nextMove.test.js
+++ b/frontend/src/utils/__tests__/nextMove.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { computeNextMove, directionsHref, LIVE_WINDOW_MIN } from '../nextMove'
+
+const BASE = new Date('2026-08-02T20:00:00').getTime()
+const now = new Date(BASE)
+const min = n => n * 60000
+
+// Build a band relative to `now`. startOffMin/endOffMin are minutes from now.
+const band = (over = {}) => ({
+  id: 1,
+  name: 'Band',
+  venue: 'Venue A',
+  venue_lat: 43.4683,
+  venue_lng: -80.5226,
+  startMs: BASE + min(30),
+  endMs: BASE + min(60),
+  ...over,
+})
+
+describe('computeNextMove', () => {
+  it('returns null when there are no bands', () => {
+    expect(computeNextMove([], now).kind).toBe(null)
+  })
+
+  it('returns null when the next set is beyond the live window', () => {
+    const far = band({ startMs: BASE + min(LIVE_WINDOW_MIN + 30), endMs: BASE + min(LIVE_WINDOW_MIN + 60) })
+    expect(computeNextMove([far], now).kind).toBe(null)
+  })
+
+  it('reports "watching" for a set playing now, with minutes left', () => {
+    const live = band({ startMs: BASE - min(10), endMs: BASE + min(20) })
+    const state = computeNextMove([live], now)
+    expect(state.kind).toBe('watching')
+    expect(state.nowBand.id).toBe(live.id)
+    expect(state.minutesLeft).toBe(20)
+  })
+
+  it('includes the next set while watching', () => {
+    const live = band({ id: 1, startMs: BASE - min(10), endMs: BASE + min(20) })
+    const next = band({ id: 2, name: 'Next', startMs: BASE + min(25), endMs: BASE + min(55) })
+    const state = computeNextMove([live, next], now)
+    expect(state.kind).toBe('watching')
+    expect(state.nextBand.id).toBe(2)
+    expect(state.minutesToNext).toBe(25)
+  })
+
+  it('reports "decide" when two saved sets play at the same time now', () => {
+    const a = band({ id: 1, name: 'A', startMs: BASE - min(5), endMs: BASE + min(25) })
+    const b = band({ id: 2, name: 'B', venue: 'Venue B', startMs: BASE - min(2), endMs: BASE + min(28) })
+    const state = computeNextMove([a, b], now)
+    expect(state.kind).toBe('decide')
+    expect(state.conflict).toHaveLength(2)
+  })
+
+  it('reports "decide" when the next two saved sets overlap', () => {
+    const a = band({ id: 1, name: 'A', startMs: BASE + min(10), endMs: BASE + min(40) })
+    const b = band({ id: 2, name: 'B', venue: 'Venue B', startMs: BASE + min(20), endMs: BASE + min(50) })
+    const state = computeNextMove([a, b], now)
+    expect(state.kind).toBe('decide')
+    expect(state.conflict.map(x => x.id).sort()).toEqual([1, 2])
+  })
+
+  it('reports "move" when the previous set ended at a different venue', () => {
+    const prev = band({ id: 1, name: 'Prev', venue: 'Venue A', startMs: BASE - min(40), endMs: BASE - min(5) })
+    const next = band({
+      id: 2,
+      name: 'Next',
+      venue: 'Venue B',
+      venue_lat: 43.4699,
+      venue_lng: -80.521,
+      startMs: BASE + min(20),
+      endMs: BASE + min(50),
+    })
+    const state = computeNextMove([prev, next], now)
+    expect(state.kind).toBe('move')
+    expect(state.nextBand.id).toBe(2)
+    expect(typeof state.walkMin).toBe('number')
+    expect(state.slackMin).toBe(state.minutesToNext - state.walkMin)
+  })
+
+  it('reports "upnext" when the next set is soon and no venue change applies', () => {
+    const next = band({ id: 2, name: 'Next', startMs: BASE + min(30), endMs: BASE + min(60) })
+    const state = computeNextMove([next], now)
+    expect(state.kind).toBe('upnext')
+    expect(state.minutesToNext).toBe(30)
+  })
+
+  it('"watching" takes precedence over an upcoming move', () => {
+    const live = band({ id: 1, startMs: BASE - min(5), endMs: BASE + min(25) })
+    const next = band({ id: 2, venue: 'Venue B', startMs: BASE + min(30), endMs: BASE + min(60) })
+    expect(computeNextMove([live, next], now).kind).toBe('watching')
+  })
+})
+
+describe('directionsHref', () => {
+  it('builds a coordinate directions link when coords are present', () => {
+    const href = directionsHref({ venue: 'Roost', venue_lat: 43.46, venue_lng: -80.52 })
+    expect(href).toBe('https://www.google.com/maps/dir/?api=1&destination=43.46,-80.52')
+  })
+
+  it('falls back to a name search when coords are missing', () => {
+    const href = directionsHref({ venue: 'The Roost' })
+    expect(href).toContain('/maps/search/')
+    expect(href).toContain(encodeURIComponent('The Roost Waterloo ON'))
+  })
+
+  it('returns null when there is nothing to locate', () => {
+    expect(directionsHref({})).toBe(null)
+    expect(directionsHref(null)).toBe(null)
+  })
+})

--- a/frontend/src/utils/nextMove.js
+++ b/frontend/src/utils/nextMove.js
@@ -1,0 +1,98 @@
+// "Next Move" live companion — pure state machine.
+//
+// Given the user's saved bands (already enriched with startMs/endMs by
+// prepareBands, so the after-midnight offset is already applied — do NOT
+// re-derive it here) and the current time, decide the single most useful thing
+// to surface right now:
+//   watching → a saved set is playing now
+//   move     → nothing playing, next set is at a different venue (walk there)
+//   decide   → two saved sets clash (now, or imminently)
+//   upnext   → next set is soon, same venue / first set of the night
+//   null     → the event isn't close enough to matter (ComingUp covers that)
+import { walkMinutesBetween } from './walkTime'
+
+// How far ahead (minutes) the live card stays relevant. Beyond this the rich
+// card stands down and the generic "coming up" banner takes over.
+export const LIVE_WINDOW_MIN = 240
+
+const toMinutes = ms => Math.round(ms / 60000)
+
+// Build a maps directions deep-link for a band's venue. Prefers exact
+// coordinates (opens the Maps app on mobile); falls back to a name search.
+export function directionsHref(band) {
+  if (!band) return null
+  const { venue_lat: lat, venue_lng: lng, venue } = band
+  if (typeof lat === 'number' && typeof lng === 'number' && !Number.isNaN(lat) && !Number.isNaN(lng)) {
+    return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`
+  }
+  if (venue) {
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${venue} Waterloo ON`)}`
+  }
+  return null
+}
+
+export function computeNextMove(bands, now, { windowMin = LIVE_WINDOW_MIN } = {}) {
+  const nowMs = (now instanceof Date ? now : new Date(now || Date.now())).getTime()
+
+  // Only bands with usable precomputed times participate.
+  const timed = (Array.isArray(bands) ? bands : []).filter(
+    b => Number.isFinite(b.startMs) && b.startMs > 0 && Number.isFinite(b.endMs) && b.endMs > 0
+  )
+
+  const playingNow = timed.filter(b => b.startMs <= nowMs && nowMs < b.endMs).sort((a, b) => a.endMs - b.endMs)
+  const upcoming = timed.filter(b => b.startMs > nowMs).sort((a, b) => a.startMs - b.startMs)
+  const finished = timed.filter(b => b.endMs <= nowMs).sort((a, b) => b.endMs - a.endMs)
+
+  const nextBand = upcoming[0] || null
+  const minutesToNext = nextBand ? toMinutes(nextBand.startMs - nowMs) : null
+
+  // 1. Hard clash: two saved sets overlap *right now* — you can't be in two
+  //    rooms at once, so the only move is to choose.
+  if (playingNow.length >= 2) {
+    return { kind: 'decide', conflict: [playingNow[0], playingNow[1]], nextBand, minutesToNext }
+  }
+
+  // 2. Currently watching a saved set.
+  if (playingNow.length === 1) {
+    const nowBand = playingNow[0]
+    return {
+      kind: 'watching',
+      nowBand,
+      minutesLeft: toMinutes(nowBand.endMs - nowMs),
+      nextBand,
+      minutesToNext,
+    }
+  }
+
+  // Nothing playing. If the next set is beyond the live window, stand down.
+  if (!nextBand || minutesToNext > windowMin) {
+    return { kind: null }
+  }
+
+  // 3. Imminent clash: the next two saved sets overlap.
+  if (upcoming.length >= 2 && upcoming[1].startMs < nextBand.endMs) {
+    return { kind: 'decide', conflict: [nextBand, upcoming[1]], nextBand, minutesToNext }
+  }
+
+  // 4. Move vs. up-next. If the most recently finished set was at a different
+  //    venue, the actionable thing is to get up and walk there now.
+  const prev = finished[0] || null
+  const venueChanged = Boolean(prev && prev.venue && nextBand.venue && prev.venue !== nextBand.venue)
+  if (venueChanged) {
+    const walkMin = walkMinutesBetween(
+      { latitude: prev.venue_lat, longitude: prev.venue_lng },
+      { latitude: nextBand.venue_lat, longitude: nextBand.venue_lng }
+    )
+    return {
+      kind: 'move',
+      fromBand: prev,
+      nextBand,
+      minutesToNext,
+      walkMin,
+      slackMin: walkMin != null ? minutesToNext - walkMin : null,
+    }
+  }
+
+  // 5. Otherwise just announce what's up next.
+  return { kind: 'upnext', nextBand, minutesToNext }
+}


### PR DESCRIPTION
Closes #372. From the UX review: during the event, collapse the live UI into one glanceable card that answers only **"what do I do right now."**

## What it does
A single card that supersedes the simpler `ComingUp` banner whenever the event is live or within the next few hours (and falls back to `ComingUp` otherwise). Four states:

| State | When | Shows |
|-------|------|-------|
| **Now playing** | a saved set is on now | band · minutes left · "then {next}" |
| **Time to move** | nothing on; next set at a *different* venue | "Head to {venue}" · `~N min walk · M to spare` / "leave now" · **Directions** |
| **Sets clash** | two saved sets overlap (now or imminent) | "A vs B overlap — pick one" · **Choose in My Route** |
| **Up next** | next set soon, same venue / first of night | band · venue · in {time} · **Directions** |

## Design
- **Logic is a pure function** — `utils/nextMove.js` `computeNextMove(myBands, now)` returns a state object; the component just paints it. This made every transition unit-testable with plain data (no DOM) and lets `App.jsx` decide NextMove-vs-ComingUp from the same call.
- **Reuses existing machinery**: consumes the `startMs`/`endMs` already produced by `prepareBands` (so the after-midnight offset invariant is preserved — not re-derived), and `walkMinutesBetween` for the Move walk/slack estimate (the same math now in MySchedule).
- **Directions deep-link**: prefers exact venue coords (`/maps/dir/?api=1&destination=lat,lng`, opens the Maps app on mobile), falls back to a name search.
- **Theme-safe**: semantic tokens + status colours (success/warning/error/info), no hardcoded white. `role="status"` `aria-live="polite"`.
- **Decide** routes the user to My Route (`setView('mine')`) to deselect.

## Tests
- 12 new unit tests in `utils/__tests__/nextMove.test.js` — every state, precedence (watching > move), window cutoff, and `directionsHref` (coords / fallback / null).
- Full frontend suite: **204 passed**. Lint/format/build clean.

## Notes
`ComingUp` is intentionally kept for the far-out pre-event banner; NextMove only takes over inside the ~4h live window. A natural follow-up (filed separately if wanted) is to also make NextMove auto-refresh on the same 1-min tick `effectiveNow` already drives — it already re-renders via the memo on `effectiveNow`, so no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)