### PR TITLE
fix(observability): log silent metrics & email-delivery failures (#406)

### DIFF
--- a/functions/api/__tests__/metrics.test.js
+++ b/functions/api/__tests__/metrics.test.js
@@ -1,0 +1,69 @@
+// Tests for POST /api/metrics
+// Covers: break-removal (all event_view counts written even above MAX_BATCH_STATEMENTS)
+// and catch-logging (swallowed page_views_daily failure now emits logger.warn).
+import { describe, expect, test, vi, afterEach } from "vitest";
+import { onRequestPost } from "../metrics.js";
+import * as loggerModule from "../../utils/logger.js";
+import { createTestEnv } from "../test-utils.js";
+
+function makeRequest(events) {
+  return new Request("https://example.test/api/metrics", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ events }),
+  });
+}
+
+describe("POST /api/metrics", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("writes ALL event_view counts when count exceeds MAX_BATCH_STATEMENTS (break removed)", async () => {
+    const { env, rawDb } = createTestEnv();
+
+    // Generate 25 unique event_view events — MAX_BATCH_STATEMENTS is 20, so without
+    // the fix the last 5 would have been silently dropped.
+    const events = Array.from({ length: 25 }, (_, i) => ({
+      event: "event_view",
+      props: { event_id: i + 1 },
+    }));
+
+    const res = await onRequestPost({ request: makeRequest(events), env });
+    expect(res.status).toBe(200);
+
+    const rows = rawDb.prepare("SELECT * FROM page_views_daily").all();
+    expect(rows).toHaveLength(25);
+    // Verify all 25 event IDs appear as keys
+    const pages = new Set(rows.map((r) => r.page));
+    for (let i = 1; i <= 25; i++) {
+      expect(pages.has(`event:${i}`)).toBe(true);
+    }
+  });
+
+  test("returns 200 and logs a warning when page_views_daily batch fails", async () => {
+    const { env } = createTestEnv();
+
+    // Stub env.DB.batch to throw, simulating a D1 write error (e.g. missing
+    // migration). better-sqlite3's prepare() validates eagerly so we can't
+    // drop the table — instead we inject a failure at batch() time.
+    env.DB.batch = async () => {
+      throw new Error("simulated page_views_daily write failure");
+    };
+
+    const warnSpy = vi.spyOn(loggerModule.logger, "warn");
+
+    // page_view events populate pvStmts only (no artist_daily_stats batch).
+    const events = [{ event: "page_view", props: { page: "/home" } }];
+    const res = await onRequestPost({ request: makeRequest(events), env });
+
+    // Best-effort: must still return 200
+    expect(res.status).toBe(200);
+
+    // The swallowed catch must now emit a structured warning
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("page_views_daily"),
+      expect.objectContaining({ statementCount: expect.any(Number) }),
+    );
+  });
+});

--- a/functions/api/metrics.js
+++ b/functions/api/metrics.js
@@ -2,6 +2,8 @@
 // POST /api/metrics
 // Privacy-first: no PII, aggregated only
 
+import { logger } from "../utils/logger.js";
+
 const MAX_BATCH_STATEMENTS = 20;
 
 const ALLOWED_EVENTS = new Set([
@@ -41,7 +43,11 @@ function parseInteger(value) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
-async function executeInChunks(db, statements, chunkSize = MAX_BATCH_STATEMENTS) {
+async function executeInChunks(
+  db,
+  statements,
+  chunkSize = MAX_BATCH_STATEMENTS,
+) {
   for (let i = 0; i < statements.length; i += chunkSize) {
     await db.batch(statements.slice(i, i + chunkSize));
   }
@@ -163,7 +169,6 @@ export async function onRequestPost(context) {
       }
 
       for (const [key, count] of eventViewCounts) {
-        if (pvStmts.length >= MAX_BATCH_STATEMENTS) break;
         pvStmts.push(
           env.DB.prepare(
             `INSERT INTO page_views_daily (page, date, views)
@@ -177,15 +182,18 @@ export async function onRequestPost(context) {
       if (pvStmts.length > 0) {
         try {
           await executeInChunks(env.DB, pvStmts);
-        } catch (_) {
-          // Table may not exist yet if migration hasn't run
+        } catch (err) {
+          logger.warn(
+            "page_views_daily upsert failed (table may be missing or write error)",
+            { error: err, statementCount: pvStmts.length },
+          );
         }
       }
     }
 
     return new Response("OK", { status: 200 });
   } catch (error) {
-    console.error("[Metrics] Ingestion error:", error);
+    logger.error("Metrics ingestion error", { error });
     return new Response("OK", { status: 200 });
   }
 }

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -149,6 +149,16 @@ export function createTestDB() {
       FOREIGN KEY (band_profile_id) REFERENCES band_profiles(id) ON DELETE CASCADE
     );
 
+    CREATE TABLE page_views_daily (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      page TEXT NOT NULL,
+      date TEXT NOT NULL,
+      views INTEGER DEFAULT 0,
+      UNIQUE(page, date)
+    );
+
+    CREATE INDEX idx_page_views_date ON page_views_daily(date);
+
     CREATE TABLE performances (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       event_id INTEGER REFERENCES events(id) ON DELETE CASCADE,

--- a/functions/utils/__tests__/bandFollowNotify.test.js
+++ b/functions/utils/__tests__/bandFollowNotify.test.js
@@ -1,151 +1,193 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi, afterEach } from "vitest";
 
-vi.mock('../email.js', () => ({
+vi.mock("../email.js", () => ({
   sendEmail: vi.fn(),
-}))
+}));
 
-import { sendEmail } from '../email.js'
-import { notifyBandFollowers } from '../bandFollowNotify.js'
+import { sendEmail } from "../email.js";
+import { notifyBandFollowers } from "../bandFollowNotify.js";
+import * as loggerModule from "../logger.js";
 import {
   createTestEnv,
   insertEvent,
   insertVenue,
   insertBand,
-} from '../../api/test-utils.js'
+} from "../../api/test-utils.js";
 
-describe('notifyBandFollowers', () => {
-  test('records a notification for each delivered email and skips failures', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
-    const venue = insertVenue(rawDb, { name: 'Hall' })
+describe("notifyBandFollowers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+  test("records a notification for each delivered email and skips failures", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Fest", slug: "fest" });
+    const venue = insertVenue(rawDb, { name: "Hall" });
     const perf = insertBand(rawDb, {
-      name: 'The Band',
+      name: "The Band",
       event_id: event.id,
       venue_id: venue.id,
-    })
-    const bandProfileId = perf.band_profile_id
+    });
+    const bandProfileId = perf.band_profile_id;
 
     const f1 = rawDb
       .prepare(
-        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
       )
-      .run('a@example.com', bandProfileId, 'tok-a').lastInsertRowid
+      .run("a@example.com", bandProfileId, "tok-a").lastInsertRowid;
     const f2 = rawDb
       .prepare(
-        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
       )
-      .run('b@example.com', bandProfileId, 'tok-b').lastInsertRowid
+      .run("b@example.com", bandProfileId, "tok-b").lastInsertRowid;
 
     // First delivers, second fails.
     sendEmail.mockImplementation((_env, { to }) =>
-      Promise.resolve({ delivered: to === 'a@example.com' })
-    )
+      Promise.resolve({ delivered: to === "a@example.com" }),
+    );
 
     const result = await notifyBandFollowers(env, env.DB, {
       performanceId: perf.id,
       bandProfileId,
-      bandName: 'The Band',
-      eventName: 'Fest',
+      bandName: "The Band",
+      eventName: "Fest",
       followers: [
-        { id: f1, email: 'a@example.com', unsubscribe_token: 'tok-a' },
-        { id: f2, email: 'b@example.com', unsubscribe_token: 'tok-b' },
+        { id: f1, email: "a@example.com", unsubscribe_token: "tok-a" },
+        { id: f2, email: "b@example.com", unsubscribe_token: "tok-b" },
       ],
-    })
+    });
 
-    expect(result).toEqual({ sent: 1, failed: 1 })
+    expect(result).toEqual({ sent: 1, failed: 1 });
 
     const notified = rawDb
       .prepare(
-        'SELECT band_follow_id FROM band_follow_notifications WHERE performance_id = ? ORDER BY band_follow_id'
+        "SELECT band_follow_id FROM band_follow_notifications WHERE performance_id = ? ORDER BY band_follow_id",
       )
-      .all(perf.id)
-    expect(notified.map((r) => r.band_follow_id)).toEqual([f1])
-  })
+      .all(perf.id);
+    expect(notified.map((r) => r.band_follow_id)).toEqual([f1]);
+  });
 
-  test('skips followers already claimed by another concurrent request', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'Test', slug: 'test' })
-    const venue = insertVenue(rawDb, { name: 'Venue' })
+  test("skips followers already claimed by another concurrent request", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Test", slug: "test" });
+    const venue = insertVenue(rawDb, { name: "Venue" });
     const perf = insertBand(rawDb, {
-      name: 'Band',
+      name: "Band",
       event_id: event.id,
       venue_id: venue.id,
-    })
-    const bandProfileId = perf.band_profile_id
+    });
+    const bandProfileId = perf.band_profile_id;
 
     const fId = rawDb
       .prepare(
-        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
       )
-      .run('fan@example.com', bandProfileId, 'tok').lastInsertRowid
+      .run("fan@example.com", bandProfileId, "tok").lastInsertRowid;
 
     // Pre-claim the follower as if another concurrent request already did
     rawDb
       .prepare(
-        'INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)'
+        "INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)",
       )
-      .run(perf.id, fId)
+      .run(perf.id, fId);
 
-    sendEmail.mockReset()
-    sendEmail.mockImplementation(() =>
-      Promise.resolve({ delivered: true })
-    )
+    sendEmail.mockReset();
+    sendEmail.mockImplementation(() => Promise.resolve({ delivered: true }));
 
     const result = await notifyBandFollowers(env, env.DB, {
       performanceId: perf.id,
       bandProfileId,
-      bandName: 'Band',
-      eventName: 'Test',
+      bandName: "Band",
+      eventName: "Test",
       followers: [
-        { id: fId, email: 'fan@example.com', unsubscribe_token: 'tok' },
+        { id: fId, email: "fan@example.com", unsubscribe_token: "tok" },
       ],
-    })
+    });
 
-    expect(result).toEqual({ sent: 0, failed: 1 })
+    expect(result).toEqual({ sent: 0, failed: 1 });
     // sendEmail should not have been called — the race was won by the other request
-    expect(sendEmail).not.toHaveBeenCalled()
-  })
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
 
-  test('releases claim when email fails so resend can retry', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'Test', slug: 'test' })
-    const venue = insertVenue(rawDb, { name: 'Venue' })
+  test("logs a warning when any notification fails", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Test", slug: "test" });
+    const venue = insertVenue(rawDb, { name: "Venue" });
     const perf = insertBand(rawDb, {
-      name: 'Band',
+      name: "Band",
       event_id: event.id,
       venue_id: venue.id,
-    })
-    const bandProfileId = perf.band_profile_id
+    });
+    const bandProfileId = perf.band_profile_id;
 
     const fId = rawDb
       .prepare(
-        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
+        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
       )
-      .run('fan@example.com', bandProfileId, 'tok').lastInsertRowid
+      .run("fan@example.com", bandProfileId, "tok").lastInsertRowid;
 
-    sendEmail.mockReset()
-    sendEmail.mockImplementation(() =>
-      Promise.resolve({ delivered: false })
-    )
+    sendEmail.mockReset();
+    sendEmail.mockImplementation(() => Promise.resolve({ delivered: false }));
+
+    const warnSpy = vi.spyOn(loggerModule.logger, "warn");
 
     const result = await notifyBandFollowers(env, env.DB, {
       performanceId: perf.id,
       bandProfileId,
-      bandName: 'Band',
-      eventName: 'Test',
+      bandName: "Band",
+      eventName: "Test",
       followers: [
-        { id: fId, email: 'fan@example.com', unsubscribe_token: 'tok' },
+        { id: fId, email: "fan@example.com", unsubscribe_token: "tok" },
       ],
-    })
+    });
 
-    expect(result).toEqual({ sent: 0, failed: 1 })
+    expect(result.failed).toBeGreaterThan(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("partially failed"),
+      expect.objectContaining({
+        performanceId: perf.id,
+        failed: result.failed,
+      }),
+    );
+  });
+
+  test("releases claim when email fails so resend can retry", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Test", slug: "test" });
+    const venue = insertVenue(rawDb, { name: "Venue" });
+    const perf = insertBand(rawDb, {
+      name: "Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    const bandProfileId = perf.band_profile_id;
+
+    const fId = rawDb
+      .prepare(
+        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
+      )
+      .run("fan@example.com", bandProfileId, "tok").lastInsertRowid;
+
+    sendEmail.mockReset();
+    sendEmail.mockImplementation(() => Promise.resolve({ delivered: false }));
+
+    const result = await notifyBandFollowers(env, env.DB, {
+      performanceId: perf.id,
+      bandProfileId,
+      bandName: "Band",
+      eventName: "Test",
+      followers: [
+        { id: fId, email: "fan@example.com", unsubscribe_token: "tok" },
+      ],
+    });
+
+    expect(result).toEqual({ sent: 0, failed: 1 });
 
     // The claim row should have been deleted — resend will pick up this follower
     const rows = rawDb
       .prepare(
-        'SELECT id FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?'
+        "SELECT id FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?",
       )
-      .all(perf.id, fId)
-    expect(rows).toHaveLength(0)
-  })
-})
+      .all(perf.id, fId);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/functions/utils/announceDigest.js
+++ b/functions/utils/announceDigest.js
@@ -10,6 +10,7 @@
 // resend that already claimed a slot simply skips that entry.
 
 import { sendEmail } from "./email.js";
+import { logger } from "./logger.js";
 
 const escapeHtml = (s) =>
   String(s ?? "")
@@ -67,7 +68,9 @@ export async function flushAnnounceDigest(env, DB) {
     // already handled by a concurrent path.
     await DB.batch(
       items.map((item) =>
-        DB.prepare("DELETE FROM band_announce_queue WHERE id = ?").bind(item.id),
+        DB.prepare("DELETE FROM band_announce_queue WHERE id = ?").bind(
+          item.id,
+        ),
       ),
     );
 
@@ -84,9 +87,7 @@ export async function flushAnnounceDigest(env, DB) {
         : `${bands.length} bands you follow are playing ${event_name}!`;
 
     const bandListText = bands.map((b) => `• ${b}`).join("\n");
-    const bandListHtml = bands
-      .map((b) => `<li>${escapeHtml(b)}</li>`)
-      .join("");
+    const bandListHtml = bands.map((b) => `<li>${escapeHtml(b)}</li>`).join("");
     const unsubText = claimed
       .map(
         (item) =>
@@ -127,5 +128,8 @@ export async function flushAnnounceDigest(env, DB) {
     }
   }
 
+  if (failed > 0) {
+    logger.warn("announce digest partially failed", { sent, failed, skipped });
+  }
   return { sent, failed, skipped };
 }

--- a/functions/utils/bandFollowNotify.js
+++ b/functions/utils/bandFollowNotify.js
@@ -7,6 +7,7 @@
 // double-sending. Used by the announce flow (bands/[id].js) and the resend
 // endpoint (bands/[id]/resend-announcement.js).
 import { sendEmail } from "./email.js";
+import { logger } from "./logger.js";
 
 // Escape plain-text band/event names for safe interpolation into the email HTML.
 // Mirrors the escaper in bands/[id].js (regex .replace, the codebase convention).
@@ -66,6 +67,13 @@ export async function notifyBandFollowers(
   for (const r of results) {
     if (r.status === "fulfilled" && r.value === true) sent++;
     else failed++;
+  }
+  if (failed > 0) {
+    logger.warn("band follow notifications partially failed", {
+      performanceId,
+      sent,
+      failed,
+    });
   }
   return { sent, failed };
 }

--- a/functions/utils/email.js
+++ b/functions/utils/email.js
@@ -1,7 +1,9 @@
-const PROVIDERS = new Set(['postmark', 'mailchannels', 'resend']);
+import { logger } from "./logger.js";
+
+const PROVIDERS = new Set(["postmark", "mailchannels", "resend"]);
 
 function getProvider(env) {
-  const provider = (env?.EMAIL_PROVIDER || '').toLowerCase();
+  const provider = (env?.EMAIL_PROVIDER || "").toLowerCase();
   return PROVIDERS.has(provider) ? provider : null;
 }
 
@@ -17,11 +19,11 @@ export function isEmailConfigured(env) {
     return false;
   }
 
-  if (provider === 'postmark') {
+  if (provider === "postmark") {
     return Boolean(env?.POSTMARK_API_TOKEN);
   }
 
-  if (provider === 'resend') {
+  if (provider === "resend") {
     return Boolean(env?.RESEND_API_KEY);
   }
 
@@ -33,20 +35,31 @@ export async function sendEmail(env, { to, subject, html, text }) {
   const from = getFrom(env);
 
   if (!provider || !from) {
-    return { delivered: false, reason: 'not_configured' };
+    logger.warn("email delivery failed", {
+      provider: provider ?? "none",
+      reason: "not_configured",
+    });
+    return { delivered: false, reason: "not_configured" };
   }
 
   if (!to || !subject) {
-    return { delivered: false, reason: 'missing_fields' };
+    logger.warn("email delivery failed", {
+      provider,
+      reason: "missing_fields",
+    });
+    return { delivered: false, reason: "missing_fields" };
   }
 
-  if (provider === 'postmark') {
+  if (provider === "postmark") {
     const token = env?.POSTMARK_API_TOKEN;
-    console.log('[Email] Using Postmark provider');
+    logger.info("email provider selected", { provider: "postmark" });
 
     if (!token) {
-      console.error('[Email] Postmark token missing');
-      return { delivered: false, reason: 'missing_postmark_token' };
+      logger.warn("email delivery failed", {
+        provider: "postmark",
+        reason: "missing_postmark_token",
+      });
+      return { delivered: false, reason: "missing_postmark_token" };
     }
 
     const payload = {
@@ -59,76 +72,98 @@ export async function sendEmail(env, { to, subject, html, text }) {
 
     let response;
     try {
-      response = await fetch('https://api.postmarkapp.com/email', {
-        method: 'POST',
+      response = await fetch("https://api.postmarkapp.com/email", {
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
-          'X-Postmark-Server-Token': token,
+          "Content-Type": "application/json",
+          "X-Postmark-Server-Token": token,
         },
         body: JSON.stringify(payload),
       });
     } catch (error) {
-      console.error('[Email] Postmark fetch error:', error?.message || error);
-      return { delivered: false, reason: 'postmark_fetch_error' };
+      logger.warn("email delivery failed", {
+        provider: "postmark",
+        reason: "postmark_fetch_error",
+        error,
+      });
+      return { delivered: false, reason: "postmark_fetch_error" };
     }
 
-    console.log('[Email] Postmark response status:', response.status);
+    logger.info("email provider response received", {
+      provider: "postmark",
+      status: response.status,
+    });
 
     if (!response.ok) {
-      console.error('[Email] Postmark delivery failed:', response.status);
-      return { delivered: false, reason: 'postmark_error' };
+      logger.warn("email delivery failed", {
+        provider: "postmark",
+        status: response.status,
+        reason: "postmark_error",
+      });
+      return { delivered: false, reason: "postmark_error" };
     }
 
-    console.log('[Email] Postmark delivery successful');
+    logger.info("email delivered", { provider: "postmark" });
     return { delivered: true };
   }
 
-  if (provider === 'mailchannels') {
-    console.log('[Email] Using MailChannels provider');
+  if (provider === "mailchannels") {
+    logger.info("email provider selected", { provider: "mailchannels" });
 
     const payload = {
       personalizations: [{ to: [{ email: to }] }],
       from: { email: from },
       subject,
       content: [
-        ...(html ? [{ type: 'text/html', value: html }] : []),
-        ...(text ? [{ type: 'text/plain', value: text }] : []),
+        ...(html ? [{ type: "text/html", value: html }] : []),
+        ...(text ? [{ type: "text/plain", value: text }] : []),
       ],
     };
 
     let response;
     try {
-      response = await fetch('https://api.mailchannels.net/tx/v1/send', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      response = await fetch("https://api.mailchannels.net/tx/v1/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
     } catch (error) {
-      console.error(
-        '[Email] MailChannels fetch error:',
-        error?.message || error
-      );
-      return { delivered: false, reason: 'mailchannels_fetch_error' };
+      logger.warn("email delivery failed", {
+        provider: "mailchannels",
+        reason: "mailchannels_fetch_error",
+        error,
+      });
+      return { delivered: false, reason: "mailchannels_fetch_error" };
     }
 
-    console.log('[Email] MailChannels response status:', response.status);
+    logger.info("email provider response received", {
+      provider: "mailchannels",
+      status: response.status,
+    });
 
     if (!response.ok) {
-      console.error('[Email] MailChannels delivery failed:', response.status);
-      return { delivered: false, reason: 'mailchannels_error' };
+      logger.warn("email delivery failed", {
+        provider: "mailchannels",
+        status: response.status,
+        reason: "mailchannels_error",
+      });
+      return { delivered: false, reason: "mailchannels_error" };
     }
 
-    console.log('[Email] MailChannels delivery successful');
+    logger.info("email delivered", { provider: "mailchannels" });
     return { delivered: true };
   }
 
-  if (provider === 'resend') {
+  if (provider === "resend") {
     const token = env?.RESEND_API_KEY;
-    console.log('[Email] Using Resend provider');
+    logger.info("email provider selected", { provider: "resend" });
 
     if (!token) {
-      console.error('[Email] Resend API key missing');
-      return { delivered: false, reason: 'missing_resend_token' };
+      logger.warn("email delivery failed", {
+        provider: "resend",
+        reason: "missing_resend_token",
+      });
+      return { delivered: false, reason: "missing_resend_token" };
     }
 
     const payload = {
@@ -141,30 +176,44 @@ export async function sendEmail(env, { to, subject, html, text }) {
 
     let response;
     try {
-      response = await fetch('https://api.resend.com/emails', {
-        method: 'POST',
+      response = await fetch("https://api.resend.com/emails", {
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(payload),
       });
     } catch (error) {
-      console.error('[Email] Resend fetch error:', error?.message || error);
-      return { delivered: false, reason: 'resend_fetch_error' };
+      logger.warn("email delivery failed", {
+        provider: "resend",
+        reason: "resend_fetch_error",
+        error,
+      });
+      return { delivered: false, reason: "resend_fetch_error" };
     }
 
-    console.log('[Email] Resend response status:', response.status);
+    logger.info("email provider response received", {
+      provider: "resend",
+      status: response.status,
+    });
 
     if (!response.ok) {
-      console.error('[Email] Resend delivery failed:', response.status);
-      return { delivered: false, reason: 'resend_error' };
+      logger.warn("email delivery failed", {
+        provider: "resend",
+        status: response.status,
+        reason: "resend_error",
+      });
+      return { delivered: false, reason: "resend_error" };
     }
 
-    console.log('[Email] Resend delivery successful');
+    logger.info("email delivered", { provider: "resend" });
     return { delivered: true };
   }
 
-  console.error('[Email] Unsupported provider:', provider);
-  return { delivered: false, reason: 'unsupported_provider' };
+  logger.warn("email delivery failed", {
+    provider,
+    reason: "unsupported_provider",
+  });
+  return { delivered: false, reason: "unsupported_provider" };
 }


### PR DESCRIPTION
Closes #406. Roadmap Track E P1(f).

Best-effort paths failed **silently** — no operator-visible signal — which is dangerous on event day when announcement emails matter most. This routes every failure through the structured `logger` (which auto-redacts PII like `email`/`ip`/tokens) while keeping all paths best-effort.

## Changes
- **`metrics.js`** — removed the `break` that silently dropped event/ticket view counts past the 20-statement cap (`executeInChunks` already chunks, so the guard only discarded data); the empty `catch (_)` and the outer handler now log via `logger`.
- **`email.js`** — all 11 provider failure branches now emit `logger.warn("email delivery failed", { provider, status, reason, error })`. No recipient address or token is ever logged.
- **`bandFollowNotify.js` / `announceDigest.js`** — log aggregate `{ sent, failed }` when `failed > 0`, at the single shared choke point.

## Review
Reviewed by `silent-failure-hunter` (Opus): best-effort contract **preserved** (metrics still 200, notify/email never throw), PII hygiene **clean**, tests **meaningful**, `test-utils` `page_views_daily` DDL **in sync** with migration 0039 / `setup-complete.sql`. Its one finding — a double-logged warning + a now-unused import on the resend path — is fixed in this branch.

## Testing
`492 passed (64 files), 6 todo` — including a regression test that all >20 event-view counts are now written, and that the metrics catch logs while still returning 200. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)