### PR TITLE
ci: inject VITE_TURNSTILE_SITE_KEY into the deploy build

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -65,6 +65,15 @@ jobs:
 
       - name: Build frontend
         working-directory: frontend
+        env:
+          # Public Turnstile site key — Vite inlines VITE_* into the client bundle
+          # at build time (import.meta.env.VITE_TURNSTILE_SITE_KEY). The deployed
+          # bundle is built HERE in CI (the deploy job only redeploys this artifact,
+          # it never rebuilds), so the site key must be present in this step or the
+          # public forms render no widget and the backend rejects with "Bot
+          # verification failed". Pairs with the runtime TURNSTILE_SECRET_KEY secret.
+          # Non-secret (it ships to browsers), so it lives in repo Variables, not Secrets.
+          VITE_TURNSTILE_SITE_KEY: ${{ vars.VITE_TURNSTILE_SITE_KEY }}
         run: npm run build
 
       - name: Upload frontend build artifact


### PR DESCRIPTION
## Problem

Turnstile is enabled on the backend (`TURNSTILE_SECRET_KEY` is set), so the API now **requires** a valid token. But the public follow/subscribe forms render **no widget** and every submission fails with **"Bot verification failed"**.

Root cause: the frontend never received the **site key**. `VITE_TURNSTILE_SITE_KEY` is consumed by **Vite at build time** (`import.meta.env.*` is inlined into the static bundle). In this repo the deployed bundle is built in the **`ci` job** of `cloudflare-pages.yml` (the `deploy` job only redeploys that artifact — it never rebuilds, and Cloudflare doesn't build it either). The build step had no site key, so the bundle shipped with an empty value → `turnstileEnabled = false` → no widget → empty token → backend rejects.

## Fix

Add `VITE_TURNSTILE_SITE_KEY` to the **"Build frontend"** step's `env:`, sourced from a repo **Variable** (it's public — it ships to browsers — so it is *not* a Secret). This matches the workflow's existing `${{ vars.* }}` convention for non-secret config.

## ⚠️ Required manual step (this PR is inert without it)

Add the GitHub Actions **repository Variable** (not a Secret):

**Settings → Secrets and variables → Actions → Variables → New repository variable**
- Name: `VITE_TURNSTILE_SITE_KEY`
- Value: `<your Turnstile widget's Site Key>`

Then merge this PR (or re-run the deploy) so the `ci` build bakes the key in. Also confirm the Turnstile widget's **allowed domains** include `settimes.ca`.

## Layers, for clarity
| Key | Layer | Where it lives |
|---|---|---|
| `TURNSTILE_SECRET_KEY` | Functions **runtime** | Cloudflare secret (already set ✅) |
| `VITE_TURNSTILE_SITE_KEY` | Vite **build** | GitHub Actions repo Variable (this PR) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)