### PR TITLE
fix(headers): real document CSP for Turnstile (frontend/public/_headers) + drop COEP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,10 +227,15 @@ Do this **every time you push**, not just when opening the PR. Dependabot merges
 - CSRF cookie must be regenerated whenever a new session is created (see `functions/api/admin/sessions/revoke-all.js`).
 - `params.id` from Cloudflare Pages Functions URL params is a string; always run it through `validateId()` from `functions/utils/validation.js` before using it in a DB query.
 
-### Content-Security-Policy (strict, no `unsafe-inline`)
+### Content-Security-Policy (strict, no `unsafe-inline`) — TWO sources
 
-The CSP is built once in `functions/_middleware.js` (enforced when `ENVIRONMENT=production` unless `CSP_ENFORCE` overrides) and applied to every response. It is deliberately strict.
+There are **two** CSPs, and the one the browser enforces on a page is **not** the middleware:
 
-- **Turnstile** requires `https://challenges.cloudflare.com` in `script-src` and `frame-src` (Cloudflare's [CSP docs](https://developers.cloudflare.com/turnstile/reference/content-security-policy/)). It does **not** need `'unsafe-inline'`.
-- **The inline theme-flash `<script>` in `frontend/index.html`** is allowed by a `'sha256-…'` hash in `script-src`. **If you edit that script, regenerate the hash** (sha256 of the exact built script body, base64) or it silently stops running and a theme flash returns. There is no test for this — verify by building and hashing `dist/index.html`.
+- **`frontend/public/_headers`** sets the CSP (and COOP/COEP/CORP) on **static/document responses** — i.e. the HTML the browser loads. **This is the browser-enforced CSP for pages and the one that governs Turnstile, the service worker, and inline scripts.** Edit this for anything affecting what the page can load.
+- **`functions/_middleware.js`** sets a CSP on **Pages Functions / API responses** (JSON), enforced when `ENVIRONMENT=production` unless `CSP_ENFORCE` overrides. It does not govern the document.
+
+For the `_headers` document CSP:
+- **Turnstile** needs `https://challenges.cloudflare.com` in `script-src`/`frame-src` ([CSP docs](https://developers.cloudflare.com/turnstile/reference/content-security-policy/)); no `'unsafe-inline'`.
+- **`Cross-Origin-Embedder-Policy: require-corp` must NOT be set** — it blocks the Turnstile iframe (which doesn't send COEP; `credentialless` isn't supported in Safari). The app needs no cross-origin isolation.
+- **The inline theme-flash `<script>` in `frontend/index.html`** is allowed by a `'sha256-…'` hash in `script-src`. **If you edit that script, regenerate the hash** (sha256 of the exact built script body, base64) or it silently stops running and a theme flash returns. No test covers this — verify by building and hashing `dist/index.html`.
 - **Cloudflare Rocket Loader must stay DISABLED** for the zone. It rewrites/inline-executes `<script>` tags, which strict CSP blocks ("Refused to execute inline script"). A modern code-split Vite SPA gains nothing from it.

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -17,11 +17,19 @@
 
   # Cross-Origin policies
   Cross-Origin-Opener-Policy: same-origin
-  Cross-Origin-Embedder-Policy: require-corp
+  # No Cross-Origin-Embedder-Policy: require-corp blocks the Cloudflare Turnstile
+  # iframe (it does not send COEP, and COEP:credentialless is unsupported in Safari).
+  # This app needs no cross-origin isolation (no SharedArrayBuffer/crossOriginIsolated),
+  # so COEP buys nothing here. Do NOT re-add it without exempting Turnstile's iframe.
   Cross-Origin-Resource-Policy: same-origin
 
   # Content Security Policy
-  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors 'none'; frame-src 'none'; child-src 'none'; worker-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  # Turnstile: challenges.cloudflare.com in script-src/frame-src/connect-src.
+  # The sha256 hash allows the inline theme-flash <script> in index.html — REGENERATE
+  # it (sha256 of the exact built script body, base64) if that script changes.
+  # worker-src 'self' permits /sw.js. NOTE: Cloudflare Rocket Loader must stay OFF
+  # for the zone (it inline-executes scripts, which this no-'unsafe-inline' CSP blocks).
+  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; script-src 'self' https://static.cloudflareinsights.com https://challenges.cloudflare.com 'sha256-AthfpLUxHMTHKKJhjnay6WvKZb8lWKmb3ca+GM+ZrkI='; connect-src 'self' https://*.settimes.ca https://*.pages.dev https://cloudflareinsights.com https://static.cloudflareinsights.com https://challenges.cloudflare.com; frame-ancestors 'none'; frame-src 'self' https://challenges.cloudflare.com; child-src 'self' https://challenges.cloudflare.com; worker-src 'self'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
 
   # Permissions policy (disable unnecessary features)
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()


### PR DESCRIPTION
## The miss this corrects

#386 added the Turnstile allowances to `functions/_middleware.js` — but that CSP only applies to **Pages Functions / API (JSON) responses**. The CSP the **browser enforces on the HTML document** comes from **`frontend/public/_headers`** (Cloudflare Pages static headers), which I hadn't touched. Verified live: the served CSP was still `script-src 'self' …cloudflareinsights…; frame-src 'none'; worker-src 'none'` — i.e. the `_headers` one. So the widget stayed blocked.

## Fix (in `_headers` `/*`)

- `script-src` / `frame-src` / `connect-src`: allow `https://challenges.cloudflare.com` (Turnstile).
- `script-src`: add `'sha256-AthfpLUxHMTHKKJhjnay6WvKZb8lWKmb3ca+GM+ZrkI='` for the inline theme-flash `<script>` (now a real inline script since Rocket Loader is off). **Verified against the freshly built `dist/index.html`.**
- `worker-src 'self'`: unblock `/sw.js`.
- **Remove `Cross-Origin-Embedder-Policy: require-corp`.** Confirmed it blocks the Turnstile *iframe* (Turnstile's iframe sends no COEP; `credentialless` is unsupported in Safari). The app uses no cross-origin isolation (`grep` for `SharedArrayBuffer`/`crossOriginIsolated` → none), so COEP buys nothing here. `COOP: same-origin` and `CORP: same-origin` kept.

## Why two CSPs existed

`_headers` = document/static responses (browser-enforced for pages). `_middleware.js` = Function/API responses. CLAUDE.md now documents this split so the next person edits the right one.

## Verification
- Built `dist/_headers`: `script-src`/`frame-src`/`worker-src` correct; no `require-corp` header (only a comment mentions it). ✓
- Theme hash matches built `index.html`. ✓
- Rocket Loader already disabled at the zone; live HTML confirmed clean (no `cdn-cgi/.../rocket-loader.min.js`). ✓

After deploy I'll re-fetch the live headers to confirm, then it's the human challenge test.

Refs #387