### PR TITLE
fix(csp): allow Turnstile + service worker; hash inline theme script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,3 +226,11 @@ Do this **every time you push**, not just when opening the PR. Dependabot merges
 - Session invalidation: `lucia.invalidateUserSessions(userId)` must be called before `lucia.createSession(user.id, {})` on re-authentication (login, MFA verify). This kills stale sessions from prior compromised contexts. Both methods live on the object returned by `initializeLucia()` in `functions/utils/auth.js`.
 - CSRF cookie must be regenerated whenever a new session is created (see `functions/api/admin/sessions/revoke-all.js`).
 - `params.id` from Cloudflare Pages Functions URL params is a string; always run it through `validateId()` from `functions/utils/validation.js` before using it in a DB query.
+
+### Content-Security-Policy (strict, no `unsafe-inline`)
+
+The CSP is built once in `functions/_middleware.js` (enforced when `ENVIRONMENT=production` unless `CSP_ENFORCE` overrides) and applied to every response. It is deliberately strict.
+
+- **Turnstile** requires `https://challenges.cloudflare.com` in `script-src` and `frame-src` (Cloudflare's [CSP docs](https://developers.cloudflare.com/turnstile/reference/content-security-policy/)). It does **not** need `'unsafe-inline'`.
+- **The inline theme-flash `<script>` in `frontend/index.html`** is allowed by a `'sha256-…'` hash in `script-src`. **If you edit that script, regenerate the hash** (sha256 of the exact built script body, base64) or it silently stops running and a theme flash returns. There is no test for this — verify by building and hashing `dist/index.html`.
+- **Cloudflare Rocket Loader must stay DISABLED** for the zone. It rewrites/inline-executes `<script>` tags, which strict CSP blocks ("Refused to execute inline script"). A modern code-split Vite SPA gains nothing from it.

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -97,6 +97,32 @@ export async function onRequest(context) {
       ? env?.CSP_ENFORCE === 'true'
       : env?.ENVIRONMENT === 'production';
 
+  // Single source of truth for the Content-Security-Policy (reused on both the
+  // success and error responses below).
+  //   - script-src/frame-src/connect-src allow https://challenges.cloudflare.com
+  //     for Cloudflare Turnstile (per its CSP docs); no 'unsafe-inline' needed.
+  //   - the inline theme-flash bootstrap in frontend/index.html is permitted by
+  //     its sha256 hash — REGENERATE this hash if that <script> ever changes
+  //     (openssl/Node sha256 over the exact script body, base64).
+  //   - worker-src 'self' permits the /sw.js service worker (main.jsx registers it).
+  // NOTE: this strict policy (no 'unsafe-inline') is incompatible with Cloudflare
+  // Rocket Loader, which rewrites/inline-executes scripts. Rocket Loader must stay
+  // DISABLED for this zone or it will trip "Refused to execute inline script".
+  const csp = [
+    "default-src 'self'",
+    "script-src 'self' https://challenges.cloudflare.com 'sha256-AthfpLUxHMTHKKJhjnay6WvKZb8lWKmb3ca+GM+ZrkI='",
+    "style-src 'self'",
+    "img-src 'self' data: blob:",
+    "font-src 'self' data:",
+    "connect-src 'self' https://challenges.cloudflare.com",
+    "object-src 'none'",
+    "frame-src 'self' https://challenges.cloudflare.com",
+    "child-src 'self' https://challenges.cloudflare.com",
+    "worker-src 'self'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+  ].join('; ');
+
   // Enable FK enforcement for this D1 session. SQLite disables it by default;
   // this must be set per-connection so it applies to every handler in this request.
   // Placed after all early returns so preflights and rejected origins don't pay
@@ -148,20 +174,6 @@ export async function onRequest(context) {
       'Permissions-Policy',
       'geolocation=(), microphone=(), camera=()'
     );
-    const csp = [
-      "default-src 'self'",
-      "script-src 'self'",
-      "style-src 'self'",
-      "img-src 'self' data: blob:",
-      "font-src 'self' data:",
-      "connect-src 'self'",
-      "object-src 'none'",
-      "frame-src 'none'",
-      "child-src 'none'",
-      "worker-src 'none'",
-      "base-uri 'self'",
-      "frame-ancestors 'none'",
-    ].join('; ');
     if (cspEnforce) {
       newHeaders.set('Content-Security-Policy', csp);
     } else {
@@ -196,14 +208,8 @@ export async function onRequest(context) {
           'Referrer-Policy': 'no-referrer',
           'Permissions-Policy': 'geolocation=(), microphone=(), camera=()',
           ...(cspEnforce
-            ? {
-                'Content-Security-Policy':
-                  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-src 'none'; child-src 'none'; worker-src 'none'; base-uri 'self'; frame-ancestors 'none'",
-              }
-            : {
-                'Content-Security-Policy-Report-Only':
-                  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-src 'none'; child-src 'none'; worker-src 'none'; base-uri 'self'; frame-ancestors 'none'",
-              }),
+            ? { 'Content-Security-Policy': csp }
+            : { 'Content-Security-Policy-Report-Only': csp }),
         },
       }
     );


### PR DESCRIPTION
## Problem

After the Turnstile site key deployed (#385), the **Follow button is stuck disabled**. The site's strict CSP (`script-src 'self'`, no `'unsafe-inline'`) refuses the Turnstile widget, so it never renders → `turnstileToken` never sets → `disabled={turnstileEnabled && !turnstileToken}` stays true.

Console errors:
- `Refused to load …challenges.cloudflare.com/turnstile/v0/api.js` — `script-src`
- `Refused to load …/sw.js` — `worker-src`
- `Refused to execute a script …` — inline scripts blocked

## Root causes (two layers)

1. **CSP too narrow.** Turnstile needs `https://challenges.cloudflare.com` in `script-src`/`frame-src` ([Turnstile CSP docs](https://developers.cloudflare.com/turnstile/reference/content-security-policy/)). `worker-src 'none'` blocked `/sw.js`. The inline theme-flash bootstrap in `index.html` had no hash, so it was blocked too (latent — flash of default theme in prod).
2. **Cloudflare Rocket Loader is enabled.** It rewrites `<script>` tags and inline-executes them, which strict CSP blocks. Cloudflare's own guidance: a no-`unsafe-inline` CSP is **incompatible** with Rocket Loader — disable it rather than weaken the policy.

## This PR (code: the CSP)

- `script-src 'self' https://challenges.cloudflare.com 'sha256-AthfpLUxHMTHKKJhjnay6WvKZb8lWKmb3ca+GM+ZrkI='`
- `frame-src 'self' https://challenges.cloudflare.com`, `connect-src 'self' https://challenges.cloudflare.com`, `child-src` aligned
- `worker-src 'self'` (service worker)
- The `sha256` hash is **verified to match the built `dist/index.html`** theme script — keeps CSP strict (no `unsafe-inline`).
- Refactored the duplicated CSP (success + error paths) into one source of truth.

## ⚠️ Required manual step

**Disable Rocket Loader** for the zone: Cloudflare dashboard → **Speed → Optimization → Content Optimization → Rocket Loader → Off**. Without this, the inline-execution errors persist and Turnstile loading stays flaky regardless of the CSP.

## Verification
- Backend tests: 453 pass (no CSP assertion existed; nothing broke)
- Hash match between shipped CSP and freshly built `index.html`: ✓
- CLAUDE.md documents the hash-regeneration footgun + the Rocket Loader constraint

After merge + Rocket Loader off: Turnstile renders → token flows → Follow enabled; `/sw.js` registers; no theme flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)