### PR TITLE
fix(theme): semantic text tokens for light-theme readability (#411)

### DIFF
--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -280,7 +280,7 @@ function ScheduleView({
               disabled={allSelected}
               className={`text-xs px-3 py-1.5 min-h-[44px] rounded transition-transform duration-150 hover:brightness-110 active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-400 ${
                 allSelected
-                  ? 'bg-gray-500/20 border border-gray-500/50 text-gray-400 cursor-not-allowed'
+                  ? 'bg-gray-500/20 border border-gray-500/50 text-text-disabled cursor-not-allowed'
                   : 'bg-accent-500/20 border border-accent-500/50 text-accent-400 hover:bg-accent-500/30'
               }`}
               title={allSelected ? 'All visible bands already selected' : 'Select all visible bands'}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -49,7 +49,7 @@ function LoadingFallback() {
       role="status"
       aria-live="polite"
     >
-      <div className="text-white text-xl">Loading...</div>
+      <div className="text-text-primary text-xl">Loading...</div>
     </div>
   )
 }

--- a/frontend/src/pages/ActivatePage.jsx
+++ b/frontend/src/pages/ActivatePage.jsx
@@ -56,7 +56,7 @@ export default function ActivatePage() {
       <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
         <div className="max-w-md w-full bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border text-center">
           <h1 className="text-2xl font-bold text-text-primary mb-4">Activation Failed</h1>
-          <p className="text-gray-300 mb-6">{message}</p>
+          <p className="text-text-secondary mb-6">{message}</p>
           <button
             onClick={() => navigate('/admin/login')}
             className="bg-accent-500 hover:bg-accent-600 text-bg-navy font-bold py-3 px-6 rounded-lg transition"
@@ -72,7 +72,7 @@ export default function ActivatePage() {
     <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
       <div className="max-w-md w-full bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border text-center">
         <h1 className="text-2xl font-bold text-text-primary mb-4">Account Activated</h1>
-        <p className="text-gray-300 mb-6">{message}</p>
+        <p className="text-text-secondary mb-6">{message}</p>
         <button
           onClick={() => navigate('/admin/login')}
           className="bg-accent-500 hover:bg-accent-600 text-bg-navy font-bold py-3 px-6 rounded-lg transition"

--- a/frontend/src/pages/EmbedPage.jsx
+++ b/frontend/src/pages/EmbedPage.jsx
@@ -80,7 +80,7 @@ export default function EmbedPage() {
       <div className="min-h-screen bg-bg-navy flex items-center justify-center p-4">
         <div className="text-center">
           <h2 className="text-text-primary text-xl font-bold mb-2">Event Not Found</h2>
-          <p className="text-gray-400">{error}</p>
+          <p className="text-text-tertiary">{error}</p>
         </div>
       </div>
     )

--- a/frontend/src/pages/PrivacyPage.jsx
+++ b/frontend/src/pages/PrivacyPage.jsx
@@ -18,7 +18,7 @@ export default function PrivacyPage() {
         <h1 className="text-text-primary text-3xl font-bold mb-2">Privacy Policy</h1>
         <p className="text-text-tertiary text-sm mb-10">Last updated: April 2026</p>
 
-        <div className="space-y-8 text-gray-300 leading-relaxed">
+        <div className="space-y-8 text-text-secondary leading-relaxed">
           <section>
             <h2 className="text-text-primary text-lg font-semibold mb-3">What SetTimes is</h2>
             <p>

--- a/frontend/src/pages/ResetPasswordPage.jsx
+++ b/frontend/src/pages/ResetPasswordPage.jsx
@@ -109,7 +109,7 @@ export default function ResetPasswordPage() {
       <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
         <div className="max-w-md w-full bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border text-center">
           <h1 className="text-2xl font-bold text-text-primary mb-4">Reset Failed</h1>
-          <p className="text-gray-300 mb-6">{message}</p>
+          <p className="text-text-secondary mb-6">{message}</p>
           <button
             onClick={() => navigate('/admin/login')}
             className="bg-accent-500 hover:bg-accent-600 text-bg-navy font-bold py-3 px-6 rounded-lg transition"
@@ -126,7 +126,7 @@ export default function ResetPasswordPage() {
       <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple flex items-center justify-center p-4">
         <div className="max-w-md w-full bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border text-center">
           <h1 className="text-2xl font-bold text-text-primary mb-4">✓ Password Reset</h1>
-          <p className="text-gray-300 mb-6">{message}</p>
+          <p className="text-text-secondary mb-6">{message}</p>
           <button
             onClick={() => navigate('/admin/login')}
             className="bg-accent-500 hover:bg-accent-600 text-bg-navy font-bold py-3 px-6 rounded-lg transition"
@@ -143,7 +143,7 @@ export default function ResetPasswordPage() {
       <div className="max-w-md w-full bg-surface backdrop-blur-lg rounded-2xl p-8 border border-border">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-text-primary mb-2">Reset Password</h1>
-          <p className="text-gray-300">
+          <p className="text-text-secondary">
             Set a new password for <span className="font-medium">{user?.email}</span>
           </p>
         </div>

--- a/frontend/src/pages/SubscribePage.jsx
+++ b/frontend/src/pages/SubscribePage.jsx
@@ -152,7 +152,7 @@ export default function SubscribePage() {
         {/* Header */}
         <div className="text-center mb-12">
           <h1 className="text-4xl font-bold text-text-primary mb-4">Never Miss a Show</h1>
-          <p className="text-xl text-gray-300">
+          <p className="text-xl text-text-secondary">
             Get weekly emails about concerts in your city. No algorithm, no ads, just shows.
           </p>
         </div>
@@ -255,7 +255,7 @@ export default function SubscribePage() {
 
           {/* Privacy note */}
           <div className="mt-8 pt-6 border-t border-border">
-            <p className="text-sm text-gray-400 text-center">
+            <p className="text-sm text-text-tertiary text-center">
               We respect your privacy. No tracking, no ads, no selling your data.
               <br />
               Unsubscribe anytime with one click.


### PR DESCRIPTION
Closes #411.

The white-literal contrast sweep was "complete," but `text-gray-300/400` is a parallel violation family the white-only grep never caught. On the `daybreak`/`silver-lining` light themes these render near-invisible (light gray on cream/white) — worst case the **entire privacy-policy body** and the global Suspense "Loading…" spinner.

## Changes (11 className swaps, 7 files)
- `text-gray-300` → `text-text-secondary` (PrivacyPage body, SubscribePage, Activate, ResetPassword status text)
- `text-gray-400` → `text-text-tertiary` (SubscribePage, EmbedPage error)
- `text-gray-400` disabled state → `text-text-disabled` (ScheduleView)
- `text-white` Suspense LoadingFallback → `text-text-primary` (main.jsx)

## Closing the class, not just instances
A widened grep (`text-gray|slate|zinc-[234]00`) across all public pages (excl. dark-pinned `admin/`) confirms **zero remaining offenders**. Judgment calls verified: EmbedPage's container is `bg-bg-navy` (theme-following → fixed), and the skip-link `bg-white`/`text-black` is kept as theme-independent a11y styling.

## Testing
Frontend suite green: prettier + eslint clean, **204 tests pass**, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)