### PR TITLE
fix: band status decoupled from archived events + name the band on unfollow

### DIFF
--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -200,12 +200,21 @@ export async function onRequestPut(context) {
       bandProfileId = performance.band_profile_id;
       linkedEvent = await getEventForPerformance(DB, realPerformanceId);
 
-      if (linkedEvent?.status === "archived") {
+      // An archived event freezes its lineup's event-specific fields (set times,
+      // venue) — but band-profile fields (is_active, name, genre, origin, photo,
+      // social links, bio) are band-WIDE and must stay editable regardless of the
+      // events the band has played. Only block when a performance field is the
+      // thing actually being changed.
+      const editsPerformanceFields =
+        venueId !== undefined ||
+        startTime !== undefined ||
+        endTime !== undefined;
+      if (linkedEvent?.status === "archived" && editsPerformanceFields) {
         return new Response(
           JSON.stringify({
             error: "Validation error",
             message:
-              "Archived event performances cannot be edited. Copy the event as a template instead.",
+              "Archived event set times cannot be edited. Copy the event as a template instead.",
           }),
           { status: 400, headers: { "Content-Type": "application/json" } },
         );

--- a/functions/api/admin/bands/__tests__/bands.test.js
+++ b/functions/api/admin/bands/__tests__/bands.test.js
@@ -100,6 +100,39 @@ describe('Admin bands API - CRUD operations', () => {
     const updated = list.bands.find(b => b.name === 'Alt Band')
     expect(updated.photo_alt_text).toBe('Alt Band performing under red stage lights')
   })
+
+  it('PUT /api/admin/bands/{id} allows band-profile edits (is_active) for a performance in an archived event', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'ArchivedEdit', slug: 'archived-edit', status: 'archived', is_published: 0 })
+    const venue = insertVenue(rawDb, { name: 'Archived Edit Venue' })
+    const band = insertBand(rawDb, { name: 'Filthy Kitty', event_id: ev.id, venue_id: venue.id })
+
+    const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ is_active: 0 }),
+    })
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
+    // Band status is band-wide, not event-specific — must not be blocked by archive.
+    expect(res.status).toBe(200)
+    const row = rawDb.prepare('SELECT is_active FROM band_profiles WHERE id = ?').get(band.band_profile_id)
+    expect(row.is_active).toBe(0)
+  })
+
+  it('PUT /api/admin/bands/{id} still rejects set-time edits for a performance in an archived event', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'ArchivedTime', slug: 'archived-time', status: 'archived', is_published: 0 })
+    const venue = insertVenue(rawDb, { name: 'Archived Time Venue' })
+    const band = insertBand(rawDb, { name: 'Frozen Set', event_id: ev.id, venue_id: venue.id })
+
+    const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ startTime: '20:00', endTime: '21:00' }),
+    })
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
+    expect(res.status).toBe(400)
+  })
 })
 
 describe('Admin bands API - Validation', () => {
@@ -273,7 +306,7 @@ describe('Admin bands API - Validation', () => {
     expect(res.status).toBe(404)
   })
 
-  it('update rejects performances for archived events', async () => {
+  it('update allows band-profile fields (name) for a performance in an archived event', async () => {
     const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
     const ev = insertEvent(rawDb, { name: 'ArchivedUpdate', slug: 'archived-update', status: 'archived', is_published: 0 })
     const venue = insertVenue(rawDb, { name: 'Archive Update Venue' })
@@ -285,10 +318,12 @@ describe('Admin bands API - Validation', () => {
       body: JSON.stringify({ name: 'Renamed Frozen Band' }),
     })
 
+    // Band name is band-wide profile data (one shared band_profiles row) — editable
+    // regardless of event archive state. Only event-specific set times are frozen.
     const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toBe('Validation error')
+    expect(res.status).toBe(200)
+    const row = rawDb.prepare('SELECT name FROM band_profiles WHERE id = ?').get(band.band_profile_id)
+    expect(row.name).toBe('Renamed Frozen Band')
   })
 
   it('delete returns 404 for non-existent band', async () => {

--- a/functions/api/bands/[name]/unfollow.js
+++ b/functions/api/bands/[name]/unfollow.js
@@ -2,6 +2,14 @@
 // Deletes the band follow associated with the unsubscribe token.
 // Returns 200 regardless of whether the token exists (avoid enumeration).
 
+const escapeHtml = (s) =>
+  String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
 export async function onRequestGet(context) {
   const { request, env } = context
   const { DB } = env
@@ -14,10 +22,26 @@ export async function onRequestGet(context) {
       return new Response('Invalid token.', { status: 400, headers: { 'Content-Type': 'text/plain' } })
     }
 
+    // Resolve the band name BEFORE deleting so the page can name it. An unknown
+    // token yields no row → a generic message (still 200), so the response never
+    // reveals whether a token was valid.
+    const follow = await DB.prepare(
+      `SELECT bp.name AS band_name
+       FROM band_follows bf
+       JOIN band_profiles bp ON bp.id = bf.band_profile_id
+       WHERE bf.unsubscribe_token = ?`
+    ).bind(token).first()
+
     await DB.prepare('DELETE FROM band_follows WHERE unsubscribe_token = ?').bind(token).run()
 
+    const bandName = follow?.band_name ? escapeHtml(follow.band_name) : null
+    const heading = bandName ? `Unfollowed ${bandName}` : 'Unfollowed'
+    const message = bandName
+      ? `You've been removed from ${bandName}'s follower list — you won't get any more emails about them.`
+      : `You have been removed from this band's follower list.`
+
     return new Response(
-      '<html><body style="font-family:sans-serif;padding:2rem"><h2>Unfollowed</h2><p>You have been removed from this band\'s follower list.</p></body></html>',
+      `<html><body style="font-family:sans-serif;padding:2rem"><h2>${heading}</h2><p>${message}</p></body></html>`,
       { status: 200, headers: { 'Content-Type': 'text/html', 'Cache-Control': 'no-store' } }
     )
   } catch (err) {

--- a/functions/api/bands/__tests__/unfollow.test.js
+++ b/functions/api/bands/__tests__/unfollow.test.js
@@ -3,10 +3,10 @@ import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
 import { onRequestGet } from '../[name]/unfollow.js'
 
 describe('GET /api/bands/:name/unfollow', () => {
-  it('deletes the follow row for a valid token and returns 200 HTML', async () => {
+  it('deletes the follow row for a valid token and names the band in the response', async () => {
     const { env, rawDb } = createTestEnv()
     const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-unfollow' })
-    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+    const band = insertBand(rawDb, { name: 'Witchrot', event_id: ev.id })
     rawDb.prepare(
       'INSERT INTO band_follows (email, band_profile_id, unsubscribe_token) VALUES (?, ?, ?)'
     ).run('fan@example.com', band.band_profile_id, 'valid-token-abc')
@@ -19,6 +19,8 @@ describe('GET /api/bands/:name/unfollow', () => {
     expect(res.status).toBe(200)
     const body = await res.text()
     expect(body).toContain('Unfollowed')
+    // Should name the specific band the fan unsubscribed from, not "this band".
+    expect(body).toContain('Witchrot')
     expect(res.headers.get('Cache-Control')).toBe('no-store')
 
     const row = rawDb.prepare('SELECT * FROM band_follows WHERE unsubscribe_token=?').get('valid-token-abc')


### PR DESCRIPTION
Two independent fixes from an admin/follow review (each with tests).

### 1. Band status (`is_active`) shouldn't be blocked by archived events — Closes #392
Editing a band's status (or any band-wide field: name, genre, origin, photo, social, bio) failed with *"Archived event performances cannot be edited"* if the band had a performance in an archived event. Those fields are on `band_profiles` (band-wide); only `venueId`/`startTime`/`endTime` are performance/event fields. The archived guard now only blocks when a **performance field** is actually being changed.
- Tests: `is_active` edit on archived → 200 + persisted; set-time edit on archived → 400; an existing test that asserted name edits were blocked was updated (name is band-wide and was never event-specific).

### 2. Unfollow page names the band — Closes #394
The unsubscribe page said "this band's follower list" generically. It now names the band (e.g. *"Unfollowed Witchrot"*) by looking up the name before deleting. Unknown token → generic message, still 200 (no enumeration).

### Related (not in this PR)
- #393 — `is_active` currently gates nothing (no public/lineup filter); needs a product decision on what "inactive" should do.

Backend only; full suite: 455 pass.