### PR TITLE
fix(security): hardening batch — enumeration, PBKDF2 600k, follow rate-limit, logs (#404)

### DIFF
--- a/functions/api/admin/__tests__/login.test.js
+++ b/functions/api/admin/__tests__/login.test.js
@@ -1,0 +1,167 @@
+// Tests for POST /api/admin/auth/login
+// Focus: account-enumeration fix (password verified before account-state revealed)
+// and confirming the correct requiresActivation behaviour.
+
+import { describe, test, expect, beforeAll } from "vitest";
+import { onRequestPost } from "../auth/login.js";
+import { createTestDB, createDBEnv } from "../../test-utils.js";
+import { hashPassword } from "../../../utils/crypto.js";
+
+// Non-secret unit-test fixtures (the "test" marker keeps secret scanners quiet).
+const TEST_PASSWORD = "correct-test-password";
+const WRONG_PASSWORD = "wrong-test-password";
+
+let passwordHash;
+
+// Compute the hash once for the whole suite to avoid repeating 600 k PBKDF2 rounds.
+beforeAll(async () => {
+  passwordHash = await hashPassword(TEST_PASSWORD);
+}, 30_000);
+
+function makeDB(rawDb) {
+  return createDBEnv(rawDb);
+}
+
+function makeEnv(rawDb) {
+  return {
+    DB: makeDB(rawDb),
+    ENVIRONMENT: "test",
+    CSRF_SECRET: "test-csrf-secret",
+  };
+}
+
+async function postLogin(env, { email, password }) {
+  const request = new Request("https://example.test/api/admin/auth/login", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "CF-Connecting-IP": "1.2.3.4",
+      "User-Agent": "test-agent",
+    },
+    body: JSON.stringify({ email, password }),
+  });
+  return onRequestPost({ request, env });
+}
+
+function insertUser(
+  rawDb,
+  {
+    email,
+    hash,
+    isActive = 1,
+    activatedAt = "2025-01-01 00:00:00",
+    role = "editor",
+  } = {},
+) {
+  rawDb
+    .prepare(
+      `INSERT INTO users
+         (email, password_hash, role, is_active, activated_at, name, first_name, last_name)
+       VALUES (?, ?, ?, ?, ?, 'Test User', 'Test', 'User')`,
+    )
+    .run(email, hash, role, isActive, activatedAt);
+}
+
+// ── Item 1: password must be verified before account state is revealed ─────────
+
+describe("login — account-enumeration guard (password-first ordering)", () => {
+  test("wrong password for an unactivated account returns 401 WITHOUT requiresActivation", async () => {
+    const rawDb = createTestDB();
+    insertUser(rawDb, {
+      email: "unactivated@test",
+      hash: passwordHash,
+      isActive: 0,
+      activatedAt: null, // not yet activated
+    });
+
+    const env = makeEnv(rawDb);
+    const response = await postLogin(env, {
+      email: "unactivated@test",
+      password: WRONG_PASSWORD,
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    // Must NOT reveal account state when password is wrong
+    expect(body).not.toHaveProperty("requiresActivation");
+    expect(body.error).toBe("Authentication failed");
+  });
+
+  test("correct password for an unactivated account returns 401 WITH requiresActivation:true", async () => {
+    const rawDb = createTestDB();
+    insertUser(rawDb, {
+      email: "pending@test",
+      hash: passwordHash,
+      isActive: 0,
+      activatedAt: null,
+    });
+
+    const env = makeEnv(rawDb);
+    const response = await postLogin(env, {
+      email: "pending@test",
+      password: TEST_PASSWORD,
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    // Password was proven — safe to hint at activation requirement
+    expect(body.requiresActivation).toBe(true);
+    expect(body.error).toBe("Authentication failed");
+  });
+
+  test("correct password for a deactivated (admin-disabled) account returns 401 WITHOUT requiresActivation", async () => {
+    const rawDb = createTestDB();
+    insertUser(rawDb, {
+      email: "deactivated@test",
+      hash: passwordHash,
+      isActive: 0,
+      // activated_at is set (account was activated, then disabled)
+      activatedAt: "2025-06-01 12:00:00",
+    });
+
+    const env = makeEnv(rawDb);
+    const response = await postLogin(env, {
+      email: "deactivated@test",
+      password: TEST_PASSWORD,
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body).not.toHaveProperty("requiresActivation");
+    expect(body.error).toBe("Authentication failed");
+  });
+
+  test("wrong password for a deactivated account returns 401 WITHOUT requiresActivation", async () => {
+    const rawDb = createTestDB();
+    insertUser(rawDb, {
+      email: "deactivated2@test",
+      hash: passwordHash,
+      isActive: 0,
+      activatedAt: "2025-06-01 12:00:00",
+    });
+
+    const env = makeEnv(rawDb);
+    const response = await postLogin(env, {
+      email: "deactivated2@test",
+      password: WRONG_PASSWORD,
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body).not.toHaveProperty("requiresActivation");
+  });
+
+  test("non-existent email returns 401 without requiresActivation (user-not-found path unchanged)", async () => {
+    const rawDb = createTestDB();
+    const env = makeEnv(rawDb);
+    const response = await postLogin(env, {
+      email: "nobody@test",
+      password: TEST_PASSWORD,
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body).not.toHaveProperty("requiresActivation");
+    expect(body.error).toBe("Authentication failed");
+  });
+});

--- a/functions/api/admin/auth/login.js
+++ b/functions/api/admin/auth/login.js
@@ -3,16 +3,21 @@
 // Body: { email: string, password: string }
 // Returns: { success: true, user: object } or error
 
-import { verifyPassword } from "../../../utils/crypto.js";
+import { verifyPassword, hashPassword } from "../../../utils/crypto.js";
 import { generateCSRFToken, setCSRFCookie } from "../../../utils/csrf.js";
 import { getClientIP } from "../../../utils/request.js";
 import { initializeLucia } from "../../../utils/auth.js";
-import { AUTH_ATTEMPT_TYPES, checkAuthRateLimit, writeAuthAttempt } from "../../../utils/authAttempts.js";
+import {
+  AUTH_ATTEMPT_TYPES,
+  checkAuthRateLimit,
+  writeAuthAttempt,
+} from "../../../utils/authAttempts.js";
 import { loadTotpSecret } from "../../../utils/mfaSecrets.js";
 import {
   getTrustedDeviceToken,
   validateTrustedDevice,
 } from "../../../utils/trustedDevice.js";
+import { logger } from "../../../utils/logger.js";
 
 export async function onRequestPost(context) {
   const { request, env } = context;
@@ -33,7 +38,7 @@ export async function onRequestPost(context) {
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -56,7 +61,7 @@ export async function onRequestPost(context) {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -77,7 +82,7 @@ export async function onRequestPost(context) {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -89,7 +94,7 @@ export async function onRequestPost(context) {
              totp_enabled, totp_secret
       FROM users
       WHERE LOWER(email) = ?
-    `
+    `,
     )
       .bind(email)
       .first();
@@ -113,64 +118,13 @@ export async function onRequestPost(context) {
         {
           status: 401,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
-    // Check if account is activated
-    if (user.is_active === 0 && !user.activated_at) {
-      await writeAuthAttempt(DB, {
-        attemptType: AUTH_ATTEMPT_TYPES.login,
-        email,
-        failureReason: "activation_required",
-        ipAddress,
-        success: false,
-        userAgent,
-        userId: user.id,
-      });
-
-      // Use 401 + generic message to prevent account enumeration.
-      // requiresActivation hint is preserved for UX but does not change HTTP status.
-      return new Response(
-        JSON.stringify({
-          error: "Authentication failed",
-          message: "Invalid email or password",
-          requiresActivation: true,
-        }),
-        {
-          status: 401,
-          headers: { "Content-Type": "application/json" },
-        }
-      );
-    }
-
-    // Check if account is active (deactivated)
-    if (user.is_active === 0) {
-      // Log failed attempt (account disabled)
-      await writeAuthAttempt(DB, {
-        attemptType: AUTH_ATTEMPT_TYPES.login,
-        email,
-        failureReason: "account_disabled",
-        ipAddress,
-        success: false,
-        userAgent,
-        userId: user.id,
-      });
-
-      // Use 401 + generic message to prevent account enumeration via status codes.
-      return new Response(
-        JSON.stringify({
-          error: "Authentication failed",
-          message: "Invalid email or password",
-        }),
-        {
-          status: 401,
-          headers: { "Content-Type": "application/json" },
-        }
-      );
-    }
-
-    // Verify password
+    // Verify password FIRST to prevent account-enumeration via account-state branches.
+    // An attacker submitting any password to an existing email must not learn whether
+    // the account exists or what state it is in until they prove knowledge of the password.
     const passwordValid = await verifyPassword(password, user.password_hash);
 
     if (!passwordValid) {
@@ -193,7 +147,77 @@ export async function onRequestPost(context) {
         {
           status: 401,
           headers: { "Content-Type": "application/json" },
-        }
+        },
+      );
+    }
+
+    // Password is valid — opportunistically upgrade the hash if it was created with
+    // fewer than 600 000 iterations. Best-effort: a write failure must not block login.
+    try {
+      const storedIterations = Number(user.password_hash.split("$")[1]);
+      if (storedIterations && storedIterations < 600000) {
+        const newHash = await hashPassword(password);
+        await DB.prepare("UPDATE users SET password_hash = ? WHERE id = ?")
+          .bind(newHash, user.id)
+          .run();
+      }
+    } catch (rehashError) {
+      logger.warn("opportunistic password rehash failed (login not affected)", {
+        userId: user.id,
+        error: rehashError?.message,
+      });
+    }
+
+    // Password proven — now safe to reveal account state without enumeration risk.
+
+    // Check if account is not yet activated (registered but email not confirmed)
+    if (user.is_active === 0 && !user.activated_at) {
+      await writeAuthAttempt(DB, {
+        attemptType: AUTH_ATTEMPT_TYPES.login,
+        email,
+        failureReason: "activation_required",
+        ipAddress,
+        success: false,
+        userAgent,
+        userId: user.id,
+      });
+
+      // Password was proven above, so revealing requiresActivation here does not
+      // enable account enumeration — the caller already knows the password is correct.
+      return new Response(
+        JSON.stringify({
+          error: "Authentication failed",
+          message: "Invalid email or password",
+          requiresActivation: true,
+        }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    // Check if account has been deactivated by an admin
+    if (user.is_active === 0) {
+      await writeAuthAttempt(DB, {
+        attemptType: AUTH_ATTEMPT_TYPES.login,
+        email,
+        failureReason: "account_disabled",
+        ipAddress,
+        success: false,
+        userAgent,
+        userId: user.id,
+      });
+
+      return new Response(
+        JSON.stringify({
+          error: "Authentication failed",
+          message: "Invalid email or password",
+        }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
 
@@ -208,18 +232,25 @@ export async function onRequestPost(context) {
             DB,
             trustedDeviceToken,
             ipAddress,
-            userAgent
+            userAgent,
           );
           if (trustedUserId === user.id) {
-            console.log("[Login] Trusted device validated, skipping MFA for user:", user.id);
+            logger.debug("trusted device validated, skipping MFA", {
+              userId: user.id,
+            });
             skipMfa = true;
           } else if (trustedUserId !== null) {
-            console.log("[Login] Trusted device belongs to different user");
+            logger.debug("trusted device belongs to different user", {
+              userId: user.id,
+            });
           }
         }
       } catch (trustedDeviceError) {
         // Don't fail login if trusted device check fails - just require MFA
-        console.error("[Login] Trusted device check failed:", trustedDeviceError?.message || trustedDeviceError);
+        console.error(
+          "[Login] Trusted device check failed:",
+          trustedDeviceError?.message || trustedDeviceError,
+        );
         skipMfa = false;
       }
     }
@@ -229,7 +260,10 @@ export async function onRequestPost(context) {
       try {
         totpSecretState = await loadTotpSecret(user.totp_secret, env);
       } catch (error) {
-        console.error("[Login] Failed to decrypt TOTP secret:", error?.message || error);
+        console.error(
+          "[Login] Failed to decrypt TOTP secret:",
+          error?.message || error,
+        );
         return new Response(
           JSON.stringify({
             error: "MFA configuration error",
@@ -239,7 +273,7 @@ export async function onRequestPost(context) {
           {
             status: 500,
             headers: { "Content-Type": "application/json" },
-          }
+          },
         );
       }
 
@@ -247,7 +281,7 @@ export async function onRequestPost(context) {
         await DB.prepare(
           `UPDATE users
            SET totp_secret = ?
-           WHERE id = ? AND totp_secret = ?`
+           WHERE id = ? AND totp_secret = ?`,
         )
           .bind(totpSecretState.encryptedSecret, user.id, user.totp_secret)
           .run();
@@ -266,7 +300,7 @@ export async function onRequestPost(context) {
           {
             status: 500,
             headers: { "Content-Type": "application/json" },
-          }
+          },
         );
       }
 
@@ -277,7 +311,7 @@ export async function onRequestPost(context) {
       // which would allow expired challenges to pass the verify query.
       const expiresAt = new Date(Date.now() + 5 * 60 * 1000)
         .toISOString()
-        .replace('T', ' ')
+        .replace("T", " ")
         .slice(0, 19);
 
       await DB.prepare(
@@ -290,7 +324,7 @@ export async function onRequestPost(context) {
            expires_at = excluded.expires_at,
            used = 0,
            used_at = NULL,
-           created_at = datetime('now')`
+           created_at = datetime('now')`,
       )
         .bind(mfaToken, user.id, ipAddress, userAgent, expiresAt)
         .run();
@@ -322,7 +356,7 @@ export async function onRequestPost(context) {
         {
           status: 200,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -333,14 +367,14 @@ export async function onRequestPost(context) {
     await DB.prepare(
       `UPDATE lucia_sessions
        SET ip_address = ?, user_agent = ?, remember_me = ?
-       WHERE id = ?`
+       WHERE id = ?`,
     )
       .bind(ipAddress, userAgent, 0, session.id)
       .run();
 
     // Update last login
     await DB.prepare(
-      "UPDATE users SET last_login = datetime('now') WHERE id = ?"
+      "UPDATE users SET last_login = datetime('now') WHERE id = ?",
     )
       .bind(user.id)
       .run();
@@ -362,7 +396,10 @@ export async function onRequestPost(context) {
     const headers = new Headers({
       "Content-Type": "application/json",
     });
-    headers.append("Set-Cookie", lucia.createSessionCookie(session.id).serialize());
+    headers.append(
+      "Set-Cookie",
+      lucia.createSessionCookie(session.id).serialize(),
+    );
     headers.append("Set-Cookie", setCSRFCookie(csrfToken, request));
 
     return new Response(
@@ -383,7 +420,7 @@ export async function onRequestPost(context) {
       {
         status: 200,
         headers,
-      }
+      },
     );
   } catch (error) {
     console.error("Login error:", error);
@@ -396,7 +433,7 @@ export async function onRequestPost(context) {
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 }

--- a/functions/api/admin/auth/signup.js
+++ b/functions/api/admin/auth/signup.js
@@ -1,9 +1,18 @@
 import { hashPassword } from "../../../utils/crypto.js";
-import { isValidEmail, validatePassword, FIELD_LIMITS } from "../../../utils/validation.js";
+import {
+  isValidEmail,
+  validatePassword,
+  FIELD_LIMITS,
+} from "../../../utils/validation.js";
 import { getClientIP } from "../../../utils/request.js";
 import { isEmailConfigured, sendEmail } from "../../../utils/email.js";
 import { buildActivationEmail } from "../../../utils/emailTemplates.js";
-import { AUTH_ATTEMPT_TYPES, checkAuthRateLimit, writeAuthAttempt } from "../../../utils/authAttempts.js";
+import {
+  AUTH_ATTEMPT_TYPES,
+  checkAuthRateLimit,
+  writeAuthAttempt,
+} from "../../../utils/authAttempts.js";
+import { logger } from "../../../utils/logger.js";
 
 export async function onRequestPost(context) {
   const { request, env } = context;
@@ -24,7 +33,7 @@ export async function onRequestPost(context) {
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -38,7 +47,7 @@ export async function onRequestPost(context) {
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -52,7 +61,7 @@ export async function onRequestPost(context) {
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -72,7 +81,7 @@ export async function onRequestPost(context) {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -93,7 +102,7 @@ export async function onRequestPost(context) {
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -105,7 +114,7 @@ export async function onRequestPost(context) {
       AND is_active = 1
       AND expires_at > datetime('now')
       AND used_by_user_id IS NULL
-    `
+    `,
     )
       .bind(inviteCode)
       .first();
@@ -130,7 +139,7 @@ export async function onRequestPost(context) {
         {
           status: 403,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -154,7 +163,7 @@ export async function onRequestPost(context) {
         {
           status: 403,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -165,13 +174,13 @@ export async function onRequestPost(context) {
     // Ignore any role parameter passed by client to prevent privilege escalation
     if (role === "admin") {
       console.warn(
-        `Signup attempt with admin role blocked for email: ${email}`
+        `Signup attempt with admin role blocked for email: ${email}`,
       );
     }
 
     // Check if user already exists
     const existingUser = await DB.prepare(
-      "SELECT id FROM users WHERE email = ?"
+      "SELECT id FROM users WHERE email = ?",
     )
       .bind(email)
       .first();
@@ -185,7 +194,7 @@ export async function onRequestPost(context) {
         {
           status: 409,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -196,7 +205,9 @@ export async function onRequestPost(context) {
         ? String(firstName).trim()
         : "";
     let resolvedLastName =
-      lastName !== undefined && lastName !== null ? String(lastName).trim() : "";
+      lastName !== undefined && lastName !== null
+        ? String(lastName).trim()
+        : "";
 
     if ((!resolvedFirstName || !resolvedLastName) && fallbackName) {
       const parts = fallbackName.split(/\s+/).filter(Boolean);
@@ -217,7 +228,7 @@ export async function onRequestPost(context) {
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -229,12 +240,12 @@ export async function onRequestPost(context) {
     const activationToken =
       crypto.randomUUID() + crypto.randomUUID().replace(/-/g, "");
     const activationExpires = new Date(
-      Date.now() + 24 * 60 * 60 * 1000
+      Date.now() + 24 * 60 * 60 * 1000,
     ).toISOString();
 
     // Create user (inactive until activation)
     const user = await DB.prepare(
-      "INSERT INTO users (email, password_hash, name, first_name, last_name, role, is_active, activation_token, activation_token_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id, email, name, first_name, last_name, role"
+      "INSERT INTO users (email, password_hash, name, first_name, last_name, role, is_active, activation_token, activation_token_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id, email, name, first_name, last_name, role",
     )
       .bind(
         email,
@@ -245,13 +256,13 @@ export async function onRequestPost(context) {
         userRole,
         0,
         activationToken,
-        activationExpires
+        activationExpires,
       )
       .first();
 
     // Mark invite code as used
     await DB.prepare(
-      "UPDATE invite_codes SET used_by_user_id = ?, used_at = datetime('now') WHERE code = ?"
+      "UPDATE invite_codes SET used_by_user_id = ?, used_at = datetime('now') WHERE code = ?",
     )
       .bind(user.id, inviteCode)
       .run();
@@ -271,10 +282,14 @@ export async function onRequestPost(context) {
     activationUrl.searchParams.set("token", activationToken);
 
     let emailResult = { delivered: false, reason: "not_configured" };
-    console.log("[Signup] Checking email configuration for activation email...");
+    logger.debug("checking email configuration for activation email", {
+      userId: user.id,
+    });
 
     if (isEmailConfigured(env)) {
-      console.log("[Signup] Email is configured, building activation email...");
+      logger.debug("email configured, sending activation email", {
+        userId: user.id,
+      });
       const emailPayload = buildActivationEmail({
         activationUrl: activationUrl.toString(),
         recipientName: resolvedName || null,
@@ -286,9 +301,11 @@ export async function onRequestPost(context) {
         text: emailPayload.text,
         html: emailPayload.html,
       });
-      console.log("[Signup] Activation email delivery attempted.");
+      logger.debug("activation email delivery attempted", { userId: user.id });
     } else {
-      console.warn("[Signup] Email not configured; activation email was not sent.");
+      console.warn(
+        "[Signup] Email not configured; activation email was not sent.",
+      );
     }
 
     return new Response(
@@ -302,7 +319,7 @@ export async function onRequestPost(context) {
       {
         status: 201,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   } catch (error) {
     console.error("Signup error:", error);
@@ -314,7 +331,7 @@ export async function onRequestPost(context) {
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 }

--- a/functions/utils/__tests__/rateLimit.test.js
+++ b/functions/utils/__tests__/rateLimit.test.js
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   checkRateLimit,
   rateLimitHeaders,
   rateLimitResponse,
-} from '../rateLimit.js';
+} from "../rateLimit.js";
 
 // Mock the caches global (Cache API, used for non-sensitive endpoints)
 const mockCache = {
@@ -29,17 +29,17 @@ function makeMockDB({ count = 1, window_start = null } = {}) {
   };
 }
 
-describe('Rate Limiting', () => {
+describe("Rate Limiting", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCache.match.mockResolvedValue(null);
     mockCache.put.mockResolvedValue(undefined);
   });
 
-  describe('checkRateLimit — Cache API path (non-sensitive endpoints)', () => {
-    it('should allow requests under the limit', async () => {
-      const request = new Request('https://example.com/api/events', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+  describe("checkRateLimit — Cache API path (non-sensitive endpoints)", () => {
+    it("should allow requests under the limit", async () => {
+      const request = new Request("https://example.com/api/events", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request);
@@ -48,9 +48,9 @@ describe('Rate Limiting', () => {
       expect(result.remaining).toBe(59); // 60 - 1
     });
 
-    it('non-auth admin routes have a generous rate limit, not completely skipped', async () => {
-      const request = new Request('https://example.com/api/admin/users', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+    it("non-auth admin routes have a generous rate limit, not completely skipped", async () => {
+      const request = new Request("https://example.com/api/admin/users", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request);
@@ -59,9 +59,9 @@ describe('Rate Limiting', () => {
       expect(result.remaining).toBeGreaterThan(100); // high limit for legitimate CRUD traffic
     });
 
-    it('should skip rate limiting for non-API routes', async () => {
-      const request = new Request('https://example.com/about', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+    it("should skip rate limiting for non-API routes", async () => {
+      const request = new Request("https://example.com/about", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request);
@@ -70,12 +70,15 @@ describe('Rate Limiting', () => {
       expect(result.remaining).toBe(-1);
     });
 
-    it('should block requests over the limit', async () => {
-      const cachedData = JSON.stringify({ count: 60, windowStart: Math.floor(Date.now() / 1000) });
+    it("should block requests over the limit", async () => {
+      const cachedData = JSON.stringify({
+        count: 60,
+        windowStart: Math.floor(Date.now() / 1000),
+      });
       mockCache.match.mockResolvedValue(new Response(cachedData));
 
-      const request = new Request('https://example.com/api/events', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/events", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request);
@@ -84,13 +87,16 @@ describe('Rate Limiting', () => {
       expect(result.remaining).toBe(0);
     });
 
-    it('should reset after window expires', async () => {
+    it("should reset after window expires", async () => {
       const oldWindowStart = Math.floor(Date.now() / 1000) - 120; // 2 minutes ago
-      const cachedData = JSON.stringify({ count: 100, windowStart: oldWindowStart });
+      const cachedData = JSON.stringify({
+        count: 100,
+        windowStart: oldWindowStart,
+      });
       mockCache.match.mockResolvedValue(new Response(cachedData));
 
-      const request = new Request('https://example.com/api/events', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/events", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request);
@@ -99,10 +105,10 @@ describe('Rate Limiting', () => {
       expect(result.remaining).toBe(59); // Window reset, so 60 - 1
     });
 
-    it('should fall back to Cache API for subscriptions when DB is unavailable', async () => {
+    it("should fall back to Cache API for subscriptions when DB is unavailable", async () => {
       // No env.DB provided — falls back to Cache API (local dev)
-      const request = new Request('https://example.com/api/subscriptions', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/subscriptions", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request);
@@ -111,11 +117,11 @@ describe('Rate Limiting', () => {
       expect(result.remaining).toBe(9); // 10 - 1 for subscriptions
     });
 
-    it('should fail open if Cache API errors (non-sensitive endpoint)', async () => {
-      mockCache.match.mockRejectedValue(new Error('Cache error'));
+    it("should fail open if Cache API errors (non-sensitive endpoint)", async () => {
+      mockCache.match.mockRejectedValue(new Error("Cache error"));
 
-      const request = new Request('https://example.com/api/events', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/events", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request);
@@ -124,12 +130,12 @@ describe('Rate Limiting', () => {
     });
   });
 
-  describe('checkRateLimit — D1 path (fail-closed endpoints)', () => {
-    it('should allow auth requests under the limit using D1', async () => {
+  describe("checkRateLimit — D1 path (fail-closed endpoints)", () => {
+    it("should allow auth requests under the limit using D1", async () => {
       const db = makeMockDB({ count: 3 }); // well under the limit
       const env = { DB: db };
-      const request = new Request('https://example.com/api/auth/activate', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/auth/activate", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request, env);
@@ -139,11 +145,11 @@ describe('Rate Limiting', () => {
       expect(db.prepare).toHaveBeenCalled();
     });
 
-    it('should block auth requests over the limit using D1', async () => {
+    it("should block auth requests over the limit using D1", async () => {
       const db = makeMockDB({ count: 11 }); // over the 10-req/min limit
       const env = { DB: db };
-      const request = new Request('https://example.com/api/auth/activate', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/auth/activate", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request, env);
@@ -152,11 +158,11 @@ describe('Rate Limiting', () => {
       expect(result.remaining).toBe(0);
     });
 
-    it('should allow subscription requests under the limit using D1', async () => {
+    it("should allow subscription requests under the limit using D1", async () => {
       const db = makeMockDB({ count: 1 });
       const env = { DB: db };
-      const request = new Request('https://example.com/api/subscriptions', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/subscriptions", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request, env);
@@ -165,18 +171,18 @@ describe('Rate Limiting', () => {
       expect(result.remaining).toBe(9); // 10 - 1
     });
 
-    it('should fail closed when D1 throws on a sensitive endpoint', async () => {
+    it("should fail closed when D1 throws on a sensitive endpoint", async () => {
       const db = {
         prepare: vi.fn().mockReturnValue({
           bind: vi.fn().mockReturnValue({
-            run: vi.fn().mockRejectedValue(new Error('D1 error')),
+            run: vi.fn().mockRejectedValue(new Error("D1 error")),
             first: vi.fn().mockResolvedValue(null),
           }),
         }),
       };
       const env = { DB: db };
-      const request = new Request('https://example.com/api/auth/activate', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/auth/activate", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request, env);
@@ -184,11 +190,11 @@ describe('Rate Limiting', () => {
       expect(result.allowed).toBe(false); // fail closed for security endpoints
     });
 
-    it('should not use D1 for non-sensitive endpoints even when env.DB is available', async () => {
+    it("should not use D1 for non-sensitive endpoints even when env.DB is available", async () => {
       const db = makeMockDB({ count: 1 });
       const env = { DB: db };
-      const request = new Request('https://example.com/api/events', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/events", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       await checkRateLimit(request, env);
@@ -199,11 +205,11 @@ describe('Rate Limiting', () => {
       expect(mockCache.match).toHaveBeenCalled();
     });
 
-    it('admin auth login route is rate-limited via D1 (fail-closed)', async () => {
+    it("admin auth login route is rate-limited via D1 (fail-closed)", async () => {
       const db = makeMockDB({ count: 2 });
       const env = { DB: db };
-      const request = new Request('https://example.com/api/admin/auth/login', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/admin/auth/login", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request, env);
@@ -213,18 +219,18 @@ describe('Rate Limiting', () => {
       expect(mockCache.match).not.toHaveBeenCalled();
     });
 
-    it('admin auth login fails closed when D1 throws (P1-S1)', async () => {
+    it("admin auth login fails closed when D1 throws (P1-S1)", async () => {
       const db = {
         prepare: vi.fn().mockReturnValue({
           bind: vi.fn().mockReturnValue({
-            run: vi.fn().mockRejectedValue(new Error('D1 unavailable')),
+            run: vi.fn().mockRejectedValue(new Error("D1 unavailable")),
             first: vi.fn().mockResolvedValue(null),
           }),
         }),
       };
       const env = { DB: db };
-      const request = new Request('https://example.com/api/admin/auth/login', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/admin/auth/login", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request, env);
@@ -232,11 +238,11 @@ describe('Rate Limiting', () => {
       expect(result.allowed).toBe(false); // must fail closed, not open
     });
 
-    it('admin auth login is blocked when limit is exceeded', async () => {
+    it("admin auth login is blocked when limit is exceeded", async () => {
       const db = makeMockDB({ count: 100 }); // way over any reasonable limit
       const env = { DB: db };
-      const request = new Request('https://example.com/api/admin/auth/login', {
-        headers: { 'CF-Connecting-IP': '1.2.3.4' },
+      const request = new Request("https://example.com/api/admin/auth/login", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
       });
 
       const result = await checkRateLimit(request, env);
@@ -246,12 +252,12 @@ describe('Rate Limiting', () => {
     });
   });
 
-  describe('IP bypass behaviour', () => {
-    it('loopback 127.0.0.1 skips rate limiting entirely (wrangler dev / CI)', async () => {
+  describe("IP bypass behaviour", () => {
+    it("loopback 127.0.0.1 skips rate limiting entirely (wrangler dev / CI)", async () => {
       const db = makeMockDB({ count: 100 });
       const env = { DB: db };
-      const request = new Request('https://example.com/api/admin/auth/login', {
-        headers: { 'CF-Connecting-IP': '127.0.0.1' },
+      const request = new Request("https://example.com/api/admin/auth/login", {
+        headers: { "CF-Connecting-IP": "127.0.0.1" },
       });
 
       const result = await checkRateLimit(request, env);
@@ -261,9 +267,9 @@ describe('Rate Limiting', () => {
       expect(db.prepare).not.toHaveBeenCalled();
     });
 
-    it('loopback ::1 skips rate limiting entirely', async () => {
-      const request = new Request('https://example.com/api/events', {
-        headers: { 'CF-Connecting-IP': '::1' },
+    it("loopback ::1 skips rate limiting entirely", async () => {
+      const request = new Request("https://example.com/api/events", {
+        headers: { "CF-Connecting-IP": "::1" },
       });
 
       const result = await checkRateLimit(request);
@@ -272,10 +278,13 @@ describe('Rate Limiting', () => {
       expect(result.remaining).toBe(-1);
     });
 
-    it('unknown IP fails closed on fail-closed (auth) endpoints', async () => {
+    it("unknown IP fails closed on fail-closed (auth) endpoints", async () => {
       const db = makeMockDB({ count: 0 });
       const env = { DB: db };
-      const request = new Request('https://example.com/api/admin/auth/login', {}); // no IP headers
+      const request = new Request(
+        "https://example.com/api/admin/auth/login",
+        {},
+      ); // no IP headers
 
       const result = await checkRateLimit(request, env);
 
@@ -284,8 +293,8 @@ describe('Rate Limiting', () => {
       expect(db.prepare).not.toHaveBeenCalled(); // blocked before hitting D1
     });
 
-    it('unknown IP fails open on non-sensitive endpoints', async () => {
-      const request = new Request('https://example.com/api/events', {}); // no IP headers
+    it("unknown IP fails open on non-sensitive endpoints", async () => {
+      const request = new Request("https://example.com/api/events", {}); // no IP headers
 
       const result = await checkRateLimit(request);
 
@@ -294,40 +303,214 @@ describe('Rate Limiting', () => {
     });
   });
 
-  describe('rateLimitHeaders', () => {
-    it('should return empty object for skipped rate limits', () => {
+  // ── Band action endpoints (Item 4) ─────────────────────────────────────────
+
+  describe("band action endpoints — fail-closed with tight limit", () => {
+    it("/api/bands/<name>/follow is fail-closed (uses D1) with limit 5/300s", async () => {
+      const db = makeMockDB({ count: 3 }); // under the 5-req/300s limit
+      const env = { DB: db };
+      const request = new Request(
+        "https://example.com/api/bands/my-band/follow",
+        {
+          headers: { "CF-Connecting-IP": "1.2.3.4" },
+        },
+      );
+
+      const result = await checkRateLimit(request, env);
+
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(2); // 5 - 3
+      // D1 must be used (fail-closed path), not Cache API
+      expect(db.prepare).toHaveBeenCalled();
+      expect(mockCache.match).not.toHaveBeenCalled();
+    });
+
+    it("/api/bands/<name>/follow fails closed when limit is exceeded", async () => {
+      const db = makeMockDB({ count: 6 }); // over the 5-req/300s limit
+      const env = { DB: db };
+      const request = new Request(
+        "https://example.com/api/bands/my-band/follow",
+        {
+          headers: { "CF-Connecting-IP": "1.2.3.4" },
+        },
+      );
+
+      const result = await checkRateLimit(request, env);
+
+      expect(result.allowed).toBe(false);
+      expect(result.remaining).toBe(0);
+    });
+
+    it("/api/bands/<name>/unfollow is fail-closed with the same tight limit", async () => {
+      const db = makeMockDB({ count: 1 });
+      const env = { DB: db };
+      const request = new Request(
+        "https://example.com/api/bands/my-band/unfollow",
+        {
+          headers: { "CF-Connecting-IP": "1.2.3.4" },
+        },
+      );
+
+      const result = await checkRateLimit(request, env);
+
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(4); // 5 - 1
+      expect(db.prepare).toHaveBeenCalled();
+    });
+
+    it("/api/bands/<name>/confirm-follow is fail-closed with the tight limit", async () => {
+      const db = makeMockDB({ count: 1 });
+      const env = { DB: db };
+      const request = new Request(
+        "https://example.com/api/bands/my-band/confirm-follow",
+        {
+          headers: { "CF-Connecting-IP": "1.2.3.4" },
+        },
+      );
+
+      const result = await checkRateLimit(request, env);
+
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(4);
+      expect(db.prepare).toHaveBeenCalled();
+    });
+
+    it("/api/bands/<name>/follow fails closed when D1 throws", async () => {
+      const db = {
+        prepare: vi.fn().mockReturnValue({
+          bind: vi.fn().mockReturnValue({
+            run: vi.fn().mockRejectedValue(new Error("D1 error")),
+            first: vi.fn().mockResolvedValue(null),
+          }),
+        }),
+      };
+      const env = { DB: db };
+      const request = new Request(
+        "https://example.com/api/bands/my-band/follow",
+        {
+          headers: { "CF-Connecting-IP": "1.2.3.4" },
+        },
+      );
+
+      const result = await checkRateLimit(request, env);
+
+      expect(result.allowed).toBe(false); // fail closed
+    });
+
+    it("public GET /api/bands/<name> (no action suffix) is NOT fail-closed and uses Cache API", async () => {
+      const db = makeMockDB({ count: 1 });
+      const env = { DB: db };
+      const request = new Request("https://example.com/api/bands/my-band", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
+      });
+
+      const result = await checkRateLimit(request, env);
+
+      expect(result.allowed).toBe(true);
+      // D1 must NOT be called — this is a read, not an action
+      expect(db.prepare).not.toHaveBeenCalled();
+      expect(mockCache.match).toHaveBeenCalled();
+    });
+
+    it("band action endpoints use depth-5 keys so each action is rate-limited independently", async () => {
+      // Two calls: one to /follow, one to /unfollow — D1 keys must differ
+      const preparedCalls = [];
+      const db = {
+        prepare: vi.fn().mockImplementation((sql) => {
+          preparedCalls.push(sql);
+          return {
+            bind: vi.fn().mockReturnValue({
+              run: vi.fn().mockResolvedValue({}),
+              first: vi
+                .fn()
+                .mockResolvedValue({
+                  count: 1,
+                  window_start: Math.floor(Date.now() / 1000),
+                }),
+            }),
+          };
+        }),
+      };
+      const env = { DB: db };
+
+      await checkRateLimit(
+        new Request("https://example.com/api/bands/my-band/follow", {
+          headers: { "CF-Connecting-IP": "1.2.3.4" },
+        }),
+        env,
+      );
+      await checkRateLimit(
+        new Request("https://example.com/api/bands/my-band/unfollow", {
+          headers: { "CF-Connecting-IP": "1.2.3.4" },
+        }),
+        env,
+      );
+
+      // Each call results in two D1 statements (upsert + select), so 4 total
+      expect(db.prepare).toHaveBeenCalledTimes(4);
+
+      // Extract the bind arguments from the key upsert calls to confirm distinct keys
+      const bindCalls = db.prepare.mock.results
+        .map((r) => r.value.bind.mock.calls[0])
+        .filter(Boolean);
+
+      // The first positional arg to bind is the key — should differ for /follow vs /unfollow
+      const keys = bindCalls.map((args) => args[0]);
+      // At least two distinct keys across the four bind calls
+      const uniqueKeys = [...new Set(keys)];
+      expect(uniqueKeys.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("rateLimitHeaders", () => {
+    it("should return empty object for skipped rate limits", () => {
       const result = { allowed: true, remaining: -1, resetAt: 0 };
       const headers = rateLimitHeaders(result);
 
       expect(headers).toEqual({});
     });
 
-    it('should return rate limit headers', () => {
-      const result = { allowed: true, remaining: 50, resetAt: 1234567890, limit: 60 };
+    it("should return rate limit headers", () => {
+      const result = {
+        allowed: true,
+        remaining: 50,
+        resetAt: 1234567890,
+        limit: 60,
+      };
       const headers = rateLimitHeaders(result);
 
-      expect(headers['X-RateLimit-Limit']).toBe('60');
-      expect(headers['X-RateLimit-Remaining']).toBe('50');
-      expect(headers['X-RateLimit-Reset']).toBe('1234567890');
+      expect(headers["X-RateLimit-Limit"]).toBe("60");
+      expect(headers["X-RateLimit-Remaining"]).toBe("50");
+      expect(headers["X-RateLimit-Reset"]).toBe("1234567890");
     });
   });
 
-  describe('rateLimitResponse', () => {
-    it('should return 429 response', () => {
-      const result = { allowed: false, remaining: 0, resetAt: Math.floor(Date.now() / 1000) + 30, limit: 60 };
+  describe("rateLimitResponse", () => {
+    it("should return 429 response", () => {
+      const result = {
+        allowed: false,
+        remaining: 0,
+        resetAt: Math.floor(Date.now() / 1000) + 30,
+        limit: 60,
+      };
       const response = rateLimitResponse(result);
 
       expect(response.status).toBe(429);
-      expect(response.headers.get('Content-Type')).toBe('application/json');
-      expect(response.headers.get('Retry-After')).toBeTruthy();
+      expect(response.headers.get("Content-Type")).toBe("application/json");
+      expect(response.headers.get("Retry-After")).toBeTruthy();
     });
 
-    it('should include CORS headers if provided', () => {
-      const result = { allowed: false, remaining: 0, resetAt: Math.floor(Date.now() / 1000) + 30, limit: 60 };
-      const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+    it("should include CORS headers if provided", () => {
+      const result = {
+        allowed: false,
+        remaining: 0,
+        resetAt: Math.floor(Date.now() / 1000) + 30,
+        limit: 60,
+      };
+      const corsHeaders = { "Access-Control-Allow-Origin": "*" };
       const response = rateLimitResponse(result, corsHeaders);
 
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
     });
   });
 });

--- a/functions/utils/crypto.js
+++ b/functions/utils/crypto.js
@@ -4,7 +4,7 @@
 
 const SALT_LENGTH = 16;
 const LEGACY_ITERATIONS = 100000;
-const DEFAULT_ITERATIONS = 100000;
+const DEFAULT_ITERATIONS = 600000;
 const KEY_LENGTH = 32;
 
 export function timingSafeEqual(a, b) {

--- a/functions/utils/rateLimit.js
+++ b/functions/utils/rateLimit.js
@@ -11,51 +11,60 @@
 //    feeds). PoP-local is acceptable here; the goal is DoS protection, not security
 //    enforcement, and fail-open behaviour avoids availability impact.
 
-import { logger } from './logger.js';
+import { logger } from "./logger.js";
 
-const RATE_LIMIT_PREFIX = 'rate-limit:';
+const RATE_LIMIT_PREFIX = "rate-limit:";
+
+// Band action endpoints that send email and must be fail-closed with a tight limit.
+// Scoped to the /follow|unfollow|confirm-follow suffix so that public GET reads
+// (e.g. /api/bands/<name>) are not affected.
+const BAND_ACTION_RE =
+  /^\/api\/bands\/[^/]+\/(follow|unfollow|confirm-follow)$/;
 
 // Rate limit configurations by endpoint pattern.
 // Order matters: more-specific prefixes must appear before less-specific ones.
 const RATE_LIMITS = {
   // Admin auth endpoints — tight limits, fail-closed via D1
-  '/api/admin/auth/login':  { requests: 5,   window: 60  }, // 5 per minute
-  '/api/admin/auth/signup': { requests: 3,   window: 300 }, // 3 per 5 min
-  '/api/admin/auth/':       { requests: 10,  window: 60  }, // logout, MFA, etc.
+  "/api/admin/auth/login": { requests: 5, window: 60 }, // 5 per minute
+  "/api/admin/auth/signup": { requests: 3, window: 300 }, // 3 per 5 min
+  "/api/admin/auth/": { requests: 10, window: 60 }, // logout, MFA, etc.
 
   // Other admin CRUD — generous limit for legitimate editor activity
-  '/api/admin/': { requests: 300, window: 60 },
+  "/api/admin/": { requests: 300, window: 60 },
 
   // Public API endpoints
-  '/api/events': { requests: 60, window: 60 },
-  '/api/schedule/share/': { requests: 60, window: 60 }, // GET /api/schedule/share/[slug]
-  '/api/schedule/share':  { requests: 10, window: 60 }, // POST /api/schedule/share
-  '/api/schedule': { requests: 30, window: 60 },
-  '/api/feeds': { requests: 20, window: 60 },
-  '/api/subscriptions': { requests: 10, window: 60 },
-  '/api/metrics': { requests: 40, window: 60 },
-  '/api/auth/activate': { requests: 10, window: 60 },
-  '/api/auth/resend': { requests: 3, window: 300 },
+  "/api/events": { requests: 60, window: 60 },
+  "/api/schedule/share/": { requests: 60, window: 60 }, // GET /api/schedule/share/[slug]
+  "/api/schedule/share": { requests: 10, window: 60 }, // POST /api/schedule/share
+  "/api/schedule": { requests: 30, window: 60 },
+  "/api/feeds": { requests: 20, window: 60 },
+  "/api/subscriptions": { requests: 10, window: 60 },
+  "/api/metrics": { requests: 40, window: 60 },
+  "/api/auth/activate": { requests: 10, window: 60 },
+  "/api/auth/resend": { requests: 3, window: 300 },
 
   // Default for unmatched public APIs
-  'default': { requests: 30, window: 60 },
+  default: { requests: 30, window: 60 },
 };
 
 // Endpoints to skip rate limiting
 const SKIP_PATTERNS = [
-  '/_',           // Cloudflare internal
+  "/_", // Cloudflare internal
 ];
 
 // Endpoints where a rate-limit failure blocks the request (fail closed).
 // These use D1 for globally-consistent counters.
 const FAIL_CLOSED_PATTERNS = [
-  '/api/admin/auth/',
-  '/api/auth/',
-  '/api/subscriptions',
+  "/api/admin/auth/",
+  "/api/auth/",
+  "/api/subscriptions",
 ];
 
 function shouldFailClosed(pathname) {
-  return FAIL_CLOSED_PATTERNS.some((pattern) => pathname.startsWith(pattern));
+  return (
+    BAND_ACTION_RE.test(pathname) ||
+    FAIL_CLOSED_PATTERNS.some((pattern) => pathname.startsWith(pattern))
+  );
 }
 
 /**
@@ -70,13 +79,17 @@ function getRateLimitConfig(pathname) {
   }
 
   // Only rate limit /api/ routes
-  if (!pathname.startsWith('/api/')) {
+  if (!pathname.startsWith("/api/")) {
     return null;
   }
 
+  // Band action endpoints (follow/unfollow/confirm-follow) — checked before the
+  // prefix loop so that the tight fail-closed limit takes precedence over 'default'.
+  if (BAND_ACTION_RE.test(pathname)) return { requests: 5, window: 300 };
+
   // Find matching config
   for (const [pattern, config] of Object.entries(RATE_LIMITS)) {
-    if (pattern !== 'default' && pathname.startsWith(pattern)) {
+    if (pattern !== "default" && pathname.startsWith(pattern)) {
       return config;
     }
   }
@@ -86,14 +99,17 @@ function getRateLimitConfig(pathname) {
 
 /**
  * Generate a stable key for rate limiting (IP + endpoint base path).
- * Auth sub-routes use 5 segments so login and signup get distinct D1 keys.
+ * Auth sub-routes and band action endpoints use 5 segments so each action
+ * (login, signup, follow, confirm-follow, etc.) gets a distinct D1 key.
  */
 function getRateLimitKey(ip, pathname) {
   const depth =
-    pathname.startsWith('/api/admin/auth/') || pathname.startsWith('/api/auth/')
+    pathname.startsWith("/api/admin/auth/") ||
+    pathname.startsWith("/api/auth/") ||
+    BAND_ACTION_RE.test(pathname)
       ? 5
       : 4;
-  const basePath = pathname.split('/').slice(0, depth).join('/');
+  const basePath = pathname.split("/").slice(0, depth).join("/");
   return `${ip}:${basePath}`;
 }
 
@@ -108,18 +124,24 @@ async function checkRateLimitD1(DB, ip, pathname, config) {
   try {
     // Atomically upsert: insert on first request, or increment/reset on subsequent ones.
     // The CASE expression resets the window when it has expired.
-    await DB.prepare(`
+    await DB.prepare(
+      `
       INSERT INTO rate_limits (key, count, window_start, updated_at)
       VALUES (?1, 1, ?2, ?2)
       ON CONFLICT(key) DO UPDATE SET
         count = CASE WHEN (?2 - window_start) >= ?3 THEN 1 ELSE count + 1 END,
         window_start = CASE WHEN (?2 - window_start) >= ?3 THEN ?2 ELSE window_start END,
         updated_at = ?2
-    `).bind(key, now, config.window).run();
+    `,
+    )
+      .bind(key, now, config.window)
+      .run();
 
     const row = await DB.prepare(
-      'SELECT count, window_start FROM rate_limits WHERE key = ?'
-    ).bind(key).first();
+      "SELECT count, window_start FROM rate_limits WHERE key = ?",
+    )
+      .bind(key)
+      .first();
 
     const count = row?.count ?? 1;
     const windowStart = row?.window_start ?? now;
@@ -133,7 +155,11 @@ async function checkRateLimitD1(DB, ip, pathname, config) {
       limit: config.requests,
     };
   } catch (error) {
-    logger.error('D1 rate limit check failed on sensitive endpoint', { error, ip, pathname });
+    logger.error("D1 rate limit check failed on sensitive endpoint", {
+      error,
+      ip,
+      pathname,
+    });
     // Fail closed: block the request when the counter is unavailable.
     return {
       allowed: false,
@@ -149,7 +175,7 @@ async function checkRateLimitD1(DB, ip, pathname, config) {
  */
 function getCacheKey(ip, pathname) {
   // Normalize path to endpoint base
-  const basePath = pathname.split('/').slice(0, 4).join('/');
+  const basePath = pathname.split("/").slice(0, 4).join("/");
   return `https://rate-limit.internal/${RATE_LIMIT_PREFIX}${ip}:${basePath}`;
 }
 
@@ -171,21 +197,27 @@ export async function checkRateLimit(request, env = null) {
   }
 
   // Get client IP (Cloudflare provides this)
-  const ip = request.headers.get('CF-Connecting-IP') ||
-             request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
-             'unknown';
+  const ip =
+    request.headers.get("CF-Connecting-IP") ||
+    request.headers.get("X-Forwarded-For")?.split(",")[0]?.trim() ||
+    "unknown";
 
   // Loopback IPs (127.0.0.1/::1) only appear in wrangler dev / CI, where miniflare
   // injects the socket's local address. Skip rate limiting entirely — no real IP is available.
-  if (ip === '127.0.0.1' || ip === '::1') {
+  if (ip === "127.0.0.1" || ip === "::1") {
     return { allowed: true, remaining: -1, resetAt: 0 };
   }
 
   // In production, CF-Connecting-IP is always present. If both IP headers are absent,
   // fail closed on auth endpoints (misconfiguration safety) and fail open elsewhere.
-  if (ip === 'unknown') {
+  if (ip === "unknown") {
     if (shouldFailClosed(pathname)) {
-      return { allowed: false, remaining: 0, resetAt: Math.floor(Date.now() / 1000) + 60, limit: config.requests };
+      return {
+        allowed: false,
+        remaining: 0,
+        resetAt: Math.floor(Date.now() / 1000) + 60,
+        limit: config.requests,
+      };
     }
     return { allowed: true, remaining: -1, resetAt: 0 };
   }
@@ -226,8 +258,8 @@ export async function checkRateLimit(request, env = null) {
     // Store updated data
     const response = new Response(JSON.stringify(data), {
       headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': `max-age=${config.window}`,
+        "Content-Type": "application/json",
+        "Cache-Control": `max-age=${config.window}`,
       },
     });
 
@@ -241,7 +273,7 @@ export async function checkRateLimit(request, env = null) {
     };
   } catch (error) {
     // Fail open for non-sensitive endpoints to avoid availability impact.
-    logger.warn('Rate limit check failed', { error, ip });
+    logger.warn("Rate limit check failed", { error, ip });
     return { allowed: true, remaining: -1, resetAt: 0 };
   }
 }
@@ -255,9 +287,9 @@ export function rateLimitHeaders(result) {
   }
 
   return {
-    'X-RateLimit-Limit': String(result.limit || 30),
-    'X-RateLimit-Remaining': String(result.remaining),
-    'X-RateLimit-Reset': String(result.resetAt),
+    "X-RateLimit-Limit": String(result.limit || 30),
+    "X-RateLimit-Remaining": String(result.remaining),
+    "X-RateLimit-Reset": String(result.resetAt),
   };
 }
 
@@ -265,22 +297,25 @@ export function rateLimitHeaders(result) {
  * Create 429 Too Many Requests response
  */
 export function rateLimitResponse(result, corsHeaders = {}) {
-  const retryAfter = Math.max(1, result.resetAt - Math.floor(Date.now() / 1000));
+  const retryAfter = Math.max(
+    1,
+    result.resetAt - Math.floor(Date.now() / 1000),
+  );
 
   return new Response(
     JSON.stringify({
-      error: 'Too many requests',
-      message: 'Rate limit exceeded. Please try again later.',
+      error: "Too many requests",
+      message: "Rate limit exceeded. Please try again later.",
       retryAfter,
     }),
     {
       status: 429,
       headers: {
-        'Content-Type': 'application/json',
-        'Retry-After': String(retryAfter),
+        "Content-Type": "application/json",
+        "Retry-After": String(retryAfter),
         ...rateLimitHeaders(result),
         ...corsHeaders,
       },
-    }
+    },
   );
 }

--- a/functions/utils/trustedDevice.js
+++ b/functions/utils/trustedDevice.js
@@ -1,5 +1,6 @@
 // Trusted Device utilities for "Remember this device" MFA feature
 import { isDevRequest } from "./auth.js";
+import { logger } from "./logger.js";
 
 // __Host- prefix enforces Secure + Path=/ + no Domain, preventing subdomain injection.
 // Must align with the name used in getTrustedDeviceToken's cookie parsing.
@@ -12,7 +13,10 @@ const TRUSTED_DEVICE_EXPIRY_DAYS = 30;
  */
 async function sha256Hex(input) {
   const encoder = new TextEncoder();
-  const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(input));
+  const hashBuffer = await crypto.subtle.digest(
+    "SHA-256",
+    encoder.encode(input),
+  );
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
@@ -57,7 +61,6 @@ async function hashTrustedDeviceToken(token) {
   return sha256Hex(token);
 }
 
-
 /**
  * Create a trusted device entry in the database
  */
@@ -70,16 +73,26 @@ export async function createTrustedDevice(DB, userId, ipAddress, userAgent) {
   // TEXT comparisons against datetime('now') are lexicographically correct.
   // ISO 8601 with 'T' compares greater than space-separated format at the
   // same instant, which would allow expired devices to pass validation.
-  const expiresAt = new Date(Date.now() + TRUSTED_DEVICE_EXPIRY_DAYS * 24 * 60 * 60 * 1000)
+  const expiresAt = new Date(
+    Date.now() + TRUSTED_DEVICE_EXPIRY_DAYS * 24 * 60 * 60 * 1000,
+  )
     .toISOString()
     .replace("T", " ")
     .slice(0, 19);
 
   await DB.prepare(
     `INSERT INTO trusted_devices (user_id, token, device_fingerprint, ua_hash, ip_address, user_agent, expires_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   )
-    .bind(userId, tokenHash, fingerprint, uaHash, ipAddress, userAgent, expiresAt)
+    .bind(
+      userId,
+      tokenHash,
+      fingerprint,
+      uaHash,
+      ipAddress,
+      userAgent,
+      expiresAt,
+    )
     .run();
 
   return { token, expiresAt };
@@ -97,7 +110,7 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
   const device = await DB.prepare(
     `SELECT id, user_id, token, device_fingerprint, ua_hash, ip_address, expires_at
      FROM trusted_devices
-     WHERE token = ? AND expires_at > datetime('now')`
+     WHERE token = ? AND expires_at > datetime('now')`,
   )
     .bind(tokenHash)
     .first();
@@ -122,7 +135,10 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
   //      password-authenticated login — it is not a standalone credential.
   // If the threat model tightens (e.g. admin-only high-value accounts), revisit
   // by adding IP-range/ASN checks rather than exact-IP pinning.
-  const currentFingerprint = await generateDeviceFingerprint(ipAddress, userAgent);
+  const currentFingerprint = await generateDeviceFingerprint(
+    ipAddress,
+    userAgent,
+  );
   const currentUaHash = await generateUaHash(userAgent);
 
   const fingerprintMatch = timingSafeStringEqual(
@@ -133,22 +149,29 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
   if (device.ua_hash) {
     const uaMatch = timingSafeStringEqual(device.ua_hash, currentUaHash);
     if (!uaMatch) {
-      console.log("[TrustedDevice] UA mismatch, device not trusted");
+      logger.debug("trusted device UA mismatch, device not trusted", {
+        userId: device.user_id,
+      });
       return null;
     }
     if (!fingerprintMatch) {
       // UA matches but IP changed — normal for DHCP, mobile, VPN users.
       // Fingerprint is refreshed in the update below.
-      console.log("[TrustedDevice] IP changed for known UA, refreshing fingerprint");
+      logger.debug(
+        "trusted device IP changed for known UA, refreshing fingerprint",
+        { userId: device.user_id },
+      );
     }
   } else if (!fingerprintMatch) {
-    console.log("[TrustedDevice] Fingerprint mismatch, device not trusted");
+    logger.debug("trusted device fingerprint mismatch, device not trusted", {
+      userId: device.user_id,
+    });
     return null;
   }
 
   // Always refresh last_used_at; also refresh IP and fingerprint so they stay current
   await DB.prepare(
-    `UPDATE trusted_devices SET last_used_at = datetime('now'), ip_address = ?, device_fingerprint = ? WHERE id = ?`
+    `UPDATE trusted_devices SET last_used_at = datetime('now'), ip_address = ?, device_fingerprint = ? WHERE id = ?`,
   )
     .bind(ipAddress, currentFingerprint, device.id)
     .run();
@@ -180,7 +203,7 @@ export async function revokeAllTrustedDevices(DB, userId) {
  */
 export async function cleanupExpiredDevices(DB) {
   await DB.prepare(
-    `DELETE FROM trusted_devices WHERE expires_at <= datetime('now')`
+    `DELETE FROM trusted_devices WHERE expires_at <= datetime('now')`,
   ).run();
 }
 
@@ -190,7 +213,9 @@ export async function cleanupExpiredDevices(DB) {
  */
 export function createTrustedDeviceCookie(token, request, env) {
   const isDev = isDevRequest(request, env);
-  const cookieName = isDev ? TRUSTED_DEVICE_COOKIE_NAME_DEV : TRUSTED_DEVICE_COOKIE_NAME_SECURE;
+  const cookieName = isDev
+    ? TRUSTED_DEVICE_COOKIE_NAME_DEV
+    : TRUSTED_DEVICE_COOKIE_NAME_SECURE;
   const maxAge = TRUSTED_DEVICE_EXPIRY_DAYS * 24 * 60 * 60;
 
   const parts = [
@@ -213,7 +238,9 @@ export function createTrustedDeviceCookie(token, request, env) {
  */
 export function deleteTrustedDeviceCookie(request, env) {
   const isDev = isDevRequest(request, env);
-  const cookieName = isDev ? TRUSTED_DEVICE_COOKIE_NAME_DEV : TRUSTED_DEVICE_COOKIE_NAME_SECURE;
+  const cookieName = isDev
+    ? TRUSTED_DEVICE_COOKIE_NAME_DEV
+    : TRUSTED_DEVICE_COOKIE_NAME_SECURE;
   const secure = isDev ? "" : "Secure; ";
 
   return `${cookieName}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; ${secure}SameSite=Strict; HttpOnly`;
@@ -229,7 +256,10 @@ export function getTrustedDeviceToken(request) {
   const cookies = cookieHeader.split(";");
   for (const cookie of cookies) {
     const [name, value] = cookie.trim().split("=");
-    if (name === TRUSTED_DEVICE_COOKIE_NAME_SECURE || name === TRUSTED_DEVICE_COOKIE_NAME_DEV) {
+    if (
+      name === TRUSTED_DEVICE_COOKIE_NAME_SECURE ||
+      name === TRUSTED_DEVICE_COOKIE_NAME_DEV
+    ) {
       return value;
     }
   }


### PR DESCRIPTION
Closes #404 (items 1, 2, 4, 5). The 5th item — `isDevRequest` default-secure — is split to **#425** because it needs coordinated dev-env config to avoid breaking local dev/E2E (details in that issue).

## Changes
- **Account-enumeration oracle closed** (`login.js`) — the activation/deactivation checks ran *before* password verification, so `requiresActivation` leaked whether an account existed. Reordered so the password is verified first; on a wrong password the response is uniform with no state hint. The hint is only revealed after the caller proves the password.
- **PBKDF2 100k → 600k** (`crypto.js`) — meets current OWASP guidance; `LEGACY_ITERATIONS` retained so existing hashes still verify (iteration count is read from the stored `pbkdf2$iters$…` string). Login **opportunistically rehashes** sub-600k hashes on successful auth — best-effort, wrapped in try/catch, never blocks login.
- **Follow rate-limit** (`rateLimit.js`) — a regex (`^/api/bands/[^/]+/(follow|unfollow|confirm-follow)$`) gives the email-sending POSTs a fail-closed D1 limit (5/5min), **without** touching the high-traffic public `GET /api/bands/[name]` reads (they stay on the fail-open default). Turnstile remains the primary control.
- **Auth debug logs** → routed through the structured `logger` (redacts PII) instead of raw `console.log` of user ids / trusted-device decisions.

## Review note
The `cloudflare-security-reviewer` agent was unavailable (session limit), so I reviewed the login reorder directly: password-first flow is correct, MFA/trusted-device/session/`writeAuthAttempt` invariants preserved, rehash is best-effort + parameterized, no new enumeration/timing oracle.

## Testing
`501 passed (64 files), 6 todo` — new tests cover: wrong-password gives no `requiresActivation` while correct-password+unactivated does; the band-action fail-closed limit vs. fail-open reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)