### PR TITLE
refactor(backend): consolidate duplicated normalizeBandName + escapeHtml helpers (#414)

### DIFF
--- a/functions/api/admin/bands.js
+++ b/functions/api/admin/bands.js
@@ -12,11 +12,7 @@ import {
 } from "../../utils/validation.js";
 import { buildIntervals, intervalsOverlap } from "../../utils/timeConflicts.js";
 import { parseOrigin } from "../../utils/parseOrigin.js";
-
-// Helper to normalize band name
-function normalizeName(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
-}
+import { normalizeBandName } from "../../utils/bandName.js";
 
 async function getEventStatus(DB, eventId) {
   if (!eventId) return null;
@@ -75,7 +71,9 @@ async function checkConflicts(
     bindings.push(excludePerformanceId);
   }
 
-  const { results: existingPerformances } = await DB.prepare(query).bind(...bindings).all();
+  const { results: existingPerformances } = await DB.prepare(query)
+    .bind(...bindings)
+    .all();
   const newIntervals = buildIntervals(startTime, endTime);
   const conflicts = [];
 
@@ -91,7 +89,10 @@ async function checkConflicts(
         name: perf.name,
         startTime: perf.start_time,
         endTime: perf.end_time,
-        type: perf.start_time === startTime && perf.end_time === endTime ? "conflict" : "overlap",
+        type:
+          perf.start_time === startTime && perf.end_time === endTime
+            ? "conflict"
+            : "overlap",
       });
     }
   }
@@ -405,7 +406,7 @@ export async function onRequestPost(context) {
     }
 
     // 1. Find or Create Band Profile
-    const nameNormalized = normalizeName(resolvedName);
+    const nameNormalized = normalizeBandName(resolvedName);
     const parsedOrigin = parseOrigin(origin?.trim());
     const trimmedOriginCity = origin_city
       ? origin_city.trim()

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -11,8 +11,12 @@ import {
   sanitizeString,
 } from "../../../utils/validation.js";
 import { getClientIP } from "../../../utils/request.js";
-import { buildIntervals, intervalsOverlap } from "../../../utils/timeConflicts.js";
+import {
+  buildIntervals,
+  intervalsOverlap,
+} from "../../../utils/timeConflicts.js";
 import { parseOrigin } from "../../../utils/parseOrigin.js";
+import { normalizeBandName } from "../../../utils/bandName.js";
 
 // Helper to extract band ID from path
 function getBandId(request) {
@@ -20,11 +24,6 @@ function getBandId(request) {
   const parts = url.pathname.split("/");
   const idIndex = parts.indexOf("bands") + 1;
   return parts[idIndex];
-}
-
-// Helper to normalize band name
-function normalizeName(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
 async function getEventForPerformance(DB, performanceId) {
@@ -64,7 +63,9 @@ async function checkConflicts(
     ? [eventId, venueId, excludePerformanceId]
     : [eventId, venueId];
 
-  const { results: existingBands } = await DB.prepare(query).bind(...bindings).all();
+  const { results: existingBands } = await DB.prepare(query)
+    .bind(...bindings)
+    .all();
   const newIntervals = buildIntervals(startTime, endTime);
   const conflicts = [];
 
@@ -80,7 +81,10 @@ async function checkConflicts(
         name: band.name,
         startTime: band.start_time,
         endTime: band.end_time,
-        type: band.start_time === startTime && band.end_time === endTime ? "conflict" : "overlap",
+        type:
+          band.start_time === startTime && band.end_time === endTime
+            ? "conflict"
+            : "overlap",
       });
     }
   }
@@ -162,7 +166,10 @@ export async function onRequestPut(context) {
       const parsed = Number(performanceId.toString().split("_")[1]);
       if (!Number.isInteger(parsed) || parsed <= 0) {
         return new Response(
-          JSON.stringify({ error: "Bad request", message: "Invalid profile ID" }),
+          JSON.stringify({
+            error: "Bad request",
+            message: "Invalid profile ID",
+          }),
           { status: 400, headers: { "Content-Type": "application/json" } },
         );
       }
@@ -264,7 +271,7 @@ export async function onRequestPut(context) {
       // Or maybe we just switch profile?
       // For now, let's just update the profile name if it's unique, or switch if it exists.
 
-      const nameNormalized = normalizeName(name);
+      const nameNormalized = normalizeBandName(name);
       const existingProfile = await DB.prepare(
         `SELECT id FROM band_profiles WHERE name_normalized = ? AND id != ?`,
       )
@@ -430,7 +437,7 @@ export async function onRequestPut(context) {
         profileUpdates.push("name_normalized = ?");
         const sanitizedName = sanitizeString(name);
         profileParams.push(sanitizedName);
-        profileParams.push(normalizeName(sanitizedName));
+        profileParams.push(normalizeBandName(sanitizedName));
       }
 
       // Update other profile fields
@@ -891,7 +898,10 @@ export async function onRequestDelete(context) {
       const bandProfileId = Number(performanceId.toString().split("_")[1]);
       if (!Number.isInteger(bandProfileId) || bandProfileId <= 0) {
         return new Response(
-          JSON.stringify({ error: "Bad request", message: "Invalid profile ID" }),
+          JSON.stringify({
+            error: "Bad request",
+            message: "Invalid profile ID",
+          }),
           { status: 400, headers: { "Content-Type": "application/json" } },
         );
       }

--- a/functions/api/admin/bands/__tests__/stats.test.js
+++ b/functions/api/admin/bands/__tests__/stats.test.js
@@ -2,6 +2,7 @@
 // Tests for GET /api/admin/bands/stats/{name}
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { normalizeBandName } from "../../../../utils/bandName.js";
 import { onRequestGet } from "../stats/[name].js";
 import {
   createTestDB,
@@ -77,32 +78,65 @@ function insertBandWithProfile(db, data) {
     social_links = null,
   } = data;
 
-  const nameNormalized = name.toLowerCase().replace(/[^a-z0-9]/g, '');
-  const existingProfile = db.prepare("SELECT id FROM band_profiles WHERE name_normalized = ?").get(nameNormalized);
+  const nameNormalized = normalizeBandName(name);
+  const existingProfile = db
+    .prepare("SELECT id FROM band_profiles WHERE name_normalized = ?")
+    .get(nameNormalized);
   const profileId = existingProfile
     ? existingProfile.id
-    : db.prepare(
-      "INSERT INTO band_profiles (name, name_normalized, genre, origin, description, photo_url, social_links) VALUES (?, ?, ?, ?, ?, ?, ?)"
-    ).run(name, nameNormalized, genre, origin, description, photo_url, social_links).lastInsertRowid;
+    : db
+        .prepare(
+          "INSERT INTO band_profiles (name, name_normalized, genre, origin, description, photo_url, social_links) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(
+          name,
+          nameNormalized,
+          genre,
+          origin,
+          description,
+          photo_url,
+          social_links,
+        ).lastInsertRowid;
 
   if (existingProfile) {
     const updates = [];
     const values = [];
-    if (genre !== null) { updates.push('genre = ?'); values.push(genre); }
-    if (origin !== null) { updates.push('origin = ?'); values.push(origin); }
-    if (description !== null) { updates.push('description = ?'); values.push(description); }
-    if (photo_url !== null) { updates.push('photo_url = ?'); values.push(photo_url); }
-    if (social_links !== null) { updates.push('social_links = ?'); values.push(social_links); }
+    if (genre !== null) {
+      updates.push("genre = ?");
+      values.push(genre);
+    }
+    if (origin !== null) {
+      updates.push("origin = ?");
+      values.push(origin);
+    }
+    if (description !== null) {
+      updates.push("description = ?");
+      values.push(description);
+    }
+    if (photo_url !== null) {
+      updates.push("photo_url = ?");
+      values.push(photo_url);
+    }
+    if (social_links !== null) {
+      updates.push("social_links = ?");
+      values.push(social_links);
+    }
     if (updates.length > 0) {
-      db.prepare(`UPDATE band_profiles SET ${updates.join(', ')} WHERE id = ?`).run(...values, profileId);
+      db.prepare(
+        `UPDATE band_profiles SET ${updates.join(", ")} WHERE id = ?`,
+      ).run(...values, profileId);
     }
   }
 
-  const info = db.prepare(
-    "INSERT INTO performances (event_id, venue_id, band_profile_id, start_time, end_time, notes) VALUES (?, ?, ?, ?, ?, ?)"
-  ).run(event_id, venue_id, profileId, start_time, end_time, null);
+  const info = db
+    .prepare(
+      "INSERT INTO performances (event_id, venue_id, band_profile_id, start_time, end_time, notes) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .run(event_id, venue_id, profileId, start_time, end_time, null);
 
-  return db.prepare("SELECT * FROM performances WHERE id = ?").get(info.lastInsertRowid);
+  return db
+    .prepare("SELECT * FROM performances WHERE id = ?")
+    .get(info.lastInsertRowid);
 }
 
 describe("GET /api/admin/bands/stats/:name", () => {
@@ -121,7 +155,10 @@ describe("GET /api/admin/bands/stats/:name", () => {
   describe("Authentication & Authorization", () => {
     it("should allow viewer role to access stats", async () => {
       // Arrange
-      const event = insertEvent(db, { name: "Test Event", slug: "test-event-1" });
+      const event = insertEvent(db, {
+        name: "Test Event",
+        slug: "test-event-1",
+      });
       const venue = insertVenue(db, { name: "Test Venue" });
       insertBandWithProfile(db, {
         name: "Test Band",
@@ -157,7 +194,10 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should allow editor and admin roles", async () => {
       // Arrange
-      const event = insertEvent(db, { name: "Test Event", slug: "test-event-2" });
+      const event = insertEvent(db, {
+        name: "Test Event",
+        slug: "test-event-2",
+      });
       const venue = insertVenue(db, { name: "Test Venue" });
       insertBandWithProfile(db, {
         name: "Test Band",
@@ -224,7 +264,10 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should handle URL-encoded band names", async () => {
       // Arrange
-      const event = insertEvent(db, { name: "Test Event", slug: "test-event-3" });
+      const event = insertEvent(db, {
+        name: "Test Event",
+        slug: "test-event-3",
+      });
       const venue = insertVenue(db, { name: "Test Venue" });
       insertBandWithProfile(db, {
         name: "The Rock Band",
@@ -255,7 +298,10 @@ describe("GET /api/admin/bands/stats/:name", () => {
   describe("Data Retrieval", () => {
     it("should return stats for existing band", async () => {
       // Arrange
-      const event = insertEvent(db, { name: "Test Event", slug: "test-event-4" });
+      const event = insertEvent(db, {
+        name: "Test Event",
+        slug: "test-event-4",
+      });
       const venue = insertVenue(db, { name: "Test Venue" });
       insertBandWithProfile(db, {
         name: "Test Band",
@@ -294,7 +340,10 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should be case-insensitive when matching band names", async () => {
       // Arrange
-      const event = insertEvent(db, { name: "Test Event", slug: "test-event-5" });
+      const event = insertEvent(db, {
+        name: "Test Event",
+        slug: "test-event-5",
+      });
       const venue = insertVenue(db, { name: "Test Venue" });
       insertBandWithProfile(db, {
         name: "Test Band",
@@ -378,7 +427,11 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should count unique venues correctly", async () => {
       // Arrange - Same band at 3 different venues
-      const event = insertEvent(db, { name: "Event", slug: "multi-venue-event", date: "2025-06-01" });
+      const event = insertEvent(db, {
+        name: "Event",
+        slug: "multi-venue-event",
+        date: "2025-06-01",
+      });
       const venue1 = insertVenue(db, { name: "Venue 1" });
       const venue2 = insertVenue(db, { name: "Venue 2" });
       const venue3 = insertVenue(db, { name: "Venue 3" });
@@ -484,7 +537,11 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should handle bands with null venue_id", async () => {
       // Arrange - Band with event but no venue
-      const event = insertEvent(db, { name: "Virtual Event", slug: "virtual-event", date: "2025-06-01" });
+      const event = insertEvent(db, {
+        name: "Virtual Event",
+        slug: "virtual-event",
+        date: "2025-06-01",
+      });
       insertBandWithProfile(db, {
         name: "Virtual Band",
         event_id: event.id,
@@ -563,7 +620,11 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should include all profile fields", async () => {
       // Arrange
-      const event = insertEvent(db, { name: "Test Event", slug: "profile-test-event", date: "2025-06-01" });
+      const event = insertEvent(db, {
+        name: "Test Event",
+        slug: "profile-test-event",
+        date: "2025-06-01",
+      });
       const venue = insertVenue(db, { name: "Test Venue" });
       insertBandWithProfile(db, {
         name: "Complete Band",
@@ -673,7 +734,10 @@ describe("GET /api/admin/bands/stats/:name", () => {
         date: "2025-07-15",
       });
       // Update event city
-      db.prepare("UPDATE events SET city = ? WHERE id = ?").run("Central Park", event.id);
+      db.prepare("UPDATE events SET city = ? WHERE id = ?").run(
+        "Central Park",
+        event.id,
+      );
 
       const venue = insertVenue(db, { name: "Main Stage" });
       insertBandWithProfile(db, {
@@ -703,7 +767,11 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should include venue details when present", async () => {
       // Arrange
-      const event = insertEvent(db, { name: "Jazz Night", slug: "jazz-night", date: "2025-06-01" });
+      const event = insertEvent(db, {
+        name: "Jazz Night",
+        slug: "jazz-night",
+        date: "2025-06-01",
+      });
       const venue = insertVenue(db, {
         name: "Blue Note Jazz Club",
         address: "131 W 3rd St, New York, NY",
@@ -803,8 +871,15 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should match response format specification", async () => {
       // Arrange
-      const event = insertEvent(db, { name: "Format Test", slug: "format-test", date: "2025-06-01" });
-      db.prepare("UPDATE events SET city = ? WHERE id = ?").run("Test Location", event.id);
+      const event = insertEvent(db, {
+        name: "Format Test",
+        slug: "format-test",
+        date: "2025-06-01",
+      });
+      db.prepare("UPDATE events SET city = ? WHERE id = ?").run(
+        "Test Location",
+        event.id,
+      );
 
       const venue = insertVenue(db, {
         name: "Format Venue",

--- a/functions/api/admin/bands/import.js
+++ b/functions/api/admin/bands/import.js
@@ -9,6 +9,7 @@
 import { auditLog, checkPermission } from "../_middleware.js";
 import { getClientIP } from "../../../utils/request.js";
 import { isValidTime } from "../../../utils/validation.js";
+import { normalizeBandName } from "../../../utils/bandName.js";
 
 const MAX_IMPORT_ROWS = 200;
 const MAX_NAME_LENGTH = 200;
@@ -18,10 +19,6 @@ function json(body, status = 200) {
     status,
     headers: { "Content-Type": "application/json" },
   });
-}
-
-function normalizeName(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
 export async function onRequestPost(context) {
@@ -101,7 +98,7 @@ export async function onRequestPost(context) {
     }
     return {
       name,
-      nameNormalized: normalizeName(name),
+      nameNormalized: normalizeBandName(name),
       genre: row.genre ? String(row.genre).trim() : null,
       origin: row.origin ? String(row.origin).trim() : null,
       startTime,

--- a/functions/api/admin/events/__tests__/test-utils.js
+++ b/functions/api/admin/events/__tests__/test-utils.js
@@ -1,4 +1,5 @@
 import Database from "better-sqlite3";
+import { normalizeBandName } from "../../../../utils/bandName.js";
 
 /**
  * createTestDB
@@ -74,7 +75,7 @@ export function createTestDB() {
 
   // Insert fixture users
   const insertUser = db.prepare(
-    "INSERT INTO users (email, role) VALUES (?, ?)"
+    "INSERT INTO users (email, role) VALUES (?, ?)",
   );
   insertUser.run("admin@test", "admin");
   insertUser.run("editor@test", "editor");
@@ -97,10 +98,10 @@ export function insertEvent(
     date = "2025-12-15",
     status = "draft",
     created_by = 1,
-  } = {}
+  } = {},
 ) {
   const stmt = db.prepare(
-    "INSERT INTO events (name, slug, date, status, created_by_user_id) VALUES (?, ?, ?, ?, ?)"
+    "INSERT INTO events (name, slug, date, status, created_by_user_id) VALUES (?, ?, ?, ?, ?)",
   );
   const info = stmt.run(name, slug, date, status, created_by);
   return db
@@ -108,16 +109,33 @@ export function insertEvent(
     .get(info.lastInsertRowid);
 }
 
-export function insertBand(db, { name = "Test Band", event_id = null, venue_id = null, start_time = "20:00", end_time = "21:00" } = {}) {
-  const nameNormalized = name.toLowerCase().replace(/[^a-z0-9]/g, '');
-  const existingProfile = db.prepare("SELECT id FROM band_profiles WHERE name_normalized = ?").get(nameNormalized);
+export function insertBand(
+  db,
+  {
+    name = "Test Band",
+    event_id = null,
+    venue_id = null,
+    start_time = "20:00",
+    end_time = "21:00",
+  } = {},
+) {
+  const nameNormalized = normalizeBandName(name);
+  const existingProfile = db
+    .prepare("SELECT id FROM band_profiles WHERE name_normalized = ?")
+    .get(nameNormalized);
   const profileId = existingProfile
     ? existingProfile.id
-    : db.prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)").run(name, nameNormalized).lastInsertRowid;
+    : db
+        .prepare(
+          "INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)",
+        )
+        .run(name, nameNormalized).lastInsertRowid;
 
-  const info = db.prepare(
-    "INSERT INTO performances (event_id, venue_id, band_profile_id, start_time, end_time) VALUES (?, ?, ?, ?, ?)"
-  ).run(event_id, venue_id, profileId, start_time, end_time);
+  const info = db
+    .prepare(
+      "INSERT INTO performances (event_id, venue_id, band_profile_id, start_time, end_time) VALUES (?, ?, ?, ?, ?)",
+    )
+    .run(event_id, venue_id, profileId, start_time, end_time);
 
   return db
     .prepare("SELECT * FROM performances WHERE id = ?")
@@ -126,10 +144,10 @@ export function insertBand(db, { name = "Test Band", event_id = null, venue_id =
 
 export function insertVenue(
   db,
-  { name = "Test Venue", city = "Portland", address = null } = {}
+  { name = "Test Venue", city = "Portland", address = null } = {},
 ) {
   const stmt = db.prepare(
-    "INSERT INTO venues (name, city, address) VALUES (?, ?, ?)"
+    "INSERT INTO venues (name, city, address) VALUES (?, ?, ?)",
   );
   const info = stmt.run(name, city, address);
   return db

--- a/functions/api/admin/events/wizard.js
+++ b/functions/api/admin/events/wizard.js
@@ -18,11 +18,11 @@ import {
   FIELD_LIMITS,
 } from "../../../utils/validation.js";
 import { getClientIP } from "../../../utils/request.js";
-import { buildIntervals, intervalsOverlap } from "../../../utils/timeConflicts.js";
-
-function normalizeName(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
-}
+import {
+  buildIntervals,
+  intervalsOverlap,
+} from "../../../utils/timeConflicts.js";
+import { normalizeBandName } from "../../../utils/bandName.js";
 
 // Detect scheduling conflicts within the submitted band list (all for a new event).
 function findConflict(bands) {
@@ -162,8 +162,7 @@ export async function onRequestPost(context) {
       if (!startCheck.valid)
         throw new Error(`Band ${i + 1}: ${startCheck.error}`);
       const endCheck = isValidTime(b.endTime);
-      if (!endCheck.valid)
-        throw new Error(`Band ${i + 1}: ${endCheck.error}`);
+      if (!endCheck.valid) throw new Error(`Band ${i + 1}: ${endCheck.error}`);
       if (b.startTime && b.endTime) {
         if (b.startTime === b.endTime) {
           throw new Error(
@@ -253,7 +252,7 @@ export async function onRequestPost(context) {
       // Resolve each band profile (find or create) sequentially — dedup by normalized name
       const profileIds = [];
       for (const band of sanitizedBands) {
-        const normalized = normalizeName(band.name);
+        const normalized = normalizeBandName(band.name);
         let profile = await DB.prepare(
           "SELECT id FROM band_profiles WHERE name_normalized = ?",
         )
@@ -317,7 +316,9 @@ export async function onRequestPost(context) {
     // so we don't leave an empty draft behind.
     if (event?.id) {
       try {
-        await DB.prepare("DELETE FROM events WHERE id = ?").bind(event.id).run();
+        await DB.prepare("DELETE FROM events WHERE id = ?")
+          .bind(event.id)
+          .run();
       } catch (e) {
         console.error("Wizard cleanup failed:", e);
       }

--- a/functions/api/admin/performers.js
+++ b/functions/api/admin/performers.js
@@ -18,6 +18,7 @@ import {
 } from "../../utils/validation.js";
 import { getClientIP } from "../../utils/request.js";
 import { parseOrigin } from "../../utils/parseOrigin.js";
+import { normalizeBandName } from "../../utils/bandName.js";
 
 const ROLE_LEVELS = { admin: 3, editor: 2, viewer: 1 };
 
@@ -31,12 +32,6 @@ function sanitizeOptionalText(value, maxLength) {
   }
   return text;
 }
-
-// Helper to normalize band name for uniqueness check
-function normalizeName(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
-}
-
 
 // Helper to unpack social links
 function unpackSocialLinks(performer) {
@@ -130,7 +125,10 @@ export async function onRequestGet(context) {
       return new Response(
         JSON.stringify({
           success: true,
-          performer: { ...redactPerformerForRole(unpackSocialLinks(performer), role), stats },
+          performer: {
+            ...redactPerformerForRole(unpackSocialLinks(performer), role),
+            stats,
+          },
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
@@ -221,7 +219,7 @@ export async function onRequestPost(context) {
     }
 
     const resolvedName = sanitizeOptionalText(name, FIELD_LIMITS.bandName.max);
-    const nameNormalized = normalizeName(resolvedName);
+    const nameNormalized = normalizeBandName(resolvedName);
 
     // Check for duplicate name
     const existing = await DB.prepare(
@@ -247,28 +245,58 @@ export async function onRequestPost(context) {
         { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }
-    const resolvedGenre = sanitizeOptionalText(genre, FIELD_LIMITS.bandGenre.max);
-    const resolvedDescription = sanitizeOptionalText(description, FIELD_LIMITS.bandDescription.max);
+    const resolvedGenre = sanitizeOptionalText(
+      genre,
+      FIELD_LIMITS.bandGenre.max,
+    );
+    const resolvedDescription = sanitizeOptionalText(
+      description,
+      FIELD_LIMITS.bandDescription.max,
+    );
     let resolvedPhotoUrl;
     let resolvedWebsite;
     let resolvedBandcamp;
     let resolvedFacebook;
     try {
-      resolvedPhotoUrl = sanitizeOptionalHttpUrl(photo_url, FIELD_LIMITS.bandUrl.max, "Photo URL");
-      resolvedWebsite = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");
-      resolvedBandcamp = sanitizeOptionalHttpUrl(bandcamp, FIELD_LIMITS.bandUrl.max, "Bandcamp URL");
-      resolvedFacebook = sanitizeOptionalHttpUrl(facebook, FIELD_LIMITS.bandUrl.max, "Facebook URL");
+      resolvedPhotoUrl = sanitizeOptionalHttpUrl(
+        photo_url,
+        FIELD_LIMITS.bandUrl.max,
+        "Photo URL",
+      );
+      resolvedWebsite = sanitizeOptionalHttpUrl(
+        url,
+        FIELD_LIMITS.bandUrl.max,
+        "Website URL",
+      );
+      resolvedBandcamp = sanitizeOptionalHttpUrl(
+        bandcamp,
+        FIELD_LIMITS.bandUrl.max,
+        "Bandcamp URL",
+      );
+      resolvedFacebook = sanitizeOptionalHttpUrl(
+        facebook,
+        FIELD_LIMITS.bandUrl.max,
+        "Facebook URL",
+      );
     } catch (error) {
       return new Response(
         JSON.stringify({ error: error.message || "Invalid URL" }),
         { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }
-    const resolvedInstagram = sanitizeOptionalText(instagram, FIELD_LIMITS.socialHandle.max);
-    const resolvedContactEmail = sanitizeOptionalText(contact_email, FIELD_LIMITS.bandContactEmail.max);
+    const resolvedInstagram = sanitizeOptionalText(
+      instagram,
+      FIELD_LIMITS.socialHandle.max,
+    );
+    const resolvedContactEmail = sanitizeOptionalText(
+      contact_email,
+      FIELD_LIMITS.bandContactEmail.max,
+    );
     if (resolvedContactEmail && !isValidEmail(resolvedContactEmail)) {
       return new Response(
-        JSON.stringify({ error: "Contact email must be a valid email address" }),
+        JSON.stringify({
+          error: "Contact email must be a valid email address",
+        }),
         { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }
@@ -413,14 +441,17 @@ export async function onRequestPut(context) {
     // Check for duplicate name (if name is being changed)
     let nameNormalized = null;
     if (name) {
-      const resolvedName = sanitizeOptionalText(name, FIELD_LIMITS.bandName.max);
+      const resolvedName = sanitizeOptionalText(
+        name,
+        FIELD_LIMITS.bandName.max,
+      );
       if (!resolvedName) {
         return new Response(
           JSON.stringify({ error: "Performer name cannot be empty" }),
           { status: 400, headers: { "Content-Type": "application/json" } },
         );
       }
-      nameNormalized = normalizeName(resolvedName);
+      nameNormalized = normalizeBandName(resolvedName);
       const duplicate = await DB.prepare(
         "SELECT id FROM band_profiles WHERE name_normalized = ? AND id != ?",
       )
@@ -438,28 +469,58 @@ export async function onRequestPut(context) {
     }
 
     // Pack social links
-    const resolvedGenre = sanitizeOptionalText(genre, FIELD_LIMITS.bandGenre.max);
-    const resolvedDescription = sanitizeOptionalText(description, FIELD_LIMITS.bandDescription.max);
+    const resolvedGenre = sanitizeOptionalText(
+      genre,
+      FIELD_LIMITS.bandGenre.max,
+    );
+    const resolvedDescription = sanitizeOptionalText(
+      description,
+      FIELD_LIMITS.bandDescription.max,
+    );
     let resolvedPhotoUrl;
     let resolvedWebsite;
     let resolvedBandcamp;
     let resolvedFacebook;
     try {
-      resolvedPhotoUrl = sanitizeOptionalHttpUrl(photo_url, FIELD_LIMITS.bandUrl.max, "Photo URL");
-      resolvedWebsite = sanitizeOptionalHttpUrl(performerUrl, FIELD_LIMITS.bandUrl.max, "Website URL");
-      resolvedBandcamp = sanitizeOptionalHttpUrl(bandcamp, FIELD_LIMITS.bandUrl.max, "Bandcamp URL");
-      resolvedFacebook = sanitizeOptionalHttpUrl(facebook, FIELD_LIMITS.bandUrl.max, "Facebook URL");
+      resolvedPhotoUrl = sanitizeOptionalHttpUrl(
+        photo_url,
+        FIELD_LIMITS.bandUrl.max,
+        "Photo URL",
+      );
+      resolvedWebsite = sanitizeOptionalHttpUrl(
+        performerUrl,
+        FIELD_LIMITS.bandUrl.max,
+        "Website URL",
+      );
+      resolvedBandcamp = sanitizeOptionalHttpUrl(
+        bandcamp,
+        FIELD_LIMITS.bandUrl.max,
+        "Bandcamp URL",
+      );
+      resolvedFacebook = sanitizeOptionalHttpUrl(
+        facebook,
+        FIELD_LIMITS.bandUrl.max,
+        "Facebook URL",
+      );
     } catch (error) {
       return new Response(
         JSON.stringify({ error: error.message || "Invalid URL" }),
         { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }
-    const resolvedInstagram = sanitizeOptionalText(instagram, FIELD_LIMITS.socialHandle.max);
-    const resolvedContactEmail = sanitizeOptionalText(contact_email, FIELD_LIMITS.bandContactEmail.max);
+    const resolvedInstagram = sanitizeOptionalText(
+      instagram,
+      FIELD_LIMITS.socialHandle.max,
+    );
+    const resolvedContactEmail = sanitizeOptionalText(
+      contact_email,
+      FIELD_LIMITS.bandContactEmail.max,
+    );
     if (resolvedContactEmail && !isValidEmail(resolvedContactEmail)) {
       return new Response(
-        JSON.stringify({ error: "Contact email must be a valid email address" }),
+        JSON.stringify({
+          error: "Contact email must be a valid email address",
+        }),
         { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }
@@ -550,8 +611,8 @@ export async function onRequestDelete(context) {
 
   // RBAC: Require admin role
   const permCheck = await checkPermission(context, "admin");
-    const currentUser = permCheck.user;
-    const ipAddress = getClientIP(request);
+  const currentUser = permCheck.user;
+  const ipAddress = getClientIP(request);
 
   if (permCheck.error) {
     return permCheck.response;

--- a/functions/api/bands/[name].js
+++ b/functions/api/bands/[name].js
@@ -1,4 +1,5 @@
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
+import { normalizeBandName } from "../../utils/bandName.js";
 
 /**
  * Public API: Get band profile by name
@@ -7,11 +8,6 @@ import { getPublicDataGateResponse } from "../../utils/publicGate.js";
  *
  * Returns band profile with performance history
  */
-
-// Normalize band name for lookup against name_normalized
-function normalizeName(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
-}
 
 function formatOrigin(profile) {
   if (!profile) return null;
@@ -74,7 +70,7 @@ export async function onRequestGet(context) {
         .bind(bandId)
         .first();
     } else {
-      const normalized = normalizeName(searchName);
+      const normalized = normalizeBandName(searchName);
       bandProfile = await DB.prepare(
         `
         SELECT * FROM band_profiles

--- a/functions/api/bands/[name]/confirm-follow.js
+++ b/functions/api/bands/[name]/confirm-follow.js
@@ -4,13 +4,7 @@
 // (see admin/bands/[id].js + resend-announcement.js). Returns a friendly HTML
 // page; messaging is generic to avoid leaking whether a given token was valid.
 
-const escapeHtml = (s) =>
-  String(s ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+import { escapeHtml } from "../../../utils/html.js";
 
 const htmlPage = (heading, body) =>
   new Response(

--- a/functions/api/bands/[name]/follow.js
+++ b/functions/api/bands/[name]/follow.js
@@ -2,14 +2,9 @@ import { isValidEmail } from "../../../utils/validation.js";
 import { generateToken } from "../../../utils/tokens.js";
 import { sendEmail, isEmailConfigured } from "../../../utils/email.js";
 import { verifyTurnstile } from "../../../utils/turnstile.js";
+import { normalizeBandName } from "../../../utils/bandName.js";
 
-const escapeHtml = (s) =>
-  String(s ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+import { escapeHtml } from "../../../utils/html.js";
 
 const MAX_EMAIL_LENGTH = 320;
 
@@ -46,7 +41,7 @@ export async function onRequestPost(context) {
         .bind(Number(nameOrId))
         .first();
     } else {
-      const normalized = nameOrId.toLowerCase().replace(/[^a-z0-9]/g, "");
+      const normalized = normalizeBandName(nameOrId);
       band = await DB.prepare(
         "SELECT id, name FROM band_profiles WHERE name_normalized = ?",
       )
@@ -93,13 +88,21 @@ export async function onRequestPost(context) {
           subject: `Confirm your follow of ${band.name} on SetTimes`,
           text: `Someone (hopefully you) asked to follow ${band.name} on SetTimes.\n\nConfirm to be notified when they join a lineup:\n${confirmUrl}\n\nIf this wasn't you, ignore this email — you won't be subscribed.`,
           html: `<p>Someone (hopefully you) asked to follow <strong>${escapeHtml(band.name)}</strong> on SetTimes.</p><p><a href="${confirmUrl}">Confirm your follow</a> to be notified when they join a lineup.</p><p>If this wasn't you, just ignore this email — you won't be subscribed.</p>`,
-        }).then(emailResult => {
-          if (!emailResult?.delivered) {
-            console.warn("[band-follow] Confirmation email not delivered:", emailResult?.reason);
-          }
-        }).catch(err => {
-          console.error("[band-follow] Failed to send confirmation email:", err);
         })
+          .then((emailResult) => {
+            if (!emailResult?.delivered) {
+              console.warn(
+                "[band-follow] Confirmation email not delivered:",
+                emailResult?.reason,
+              );
+            }
+          })
+          .catch((err) => {
+            console.error(
+              "[band-follow] Failed to send confirmation email:",
+              err,
+            );
+          }),
       );
     }
 

--- a/functions/api/bands/[name]/unfollow.js
+++ b/functions/api/bands/[name]/unfollow.js
@@ -2,24 +2,21 @@
 // Deletes the band follow associated with the unsubscribe token.
 // Returns 200 regardless of whether the token exists (avoid enumeration).
 
-const escapeHtml = (s) =>
-  String(s ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+import { escapeHtml } from "../../../utils/html.js";
 
 export async function onRequestGet(context) {
-  const { request, env } = context
-  const { DB } = env
+  const { request, env } = context;
+  const { DB } = env;
 
   try {
-    const url = new URL(request.url)
-    const token = url.searchParams.get('token')
+    const url = new URL(request.url);
+    const token = url.searchParams.get("token");
 
     if (!token || token.length > 256) {
-      return new Response('Invalid token.', { status: 400, headers: { 'Content-Type': 'text/plain' } })
+      return new Response("Invalid token.", {
+        status: 400,
+        headers: { "Content-Type": "text/plain" },
+      });
     }
 
     // Resolve the band name BEFORE deleting so the page can name it. An unknown
@@ -29,23 +26,33 @@ export async function onRequestGet(context) {
       `SELECT bp.name AS band_name
        FROM band_follows bf
        JOIN band_profiles bp ON bp.id = bf.band_profile_id
-       WHERE bf.unsubscribe_token = ?`
-    ).bind(token).first()
+       WHERE bf.unsubscribe_token = ?`,
+    )
+      .bind(token)
+      .first();
 
-    await DB.prepare('DELETE FROM band_follows WHERE unsubscribe_token = ?').bind(token).run()
+    await DB.prepare("DELETE FROM band_follows WHERE unsubscribe_token = ?")
+      .bind(token)
+      .run();
 
-    const bandName = follow?.band_name ? escapeHtml(follow.band_name) : null
-    const heading = bandName ? `Unfollowed ${bandName}` : 'Unfollowed'
+    const bandName = follow?.band_name ? escapeHtml(follow.band_name) : null;
+    const heading = bandName ? `Unfollowed ${bandName}` : "Unfollowed";
     const message = bandName
       ? `You've been removed from ${bandName}'s follower list — you won't get any more emails about them.`
-      : `You have been removed from this band's follower list.`
+      : `You have been removed from this band's follower list.`;
 
     return new Response(
       `<html><body style="font-family:sans-serif;padding:2rem"><h2>${heading}</h2><p>${message}</p></body></html>`,
-      { status: 200, headers: { 'Content-Type': 'text/html', 'Cache-Control': 'no-store' } }
-    )
+      {
+        status: 200,
+        headers: { "Content-Type": "text/html", "Cache-Control": "no-store" },
+      },
+    );
   } catch (err) {
-    console.error('[band-unfollow] Error:', err)
-    return new Response('An error occurred.', { status: 500, headers: { 'Content-Type': 'text/plain' } })
+    console.error("[band-unfollow] Error:", err);
+    return new Response("An error occurred.", {
+      status: 500,
+      headers: { "Content-Type": "text/plain" },
+    });
   }
 }

--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -1,4 +1,5 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
+import { normalizeBandName } from "../../../utils/bandName.js";
 
 /**
  * Public API: Get band profile with rich stats
@@ -8,11 +9,6 @@ import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
  * Returns band profile with performance statistics, upcoming shows, and history
  * Supports both numeric IDs and band names (URL-encoded)
  */
-
-// Normalize band name for lookup against name_normalized
-function normalizeName(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
-}
 
 function formatOrigin(profile) {
   if (!profile) return null;
@@ -75,7 +71,7 @@ export async function onRequestGet(context) {
         .bind(bandId)
         .first();
     } else {
-      const normalized = normalizeName(searchName);
+      const normalized = normalizeBandName(searchName);
       bandProfile = await DB.prepare(
         `
         SELECT * FROM band_profiles

--- a/functions/api/subscriptions/subscribe.js
+++ b/functions/api/subscriptions/subscribe.js
@@ -1,36 +1,28 @@
 // Subscription endpoint
 // POST /api/subscriptions/subscribe
 
-import { generateToken } from '../../utils/tokens.js';
-import { sendEmail, isEmailConfigured } from '../../utils/email.js';
-import { isValidEmail } from '../../utils/validation.js';
-import { verifyTurnstile } from '../../utils/turnstile.js';
+import { generateToken } from "../../utils/tokens.js";
+import { sendEmail, isEmailConfigured } from "../../utils/email.js";
+import { isValidEmail } from "../../utils/validation.js";
+import { verifyTurnstile } from "../../utils/turnstile.js";
+import { escapeHtml } from "../../utils/html.js";
 
-const FREQUENCY_OPTIONS = new Set(['daily', 'weekly', 'monthly']);
+const FREQUENCY_OPTIONS = new Set(["daily", "weekly", "monthly"]);
 const MAX_EMAIL_LENGTH = 320;
 const MAX_CITY_LENGTH = 100;
 const MAX_GENRE_LENGTH = 100;
 const MAX_FREQUENCY_LENGTH = 20;
 
-function escapeHtml(value) {
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/\"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
 // Build a JSON Response, merging an optional verificationUrl when email
 // delivery was skipped so local/dev environments can verify without email.
 function subscriptionResponse(body, status, emailResult) {
   const payload =
-    !emailResult.delivered && emailResult.reason === 'not_configured'
+    !emailResult.delivered && emailResult.reason === "not_configured"
       ? { ...body, verificationUrl: emailResult.verifyUrl }
       : body;
   return new Response(JSON.stringify(payload), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { "Content-Type": "application/json" },
   });
 }
 
@@ -39,30 +31,30 @@ export async function onRequestPost(context) {
 
   try {
     const body = await request.json().catch(() => ({}));
-    const email = typeof body.email === 'string' ? body.email.trim() : '';
-    const city = typeof body.city === 'string' ? body.city.trim() : '';
-    const genre = typeof body.genre === 'string' ? body.genre.trim() : '';
+    const email = typeof body.email === "string" ? body.email.trim() : "";
+    const city = typeof body.city === "string" ? body.city.trim() : "";
+    const genre = typeof body.genre === "string" ? body.genre.trim() : "";
     const frequency =
-      typeof body.frequency === 'string'
+      typeof body.frequency === "string"
         ? body.frequency.trim().toLowerCase()
-        : '';
+        : "";
     const turnstileToken = body.turnstileToken;
 
     // Validation
     if (!email || email.length > MAX_EMAIL_LENGTH || !isValidEmail(email)) {
-      return new Response(JSON.stringify({ error: 'Invalid email address' }), {
+      return new Response(JSON.stringify({ error: "Invalid email address" }), {
         status: 400,
-        headers: { 'Content-Type': 'application/json' },
+        headers: { "Content-Type": "application/json" },
       });
     }
 
     if (!city || !genre || !frequency) {
       return new Response(
-        JSON.stringify({ error: 'Missing required fields' }),
+        JSON.stringify({ error: "Missing required fields" }),
         {
           status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        }
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
 
@@ -72,32 +64,32 @@ export async function onRequestPost(context) {
       frequency.length > MAX_FREQUENCY_LENGTH
     ) {
       return new Response(
-        JSON.stringify({ error: 'One or more fields exceed maximum length' }),
+        JSON.stringify({ error: "One or more fields exceed maximum length" }),
         {
           status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        }
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
 
     if (!FREQUENCY_OPTIONS.has(frequency)) {
       return new Response(
-        JSON.stringify({ error: 'Invalid frequency value' }),
+        JSON.stringify({ error: "Invalid frequency value" }),
         {
           status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        }
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
 
     const turnstileValid = await verifyTurnstile(request, env, turnstileToken);
     if (!turnstileValid) {
       return new Response(
-        JSON.stringify({ error: 'Bot verification failed' }),
+        JSON.stringify({ error: "Bot verification failed" }),
         {
           status: 403,
-          headers: { 'Content-Type': 'application/json' },
-        }
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
 
@@ -110,7 +102,7 @@ export async function onRequestPost(context) {
       `
       SELECT id, verified, verification_token FROM email_subscriptions
       WHERE email = ? AND city = ? AND genre = ?
-    `
+    `,
     )
       .bind(email, city, genre)
       .all();
@@ -119,12 +111,12 @@ export async function onRequestPost(context) {
       if (existing[0].verified) {
         return new Response(
           JSON.stringify({
-            error: 'You are already subscribed to this feed',
+            error: "You are already subscribed to this feed",
           }),
           {
             status: 400,
-            headers: { 'Content-Type': 'application/json' },
-          }
+            headers: { "Content-Type": "application/json" },
+          },
         );
       } else {
         // Re-send verification email
@@ -133,89 +125,103 @@ export async function onRequestPost(context) {
           email,
           city,
           genre,
-          existing[0].verification_token
+          existing[0].verification_token,
         );
 
-        if (!emailResult.delivered && emailResult.reason === 'not_configured') {
+        if (!emailResult.delivered && emailResult.reason === "not_configured") {
           return subscriptionResponse(
             {
               message:
-                'Email delivery is not configured. Use the link below to verify your subscription.',
+                "Email delivery is not configured. Use the link below to verify your subscription.",
             },
             200,
-            emailResult
+            emailResult,
           );
         }
 
         return new Response(
           JSON.stringify({
-            message: 'Verification email sent. Please check your inbox.',
+            message: "Verification email sent. Please check your inbox.",
           }),
           {
             status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          }
+            headers: { "Content-Type": "application/json" },
+          },
         );
       }
     }
 
     // Create subscription
-    const consentIp = request.headers.get('CF-Connecting-IP') ?? null;
+    const consentIp = request.headers.get("CF-Connecting-IP") ?? null;
     try {
       await env.DB.prepare(
         `
         INSERT INTO email_subscriptions (email, city, genre, frequency, verification_token, unsubscribe_token, consent_ip, consent_method)
         VALUES (?, ?, ?, ?, ?, ?, ?, 'web_form')
-      `
+      `,
       )
-        .bind(email, city, genre, frequency, verificationToken, unsubscribeToken, consentIp)
+        .bind(
+          email,
+          city,
+          genre,
+          frequency,
+          verificationToken,
+          unsubscribeToken,
+          consentIp,
+        )
         .run();
     } catch (insertError) {
-      if (insertError?.message?.includes('UNIQUE constraint failed')) {
+      if (insertError?.message?.includes("UNIQUE constraint failed")) {
         return new Response(
-          JSON.stringify({ error: 'You are already subscribed to this feed' }),
-          { status: 400, headers: { 'Content-Type': 'application/json' } }
+          JSON.stringify({ error: "You are already subscribed to this feed" }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
         );
       }
       throw insertError;
     }
 
     // Send verification email
-    const emailResult = await sendVerificationEmail(env, email, city, genre, verificationToken);
+    const emailResult = await sendVerificationEmail(
+      env,
+      email,
+      city,
+      genre,
+      verificationToken,
+    );
 
-    if (!emailResult.delivered && emailResult.reason === 'not_configured') {
+    if (!emailResult.delivered && emailResult.reason === "not_configured") {
       return subscriptionResponse(
         {
           message:
-            'Subscription created. Email delivery is not configured; use the link below to verify your subscription.',
+            "Subscription created. Email delivery is not configured; use the link below to verify your subscription.",
         },
         201,
-        emailResult
+        emailResult,
       );
     }
 
     return new Response(
       JSON.stringify({
-        message: 'Subscription created. Please check your email to verify.',
+        message: "Subscription created. Please check your email to verify.",
       }),
       {
         status: 201,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   } catch (error) {
-    console.error('Subscription error:', error);
-    return new Response(JSON.stringify({ error: 'Subscription failed' }), {
+    console.error("Subscription error:", error);
+    return new Response(JSON.stringify({ error: "Subscription failed" }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 }
 
 async function sendVerificationEmail(env, email, city, genre, token) {
-  const baseUrl = env.PUBLIC_URL || 'http://localhost:5173';
+  const baseUrl = env.PUBLIC_URL || "http://localhost:5173";
   const verifyUrl = `${baseUrl}/verify?token=${token}`;
-  const subject = 'Confirm your SetTimes subscription';
+  const subject = "Confirm your SetTimes subscription";
   const safeCity = escapeHtml(city);
   const safeGenre = escapeHtml(genre);
   const text = `Please confirm your subscription.\n\nVerify: ${verifyUrl}\n\nCity: ${city}\nGenre: ${genre}`;
@@ -235,8 +241,8 @@ async function sendVerificationEmail(env, email, city, genre, token) {
     return { ...emailResult, verifyUrl };
   } else {
     console.warn(
-      '[Subscribe] Email not configured; verification email was not sent.'
+      "[Subscribe] Email not configured; verification email was not sent.",
     );
-    return { delivered: false, reason: 'not_configured', verifyUrl };
+    return { delivered: false, reason: "not_configured", verifyUrl };
   }
 }

--- a/functions/api/subscriptions/unsubscribe.js
+++ b/functions/api/subscriptions/unsubscribe.js
@@ -1,17 +1,7 @@
 // Unsubscribe endpoint
 // GET /api/subscriptions/unsubscribe?token=xxx
 
-// HTML escape function to prevent XSS
-function escapeHtml(text) {
-  const map = {
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    '"': "&quot;",
-    "'": "&#039;",
-  };
-  return text.replace(/[&<>"']/g, (m) => map[m]);
-}
+import { escapeHtml } from "../../utils/html.js";
 
 export async function onRequestGet(context) {
   const { request, env } = context;

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -1,4 +1,5 @@
 import Database from "better-sqlite3";
+import { normalizeBandName } from "../utils/bandName.js";
 
 export function createTestDB() {
   const db = new Database(":memory:");
@@ -406,7 +407,7 @@ export function insertBand(
   } = {},
 ) {
   // Insert into band_profiles + performances (v2 schema)
-  const nameNormalized = name.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const nameNormalized = normalizeBandName(name);
   let profileId;
   const resolvedSocialLinks =
     social_links ?? (url ? JSON.stringify({ website: url }) : null);

--- a/functions/utils/announceDigest.js
+++ b/functions/utils/announceDigest.js
@@ -11,14 +11,7 @@
 
 import { sendEmail } from "./email.js";
 import { logger } from "./logger.js";
-
-const escapeHtml = (s) =>
-  String(s ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+import { escapeHtml } from "./html.js";
 
 export async function flushAnnounceDigest(env, DB) {
   const publicUrl = env.PUBLIC_URL || "https://settimes.ca";

--- a/functions/utils/bandFollowNotify.js
+++ b/functions/utils/bandFollowNotify.js
@@ -8,16 +8,7 @@
 // endpoint (bands/[id]/resend-announcement.js).
 import { sendEmail } from "./email.js";
 import { logger } from "./logger.js";
-
-// Escape plain-text band/event names for safe interpolation into the email HTML.
-// Mirrors the escaper in bands/[id].js (regex .replace, the codebase convention).
-const escapeHtml = (s) =>
-  String(s ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+import { escapeHtml } from "./html.js";
 
 export async function notifyBandFollowers(
   env,

--- a/functions/utils/bandName.js
+++ b/functions/utils/bandName.js
@@ -1,0 +1,8 @@
+// Canonical band-name matching key. Populates/matches band_profiles.name_normalized.
+// Must stay byte-identical everywhere — changing it breaks find-or-create matching
+// of bands (lineup import, follow-matching). Do not "improve" the regex.
+export function normalizeBandName(name) {
+  return String(name ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}

--- a/functions/utils/html.js
+++ b/functions/utils/html.js
@@ -1,0 +1,9 @@
+// Escape plain text for safe interpolation into HTML email bodies.
+export function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}


### PR DESCRIPTION
Closes #414.

Two security/correctness-relevant helpers were copy-pasted with no single source of truth:
- **`normalizeName`** (9 copies) — the canonical find-or-create matching key for band profiles (populates/matches `band_profiles.name_normalized`). If one copy diverged, lineup imports and follow-matching would silently mismatch / create duplicate profiles.
- **`escapeHtml`** (7 copies) — HTML-escaping for outbound email bodies; a security-relevant primitive that should have one definition.

## Changes
- New `functions/utils/bandName.js` → `normalizeBandName()` (with a "do not change the regex" warning, since it must stay byte-identical to existing `name_normalized` values).
- New `functions/utils/html.js` → `escapeHtml()`.
- All 9 + 7 inline copies replaced with imports across 17 files.

## Behavior preservation
All 9 `normalizeName` copies were verified **byte-identical** before unifying. For `escapeHtml`, 5 of 7 were identical; two diverged and were unified to the canonical form: `subscribe.js` was missing `?? ""` null-handling (no output change for real string inputs), and `unsubscribe.js` used `&#039;` instead of `&#39;` for the apostrophe entity — **equivalent HTML** (the leading zero is insignificant), and the escaped values (`city`, `PUBLIC_URL`) don't realistically contain a single quote.

## Testing
`492 passed (64 files), 6 todo` — the band import/follow/announce hot paths are covered and stayed green. Confirming greps show zero remaining inline copies of either helper.

> Note: touches `announceDigest.js` + `bandFollowNotify.js`, which PR #423 (#406) also touches (different lines — helper removal vs. logger calls); whichever merges second may want a one-click rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)