### PR TITLE
ux(turnstile): interaction-only widget to reduce form clutter

### DIFF
--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -297,6 +297,9 @@ export default function BandProfilePage() {
 
       turnstileWidgetIdRef.current = window.turnstile.render(turnstileContainerRef.current, {
         sitekey: turnstileSiteKey,
+        // Invisible unless Turnstile actually needs a human challenge — keeps the
+        // form uncluttered for legit visitors while preserving bot protection.
+        appearance: 'interaction-only',
         callback: token => {
           setTurnstileToken(token)
         },

--- a/frontend/src/pages/SubscribePage.jsx
+++ b/frontend/src/pages/SubscribePage.jsx
@@ -48,6 +48,9 @@ export default function SubscribePage() {
 
       turnstileWidgetIdRef.current = window.turnstile.render(turnstileContainerRef.current, {
         sitekey: turnstileSiteKey,
+        // Invisible unless Turnstile actually needs a human challenge — keeps the
+        // form uncluttered for legit visitors while preserving bot protection.
+        appearance: 'interaction-only',
         callback: token => {
           setTurnstileToken(token)
         },


### PR DESCRIPTION
Per request: only surface the Turnstile check when necessary.

`window.turnstile.render()` now gets `appearance: 'interaction-only'` on both the band-follow (`BandProfilePage.jsx`) and subscribe (`SubscribePage.jsx`) forms. The widget stays **invisible** and silently issues a token for legit visitors (managed mode auto-passes); it only appears if Turnstile actually needs a human to solve a challenge. Bot protection is unchanged.

204 frontend tests pass; lint/format/build clean.

Closes #390