### PR TITLE
fix(a11y): visible theme ring, distinct ForkCard labels, page titles (#412)

### DIFF
--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -71,7 +71,8 @@ function ForkCard({ band1, band2, onToggleBand }) {
             <p className="text-xs text-text-tertiary">{formatTimeRange(band.startTime, band.endTime)}</p>
             <button
               onClick={() => onToggleBand(removeId)}
-              className="mt-2 w-full py-2 text-xs font-semibold rounded-lg bg-accent-500/20 border border-accent-500/50 text-accent-400 hover:bg-accent-500/30 active:scale-95 transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500 min-h-[36px]"
+              aria-label={`Keep ${band.name}, remove ${removeId === band2.id ? band2.name : band1.name}`}
+              className="mt-2 w-full py-2 text-xs font-semibold rounded-lg bg-accent-500/20 border border-accent-500/50 text-accent-400 hover:bg-accent-500/30 active:scale-95 transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500 min-h-[44px]"
             >
               Keep this one
             </button>

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -52,13 +52,13 @@ export default function ThemeToggle() {
         title="Colour theme"
         className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
       >
-        <span aria-hidden="true" className={`h-5 w-5 rounded-full ${SWATCH_CLASSES[theme]} ring-1 ring-white/40`} />
+        <span aria-hidden="true" className={`h-5 w-5 rounded-full ${SWATCH_CLASSES[theme]} ring-1 ring-border`} />
       </button>
       {open && (
         <div
           role="group"
           aria-label="Colour theme"
-          className="absolute right-0 top-full z-50 mt-1 flex items-center gap-1 rounded-full border border-white/10 bg-bg-purple/95 px-1.5 py-1 shadow-lg backdrop-blur-xs"
+          className="absolute right-0 top-full z-50 mt-1 flex items-center gap-1 rounded-full border border-border bg-bg-purple/95 px-1.5 py-1 shadow-lg backdrop-blur-xs"
         >
           {VALID_THEMES.map(name => {
             const isActive = name === theme
@@ -79,7 +79,7 @@ export default function ThemeToggle() {
                 <span
                   aria-hidden="true"
                   className={`h-5 w-5 rounded-full ${SWATCH_CLASSES[name]} ${
-                    isActive ? 'ring-2 ring-white ring-offset-1 ring-offset-bg-purple' : 'opacity-60'
+                    isActive ? 'ring-2 ring-accent-500 ring-offset-1 ring-offset-bg-purple' : 'opacity-60'
                   }`}
                 />
               </button>

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -1,9 +1,16 @@
 import { Compass } from 'lucide-react'
+import { useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { Link } from 'react-router-dom'
 import Footer from '../components/Footer'
 
 export default function NotFoundPage() {
+  // react-helmet-async does not reliably set document.title in React 19 — set it
+  // directly to match the <Helmet> title below. See BandProfilePage.jsx.
+  useEffect(() => {
+    document.title = 'Page Not Found | SetTimes'
+  }, [])
+
   return (
     <div className="min-h-screen flex flex-col bg-linear-to-br from-bg-navy to-bg-purple">
       <Helmet>

--- a/frontend/src/pages/PrivacyPage.jsx
+++ b/frontend/src/pages/PrivacyPage.jsx
@@ -1,7 +1,14 @@
+import { useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { Link } from 'react-router-dom'
 
 export default function PrivacyPage() {
+  // react-helmet-async does not reliably set document.title in React 19 — set it
+  // directly to match the <Helmet> title below. See BandProfilePage.jsx.
+  useEffect(() => {
+    document.title = 'Privacy Policy | SetTimes'
+  }, [])
+
   return (
     <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple">
       <Helmet>

--- a/frontend/src/test/MySchedule.test.jsx
+++ b/frontend/src/test/MySchedule.test.jsx
@@ -107,8 +107,8 @@ describe('MySchedule — conflict vs overlap severity', () => {
     // Both band names must appear (in the fork card)
     expect(screen.getAllByText('Band Alpha').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Band Beta').length).toBeGreaterThan(0)
-    // Two "Keep this one" buttons must exist — one per side
-    expect(screen.getAllByRole('button', { name: /keep this one/i }).length).toBe(2)
+    // Two "Keep …" buttons must exist — one per side (accessible name is the aria-label, e.g. "Keep Band Alpha, remove Band Beta")
+    expect(screen.getAllByRole('button', { name: /^keep /i }).length).toBe(2)
     // These bands conflict (same start), so no partial-overlap banner
     expect(screen.queryByText(/overlapping set/i)).not.toBeInTheDocument()
   })


### PR DESCRIPTION
Closes #412. Three small a11y/UX fixes from the review.

- **Theme-picker active ring** — used `ring-white`/`border-white/10`/`ring-white/40`, invisible on the `daybreak`/`silver-lining` light themes (white ring on a light popover). Switched to `ring-accent-500` (vivid on all four themes) + `border-border`, so the selected swatch is clearly indicated everywhere.
- **ForkCard conflict chooser** — both side buttons rendered the identical accessible name "Keep this one"; a screen-reader user couldn't tell them apart. Added `aria-label={`Keep ${band.name}, remove …`}` so each has a distinct name, and bumped the tap target from `min-h-[36px]` to `min-h-[44px]` (matters in the low-light/phone live context). Visible text unchanged.
- **`document.title`** — PrivacyPage & NotFoundPage relied solely on `<Helmet><title>`, which is unreliable in React 19; added the direct `useEffect` assignment every other page uses.

## Testing
Frontend suite green: lint + format clean, **204 tests** (one updated to match the new aria-label accessible names), build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)