### PR TITLE
fix(follow): render Turnstile after profile loads (button stuck disabled)

### DIFF
--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -272,7 +272,15 @@ export default function BandProfilePage() {
   )
 
   useEffect(() => {
-    if (!turnstileEnabled) {
+    // The Turnstile container lives inside the follow form, which is NOT mounted
+    // while the page shows its loading skeleton (`if (loading) return <Skeleton>`).
+    // Gate on the loaded state AND depend on it so the effect re-runs once the
+    // form (and the container ref) actually exists. Without this, when
+    // window.turnstile becomes ready before the profile fetch resolves — always
+    // the case on SPA client-nav with a cached script — render() is attempted
+    // against a null container, bails, and never retries, leaving the Follow
+    // button permanently disabled.
+    if (!turnstileEnabled || loading || error || !profile) {
       return undefined
     }
 
@@ -328,7 +336,7 @@ export default function BandProfilePage() {
         turnstileWidgetIdRef.current = null
       }
     }
-  }, [turnstileEnabled, turnstileSiteKey])
+  }, [turnstileEnabled, turnstileSiteKey, loading, error, profile])
 
   useEffect(() => {
     document.title = pageTitle


### PR DESCRIPTION
## Symptom
On `/band/:id`, the **Follow button is permanently greyed out** — even with all the infra fixes (site key, CSP, COEP, Rocket Loader) in place.

## Diagnosis (verified live in a real browser)
Loading the live page and manually calling `window.turnstile.render(div, { sitekey })` returned **`gotToken: true`** — so sitekey, domain allowlist, CSP, and COEP are all correct. The script loads and Turnstile issues tokens fine. The failure is purely in the React integration:

The Turnstile container (`<div ref={turnstileContainerRef}>`) lives **inside the follow form**, which isn't mounted while the page shows its loading skeleton (`if (loading) return <Skeleton>`). The render effect (`BandProfilePage.jsx`) depended only on `[turnstileEnabled, turnstileSiteKey]`, and `renderTurnstile()` bails when `turnstileContainerRef.current` is null. So whenever `window.turnstile` is ready **before** the profile fetch resolves — always the case on SPA client-nav with a cached script — `render()` runs against a null container, bails, and **never retries**. No token → button disabled forever.

## Fix
Gate the effect on `!loading && !error && profile` and add those to the dependency array, so it re-runs once the form (and the container ref) actually mounts.

```diff
- if (!turnstileEnabled) return undefined
+ if (!turnstileEnabled || loading || error || !profile) return undefined
...
- }, [turnstileEnabled, turnstileSiteKey])
+ }, [turnstileEnabled, turnstileSiteKey, loading, error, profile])
```

## Verification
- 204 frontend unit tests pass; lint (incl. exhaustive-deps) clean; build OK.
- **Note on testing:** this is a browser render-timing race with no existing BandProfilePage test harness; I verified it on the live deployed site (manual `render()` → token) rather than with a heavily-mocked unit test. After deploy I'll re-confirm the real widget issues a token and the button enables. Happy to add a regression test as a follow-up.

Refs #387