### PR TITLE
perf(admin): lazy-load admin panel — login route 669KB → 11KB (#409)

### DIFF
--- a/frontend/src/admin/AdminApp.jsx
+++ b/frontend/src/admin/AdminApp.jsx
@@ -1,10 +1,15 @@
+import { lazy, Suspense } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import AdminLogin from './AdminLogin'
-import AdminPanel from './AdminPanel'
-import SignupPage from './SignupPage'
 import { EventProvider } from '../contexts/EventContext'
 import { ConfirmDialog } from '../components/ui'
 import { useAdminAuthSession } from './hooks/useAdminAuthSession'
+
+// Lazy-load heavy admin routes so the /admin/login path ships a minimal chunk.
+// Quill + DOMPurify (pulled in by AdminPanel's RichTextEditor) stay out of the
+// login bundle and are fetched only after the user authenticates.
+const AdminPanel = lazy(() => import('./AdminPanel'))
+const SignupPage = lazy(() => import('./SignupPage'))
 
 /**
  * AdminApp - Root component for the admin interface
@@ -43,32 +48,42 @@ export default function AdminApp() {
     )
   }
 
+  // Suspense fallback shown while the AdminPanel / SignupPage lazy chunk loads.
+  // Admin is dark-pinned, so text-white is correct here (not a theme violation).
+  const adminFallback = (
+    <div className="min-h-screen bg-bg-navy flex items-center justify-center">
+      <div className="text-white/60 text-lg">Loading…</div>
+    </div>
+  )
+
   return (
     // Admin is pinned to the dark theme — it should not follow the visitor's
     // public theme pick (it is a tool, not a vibe). display:contents keeps this
     // wrapper layout-transparent while providing the data-theme token context.
     <div data-theme="midnight-ember" className="contents">
-      <Routes>
-        <Route
-          path="login"
-          element={
-            isAuthenticated ? <Navigate to="/admin" replace /> : <AdminLogin onLoginSuccess={handleLoginSuccess} />
-          }
-        />
-        <Route path="signup" element={isAuthenticated ? <Navigate to="/admin" replace /> : <SignupPage />} />
-        <Route
-          path="*"
-          element={
-            isAuthenticated ? (
-              <EventProvider>
-                <AdminPanel currentUser={currentUser} onLogout={logout} />
-              </EventProvider>
-            ) : (
-              <Navigate to="/admin/login" replace />
-            )
-          }
-        />
-      </Routes>
+      <Suspense fallback={adminFallback}>
+        <Routes>
+          <Route
+            path="login"
+            element={
+              isAuthenticated ? <Navigate to="/admin" replace /> : <AdminLogin onLoginSuccess={handleLoginSuccess} />
+            }
+          />
+          <Route path="signup" element={isAuthenticated ? <Navigate to="/admin" replace /> : <SignupPage />} />
+          <Route
+            path="*"
+            element={
+              isAuthenticated ? (
+                <EventProvider>
+                  <AdminPanel currentUser={currentUser} onLogout={logout} />
+                </EventProvider>
+              ) : (
+                <Navigate to="/admin/login" replace />
+              )
+            }
+          />
+        </Routes>
+      </Suspense>
 
       <ConfirmDialog
         isOpen={showIdleWarning}


### PR DESCRIPTION
Closes #409. Roadmap Track E P0(a) follow-up.

`/admin/login` statically imported `AdminPanel` (→ Quill rich-text editor + DOMPurify) and `SignupPage`, so the login screen downloaded the **entire** admin surface as one 669 KB / 188 KB-gz chunk.

## Fix
Lazy-load `AdminPanel` + `SignupPage` behind `Suspense` (`AdminLogin` stays eager — it's the first paint). Dark-pinned fallback (`text-white` is correct inside admin).

## Measured win (real `npm run build`)
| Chunk | Before | After |
|---|---|---|
| `AdminApp` (login route, initial) | 669 KB / 188 KB gz | **10.93 KB / 3.63 KB gz** |
| `AdminPanel` (lazy, post-auth) | — | 642 KB / 181 KB gz |
| `SignupPage` (lazy) | — | 6.6 KB / 1.9 KB gz |
| `purify.es` (DOMPurify) | eager | **deferred** to AdminPanel |

Login route initial JS is **~61× smaller**; Quill/DOMPurify load only after authentication.

## Testing
Frontend suite green: lint + format clean, 204 tests, build succeeds. Admin behavior unchanged — `AdminPanel` renders after login with a brief fallback while its chunk loads (admin-only, behind auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)