### PR TITLE
fix: reveal-mode lineup embargo gate (#403) + GitHub Actions scheduler (#405)

### DIFF
--- a/.github/workflows/scheduled-jobs.yml
+++ b/.github/workflows/scheduled-jobs.yml
@@ -1,0 +1,35 @@
+name: Scheduled Jobs
+
+# Cloudflare Pages does not support cron triggers, so scheduled tasks
+# (popularity aggregation, PII retention cleanup, share-link expiry) are
+# triggered by this workflow POSTing to the secret-protected endpoint
+# /api/internal/run-scheduled. Mirrors the pattern used by zap-baseline.yml.
+#
+# Required secrets:
+#   CRON_SECRET — must match the CRON_SECRET env var in the Cloudflare Pages
+#                 project (Settings → Environment Variables → Production).
+
+on:
+  schedule:
+    # Daily at 07:17 UTC (off-peak; intentionally non-round to avoid thundering herd)
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run-scheduled:
+    name: Run scheduled handler
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Invoke /api/internal/run-scheduled
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          echo "Triggering scheduled handler..."
+          curl -fsS -X POST "https://settimes.ca/api/internal/run-scheduled" \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            -H "Content-Type: application/json"
+          echo "Scheduled handler completed successfully."

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -533,6 +533,7 @@ The checked-in release workflow expects these repository secrets:
 
 - `CF_ACCOUNT_ID`
 - `CF_PAGES_API_TOKEN`
+- `CRON_SECRET` — required by `.github/workflows/scheduled-jobs.yml` (daily scheduled tasks). Generate a strong random value (e.g. `openssl rand -base64 32`) and set it **both** here as a GitHub Actions repository secret **and** in Cloudflare Pages → Settings → Environment Variables (Production) with the same value. The `/api/internal/run-scheduled` endpoint fails closed (503) if this variable is missing from the Pages environment.
 
 The workflow also supports these repository variables:
 

--- a/functions/api/bands/[name].js
+++ b/functions/api/bands/[name].js
@@ -21,9 +21,14 @@ function formatOrigin(profile) {
 
 function formatVenueAddress(venue) {
   if (!venue) return null;
-  const line1 = [venue.address_line1, venue.address_line2].filter(Boolean).join(", ");
+  const line1 = [venue.address_line1, venue.address_line2]
+    .filter(Boolean)
+    .join(", ");
   const line2 = [venue.city, venue.region].filter(Boolean).join(", ");
-  const line3 = [venue.postal_code, venue.country].filter(Boolean).join(" ").trim();
+  const line3 = [venue.postal_code, venue.country]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
   return [line1, line2, line3].filter(Boolean).join(", ");
 }
 
@@ -83,10 +88,10 @@ export async function onRequestGet(context) {
     }
 
     if (!bandProfile) {
-      return new Response(
-        JSON.stringify({ error: "Band not found" }),
-        { status: 404, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Band not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Get all performances for this band profile
@@ -113,6 +118,7 @@ export async function onRequestGet(context) {
       LEFT JOIN events e ON p.event_id = e.id
       WHERE p.band_profile_id = ?
         AND e.is_published = 1
+        AND (e.reveal_mode = 0 OR p.is_announced = 1)
       ORDER BY e.date DESC, p.start_time
     `,
     )
@@ -121,10 +127,10 @@ export async function onRequestGet(context) {
 
     const history = performances.results || [];
     if (history.length === 0) {
-      return new Response(
-        JSON.stringify({ error: "Band not found" }),
-        { status: 404, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Band not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     let socialLinks = {};

--- a/functions/api/bands/__tests__/profile.test.js
+++ b/functions/api/bands/__tests__/profile.test.js
@@ -1,0 +1,105 @@
+import { describe, test, expect } from "vitest";
+import { onRequestGet } from "../[name].js";
+import {
+  createTestEnv,
+  insertEvent,
+  insertVenue,
+  insertBand,
+} from "../../test-utils.js";
+
+describe("GET /api/bands/:name - reveal_mode gate", () => {
+  test("hides unannounced performance when reveal_mode=1", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Band Crawl Vol 17",
+      slug: "vol17-band-profile-1",
+      date: "2026-08-02",
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+    const venue = insertVenue(rawDb, { name: "Prohibition Warehouse" });
+    const perf = insertBand(rawDb, {
+      name: "Embargoed Artist",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(perf.id);
+
+    const request = new Request(
+      "https://example.test/api/bands/Embargoed%20Artist",
+    );
+    const response = await onRequestGet({ request, env, params: {} });
+
+    // The only performance is embargoed — band appears to have no performances
+    // so the handler returns 404 (same as "band not found")
+    expect(response.status).toBe(404);
+  });
+
+  test("shows announced performance when reveal_mode=1", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Band Crawl Vol 17",
+      slug: "vol17-band-profile-2",
+      date: "2026-08-02",
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    const perf = insertBand(rawDb, {
+      name: "Revealed Artist",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
+      .run(perf.id);
+
+    const request = new Request(
+      "https://example.test/api/bands/Revealed%20Artist",
+    );
+    const response = await onRequestGet({ request, env, params: {} });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.performances).toHaveLength(1);
+    expect(payload.performances[0].event_slug).toBe("vol17-band-profile-2");
+  });
+
+  test("shows unannounced performance when reveal_mode=0", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Normal Event",
+      slug: "vol17-band-profile-3",
+      date: "2026-08-02",
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?")
+      .run(event.id);
+    const venue = insertVenue(rawDb, { name: "Revive Karaoke" });
+    const perf = insertBand(rawDb, {
+      name: "Normal Artist",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(perf.id);
+
+    const request = new Request(
+      "https://example.test/api/bands/Normal%20Artist",
+    );
+    const response = await onRequestGet({ request, env, params: {} });
+
+    // reveal_mode=0: unannounced performances still visible
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.performances).toHaveLength(1);
+  });
+});

--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -121,6 +121,7 @@ export async function onRequestGet(context) {
       LEFT JOIN events e ON p.event_id = e.id
       WHERE p.band_profile_id = ?
         AND e.status IN ('published', 'archived')
+        AND (e.reveal_mode = 0 OR p.is_announced = 1)
       ORDER BY e.date DESC, p.start_time
     `,
     )

--- a/functions/api/bands/stats/__tests__/stats.test.js
+++ b/functions/api/bands/stats/__tests__/stats.test.js
@@ -1,0 +1,119 @@
+import { describe, test, expect } from "vitest";
+import { onRequestGet } from "../[name].js";
+import {
+  createTestEnv,
+  insertEvent,
+  insertVenue,
+  insertBand,
+} from "../../../test-utils.js";
+
+describe("GET /api/bands/stats/:name — reveal_mode gate", () => {
+  // Use a far-future date so performances land in the "upcoming" bucket
+  // and event_status = 'published' satisfies the IN ('published', 'archived') guard.
+  const futureDate = "2099-01-01";
+
+  test("unannounced performance in reveal_mode=1 event is hidden from band stats", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Room 47" });
+    const event = insertEvent(rawDb, {
+      name: "Vol 17 Stats Hidden",
+      slug: "stats-reveal-hidden",
+      date: futureDate,
+      status: "published",
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+    const perf = insertBand(rawDb, {
+      name: "Stats Hidden Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(perf.id);
+
+    const request = new Request(
+      "https://example.test/api/bands/stats/Stats%20Hidden%20Band",
+    );
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    // The embargoed performance must be absent from both upcoming and stats
+    expect(payload.upcoming).toHaveLength(0);
+    expect(payload.stats.total_performances).toBe(0);
+  });
+
+  test("announced performance in reveal_mode=1 event is shown in band stats", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Revive Karaoke" });
+    const event = insertEvent(rawDb, {
+      name: "Vol 17 Stats Shown",
+      slug: "stats-reveal-shown",
+      date: futureDate,
+      status: "published",
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+    const perf = insertBand(rawDb, {
+      name: "Stats Revealed Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
+      .run(perf.id);
+
+    const request = new Request(
+      "https://example.test/api/bands/stats/Stats%20Revealed%20Band",
+    );
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(1);
+    expect(payload.upcoming[0].event_slug).toBe("stats-reveal-shown");
+    expect(payload.stats.total_performances).toBe(1);
+  });
+
+  test("unannounced performance in reveal_mode=0 event is shown (gate is no-op)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Princess Cafe" });
+    const event = insertEvent(rawDb, {
+      name: "Normal Stats Event",
+      slug: "stats-reveal-mode0",
+      date: futureDate,
+      status: "published",
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?")
+      .run(event.id);
+    const perf = insertBand(rawDb, {
+      name: "Stats Normal Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(perf.id);
+
+    const request = new Request(
+      "https://example.test/api/bands/stats/Stats%20Normal%20Band",
+    );
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    // reveal_mode=0: gate is a no-op, unannounced performances still visible
+    expect(payload.upcoming).toHaveLength(1);
+    expect(payload.stats.total_performances).toBe(1);
+  });
+});

--- a/functions/api/events/[id]/details.js
+++ b/functions/api/events/[id]/details.js
@@ -16,9 +16,14 @@ export async function onRequestGet(context) {
 
   const formatVenueAddress = (venue) => {
     if (!venue) return null;
-    const line1 = [venue.address_line1, venue.address_line2].filter(Boolean).join(", ");
+    const line1 = [venue.address_line1, venue.address_line2]
+      .filter(Boolean)
+      .join(", ");
     const line2 = [venue.city, venue.region].filter(Boolean).join(", ");
-    const line3 = [venue.postal_code, venue.country].filter(Boolean).join(" ").trim();
+    const line3 = [venue.postal_code, venue.country]
+      .filter(Boolean)
+      .join(" ")
+      .trim();
     return [line1, line2, line3].filter(Boolean).join(", ");
   };
 
@@ -33,7 +38,7 @@ export async function onRequestGet(context) {
   try {
     const event = await DB.prepare(
       `
-      SELECT id, name, slug, date, ticket_url, status
+      SELECT id, name, slug, date, ticket_url, status, reveal_mode
       FROM events
       WHERE id = ? AND (is_published = 1 OR status = 'archived')
       LIMIT 1
@@ -72,10 +77,11 @@ export async function onRequestGet(context) {
       LEFT JOIN band_profiles b ON p.band_profile_id = b.id
       LEFT JOIN venues v ON p.venue_id = v.id
       WHERE p.event_id = ?
+        AND (? = 0 OR p.is_announced = 1)
       ORDER BY p.start_time, v.name
     `,
     )
-      .bind(eventId)
+      .bind(eventId, event.reveal_mode ?? 0)
       .all();
 
     const rows = bandsResult.results || [];

--- a/functions/api/events/__tests__/details.test.js
+++ b/functions/api/events/__tests__/details.test.js
@@ -1,36 +1,36 @@
-import { describe, expect, test } from 'vitest';
-import { onRequestGet } from '../[id]/details.js';
+import { describe, expect, test } from "vitest";
+import { onRequestGet } from "../[id]/details.js";
 import {
   createTestEnv,
   insertEvent,
   insertVenue,
   insertBand,
-} from '../../test-utils.js';
+} from "../../test-utils.js";
 
-describe('GET /api/events/:id/details', () => {
-  test('returns event details for a published event', async () => {
+describe("GET /api/events/:id/details", () => {
+  test("returns event details for a published event", async () => {
     const { env, rawDb } = createTestEnv();
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const event = insertEvent(rawDb, {
-      name: 'Test Event',
-      slug: 'test-event',
-      date: '2026-01-01',
+      name: "Test Event",
+      slug: "test-event",
+      date: "2026-01-01",
     });
     rawDb
-      .prepare('UPDATE events SET is_published = 1 WHERE id = ?')
+      .prepare("UPDATE events SET is_published = 1 WHERE id = ?")
       .run(event.id);
 
-    const venue = insertVenue(rawDb, { name: 'Test Venue', city: 'Portland' });
+    const venue = insertVenue(rawDb, { name: "Test Venue", city: "Portland" });
     insertBand(rawDb, {
-      name: 'Test Band',
+      name: "Test Band",
       event_id: event.id,
       venue_id: venue.id,
-      start_time: '19:00',
-      end_time: '20:00',
+      start_time: "19:00",
+      end_time: "20:00",
     });
 
     const request = new Request(
-      `https://example.test/api/events/${event.id}/details`
+      `https://example.test/api/events/${event.id}/details`,
     );
     const response = await onRequestGet({
       request,
@@ -51,35 +51,35 @@ describe('GET /api/events/:id/details', () => {
     expect(payload.band_count).toBe(1);
     expect(payload.venue_count).toBe(1);
     expect(payload.bands[0]).toMatchObject({
-      name: 'Test Band',
+      name: "Test Band",
       venue_id: venue.id,
       venue_name: venue.name,
     });
   });
 
-  test('returns 400 for invalid event id', async () => {
+  test("returns 400 for invalid event id", async () => {
     const { env } = createTestEnv();
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
-    const request = new Request('https://example.test/api/events/abc/details');
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const request = new Request("https://example.test/api/events/abc/details");
     const response = await onRequestGet({
       request,
       env,
-      params: { id: 'abc' },
+      params: { id: "abc" },
     });
 
     expect(response.status).toBe(400);
   });
 
-  test('returns 404 when event is not published', async () => {
+  test("returns 404 when event is not published", async () => {
     const { env, rawDb } = createTestEnv();
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const event = insertEvent(rawDb, {
-      name: 'Draft Event',
-      slug: 'draft-event',
+      name: "Draft Event",
+      slug: "draft-event",
     });
 
     const request = new Request(
-      `https://example.test/api/events/${event.id}/details`
+      `https://example.test/api/events/${event.id}/details`,
     );
     const response = await onRequestGet({
       request,
@@ -88,5 +88,123 @@ describe('GET /api/events/:id/details', () => {
     });
 
     expect(response.status).toBe(404);
+  });
+});
+
+describe("GET /api/events/:id/details - reveal_mode gate", () => {
+  test("hides unannounced band when reveal_mode=1", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Reveal Event",
+      slug: "reveal-details-1",
+      date: "2026-08-02",
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+    const venue = insertVenue(rawDb, { name: "Blue Room" });
+    const announced = insertBand(rawDb, {
+      name: "Visible Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
+      .run(announced.id);
+    const hidden = insertBand(rawDb, {
+      name: "Hidden Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(hidden.id);
+
+    const request = new Request(
+      `https://example.test/api/events/${event.id}/details`,
+    );
+    const response = await onRequestGet({
+      request,
+      env,
+      params: { id: String(event.id) },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.bands).toHaveLength(1);
+    expect(payload.bands[0].name).toBe("Visible Band");
+  });
+
+  test("shows announced band when reveal_mode=1", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Reveal Event",
+      slug: "reveal-details-2",
+      date: "2026-08-02",
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+    const venue = insertVenue(rawDb, { name: "Princess Cafe" });
+    const announced = insertBand(rawDb, {
+      name: "Announced Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
+      .run(announced.id);
+
+    const request = new Request(
+      `https://example.test/api/events/${event.id}/details`,
+    );
+    const response = await onRequestGet({
+      request,
+      env,
+      params: { id: String(event.id) },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.bands).toHaveLength(1);
+    expect(payload.bands[0].name).toBe("Announced Band");
+  });
+
+  test("shows unannounced band when reveal_mode=0", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Normal Event",
+      slug: "reveal-details-0",
+      date: "2026-08-02",
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?")
+      .run(event.id);
+    const venue = insertVenue(rawDb, { name: "Room 47" });
+    const unannounced = insertBand(rawDb, {
+      name: "Unannounced But Visible",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(unannounced.id);
+
+    const request = new Request(
+      `https://example.test/api/events/${event.id}/details`,
+    );
+    const response = await onRequestGet({
+      request,
+      env,
+      params: { id: String(event.id) },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.bands).toHaveLength(1);
+    expect(payload.bands[0].name).toBe("Unannounced But Visible");
   });
 });

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -5,74 +5,81 @@
  * Validates N+1 query fix and correct data grouping
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, test, expect, beforeEach, vi } from "vitest";
+import { onRequestGet as timelineHandler } from "../timeline.js";
+import {
+  createTestEnv,
+  insertEvent,
+  insertVenue,
+  insertBand,
+} from "../../test-utils.js";
 
 // Returns the mock result set for a query string, keyed off the distinctive
 // WHERE clause for each period (now / upcoming / past).
 const resultForQuery = (query) => {
-  if (query.includes('e.date = ?')) {
+  if (query.includes("e.date = ?")) {
     // "Now" events query
     return {
       results: [
         {
           event_id: 1,
-          event_name: 'Test Event Today',
-          event_slug: 'test-event-today',
-          event_date: '2025-11-05',
+          event_name: "Test Event Today",
+          event_slug: "test-event-today",
+          event_date: "2025-11-05",
           band_id: 1,
-          band_name: 'Test Band 1',
-          start_time: '20:00',
-          end_time: '21:00',
-          url: 'https://testband1.com',
-          genre: 'Rock',
-          origin: 'Toronto',
-          photo_url: 'https://example.com/band1.jpg',
+          band_name: "Test Band 1",
+          start_time: "20:00",
+          end_time: "21:00",
+          url: "https://testband1.com",
+          genre: "Rock",
+          origin: "Toronto",
+          photo_url: "https://example.com/band1.jpg",
           venue_id: 1,
-          venue_name: 'Test Venue 1',
-          venue_address: '123 Test St',
+          venue_name: "Test Venue 1",
+          venue_address: "123 Test St",
         },
         {
           event_id: 1,
-          event_name: 'Test Event Today',
-          event_slug: 'test-event-today',
-          event_date: '2025-11-05',
+          event_name: "Test Event Today",
+          event_slug: "test-event-today",
+          event_date: "2025-11-05",
           band_id: 2,
-          band_name: 'Test Band 2',
-          start_time: '21:00',
-          end_time: '22:00',
-          url: 'https://testband2.com',
-          genre: 'Jazz',
-          origin: 'Montreal',
-          photo_url: 'https://example.com/band2.jpg',
+          band_name: "Test Band 2",
+          start_time: "21:00",
+          end_time: "22:00",
+          url: "https://testband2.com",
+          genre: "Jazz",
+          origin: "Montreal",
+          photo_url: "https://example.com/band2.jpg",
           venue_id: 2,
-          venue_name: 'Test Venue 2',
-          venue_address: '456 Test Ave',
+          venue_name: "Test Venue 2",
+          venue_address: "456 Test Ave",
         },
       ],
     };
-  } else if (query.includes('e.date > ?')) {
+  } else if (query.includes("e.date > ?")) {
     // "Upcoming" events query
     return { results: [] };
-  } else if (query.includes('e.date < ?')) {
+  } else if (query.includes("e.date < ?")) {
     // "Past" events query
     return {
       results: [
         {
           event_id: 2,
-          event_name: 'Past Event',
-          event_slug: 'past-event',
-          event_date: '2025-11-01',
+          event_name: "Past Event",
+          event_slug: "past-event",
+          event_date: "2025-11-01",
           band_id: 3,
-          band_name: 'Past Band',
-          start_time: '19:00',
-          end_time: '20:00',
-          url: 'https://pastband.com',
-          genre: 'Blues',
-          origin: 'Ottawa',
-          photo_url: 'https://example.com/band3.jpg',
+          band_name: "Past Band",
+          start_time: "19:00",
+          end_time: "20:00",
+          url: "https://pastband.com",
+          genre: "Blues",
+          origin: "Ottawa",
+          photo_url: "https://example.com/band3.jpg",
           venue_id: 3,
-          venue_name: 'Past Venue',
-          venue_address: '789 Past Rd',
+          venue_name: "Past Venue",
+          venue_address: "789 Past Rd",
         },
       ],
     };
@@ -99,7 +106,7 @@ const createMockDB = () => {
   };
 };
 
-describe('Timeline API - Optimized JOIN Queries', () => {
+describe("Timeline API - Optimized JOIN Queries", () => {
   let mockContext;
   let onRequestGet;
 
@@ -109,27 +116,27 @@ describe('Timeline API - Optimized JOIN Queries', () => {
 
     // Mock environment
     mockContext = {
-      request: new Request('https://example.com/api/events/timeline'),
-      env: { DB: createMockDB(), PUBLIC_DATA_PUBLISH_ENABLED: 'true' },
+      request: new Request("https://example.com/api/events/timeline"),
+      env: { DB: createMockDB(), PUBLIC_DATA_PUBLISH_ENABLED: "true" },
     };
 
     // Dynamic import to get fresh module
-    const module = await import('../timeline.js');
+    const module = await import("../timeline.js");
     onRequestGet = module.onRequestGet;
   });
 
-  describe('Data Grouping - groupEventData helper', () => {
-    it('should group bands by event correctly', async () => {
+  describe("Data Grouping - groupEventData helper", () => {
+    it("should group bands by event correctly", async () => {
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
       expect(data.now).toHaveLength(1);
       expect(data.now[0].id).toBe(1);
-      expect(data.now[0].name).toBe('Test Event Today');
+      expect(data.now[0].name).toBe("Test Event Today");
       expect(data.now[0].bands).toHaveLength(2);
     });
 
-    it('should create unique venue list with band counts', async () => {
+    it("should create unique venue list with band counts", async () => {
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
@@ -139,24 +146,24 @@ describe('Timeline API - Optimized JOIN Queries', () => {
       expect(event.venues[1].band_count).toBe(1);
     });
 
-    it('should preserve all band data fields', async () => {
+    it("should preserve all band data fields", async () => {
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
       const band = data.now[0].bands[0];
-      expect(band).toHaveProperty('id');
-      expect(band).toHaveProperty('name');
-      expect(band).toHaveProperty('start_time');
-      expect(band).toHaveProperty('end_time');
-      expect(band).toHaveProperty('url');
-      expect(band).toHaveProperty('genre');
-      expect(band).toHaveProperty('origin');
-      expect(band).toHaveProperty('photo_url');
-      expect(band).toHaveProperty('venue_id');
-      expect(band).toHaveProperty('venue_name');
+      expect(band).toHaveProperty("id");
+      expect(band).toHaveProperty("name");
+      expect(band).toHaveProperty("start_time");
+      expect(band).toHaveProperty("end_time");
+      expect(band).toHaveProperty("url");
+      expect(band).toHaveProperty("genre");
+      expect(band).toHaveProperty("origin");
+      expect(band).toHaveProperty("photo_url");
+      expect(band).toHaveProperty("venue_id");
+      expect(band).toHaveProperty("venue_name");
     });
 
-    it('should calculate event metadata correctly', async () => {
+    it("should calculate event metadata correctly", async () => {
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
@@ -166,10 +173,10 @@ describe('Timeline API - Optimized JOIN Queries', () => {
     });
   });
 
-  describe('Query Parameters', () => {
+  describe("Query Parameters", () => {
     it('should support disabling "now" events', async () => {
       mockContext.request = new Request(
-        'https://example.com/api/events/timeline?now=false'
+        "https://example.com/api/events/timeline?now=false",
       );
       const response = await onRequestGet(mockContext);
       const data = await response.json();
@@ -179,7 +186,7 @@ describe('Timeline API - Optimized JOIN Queries', () => {
 
     it('should support disabling "upcoming" events', async () => {
       mockContext.request = new Request(
-        'https://example.com/api/events/timeline?upcoming=false'
+        "https://example.com/api/events/timeline?upcoming=false",
       );
       const response = await onRequestGet(mockContext);
       const data = await response.json();
@@ -189,7 +196,7 @@ describe('Timeline API - Optimized JOIN Queries', () => {
 
     it('should support disabling "past" events', async () => {
       mockContext.request = new Request(
-        'https://example.com/api/events/timeline?past=false'
+        "https://example.com/api/events/timeline?past=false",
       );
       const response = await onRequestGet(mockContext);
       const data = await response.json();
@@ -197,9 +204,9 @@ describe('Timeline API - Optimized JOIN Queries', () => {
       expect(data.past).toHaveLength(0);
     });
 
-    it('should respect pastLimit parameter', async () => {
+    it("should respect pastLimit parameter", async () => {
       mockContext.request = new Request(
-        'https://example.com/api/events/timeline?pastLimit=5'
+        "https://example.com/api/events/timeline?pastLimit=5",
       );
       const response = await onRequestGet(mockContext);
       const data = await response.json();
@@ -208,44 +215,44 @@ describe('Timeline API - Optimized JOIN Queries', () => {
       expect(response.status).toBe(200);
     });
 
-    it('should default pastLimit to 10', async () => {
+    it("should default pastLimit to 10", async () => {
       const response = await onRequestGet(mockContext);
       expect(response.status).toBe(200);
       // Default is 10, verified by not throwing
     });
   });
 
-  describe('Response Format', () => {
-    it('should return correct response structure', async () => {
+  describe("Response Format", () => {
+    it("should return correct response structure", async () => {
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
-      expect(data).toHaveProperty('now');
-      expect(data).toHaveProperty('upcoming');
-      expect(data).toHaveProperty('past');
+      expect(data).toHaveProperty("now");
+      expect(data).toHaveProperty("upcoming");
+      expect(data).toHaveProperty("past");
       expect(Array.isArray(data.now)).toBe(true);
       expect(Array.isArray(data.upcoming)).toBe(true);
       expect(Array.isArray(data.past)).toBe(true);
     });
 
-    it('should include correct HTTP headers', async () => {
+    it("should include correct HTTP headers", async () => {
       const response = await onRequestGet(mockContext);
 
-      expect(response.headers.get('Content-Type')).toBe('application/json');
-      expect(response.headers.get('Cache-Control')).toBe('public, max-age=300');
+      expect(response.headers.get("Content-Type")).toBe("application/json");
+      expect(response.headers.get("Cache-Control")).toBe("public, max-age=300");
     });
 
-    it('should return 200 status on success', async () => {
+    it("should return 200 status on success", async () => {
       const response = await onRequestGet(mockContext);
       expect(response.status).toBe(200);
     });
   });
 
-  describe('Error Handling', () => {
-    it('should handle database errors gracefully', async () => {
+  describe("Error Handling", () => {
+    it("should handle database errors gracefully", async () => {
       mockContext.env.DB = {
         prepare: () => {
-          throw new Error('Database connection failed');
+          throw new Error("Database connection failed");
         },
       };
 
@@ -253,11 +260,11 @@ describe('Timeline API - Optimized JOIN Queries', () => {
       expect(response.status).toBe(500);
 
       const data = await response.json();
-      expect(data).toHaveProperty('error');
-      expect(data.error).toBe('Failed to fetch events timeline');
+      expect(data).toHaveProperty("error");
+      expect(data.error).toBe("Failed to fetch events timeline");
     });
 
-    it('should handle empty results', async () => {
+    it("should handle empty results", async () => {
       mockContext.env.DB = {
         prepare: () => ({
           bind: () => ({ all: async () => ({ results: [] }) }),
@@ -273,7 +280,7 @@ describe('Timeline API - Optimized JOIN Queries', () => {
       expect(data.past).toHaveLength(0);
     });
 
-    it('should handle null results', async () => {
+    it("should handle null results", async () => {
       mockContext.env.DB = {
         prepare: () => ({
           bind: () => ({ all: async () => ({ results: null }) }),
@@ -290,8 +297,8 @@ describe('Timeline API - Optimized JOIN Queries', () => {
     });
   });
 
-  describe('Performance - N+1 Query Fix Validation', () => {
-    it('should use single query per time period (not N queries)', async () => {
+  describe("Performance - N+1 Query Fix Validation", () => {
+    it("should use single query per time period (not N queries)", async () => {
       const prepareCallCount = { count: 0 };
       const originalPrepare = mockContext.env.DB.prepare;
 
@@ -307,7 +314,7 @@ describe('Timeline API - Optimized JOIN Queries', () => {
       expect(prepareCallCount.count).toBe(3);
     });
 
-    it('should run all period queries in a single batched round-trip', async () => {
+    it("should run all period queries in a single batched round-trip", async () => {
       const batchCallCount = { count: 0 };
       const originalBatch = mockContext.env.DB.batch;
 
@@ -323,7 +330,7 @@ describe('Timeline API - Optimized JOIN Queries', () => {
       expect(batchCallCount.count).toBe(1);
     });
 
-    it('should group multiple bands per event without additional queries', async () => {
+    it("should group multiple bands per event without additional queries", async () => {
       // This validates that groupEventData works in-memory
       // without triggering additional database calls
       const response = await onRequestGet(mockContext);
@@ -335,14 +342,184 @@ describe('Timeline API - Optimized JOIN Queries', () => {
     });
   });
 
-  describe('Edge Cases', () => {
-    it('should handle events with no bands', async () => {
+  describe("reveal_mode gate - JOIN condition (not WHERE)", () => {
+    it("hides unannounced bands when reveal_mode=1", async () => {
+      // When the DB applies the JOIN gate, unannounced rows are NULL-expanded;
+      // band_id will be null so groupEventData skips them. The mock here
+      // simulates what the DB returns after the JOIN filter is applied.
+      mockContext.env.DB = {
+        prepare: () => ({
+          bind: () => ({ query: "e.date = ?" }),
+        }),
+        batch: async () => [
+          {
+            results: [
+              {
+                event_id: 10,
+                event_name: "Vol 17",
+                event_slug: "vol17",
+                event_date: "2026-08-02",
+                ticket_url: null,
+                // Only one announced band comes through the JOIN gate
+                band_id: 5,
+                band_name: "Announced Only",
+                start_time: "20:00",
+                end_time: "21:00",
+                social_links: null,
+                genre: "Rock",
+                origin: null,
+                origin_city: null,
+                origin_region: null,
+                photo_url: null,
+                venue_id: 1,
+                venue_name: "Blue Room",
+                venue_address: "123 King St N",
+                address_line1: null,
+                address_line2: null,
+                city: "Waterloo",
+                region: "ON",
+                postal_code: null,
+                country: "CA",
+              },
+            ],
+          },
+          { results: [] },
+          { results: [] },
+        ],
+      };
+
+      mockContext.request = new Request(
+        "https://example.test/api/events/timeline",
+      );
+      const response = await onRequestGet(mockContext);
+      const data = await response.json();
+
+      expect(data.now).toHaveLength(1);
+      expect(data.now[0].bands).toHaveLength(1);
+      expect(data.now[0].bands[0].name).toBe("Announced Only");
+    });
+
+    it("event still appears in timeline when its only band is unannounced (reveal_mode=1)", async () => {
+      // This is the critical test: the JOIN-condition approach means the event
+      // row survives even when every performance is filtered out. The event
+      // appears in the timeline with band_count=0, not missing entirely.
+      mockContext.env.DB = {
+        prepare: () => ({
+          bind: () => ({ query: "e.date = ?" }),
+        }),
+        batch: async () => [
+          {
+            results: [
+              {
+                event_id: 20,
+                event_name: "Teaser Event",
+                event_slug: "teaser",
+                event_date: "2026-08-02",
+                ticket_url: null,
+                // All bands filtered by JOIN gate → NULL row returned
+                band_id: null,
+                band_name: null,
+                start_time: null,
+                end_time: null,
+                social_links: null,
+                genre: null,
+                origin: null,
+                origin_city: null,
+                origin_region: null,
+                photo_url: null,
+                venue_id: null,
+                venue_name: null,
+                venue_address: null,
+                address_line1: null,
+                address_line2: null,
+                city: null,
+                region: null,
+                postal_code: null,
+                country: null,
+              },
+            ],
+          },
+          { results: [] },
+          { results: [] },
+        ],
+      };
+
+      mockContext.request = new Request(
+        "https://example.test/api/events/timeline",
+      );
+      const response = await onRequestGet(mockContext);
+      const data = await response.json();
+
+      // Event is present but has no bands
+      expect(data.now).toHaveLength(1);
+      expect(data.now[0].id).toBe(20);
+      expect(data.now[0].band_count).toBe(0);
+      expect(data.now[0].bands).toHaveLength(0);
+    });
+
+    it("shows unannounced bands when reveal_mode=0", async () => {
+      // When reveal_mode=0 the JOIN condition passes all rows through;
+      // unannounced bands are visible (no change to normal events).
+      mockContext.env.DB = {
+        prepare: () => ({
+          bind: () => ({ query: "e.date > ?" }),
+        }),
+        batch: async () => [
+          { results: [] },
+          {
+            results: [
+              {
+                event_id: 30,
+                event_name: "Normal Upcoming",
+                event_slug: "normal-upcoming",
+                event_date: "2026-09-01",
+                ticket_url: null,
+                band_id: 9,
+                band_name: "Unannounced But Visible",
+                start_time: "19:00",
+                end_time: "20:00",
+                social_links: null,
+                genre: "Punk",
+                origin: null,
+                origin_city: null,
+                origin_region: null,
+                photo_url: null,
+                venue_id: 2,
+                venue_name: "Room 47",
+                venue_address: null,
+                address_line1: null,
+                address_line2: null,
+                city: "Waterloo",
+                region: "ON",
+                postal_code: null,
+                country: "CA",
+              },
+            ],
+          },
+          { results: [] },
+        ],
+      };
+
+      mockContext.request = new Request(
+        "https://example.test/api/events/timeline",
+      );
+      const response = await onRequestGet(mockContext);
+      const data = await response.json();
+
+      expect(data.upcoming).toHaveLength(1);
+      expect(data.upcoming[0].bands).toHaveLength(1);
+      expect(data.upcoming[0].bands[0].name).toBe("Unannounced But Visible");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle events with no bands", async () => {
       const results = [
         {
           event_id: 99,
-          event_name: 'Empty Event',
-          event_slug: 'empty-event',
-          event_date: '2025-11-05',
+          event_name: "Empty Event",
+          event_slug: "empty-event",
+          event_date: "2025-11-05",
           band_id: null,
           band_name: null,
           start_time: null,
@@ -370,41 +547,41 @@ describe('Timeline API - Optimized JOIN Queries', () => {
       expect(data.now[0].venue_count).toBe(0);
     });
 
-    it('should handle same venue with multiple bands', async () => {
+    it("should handle same venue with multiple bands", async () => {
       const results = [
         {
           event_id: 1,
-          event_name: 'Multi-Band Event',
-          event_slug: 'multi-band',
-          event_date: '2025-11-05',
+          event_name: "Multi-Band Event",
+          event_slug: "multi-band",
+          event_date: "2025-11-05",
           band_id: 1,
-          band_name: 'Band 1',
-          start_time: '20:00',
-          end_time: '21:00',
+          band_name: "Band 1",
+          start_time: "20:00",
+          end_time: "21:00",
           url: null,
           genre: null,
           origin: null,
           photo_url: null,
           venue_id: 1,
-          venue_name: 'Same Venue',
-          venue_address: '123 St',
+          venue_name: "Same Venue",
+          venue_address: "123 St",
         },
         {
           event_id: 1,
-          event_name: 'Multi-Band Event',
-          event_slug: 'multi-band',
-          event_date: '2025-11-05',
+          event_name: "Multi-Band Event",
+          event_slug: "multi-band",
+          event_date: "2025-11-05",
           band_id: 2,
-          band_name: 'Band 2',
-          start_time: '21:00',
-          end_time: '22:00',
+          band_name: "Band 2",
+          start_time: "21:00",
+          end_time: "22:00",
           url: null,
           genre: null,
           origin: null,
           photo_url: null,
           venue_id: 1,
-          venue_name: 'Same Venue',
-          venue_address: '123 St',
+          venue_name: "Same Venue",
+          venue_address: "123 St",
         },
       ];
       mockContext.env.DB = {
@@ -419,5 +596,56 @@ describe('Timeline API - Optimized JOIN Queries', () => {
       expect(data.now[0].venues[0].band_count).toBe(2);
       expect(data.now[0].bands).toHaveLength(2);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-DB integration test — exercises the actual SQL JOIN gate.
+// The mock tests above verify application-layer grouping logic; this test
+// verifies that the `LEFT JOIN … AND (e.reveal_mode = 0 OR p.is_announced = 1)`
+// clause in timeline.js actually filters rows in SQLite, which would break if
+// someone mistakenly moved the gate to a WHERE clause (which turns the LEFT
+// JOIN into an implicit INNER JOIN and drops the event row entirely).
+// ---------------------------------------------------------------------------
+describe("Timeline real-DB — reveal_mode JOIN gate (SQL exercise)", () => {
+  test("reveal_mode=1 event with all-unannounced performances still appears in 'now' with band_count=0", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const today = new Date().toISOString().split("T")[0];
+
+    const event = insertEvent(rawDb, {
+      name: "Embargo Event",
+      slug: "timeline-realdb-reveal-gate",
+      date: today,
+      status: "published",
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "Blue Room" });
+    const perf = insertBand(rawDb, {
+      name: "Secret Band RealDB",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(perf.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    // The event MUST appear in the "now" bucket — the JOIN-condition approach
+    // keeps the event row even when all performances are filtered out.
+    // If the gate were a WHERE clause, data.now would be [] and this fails.
+    const found = data.now.find((e) => e.id === event.id);
+    expect(found).toBeDefined();
+    expect(found.band_count).toBe(0);
+    expect(found.bands).toHaveLength(0);
   });
 });

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -43,7 +43,10 @@ export async function onRequestGet(context) {
     const includeUpcoming = url.searchParams.get("upcoming") !== "false"; // default true
     const includePast = url.searchParams.get("past") !== "false"; // default true
     const includeBands = url.searchParams.get("includeBands") !== "false"; // default true
-    const parsedPastLimit = parseInt(url.searchParams.get("pastLimit") || "10", 10);
+    const parsedPastLimit = parseInt(
+      url.searchParams.get("pastLimit") || "10",
+      10,
+    );
     const pastLimit = Number.isFinite(parsedPastLimit)
       ? Math.min(Math.max(parsedPastLimit, 1), 100)
       : 10;
@@ -170,7 +173,7 @@ export async function onRequestGet(context) {
           v.postal_code,
           v.country
         FROM events e
-        LEFT JOIN performances p ON p.event_id = e.id
+        LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1)
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
         WHERE e.is_published = 1
@@ -213,7 +216,7 @@ export async function onRequestGet(context) {
           v.postal_code,
           v.country
         FROM events e
-        LEFT JOIN performances p ON p.event_id = e.id
+        LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1)
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
         WHERE e.is_published = 1
@@ -266,7 +269,7 @@ export async function onRequestGet(context) {
           v.postal_code,
           v.country
         FROM events e
-        LEFT JOIN performances p ON p.event_id = e.id
+        LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1)
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
         WHERE (

--- a/functions/api/feeds/__tests__/ical.test.js
+++ b/functions/api/feeds/__tests__/ical.test.js
@@ -1,6 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { onRequestGet } from '../ical.js';
-import { MockD1Database } from '../../subscriptions/__tests__/mocks/d1.js';
+import { describe, it, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { onRequestGet } from "../ical.js";
+import {
+  createTestEnv,
+  insertEvent,
+  insertVenue,
+  insertBand,
+} from "../../test-utils.js";
+import { MockD1Database } from "../../subscriptions/__tests__/mocks/d1.js";
 
 // Reuse helpers from events tests
 import {
@@ -8,9 +14,9 @@ import {
   createMockVenue,
   createMockBand,
   seedMockData,
-} from '../../events/__tests__/helpers.js';
+} from "../../events/__tests__/helpers.js";
 
-describe('GET /api/feeds/ical', () => {
+describe("GET /api/feeds/ical", () => {
   let mockDB;
   let mockEnv;
 
@@ -18,148 +24,148 @@ describe('GET /api/feeds/ical', () => {
     mockDB = new MockD1Database();
     mockEnv = {
       DB: mockDB,
-      PUBLIC_URL: 'https://settimes.example.com',
-      PUBLIC_DATA_PUBLISH_ENABLED: 'true',
+      PUBLIC_URL: "https://settimes.example.com",
+      PUBLIC_DATA_PUBLISH_ENABLED: "true",
     };
 
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('should generate valid iCal format with events', async () => {
+  it("should generate valid iCal format with events", async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
 
     const event = createMockEvent({
-      date: tomorrow.toISOString().split('T')[0],
+      date: tomorrow.toISOString().split("T")[0],
     });
     const venue = createMockVenue();
-    const band = createMockBand({ start_time: '20:00', end_time: '21:00' });
+    const band = createMockBand({ start_time: "20:00", end_time: "21:00" });
 
     seedMockData(mockDB, [event], [venue], [band]);
 
-    const request = new Request('http://localhost/api/feeds/ical');
+    const request = new Request("http://localhost/api/feeds/ical");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
     const icalData = await response.text();
 
     expect(response.status).toBe(200);
-    expect(icalData).toContain('BEGIN:VCALENDAR');
-    expect(icalData).toContain('END:VCALENDAR');
-    expect(icalData).toContain('BEGIN:VEVENT');
-    expect(icalData).toContain('END:VEVENT');
+    expect(icalData).toContain("BEGIN:VCALENDAR");
+    expect(icalData).toContain("END:VCALENDAR");
+    expect(icalData).toContain("BEGIN:VEVENT");
+    expect(icalData).toContain("END:VEVENT");
   });
 
-  it('should return text/calendar Content-Type header', async () => {
+  it("should return text/calendar Content-Type header", async () => {
     const event = createMockEvent();
     const venue = createMockVenue();
     const band = createMockBand();
 
     seedMockData(mockDB, [event], [venue], [band]);
 
-    const request = new Request('http://localhost/api/feeds/ical');
+    const request = new Request("http://localhost/api/feeds/ical");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Type')).toBe(
-      'text/calendar; charset=utf-8'
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/calendar; charset=utf-8",
     );
   });
 
-  it('should include iCal headers VERSION, PRODID, CALSCALE', async () => {
+  it("should include iCal headers VERSION, PRODID, CALSCALE", async () => {
     const event = createMockEvent();
     const venue = createMockVenue();
     const band = createMockBand();
 
     seedMockData(mockDB, [event], [venue], [band]);
 
-    const request = new Request('http://localhost/api/feeds/ical');
+    const request = new Request("http://localhost/api/feeds/ical");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
     const icalData = await response.text();
 
     expect(response.status).toBe(200);
-    expect(icalData).toContain('VERSION:2.0');
-    expect(icalData).toContain('PRODID:-//Concert Schedule//EN');
-    expect(icalData).toContain('CALSCALE:GREGORIAN');
+    expect(icalData).toContain("VERSION:2.0");
+    expect(icalData).toContain("PRODID:-//Concert Schedule//EN");
+    expect(icalData).toContain("CALSCALE:GREGORIAN");
   });
 
-  it('should format each event with VEVENT block including DTSTART, DTEND, SUMMARY', async () => {
+  it("should format each event with VEVENT block including DTSTART, DTEND, SUMMARY", async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    const dateStr = tomorrow.toISOString().split('T')[0];
+    const dateStr = tomorrow.toISOString().split("T")[0];
 
     const event = createMockEvent({ date: dateStr });
     const venue = createMockVenue({
-      name: 'Test Venue',
-      address: '123 Main St',
+      name: "Test Venue",
+      address: "123 Main St",
     });
     const band = createMockBand({
-      name: 'Test Band',
-      start_time: '20:00',
-      end_time: '21:00',
+      name: "Test Band",
+      start_time: "20:00",
+      end_time: "21:00",
     });
 
     seedMockData(mockDB, [event], [venue], [band]);
 
-    const request = new Request('http://localhost/api/feeds/ical');
+    const request = new Request("http://localhost/api/feeds/ical");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
     const icalData = await response.text();
 
     expect(response.status).toBe(200);
-    expect(icalData).toContain('BEGIN:VEVENT');
-    expect(icalData).toContain('END:VEVENT');
-    expect(icalData).toContain('SUMMARY:Test Band');
+    expect(icalData).toContain("BEGIN:VEVENT");
+    expect(icalData).toContain("END:VEVENT");
+    expect(icalData).toContain("SUMMARY:Test Band");
     // iCal format escapes commas in LOCATION
-    expect(icalData).toContain('LOCATION:Test Venue\\');
+    expect(icalData).toContain("LOCATION:Test Venue\\");
     expect(icalData).toMatch(/DTSTART:\d{8}T\d{6}/);
     expect(icalData).toMatch(/DTEND:\d{8}T\d{6}/);
   });
 
-  it('should generate valid empty calendar when no events', async () => {
+  it("should generate valid empty calendar when no events", async () => {
     seedMockData(mockDB, [], [], []);
 
-    const request = new Request('http://localhost/api/feeds/ical');
+    const request = new Request("http://localhost/api/feeds/ical");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
     const icalData = await response.text();
 
     expect(response.status).toBe(200);
-    expect(icalData).toContain('BEGIN:VCALENDAR');
-    expect(icalData).toContain('END:VCALENDAR');
+    expect(icalData).toContain("BEGIN:VCALENDAR");
+    expect(icalData).toContain("END:VCALENDAR");
     // Should not contain any VEVENT blocks
-    expect(icalData.split('BEGIN:VEVENT').length).toBe(1);
+    expect(icalData.split("BEGIN:VEVENT").length).toBe(1);
   });
 
-  it('should escape special characters in event data', async () => {
+  it("should escape special characters in event data", async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    const dateStr = tomorrow.toISOString().split('T')[0];
+    const dateStr = tomorrow.toISOString().split("T")[0];
 
     const event = createMockEvent({ date: dateStr });
     const venue = createMockVenue({
-      name: 'Venue, Inc; Address',
-      address: '123 Main St, Suite 100',
+      name: "Venue, Inc; Address",
+      address: "123 Main St, Suite 100",
     });
     const band = createMockBand({
-      name: 'Band Name, Special; Characters\nDescription',
-      start_time: '20:00',
-      end_time: '21:00',
+      name: "Band Name, Special; Characters\nDescription",
+      start_time: "20:00",
+      end_time: "21:00",
     });
 
     seedMockData(mockDB, [event], [venue], [band]);
 
-    const request = new Request('http://localhost/api/feeds/ical');
+    const request = new Request("http://localhost/api/feeds/ical");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
@@ -167,15 +173,15 @@ describe('GET /api/feeds/ical', () => {
 
     expect(response.status).toBe(200);
     // Should contain escaped characters
-    expect(icalData).toContain('\\,'); // Escaped comma
-    expect(icalData).toContain('\\;'); // Escaped semicolon
-    expect(icalData).toContain('\\n'); // Escaped newline
+    expect(icalData).toContain("\\,"); // Escaped comma
+    expect(icalData).toContain("\\;"); // Escaped semicolon
+    expect(icalData).toContain("\\n"); // Escaped newline
   });
 
-  it('should generate unique UIDs for multiple bands at the same event', async () => {
+  it("should generate unique UIDs for multiple bands at the same event", async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    const dateStr = tomorrow.toISOString().split('T')[0];
+    const dateStr = tomorrow.toISOString().split("T")[0];
 
     // Create one event
     const event = createMockEvent({ id: 1, date: dateStr });
@@ -187,23 +193,23 @@ describe('GET /api/feeds/ical', () => {
       performance_id: 1,
       event_id: 1,
       venue_id: 1,
-      name: 'Band One',
-      start_time: '20:00',
-      end_time: '21:00',
+      name: "Band One",
+      start_time: "20:00",
+      end_time: "21:00",
     });
     const band2 = createMockBand({
       id: 102,
       performance_id: 2,
       event_id: 1,
       venue_id: 1,
-      name: 'Band Two',
-      start_time: '21:30',
-      end_time: '22:30',
+      name: "Band Two",
+      start_time: "21:30",
+      end_time: "22:30",
     });
 
     seedMockData(mockDB, [event], [venue], [band1, band2]);
 
-    const request = new Request('http://localhost/api/feeds/ical');
+    const request = new Request("http://localhost/api/feeds/ical");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
@@ -212,19 +218,121 @@ describe('GET /api/feeds/ical', () => {
     expect(response.status).toBe(200);
 
     // Both bands should appear in the calendar
-    expect(icalData).toContain('SUMMARY:Band One');
-    expect(icalData).toContain('SUMMARY:Band Two');
+    expect(icalData).toContain("SUMMARY:Band One");
+    expect(icalData).toContain("SUMMARY:Band Two");
 
     // UIDs should be unique (using performance IDs)
     expect(icalData).toContain(
-      `UID:performance-1-${dateStr}@concertschedule.app`
+      `UID:performance-1-${dateStr}@concertschedule.app`,
     );
     expect(icalData).toContain(
-      `UID:performance-2-${dateStr}@concertschedule.app`
+      `UID:performance-2-${dateStr}@concertschedule.app`,
     );
 
     // Count VEVENT blocks - should be 2
-    const vevents = icalData.split('BEGIN:VEVENT').length - 1;
+    const vevents = icalData.split("BEGIN:VEVENT").length - 1;
     expect(vevents).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-DB integration tests for the reveal_mode gate in the iCal feed.
+// These exercise the actual SQL LEFT JOIN condition added to ical.js.
+// ---------------------------------------------------------------------------
+describe("GET /api/feeds/ical — reveal_mode gate (real-DB)", () => {
+  // Use a far-future date so e.date >= date('now') always passes.
+  const futureDate = "2099-01-01";
+
+  test("unannounced performance in reveal_mode=1 event emits NO VEVENT", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const event = insertEvent(rawDb, {
+      name: "Embargo Ical Event",
+      slug: "ical-reveal-hidden",
+      date: futureDate,
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+    const venue = insertVenue(rawDb, { name: "Blue Room" });
+    const perf = insertBand(rawDb, {
+      name: "Hidden iCal Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(perf.id);
+
+    const request = new Request("https://example.test/api/feeds/ical");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const icalData = await response.text();
+    expect(icalData).not.toContain("Hidden iCal Band");
+    expect(icalData.split("BEGIN:VEVENT").length - 1).toBe(0);
+  });
+
+  test("announced performance in reveal_mode=1 event emits a VEVENT", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const event = insertEvent(rawDb, {
+      name: "Announced Ical Event",
+      slug: "ical-reveal-shown",
+      date: futureDate,
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+    const venue = insertVenue(rawDb, { name: "Princess Cafe" });
+    const perf = insertBand(rawDb, {
+      name: "Revealed iCal Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
+      .run(perf.id);
+
+    const request = new Request("https://example.test/api/feeds/ical");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const icalData = await response.text();
+    expect(icalData).toContain("Revealed iCal Band");
+    expect(icalData.split("BEGIN:VEVENT").length - 1).toBe(1);
+  });
+
+  test("unannounced performance in reveal_mode=0 event emits a VEVENT (gate is no-op)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const event = insertEvent(rawDb, {
+      name: "Normal Ical Event",
+      slug: "ical-reveal-mode0",
+      date: futureDate,
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?")
+      .run(event.id);
+    const venue = insertVenue(rawDb, { name: "Room 47" });
+    const perf = insertBand(rawDb, {
+      name: "Normal iCal Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(perf.id);
+
+    const request = new Request("https://example.test/api/feeds/ical");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const icalData = await response.text();
+    expect(icalData).toContain("Normal iCal Band");
+    expect(icalData.split("BEGIN:VEVENT").length - 1).toBe(1);
   });
 });

--- a/functions/api/feeds/ical.js
+++ b/functions/api/feeds/ical.js
@@ -5,11 +5,13 @@
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 
 function sanitizeFilenamePart(value) {
-  return String(value || "all")
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "") || "all";
+  return (
+    String(value || "all")
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "all"
+  );
 }
 
 export async function onRequestGet(context) {
@@ -43,7 +45,7 @@ export async function onRequestGet(context) {
         v.name as venue_name,
         v.address
       FROM events e
-      LEFT JOIN performances p ON p.event_id = e.id
+      LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1)
       LEFT JOIN band_profiles bp ON p.band_profile_id = bp.id
       LEFT JOIN venues v ON v.id = p.venue_id
       WHERE e.is_published = 1

--- a/functions/api/internal/__tests__/run-scheduled.test.js
+++ b/functions/api/internal/__tests__/run-scheduled.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { createTestEnv } from "../../test-utils.js";
+import { onRequestPost } from "../run-scheduled.js";
+
+const SECRET = "test-cron-secret-for-unit-tests";
+
+function makeRequest(headers = {}) {
+  return new Request("https://example.test/api/internal/run-scheduled", {
+    method: "POST",
+    headers,
+  });
+}
+
+function makeContext(request, envOverrides = {}) {
+  const { env } = createTestEnv({ role: "admin" });
+  return {
+    request,
+    env: { ...env, ...envOverrides },
+    waitUntil: () => {},
+  };
+}
+
+describe("POST /api/internal/run-scheduled", () => {
+  it("returns 503 when CRON_SECRET is not configured", async () => {
+    const ctx = makeContext(makeRequest(), { CRON_SECRET: undefined });
+    const res = await onRequestPost(ctx);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    // Generic body hides the internal env-var name from callers (server log
+    // still records the specific reason via console.error).
+    expect(body.error).toBe("Service unavailable");
+  });
+
+  it("returns 503 when CRON_SECRET is an empty string", async () => {
+    const ctx = makeContext(makeRequest(), { CRON_SECRET: "" });
+    const res = await onRequestPost(ctx);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const ctx = makeContext(makeRequest(), { CRON_SECRET: SECRET });
+    const res = await onRequestPost(ctx);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when Bearer token is wrong", async () => {
+    const ctx = makeContext(
+      makeRequest({ Authorization: "Bearer wrong-secret" }),
+      { CRON_SECRET: SECRET },
+    );
+    const res = await onRequestPost(ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when X-Cron-Secret header has wrong token", async () => {
+    const ctx = makeContext(
+      makeRequest({ "X-Cron-Secret": "not-the-secret" }),
+      { CRON_SECRET: SECRET },
+    );
+    const res = await onRequestPost(ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 and invokes scheduled handler when Bearer token is correct", async () => {
+    const ctx = makeContext(
+      makeRequest({ Authorization: `Bearer ${SECRET}` }),
+      { CRON_SECRET: SECRET },
+    );
+    const res = await onRequestPost(ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.ranAt).toBe("string");
+    expect(typeof body.durationMs).toBe("number");
+  });
+
+  it("returns 200 when X-Cron-Secret header carries the correct token", async () => {
+    const ctx = makeContext(makeRequest({ "X-Cron-Secret": SECRET }), {
+      CRON_SECRET: SECRET,
+    });
+    const res = await onRequestPost(ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+});

--- a/functions/api/internal/run-scheduled.js
+++ b/functions/api/internal/run-scheduled.js
@@ -1,0 +1,70 @@
+import { scheduled } from "../../_scheduled.js";
+import { timingSafeEqual } from "../../utils/crypto.js";
+
+const enc = new TextEncoder();
+
+/**
+ * Constant-time comparison for two secret strings.
+ * Encodes both as UTF-8 bytes and delegates to timingSafeEqual (Uint8Array XOR
+ * accumulate), reusing the helper from functions/utils/crypto.js rather than
+ * rolling a new comparison.
+ */
+function secretsMatch(a, b) {
+  const ab = enc.encode(a);
+  const bb = enc.encode(b);
+  // Length-difference leak is accepted: the secret is high-entropy (256-bit)
+  // so its byte-length is not a useful signal to an attacker.
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * POST /api/internal/run-scheduled
+ *
+ * Secret-protected endpoint that invokes the scheduled handler (popularity
+ * aggregation + PII retention cleanup + share-link expiry). Called by the
+ * .github/workflows/scheduled-jobs.yml GitHub Actions cron workflow because
+ * Cloudflare Pages does not support native cron triggers.
+ *
+ * Authentication: Authorization: Bearer <CRON_SECRET>
+ *   or            X-Cron-Secret: <CRON_SECRET>
+ *
+ * Fail-closed: if CRON_SECRET is unset the endpoint returns 503 and refuses
+ * all requests, mirroring the Turnstile / CSRF fail-closed pattern.
+ */
+export async function onRequestPost(context) {
+  const { request, env } = context;
+
+  // Fail closed: CRON_SECRET must be configured in the Cloudflare Pages project.
+  if (!env.CRON_SECRET) {
+    console.error(
+      "[run-scheduled] CRON_SECRET is not configured — refusing request.",
+    );
+    return Response.json({ error: "Service unavailable" }, { status: 503 });
+  }
+
+  // Accept token from Authorization: Bearer <token> or X-Cron-Secret: <token>.
+  const authHeader = request.headers.get("Authorization") ?? "";
+  const cronHeader = request.headers.get("X-Cron-Secret") ?? "";
+  const presented = authHeader.startsWith("Bearer ")
+    ? authHeader.slice(7)
+    : cronHeader || null;
+
+  if (!presented || !secretsMatch(presented, env.CRON_SECRET)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const start = Date.now();
+  try {
+    await scheduled({ scheduledTime: start }, env, context);
+  } catch (err) {
+    console.error("[run-scheduled] scheduled() threw:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+
+  return Response.json({
+    ok: true,
+    ranAt: new Date(start).toISOString(),
+    durationMs: Date.now() - start,
+  });
+}

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -1,8 +1,8 @@
-import Database from 'better-sqlite3';
+import Database from "better-sqlite3";
 
 export function createTestDB() {
-  const db = new Database(':memory:');
-  db.pragma('foreign_keys = ON');
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
 
   db.exec(`
     CREATE TABLE users (
@@ -345,97 +345,97 @@ export function createTestDB() {
   `);
 
   const insertUser = db.prepare(
-    "INSERT INTO users (email, role, activated_at) VALUES (?, ?, datetime('now'))"
+    "INSERT INTO users (email, role, activated_at) VALUES (?, ?, datetime('now'))",
   );
-  insertUser.run('admin@test', 'admin');
-  insertUser.run('editor@test', 'editor');
-  insertUser.run('viewer@test', 'viewer');
+  insertUser.run("admin@test", "admin");
+  insertUser.run("editor@test", "editor");
+  insertUser.run("viewer@test", "viewer");
 
   return db;
 }
 
 export const mockUsers = {
-  admin: { id: 1, email: 'admin@test', role: 'admin' },
-  editor: { id: 2, email: 'editor@test', role: 'editor' },
-  viewer: { id: 3, email: 'viewer@test', role: 'viewer' },
+  admin: { id: 1, email: "admin@test", role: "admin" },
+  editor: { id: 2, email: "editor@test", role: "editor" },
+  viewer: { id: 3, email: "viewer@test", role: "viewer" },
 };
 
 export function insertEvent(
   db,
   {
-    name = 'Test Event',
-    slug = 'test-event',
-    date = '2025-12-15',
-    status = 'draft',
+    name = "Test Event",
+    slug = "test-event",
+    date = "2025-12-15",
+    status = "draft",
     created_by = 1,
-  } = {}
+  } = {},
 ) {
   const stmt = db.prepare(
-    'INSERT INTO events (name, slug, date, status, created_by_user_id) VALUES (?, ?, ?, ?, ?)'
+    "INSERT INTO events (name, slug, date, status, created_by_user_id) VALUES (?, ?, ?, ?, ?)",
   );
   const info = stmt.run(name, slug, date, status, created_by);
   return db
-    .prepare('SELECT * FROM events WHERE id = ?')
+    .prepare("SELECT * FROM events WHERE id = ?")
     .get(info.lastInsertRowid);
 }
 
 export function insertBand(
   db,
   {
-    name = 'Test Band',
+    name = "Test Band",
     event_id = null,
     venue_id = null,
-    start_time = '18:00',
-    end_time = '19:00',
+    start_time = "18:00",
+    end_time = "19:00",
     url = null,
     genre = null,
     origin = null,
     description = null,
     photo_url = null,
     social_links = null,
-  } = {}
+  } = {},
 ) {
   // Insert into band_profiles + performances (v2 schema)
-  const nameNormalized = name.toLowerCase().replace(/[^a-z0-9]/g, '');
+  const nameNormalized = name.toLowerCase().replace(/[^a-z0-9]/g, "");
   let profileId;
   const resolvedSocialLinks =
     social_links ?? (url ? JSON.stringify({ website: url }) : null);
   const existingProfile = db
-    .prepare('SELECT * FROM band_profiles WHERE name_normalized = ?')
+    .prepare("SELECT * FROM band_profiles WHERE name_normalized = ?")
     .get(nameNormalized);
   if (existingProfile) {
     profileId = existingProfile.id;
     const updates = [];
     const values = [];
     if (genre !== null) {
-      updates.push('genre = ?');
+      updates.push("genre = ?");
       values.push(genre);
     }
     if (origin !== null) {
-      updates.push('origin = ?');
+      updates.push("origin = ?");
       values.push(origin);
     }
     if (description !== null) {
-      updates.push('description = ?');
+      updates.push("description = ?");
       values.push(description);
     }
     if (photo_url !== null) {
-      updates.push('photo_url = ?');
+      updates.push("photo_url = ?");
       values.push(photo_url);
     }
     if (resolvedSocialLinks !== null) {
-      updates.push('social_links = ?');
+      updates.push("social_links = ?");
       values.push(resolvedSocialLinks);
     }
     if (updates.length > 0) {
       db.prepare(
-        `UPDATE band_profiles SET ${updates.join(', ')} WHERE id = ?`
+        `UPDATE band_profiles SET ${updates.join(", ")} WHERE id = ?`,
       ).run(...values, profileId);
     }
   } else {
     const profileInfo = db
       .prepare(
-        'INSERT INTO band_profiles (name, name_normalized, genre, origin, description, photo_url, social_links) VALUES (?, ?, ?, ?, ?, ?, ?)'
+        "INSERT INTO band_profiles (name, name_normalized, genre, origin, description, photo_url, social_links) VALUES (?, ?, ?, ?, ?, ?, ?)",
       )
       .run(
         name,
@@ -444,14 +444,14 @@ export function insertBand(
         origin,
         description,
         photo_url,
-        resolvedSocialLinks
+        resolvedSocialLinks,
       );
     profileId = profileInfo.lastInsertRowid;
   }
 
   const perfInfo = db
     .prepare(
-      'INSERT INTO performances (event_id, venue_id, band_profile_id, start_time, end_time) VALUES (?, ?, ?, ?, ?)'
+      "INSERT INTO performances (event_id, venue_id, band_profile_id, start_time, end_time) VALUES (?, ?, ?, ?, ?)",
     )
     .run(event_id, venue_id, profileId, start_time, end_time);
 
@@ -462,7 +462,7 @@ export function insertBand(
     FROM performances p
     JOIN band_profiles bp ON p.band_profile_id = bp.id
     WHERE p.id = ?
-  `
+  `,
     )
     .get(perfInfo.lastInsertRowid);
 }
@@ -470,8 +470,8 @@ export function insertBand(
 export function insertVenue(
   db,
   {
-    name = 'Test Venue',
-    city = 'Portland',
+    name = "Test Venue",
+    city = "Portland",
     region = null,
     address_line1 = null,
     address_line2 = null,
@@ -480,7 +480,7 @@ export function insertVenue(
     phone = null,
     contact_email = null,
     address = null,
-  } = {}
+  } = {},
 ) {
   const stmt = db.prepare(
     `INSERT INTO venues (
@@ -494,7 +494,7 @@ export function insertVenue(
       phone,
       contact_email,
       address
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   const info = stmt.run(
     name,
@@ -506,10 +506,10 @@ export function insertVenue(
     country,
     phone,
     contact_email,
-    address
+    address,
   );
   return db
-    .prepare('SELECT * FROM venues WHERE id = ?')
+    .prepare("SELECT * FROM venues WHERE id = ?")
     .get(info.lastInsertRowid);
 }
 
@@ -579,43 +579,50 @@ export function createDBEnv(db) {
 
       return wrapper;
     },
-    // Cloudflare D1 batch() method
+    // Cloudflare D1 batch() method.
+    // For SELECT statements the bound wrapper's all() returns { results: [...] };
+    // for mutations (INSERT/UPDATE/DELETE) all() throws so we fall back to
+    // run() which returns { success, meta }.  This mirrors how D1.batch() works.
     async batch(statements) {
       const results = [];
       for (const stmt of statements) {
-        results.push(await stmt.run());
+        try {
+          results.push(stmt.all());
+        } catch {
+          results.push(stmt.run());
+        }
       }
       return results;
     },
   };
 }
 
-export function createTestEnv({ role = 'editor' } = {}) {
+export function createTestEnv({ role = "editor" } = {}) {
   const rawDb = createTestDB();
 
   // Create a valid session for the test user
-  const userId = role === 'admin' ? 1 : role === 'editor' ? 2 : 3;
+  const userId = role === "admin" ? 1 : role === "editor" ? 2 : 3;
   const sessionId = crypto.randomUUID();
   const expiresAt = Math.floor(Date.now() / 1000) + 24 * 60 * 60;
 
   rawDb
     .prepare(
-      'INSERT INTO lucia_sessions (id, user_id, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)'
+      "INSERT INTO lucia_sessions (id, user_id, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)",
     )
-    .run(sessionId, userId, expiresAt, '127.0.0.1', 'test-agent');
+    .run(sessionId, userId, expiresAt, "127.0.0.1", "test-agent");
 
   return {
     env: {
       DB: createDBEnv(rawDb),
-      ALLOW_HEADER_AUTH: 'true',
-      ENVIRONMENT: 'test',
-      CSRF_SECRET: 'test-csrf-secret-for-unit-tests',
-      MFA_TOTP_ENCRYPTION_KEY: 'test-mfa-totp-encryption-key',
+      ALLOW_HEADER_AUTH: "true",
+      ENVIRONMENT: "test",
+      CSRF_SECRET: "test-csrf-secret-for-unit-tests",
+      MFA_TOTP_ENCRYPTION_KEY: "test-mfa-totp-encryption-key",
     },
     rawDb,
     role,
     headers: {
-      'x-test-role': role,
+      "x-test-role": role,
       Authorization: `Bearer ${sessionId}`,
     },
   };
@@ -624,32 +631,34 @@ export function createTestEnv({ role = 'editor' } = {}) {
 export function insertShareLink(
   db,
   {
-    slug = 'testslug',
+    slug = "testslug",
     event_id,
-    event_slug = 'test-event',
+    event_slug = "test-event",
     performance_ids = [1],
-    band_names = ['Test Band'],
+    band_names = ["Test Band"],
     expires_at = null,
-  } = {}
+  } = {},
 ) {
   const expiresAt =
     expires_at ??
     new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
       .toISOString()
-      .replace('T', ' ')
-      .replace(/\.\d+Z$/, '')
+      .replace("T", " ")
+      .replace(/\.\d+Z$/, "");
 
   const stmt = db.prepare(
     `INSERT INTO share_links (slug, event_id, event_slug, performance_ids, band_names, expires_at)
-     VALUES (?, ?, ?, ?, ?, ?)`
-  )
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  );
   const info = stmt.run(
     slug,
     event_id,
     event_slug,
     JSON.stringify(performance_ids),
     JSON.stringify(band_names),
-    expiresAt
-  )
-  return db.prepare('SELECT * FROM share_links WHERE id = ?').get(info.lastInsertRowid)
+    expiresAt,
+  );
+  return db
+    .prepare("SELECT * FROM share_links WHERE id = ?")
+    .get(info.lastInsertRowid);
 }

--- a/functions/api/venues/[id].js
+++ b/functions/api/venues/[id].js
@@ -70,6 +70,7 @@ export async function onRequestGet(context) {
       JOIN band_profiles bp ON bp.id = p.band_profile_id
       WHERE p.venue_id = ?
         AND (e.is_published = 1 OR e.status = 'archived')
+        AND (e.reveal_mode = 0 OR p.is_announced = 1)
       ORDER BY e.date DESC, p.start_time
     `,
     )

--- a/functions/api/venues/__tests__/venue-detail.test.js
+++ b/functions/api/venues/__tests__/venue-detail.test.js
@@ -1,0 +1,112 @@
+import { describe, test, expect } from "vitest";
+import { onRequestGet } from "../[id].js";
+import {
+  createTestEnv,
+  insertEvent,
+  insertVenue,
+  insertBand,
+} from "../../test-utils.js";
+
+describe("GET /api/venues/:id — reveal_mode gate", () => {
+  // Use a far-future date so performances land in the "upcoming" bucket.
+  const futureDate = "2099-01-01";
+
+  test("unannounced performance in reveal_mode=1 event is hidden from venue lineup", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Prohibition Warehouse" });
+    const event = insertEvent(rawDb, {
+      name: "Vol 17 Venue Hidden",
+      slug: "venue-reveal-hidden",
+      date: futureDate,
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+    const perf = insertBand(rawDb, {
+      name: "Hidden Venue Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(perf.id);
+
+    const response = await onRequestGet({
+      env,
+      params: { id: String(venue.id) },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(0);
+    expect(payload.past).toHaveLength(0);
+  });
+
+  test("announced performance in reveal_mode=1 event is shown in venue lineup", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Blue Room" });
+    const event = insertEvent(rawDb, {
+      name: "Vol 17 Venue Shown",
+      slug: "venue-reveal-shown",
+      date: futureDate,
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
+      .run(event.id);
+    const perf = insertBand(rawDb, {
+      name: "Revealed Venue Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
+      .run(perf.id);
+
+    const response = await onRequestGet({
+      env,
+      params: { id: String(venue.id) },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(1);
+    expect(payload.upcoming[0].band_name).toBe("Revealed Venue Band");
+  });
+
+  test("unannounced performance in reveal_mode=0 event is shown (gate is no-op)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    const event = insertEvent(rawDb, {
+      name: "Normal Venue Event",
+      slug: "venue-reveal-mode0",
+      date: futureDate,
+    });
+    rawDb
+      .prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?")
+      .run(event.id);
+    const perf = insertBand(rawDb, {
+      name: "Normal Venue Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb
+      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
+      .run(perf.id);
+
+    const response = await onRequestGet({
+      env,
+      params: { id: String(venue.id) },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(1);
+    expect(payload.upcoming[0].band_name).toBe("Normal Venue Band");
+  });
+});

--- a/functions/utils/crypto.js
+++ b/functions/utils/crypto.js
@@ -7,7 +7,7 @@ const LEGACY_ITERATIONS = 100000;
 const DEFAULT_ITERATIONS = 100000;
 const KEY_LENGTH = 32;
 
-function timingSafeEqual(a, b) {
+export function timingSafeEqual(a, b) {
   if (a.length !== b.length) {
     return false;
   }
@@ -32,7 +32,7 @@ async function deriveKey(password, salt, iterations) {
     encoder.encode(password),
     "PBKDF2",
     false,
-    ["deriveBits"]
+    ["deriveBits"],
   );
 
   const derived = await crypto.subtle.deriveBits(
@@ -43,7 +43,7 @@ async function deriveKey(password, salt, iterations) {
       hash: "SHA-256",
     },
     keyMaterial,
-    KEY_LENGTH * 8
+    KEY_LENGTH * 8,
   );
 
   return new Uint8Array(derived);
@@ -102,7 +102,7 @@ export async function verifyPassword(password, storedHash) {
 
     const hashArray = await deriveKey(password, salt, iterations);
     const storedHashArray = Uint8Array.from(atob(hashBase64), (c) =>
-      c.charCodeAt(0)
+      c.charCodeAt(0),
     );
 
     return timingSafeEqual(hashArray, storedHashArray);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -43,10 +43,12 @@ database_id = "c6c8b4a6-f951-47c1-a787-aab0a61ca09b" # binding reference only �
 binding = "ANALYTICS"
 dataset = "settimes_metrics"
 
-# Cron triggers are not supported for Cloudflare Pages
-# Use a separate Worker if scheduled tasks are needed
-# [triggers]
-# crons = ["0 * * * *"]
+# Cron triggers are not supported for Cloudflare Pages.
+# Scheduled tasks (popularity aggregation, PII retention cleanup, share-link
+# expiry) run via .github/workflows/scheduled-jobs.yml, which POSTs daily to
+# /api/internal/run-scheduled. That endpoint is gated by the CRON_SECRET env
+# var — configure it in Cloudflare Pages Settings → Environment Variables and
+# as a GitHub Actions repository secret with the same value.
 
 # For local development, Wrangler will create a local SQLite database
 # Local DB path: .wrangler/state/v3/d1/miniflare-D1DatabaseObject/


### PR DESCRIPTION
Fixes two issues surfaced by the 2026-06-27 multi-agent review. Two focused commits.

## `fix(security)`: reveal-mode lineup embargo — Closes #403

Events in **reveal mode** hide not-yet-announced performances on `/api/schedule`, but seven sibling public endpoints leaked the embargoed lineup (band name, set time, venue). This applies the canonical gate `(reveal_mode = 0 OR p.is_announced = 1)` everywhere a published event's performances are exposed:

- `events/[id]/details.js`, `bands/[name].js`, `bands/stats/[name].js`, `venues/[id].js` — gate in `WHERE` (performances drive the query)
- `feeds/ical.js`, `events/timeline.js` ×3 — gate in the **JOIN condition** (`LEFT JOIN`, so the event row survives a fully-embargoed lineup)

A code-review pass enumerated the whole `performances`-join surface to confirm closure. Endpoints exposing only **counts/existence** (`events/public`, `venues`, `artists`) and **post-event** (`recap`) are intentionally left ungated — reveal-mode hides *who*, not *how many*. All `admin/*` are auth-gated.

Real-DB tests added for every endpoint, including a timeline test that guards the JOIN-vs-WHERE invariant (event must remain visible when all its bands are embargoed). Includes a `test-utils.js` `batch()` fidelity fix so `DB.batch()` returns SELECT rows like real D1.

## `fix(reliability)`: scheduler never ran — Closes #405

Cloudflare Pages has no native cron, so `scheduled()` (popularity aggregation, **PII retention cleanup**, share-link expiry) never executed — popularity scores froze and retention cleanup never ran. Adds:

- `POST /api/internal/run-scheduled` — invokes `scheduled()`; **fails closed (503)** if `CRON_SECRET` is unset; constant-time bearer-token compare (reuses `timingSafeEqual`)
- `.github/workflows/scheduled-jobs.yml` — daily cron (`17 7 * * *`) + `workflow_dispatch`, secret passed via `env:`

Reviewed by `cloudflare-security-reviewer` (sound — no Critical/High/Medium); 503 body hardened to not disclose the env-var name.

### ⚠️ Required before this works in prod
Set **`CRON_SECRET`** to the same value in **both**:
- GitHub Actions → repository secrets
- Cloudflare Pages → Settings → Environment Variables (Production)

Generate with `openssl rand -base64 32`. (Documented in `docs/DEPLOYMENT.md`.)

## Testing
`489 passed (63 files), 6 todo` — full backend suite, run locally. Dual Opus review (security + code) before and after the gap-closure pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
