### PR TITLE
feat(notifications): digest emails for band lineup announcements

### DIFF
--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -382,6 +382,21 @@ CREATE TABLE IF NOT EXISTS band_follow_notifications (
 );
 CREATE INDEX IF NOT EXISTS idx_band_follow_notifications_performance ON band_follow_notifications(performance_id);
 
+CREATE TABLE IF NOT EXISTS band_announce_queue (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  band_follow_id INTEGER NOT NULL REFERENCES band_follows(id) ON DELETE CASCADE,
+  performance_id INTEGER NOT NULL REFERENCES performances(id) ON DELETE CASCADE,
+  event_id INTEGER NOT NULL,
+  band_name TEXT NOT NULL,
+  event_name TEXT NOT NULL,
+  event_slug TEXT NOT NULL,
+  band_profile_id INTEGER NOT NULL,
+  queued_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(band_follow_id, performance_id)
+);
+CREATE INDEX IF NOT EXISTS idx_band_announce_queue_event ON band_announce_queue(event_id);
+CREATE INDEX IF NOT EXISTS idx_band_announce_queue_follow ON band_announce_queue(band_follow_id);
+
 -- ============================================
 -- INDEXES
 -- ============================================

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -11,8 +11,6 @@ import {
   sanitizeString,
 } from "../../../utils/validation.js";
 import { getClientIP } from "../../../utils/request.js";
-import { isEmailConfigured } from "../../../utils/email.js";
-import { notifyBandFollowers } from "../../../utils/bandFollowNotify.js";
 import { buildIntervals, intervalsOverlap } from "../../../utils/timeConflicts.js";
 import { parseOrigin } from "../../../utils/parseOrigin.js";
 
@@ -758,14 +756,17 @@ export async function onRequestPatch(context) {
       .bind(newValue, performanceId)
       .run();
 
-    // Notify band followers on first 0 → 1 transition only
+    // Queue band-follower notifications on first 0 → 1 transition.
+    // Followers are batched into band_announce_queue; POST /api/admin/flush-announce-digest
+    // groups them by (email, event) and sends one digest per fan per event.
     if (
       newValue === 1 &&
       performance.is_announced === 0 &&
       !performance.band_follow_notified
     ) {
       const perf = await DB.prepare(
-        `SELECT p.band_profile_id, bp.name as band_name, e.name as event_name
+        `SELECT p.band_profile_id, bp.name as band_name,
+                e.id as event_id, e.name as event_name, e.slug as event_slug
          FROM performances p
          JOIN band_profiles bp ON p.band_profile_id = bp.id
          JOIN events e ON p.event_id = e.id
@@ -776,15 +777,13 @@ export async function onRequestPatch(context) {
 
       if (perf) {
         const { results: followers = [] } = await DB.prepare(
-          "SELECT id, email, unsubscribe_token FROM band_follows WHERE band_profile_id = ? AND verified = 1",
+          "SELECT id FROM band_follows WHERE band_profile_id = ? AND verified = 1",
         )
           .bind(perf.band_profile_id)
           .all();
 
-        if (followers.length > 0 && isEmailConfigured(env)) {
-          // Atomic claim: only the first concurrent request sees changes > 0.
-          // Latch is only set when email is actually configured — if email is temporarily
-          // misconfigured, band_follow_notified stays 0 so notifications can fire later.
+        if (followers.length > 0) {
+          // Atomic latch: only the first concurrent announce-toggle queues followers.
           const claimed = await DB.prepare(
             "UPDATE performances SET band_follow_notified = 1 WHERE id = ? AND band_follow_notified = 0",
           )
@@ -792,27 +791,25 @@ export async function onRequestPatch(context) {
             .run();
 
           if (claimed.meta.changes > 0) {
-            // Send + record each successful delivery (see bandFollowNotify.js).
-            // A failed send leaves no notification row, so it can be recovered
-            // later via the resend-announcement endpoint.
-            const { failed } = await notifyBandFollowers(env, DB, {
-              performanceId: Number(performanceId),
-              bandProfileId: perf.band_profile_id,
-              bandName: perf.band_name,
-              eventName: perf.event_name,
-              followers,
-            });
-            if (failed > 0) {
-              await auditLog(
-                env,
-                user.userId,
-                "performance.announced.email_failure",
-                "performance",
-                Number(performanceId),
-                { failed_count: failed, band_name: perf.band_name },
-                ipAddress,
-              ).catch(() => {});
-            }
+            // Queue one row per follower. INSERT OR IGNORE on UNIQUE(band_follow_id,
+            // performance_id) prevents double-queuing from a retry.
+            await DB.batch(
+              followers.map((f) =>
+                DB.prepare(
+                  `INSERT OR IGNORE INTO band_announce_queue
+                   (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)`,
+                ).bind(
+                  f.id,
+                  Number(performanceId),
+                  perf.event_id,
+                  perf.band_name,
+                  perf.event_name,
+                  perf.event_slug,
+                  perf.band_profile_id,
+                ),
+              ),
+            );
           }
         }
       }

--- a/functions/api/admin/bands/__tests__/announce-digest.test.js
+++ b/functions/api/admin/bands/__tests__/announce-digest.test.js
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createTestEnv, insertEvent, insertVenue, insertBand } from '../../../test-utils.js'
+import { flushAnnounceDigest } from '../../../../utils/announceDigest.js'
+
+vi.mock('../../../../utils/email.js', () => ({
+  sendEmail: vi.fn(() => Promise.resolve({ delivered: true })),
+  isEmailConfigured: () => true,
+}))
+
+import { sendEmail } from '../../../../utils/email.js'
+
+describe('flushAnnounceDigest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sends a single-band email when only one band is queued for a fan+event', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Fest', slug: 'fest-single' })
+    const venue = insertVenue(rawDb, { name: 'Hall' })
+    const perf = insertBand(rawDb, { name: 'The Band', event_id: ev.id, venue_id: venue.id })
+
+    const followId = rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+    ).run('fan@example.com', perf.band_profile_id, 'tok-unsub').lastInsertRowid
+
+    rawDb.prepare(
+      `INSERT INTO band_announce_queue
+       (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(followId, perf.id, ev.id, 'The Band', 'Fest', 'fest-single', perf.band_profile_id)
+
+    const stats = await flushAnnounceDigest(env, env.DB)
+
+    expect(stats.sent).toBe(1)
+    expect(stats.failed).toBe(0)
+    expect(sendEmail).toHaveBeenCalledOnce()
+    const [, { subject }] = sendEmail.mock.calls[0]
+    expect(subject).toBe('The Band just joined the lineup for Fest!')
+
+    // Queue entry consumed
+    const remaining = rawDb.prepare('SELECT * FROM band_announce_queue').all()
+    expect(remaining).toHaveLength(0)
+    // Notification row recorded
+    const notif = rawDb.prepare('SELECT * FROM band_follow_notifications').all()
+    expect(notif).toHaveLength(1)
+  })
+
+  it('sends a digest when a fan follows multiple announced bands on the same event', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Crawl', slug: 'crawl-digest' })
+    const venue = insertVenue(rawDb, { name: 'Stage' })
+
+    const perfA = insertBand(rawDb, { name: 'Band A', event_id: ev.id, venue_id: venue.id })
+    const perfB = insertBand(rawDb, { name: 'Band B', event_id: ev.id, venue_id: venue.id })
+
+    const fanFollowA = rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+    ).run('fan@example.com', perfA.band_profile_id, 'tok-a').lastInsertRowid
+
+    const fanFollowB = rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+    ).run('fan@example.com', perfB.band_profile_id, 'tok-b').lastInsertRowid
+
+    rawDb.prepare(
+      `INSERT INTO band_announce_queue
+       (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(fanFollowA, perfA.id, ev.id, 'Band A', 'Crawl', 'crawl-digest', perfA.band_profile_id)
+
+    rawDb.prepare(
+      `INSERT INTO band_announce_queue
+       (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(fanFollowB, perfB.id, ev.id, 'Band B', 'Crawl', 'crawl-digest', perfB.band_profile_id)
+
+    const stats = await flushAnnounceDigest(env, env.DB)
+
+    // One email for the fan, not two
+    expect(stats.sent).toBe(1)
+    expect(sendEmail).toHaveBeenCalledOnce()
+    const [, { subject }] = sendEmail.mock.calls[0]
+    expect(subject).toBe('2 bands you follow are playing Crawl!')
+
+    // Both queue entries consumed, both notification rows written
+    expect(rawDb.prepare('SELECT * FROM band_announce_queue').all()).toHaveLength(0)
+    expect(rawDb.prepare('SELECT * FROM band_follow_notifications').all()).toHaveLength(2)
+  })
+
+  it('sends separate digests for different fans', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Fest', slug: 'fest-fans' })
+    const venue = insertVenue(rawDb, { name: 'Spot' })
+    const perf = insertBand(rawDb, { name: 'Band X', event_id: ev.id, venue_id: venue.id })
+
+    const f1 = rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+    ).run('fan1@example.com', perf.band_profile_id, 'tok-f1').lastInsertRowid
+
+    const f2 = rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+    ).run('fan2@example.com', perf.band_profile_id, 'tok-f2').lastInsertRowid
+
+    for (const [followId, token] of [[f1, 'tok-f1'], [f2, 'tok-f2']]) {
+      rawDb.prepare(
+        `INSERT INTO band_announce_queue
+         (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run(followId, perf.id, ev.id, 'Band X', 'Fest', 'fest-fans', perf.band_profile_id)
+    }
+
+    const stats = await flushAnnounceDigest(env, env.DB)
+
+    expect(stats.sent).toBe(2)
+    expect(sendEmail).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns empty stats when the queue is empty', async () => {
+    const { env, rawDb } = createTestEnv()
+    const stats = await flushAnnounceDigest(env, env.DB)
+    expect(stats).toEqual({ sent: 0, failed: 0, skipped: 0 })
+    expect(sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('releases the claim and increments failed when send fails', async () => {
+    const { env, rawDb } = createTestEnv()
+    sendEmail.mockResolvedValueOnce({ delivered: false, reason: 'provider_error' })
+
+    const ev = insertEvent(rawDb, { name: 'Fest', slug: 'fest-fail' })
+    const venue = insertVenue(rawDb, { name: 'Room' })
+    const perf = insertBand(rawDb, { name: 'Band Z', event_id: ev.id, venue_id: venue.id })
+
+    const followId = rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+    ).run('fail@example.com', perf.band_profile_id, 'tok-z').lastInsertRowid
+
+    rawDb.prepare(
+      `INSERT INTO band_announce_queue
+       (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(followId, perf.id, ev.id, 'Band Z', 'Fest', 'fest-fail', perf.band_profile_id)
+
+    const stats = await flushAnnounceDigest(env, env.DB)
+
+    expect(stats.failed).toBe(1)
+    // Queue consumed (won't retry via digest; resend-announcement handles recovery)
+    expect(rawDb.prepare('SELECT * FROM band_announce_queue').all()).toHaveLength(0)
+    // Claim released so resend-announcement can recover
+    expect(rawDb.prepare('SELECT * FROM band_follow_notifications').all()).toHaveLength(0)
+  })
+
+  it('skips entries already claimed by a concurrent flush or resend', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Fest', slug: 'fest-skip' })
+    const venue = insertVenue(rawDb, { name: 'Stage' })
+    const perf = insertBand(rawDb, { name: 'Band Q', event_id: ev.id, venue_id: venue.id })
+
+    const followId = rawDb.prepare(
+      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+    ).run('skip@example.com', perf.band_profile_id, 'tok-q').lastInsertRowid
+
+    rawDb.prepare(
+      `INSERT INTO band_announce_queue
+       (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(followId, perf.id, ev.id, 'Band Q', 'Fest', 'fest-skip', perf.band_profile_id)
+
+    // Simulate a concurrent resend that already claimed the notification row
+    rawDb.prepare(
+      'INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)'
+    ).run(perf.id, followId)
+
+    const stats = await flushAnnounceDigest(env, env.DB)
+
+    expect(stats.skipped).toBe(1)
+    expect(stats.sent).toBe(0)
+    expect(sendEmail).not.toHaveBeenCalled()
+    // Queue entry still cleaned up
+    expect(rawDb.prepare('SELECT * FROM band_announce_queue').all()).toHaveLength(0)
+  })
+})

--- a/functions/api/admin/bands/__tests__/announce.test.js
+++ b/functions/api/admin/bands/__tests__/announce.test.js
@@ -89,22 +89,17 @@ describe('PATCH /api/admin/bands/:id - announce toggle', () => {
     expect(res.status).toBe(403)
   })
 
-  it('sets band_follow_notified=1 when band is announced and followers exist', async () => {
+  it('queues followers in band_announce_queue when band is announced', async () => {
     const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    env.EMAIL_PROVIDER = 'mailchannels'
-    env.EMAIL_FROM = 'noreply@settimes.ca'
-    // Stub fetch so sendEmail resolves without a real network call.
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 202 }))
-
     const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-notify' })
     rawDb.prepare('UPDATE events SET reveal_mode=1 WHERE id=?').run(ev.id)
     const venue = insertVenue(rawDb, { name: 'Venue N' })
     const band = insertBand(rawDb, { name: 'Notify Band', event_id: ev.id, venue_id: venue.id })
     rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(band.id)
 
-    rawDb.prepare(
+    const followId = rawDb.prepare(
       'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
-    ).run('follower@example.com', band.band_profile_id, 'unsub-token-1')
+    ).run('follower@example.com', band.band_profile_id, 'unsub-token-1').lastInsertRowid
 
     const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
       method: 'PATCH',
@@ -117,10 +112,16 @@ describe('PATCH /api/admin/bands/:id - announce toggle', () => {
       data: { user: { role: 'editor', id: 2 } },
     })
 
-    vi.unstubAllGlobals()
+    // Latch is set so a repeat announce does not re-queue.
+    const perfRow = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
+    expect(perfRow.band_follow_notified).toBe(1)
 
-    const row = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
-    expect(row.band_follow_notified).toBe(1)
+    // Follower is queued for digest delivery, not emailed immediately.
+    const queued = rawDb.prepare('SELECT * FROM band_announce_queue WHERE band_follow_id=?').all(followId)
+    expect(queued).toHaveLength(1)
+    expect(queued[0].band_name).toBe('Notify Band')
+    expect(queued[0].event_name).toBe('Vol6')
+    expect(queued[0].performance_id).toBe(band.id)
   })
 
   it('does not set band_follow_notified when no followers exist', async () => {

--- a/functions/api/admin/flush-announce-digest.js
+++ b/functions/api/admin/flush-announce-digest.js
@@ -1,0 +1,50 @@
+// POST /api/admin/flush-announce-digest
+//
+// Groups pending band_announce_queue entries by (email, event) and sends one
+// digest email per fan per event, then records each successful send in
+// band_follow_notifications (the idempotency ledger). Failed sends release
+// their claims so resend-announcement can recover them.
+//
+// Call this after a batch of announce toggles so fans following multiple bands
+// on the same bill receive one digest rather than N separate emails.
+
+import { checkPermission, auditLog } from "./_middleware.js";
+import { getClientIP } from "../../utils/request.js";
+import { isEmailConfigured } from "../../utils/email.js";
+import { flushAnnounceDigest } from "../../utils/announceDigest.js";
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const { DB } = env;
+
+  const perm = await checkPermission(context, "editor");
+  if (perm.error) return perm.response;
+
+  if (!isEmailConfigured(env)) {
+    return json(
+      { error: "Email not configured", message: "Configure an email provider before flushing." },
+      400,
+    );
+  }
+
+  const { sent, failed, skipped } = await flushAnnounceDigest(env, DB);
+
+  await auditLog(
+    env,
+    perm.user.userId,
+    "announce_digest.flushed",
+    "system",
+    null,
+    { sent, failed, skipped },
+    getClientIP(request),
+  ).catch(() => {});
+
+  return json({ success: true, sent, failed, skipped });
+}

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -231,6 +231,19 @@ export function createTestDB() {
       UNIQUE(performance_id, band_follow_id)
     );
 
+    CREATE TABLE band_announce_queue (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      band_follow_id INTEGER NOT NULL REFERENCES band_follows(id) ON DELETE CASCADE,
+      performance_id INTEGER NOT NULL REFERENCES performances(id) ON DELETE CASCADE,
+      event_id INTEGER NOT NULL,
+      band_name TEXT NOT NULL,
+      event_name TEXT NOT NULL,
+      event_slug TEXT NOT NULL,
+      band_profile_id INTEGER NOT NULL,
+      queued_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(band_follow_id, performance_id)
+    );
+
     CREATE TABLE password_reset_tokens (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/functions/utils/announceDigest.js
+++ b/functions/utils/announceDigest.js
@@ -1,0 +1,131 @@
+// Digest flush for band-lineup announcements.
+//
+// Groups pending band_announce_queue entries by (email, event_id) and sends
+// one email per fan per event. Fans following a single announced band on the
+// event get the standard per-band email; fans following multiple get a digest.
+//
+// band_follow_notifications remains the idempotency ledger: each entry is
+// claimed (INSERT OR IGNORE) immediately before sending. A send failure
+// releases the claim so resend-announcement can retry. A concurrent flush or
+// resend that already claimed a slot simply skips that entry.
+
+import { sendEmail } from "./email.js";
+
+const escapeHtml = (s) =>
+  String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+export async function flushAnnounceDigest(env, DB) {
+  const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
+
+  // Fetch every pending entry, joining band_follows for email + unsubscribe_token.
+  const { results: queue } = await DB.prepare(
+    `SELECT q.id, q.band_follow_id, q.performance_id, q.event_id,
+            q.band_name, q.event_name, q.event_slug, q.band_profile_id,
+            bf.email, bf.unsubscribe_token
+     FROM band_announce_queue q
+     JOIN band_follows bf ON bf.id = q.band_follow_id
+     ORDER BY q.event_id, bf.email, q.queued_at`,
+  ).all();
+
+  if (!queue.length) return { sent: 0, failed: 0, skipped: 0 };
+
+  // Group by (email, event_id) — one digest per fan per event.
+  const groups = new Map();
+  for (const item of queue) {
+    const key = `${item.email}::${item.event_id}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(item);
+  }
+
+  let sent = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const items of groups.values()) {
+    const { email, event_name, event_slug } = items[0];
+    const eventUrl = `${publicUrl}/events/${event_slug}`;
+
+    // Claim each (performance_id, band_follow_id) atomically before sending.
+    // INSERT OR IGNORE: changes=0 means already claimed by a concurrent flush
+    // or by the resend-announcement endpoint — skip those items.
+    const claimed = [];
+    for (const item of items) {
+      const result = await DB.prepare(
+        "INSERT OR IGNORE INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)",
+      )
+        .bind(item.performance_id, item.band_follow_id)
+        .run();
+      if (result.meta.changes > 0) claimed.push(item);
+    }
+
+    // Delete every queue entry for this group — whether claimed now or
+    // already handled by a concurrent path.
+    await DB.batch(
+      items.map((item) =>
+        DB.prepare("DELETE FROM band_announce_queue WHERE id = ?").bind(item.id),
+      ),
+    );
+
+    if (!claimed.length) {
+      skipped += items.length;
+      continue;
+    }
+
+    // Build the email.
+    const bands = claimed.map((item) => item.band_name);
+    const subject =
+      bands.length === 1
+        ? `${bands[0]} just joined the lineup for ${event_name}!`
+        : `${bands.length} bands you follow are playing ${event_name}!`;
+
+    const bandListText = bands.map((b) => `• ${b}`).join("\n");
+    const bandListHtml = bands
+      .map((b) => `<li>${escapeHtml(b)}</li>`)
+      .join("");
+    const unsubText = claimed
+      .map(
+        (item) =>
+          `Unfollow ${item.band_name}: ${publicUrl}/api/bands/${item.band_profile_id}/unfollow?token=${item.unsubscribe_token}`,
+      )
+      .join("\n");
+    const unsubHtml = claimed
+      .map(
+        (item) =>
+          `<a href="${publicUrl}/api/bands/${item.band_profile_id}/unfollow?token=${item.unsubscribe_token}">Unfollow ${escapeHtml(item.band_name)}</a>`,
+      )
+      .join(" · ");
+
+    const text =
+      bands.length === 1
+        ? `${bands[0]} is now on the lineup for ${event_name}.\n\nView the schedule: ${eventUrl}\n\n${unsubText}`
+        : `${bands.length} bands you follow just joined the lineup for ${event_name}:\n\n${bandListText}\n\nView the schedule: ${eventUrl}\n\n${unsubText}`;
+
+    const html =
+      bands.length === 1
+        ? `<p><strong>${escapeHtml(bands[0])}</strong> is now on the lineup for <strong>${escapeHtml(event_name)}</strong>.</p><p><a href="${eventUrl}">View the schedule</a></p><p style="font-size:0.85em">${unsubHtml}</p>`
+        : `<p><strong>${bands.length} bands you follow</strong> just joined the lineup for <strong>${escapeHtml(event_name)}</strong>:</p><ul>${bandListHtml}</ul><p><a href="${eventUrl}">View the schedule</a></p><p style="font-size:0.85em">${unsubHtml}</p>`;
+
+    const result = await sendEmail(env, { to: email, subject, text, html });
+
+    if (result?.delivered) {
+      sent++;
+    } else {
+      // Release claims so resend-announcement can recover this fan.
+      await DB.batch(
+        claimed.map((item) =>
+          DB.prepare(
+            "DELETE FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?",
+          ).bind(item.performance_id, item.band_follow_id),
+        ),
+      );
+      failed++;
+    }
+  }
+
+  return { sent, failed, skipped };
+}

--- a/migrations/0046_band_announce_queue.sql
+++ b/migrations/0046_band_announce_queue.sql
@@ -1,0 +1,30 @@
+-- Migration: 0046_band_announce_queue
+-- Description: Digest queue for band-lineup announcements.
+--   When a band is announced, verified followers are queued here instead of
+--   emailed immediately. POST /api/admin/flush-announce-digest groups pending
+--   entries by (email, event) and sends one digest per fan per event — so a
+--   fan following 5 bands on one bill gets a single "5 bands you follow are
+--   playing X" email rather than 5 separate ones.
+--
+--   band_follow_notifications remains the idempotency ledger: a row is
+--   inserted (claimed) just before each email send, and released on failure,
+--   so the resend-announcement endpoint can still recover missed deliveries.
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+CREATE TABLE band_announce_queue (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  band_follow_id INTEGER NOT NULL REFERENCES band_follows(id) ON DELETE CASCADE,
+  performance_id INTEGER NOT NULL REFERENCES performances(id) ON DELETE CASCADE,
+  event_id INTEGER NOT NULL,
+  band_name TEXT NOT NULL,
+  event_name TEXT NOT NULL,
+  event_slug TEXT NOT NULL,
+  band_profile_id INTEGER NOT NULL,
+  queued_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(band_follow_id, performance_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_band_announce_queue_event ON band_announce_queue(event_id);
+CREATE INDEX IF NOT EXISTS idx_band_announce_queue_follow ON band_announce_queue(band_follow_id);


### PR DESCRIPTION
## Summary

- Fans following multiple bands on the same event now receive a single digest email ("3 bands you follow are playing Long Weekend Band Crawl Vol. 17!") instead of N separate ones
- A new `band_announce_queue` table accumulates per-follower entries when a performance is announced; `POST /api/admin/flush-announce-digest` (editor+) groups them and sends one email per fan per event
- `band_follow_notifications` remains the idempotency ledger — claims are taken before sending and released on failure so `resend-announcement` can still recover missed deliveries

## Changes

- `migrations/0046_band_announce_queue.sql` — new queue table with `UNIQUE(band_follow_id, performance_id)` guard
- `functions/utils/announceDigest.js` — `flushAnnounceDigest(env, DB)`: fetch queue → group by (email, event) → claim → send → clean up
- `functions/api/admin/flush-announce-digest.js` — `POST /api/admin/flush-announce-digest` endpoint
- `functions/api/admin/bands/[id].js` — announce flow now queues followers instead of emailing immediately; `resend-announcement` path is unchanged
- 6 new unit tests covering: single-band email, multi-band digest, multi-fan, empty queue, send failure (claim release), concurrent skip

## Test plan

- [ ] `npm test -- --run` passes (461 tests green)
- [ ] Announce a band with 1 verified follower → `band_announce_queue` has 1 row; call flush → single-band email sent, queue empty
- [ ] Announce 2 bands on same event, both followed by same fan → flush sends 1 digest email, not 2
- [ ] `POST /api/admin/flush-announce-digest` returns `{ sent, failed, skipped }`

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)