### PR TITLE
fix(pwa): network-first navigations + bounded API cache in the service worker (Closes #407)

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,19 +1,28 @@
-const CACHE_VERSION = 'v3'
-const CACHE_NAME = `schedule-${CACHE_VERSION}`
+const CACHE_VERSION = 'v4'
+const STATIC_CACHE = `schedule-${CACHE_VERSION}`
+const API_CACHE = `api-${CACHE_VERSION}`
+
+// Public API responses are only an offline fallback (navigations and API calls
+// are network-first), so this cache is bounded to keep storage from growing
+// without limit across every /api/schedule, /s/*, timeline call.
+const API_CACHE_MAX_ENTRIES = 50
+
+const CURRENT_CACHES = [STATIC_CACHE, API_CACHE]
 
 // Only cache stable, non-hashed assets on install.
 // Vite hashes JS/CSS filenames (e.g. assets/index-a3f9c.js) so those
 // cannot be precached by name — they are picked up by runtime caching instead.
-const STATIC_ASSETS = ['/', '/index.html', '/manifest.json']
+const STATIC_ASSETS = ['/', '/index.html', '/manifest.json', '/offline.html']
 
 // Install: cache static assets
 self.addEventListener('install', event => {
   console.log('[SW] Installing service worker', CACHE_VERSION)
 
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => {
+    caches.open(STATIC_CACHE).then(cache => {
       console.log('[SW] Caching static assets')
-      return cache.addAll(STATIC_ASSETS)
+      // Don't let one missing optional asset (e.g. offline.html) abort install.
+      return Promise.allSettled(STATIC_ASSETS.map(asset => cache.add(asset)))
     })
   )
 
@@ -21,7 +30,7 @@ self.addEventListener('install', event => {
   self.skipWaiting()
 })
 
-// Activate: clean up old caches
+// Activate: clean up old caches (both the static and api families)
 self.addEventListener('activate', event => {
   console.log('[SW] Activating service worker', CACHE_VERSION)
 
@@ -29,7 +38,11 @@ self.addEventListener('activate', event => {
     caches.keys().then(cacheNames => {
       return Promise.all(
         cacheNames
-          .filter(name => name.startsWith('schedule-') && name !== CACHE_NAME)
+          .filter(
+            name =>
+              (name.startsWith('schedule-') || name.startsWith('api-')) &&
+              !CURRENT_CACHES.includes(name)
+          )
           .map(name => {
             console.log('[SW] Deleting old cache:', name)
             return caches.delete(name)
@@ -42,12 +55,12 @@ self.addEventListener('activate', event => {
   self.clients.claim()
 })
 
-// Fetch: Cache-first with network fallback
+// Fetch routing
 self.addEventListener('fetch', event => {
   const { request } = event
   const url = new URL(request.url)
 
-  // Only cache same-origin requests
+  // Only handle same-origin requests
   if (url.origin !== self.location.origin) {
     return
   }
@@ -58,23 +71,67 @@ self.addEventListener('fetch', event => {
     return
   }
 
-  // Public API requests: Network-first with cache fallback
+  // Public API requests: network-first with a bounded cache fallback.
+  // Must come before the navigate check so that navigations to /api/ URLs
+  // (e.g. /api/bands/:name/confirm-follow, /api/feeds/ical) are handled here
+  // instead of navigationStrategy — preventing non-shell content from being
+  // written to the /index.html cache slot.
   if (url.pathname.startsWith('/api/')) {
     event.respondWith(networkFirstStrategy(request))
     return
   }
 
-  // Static assets: Cache-first with network fallback
+  // Navigations (the HTML document): network-first so a deploy's fresh shell —
+  // which references the current hashed chunks — is always used when online.
+  // Serving a cached shell here pinned stale HTML and caused ChunkLoadError /
+  // blank screens after a deploy until the cache version was bumped.
+  // /api/ paths are already handled above — only true SPA routes reach here.
+  if (request.mode === 'navigate') {
+    event.respondWith(navigationStrategy(request))
+    return
+  }
+
+  // Static assets (hashed JS/CSS/images, manifest): cache-first. These are
+  // content-hashed and immutable, so a cached copy is never stale.
   event.respondWith(cacheFirstStrategy(request))
 })
 
-// Cache-first strategy (for static assets)
+// Network-first navigation strategy. Refreshes the cached shell on success and
+// falls back to it (then the offline page) when the network is unavailable.
+async function navigationStrategy(request) {
+  try {
+    const response = await fetch(request)
+
+    const contentType = response.headers?.get?.('content-type') || ''
+    if (response.ok && contentType.includes('text/html')) {
+      const cache = await caches.open(STATIC_CACHE)
+      // Best-effort shell refresh; swallow rejections so a failed put never
+      // surfaces as an unhandled rejection (the response is returned regardless).
+      cache.put('/index.html', response.clone()).catch(() => {})
+    }
+
+    return response
+  } catch (error) {
+    const cachedShell =
+      (await caches.match('/index.html')) || (await caches.match('/'))
+    if (cachedShell) return cachedShell
+
+    const offlinePage = await caches.match('/offline.html')
+    if (offlinePage) return offlinePage
+
+    return new Response('Offline - content not cached', {
+      status: 503,
+      statusText: 'Service Unavailable',
+    })
+  }
+}
+
+// Cache-first strategy (for immutable, content-hashed static assets)
 async function cacheFirstStrategy(request) {
   const cached = await caches.match(request)
 
   if (cached) {
-    // Return cached version immediately
-    // Update cache in background
+    // Return cached version immediately; refresh in the background.
     updateCache(request)
     return cached
   }
@@ -83,9 +140,8 @@ async function cacheFirstStrategy(request) {
   try {
     const response = await fetch(request)
 
-    // Cache successful responses
     if (response.ok) {
-      const cache = await caches.open(CACHE_NAME)
+      const cache = await caches.open(STATIC_CACHE)
       cache.put(request, response.clone())
     }
 
@@ -93,11 +149,9 @@ async function cacheFirstStrategy(request) {
   } catch (error) {
     console.error('[SW] Fetch failed:', error)
 
-    // Return offline page if available
     const offlinePage = await caches.match('/offline.html')
     if (offlinePage) return offlinePage
 
-    // Return basic error response
     return new Response('Offline - content not cached', {
       status: 503,
       statusText: 'Service Unavailable',
@@ -105,15 +159,16 @@ async function cacheFirstStrategy(request) {
   }
 }
 
-// Network-first strategy (for API requests)
+// Network-first strategy (for public API requests) with a bounded fallback cache
 async function networkFirstStrategy(request) {
   try {
     const response = await fetch(request)
 
-    // Cache successful GET requests
+    // Cache successful GETs as an offline fallback, capping the cache size.
     if (response.ok && request.method === 'GET') {
-      const cache = await caches.open(CACHE_NAME)
-      cache.put(request, response.clone())
+      const cache = await caches.open(API_CACHE)
+      await cache.put(request, response.clone())
+      await trimCache(cache, API_CACHE_MAX_ENTRIES)
     }
 
     return response
@@ -130,13 +185,22 @@ async function networkFirstStrategy(request) {
   }
 }
 
-// Update cache in background
+// Evict oldest entries (Cache.keys() preserves insertion order → FIFO) until the
+// cache holds at most maxEntries.
+async function trimCache(cache, maxEntries) {
+  const keys = await cache.keys()
+  for (let i = 0; i < keys.length - maxEntries; i++) {
+    await cache.delete(keys[i])
+  }
+}
+
+// Update the static cache in the background (best-effort)
 async function updateCache(request) {
   try {
     const response = await fetch(request)
 
     if (response.ok) {
-      const cache = await caches.open(CACHE_NAME)
+      const cache = await caches.open(STATIC_CACHE)
       await cache.put(request, response)
     }
   } catch (error) {

--- a/frontend/src/test/sw.test.js
+++ b/frontend/src/test/sw.test.js
@@ -1,0 +1,306 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Unit tests for the service worker (frontend/public/sw.js).
+//
+// The SW is a classic worker script that talks to the global `self`, `caches`,
+// and `fetch`. We mock those globals, import the script so its event listeners
+// register against our mock `self`, then drive the captured `fetch` handler with
+// duck-typed request objects (a real Request can't be constructed with
+// mode: "navigate", so we pass plain objects exposing the fields the SW reads).
+
+const ORIGIN = 'https://example.test'
+const API_CACHE_MAX_ENTRIES = 50
+
+function cacheKey(req) {
+  return typeof req === 'string' ? new URL(req, ORIGIN).toString() : req.url
+}
+
+// Minimal CacheStorage mock backed by Maps (one per cache name).
+function makeCacheStorage() {
+  const stores = new Map()
+  const wrap = store => ({
+    async match(req) {
+      return store.get(cacheKey(req))
+    },
+    async put(req, res) {
+      store.set(cacheKey(req), res)
+    },
+    async keys() {
+      // Cache.keys() preserves insertion order; return Request-like stubs.
+      return [...store.keys()].map(url => ({ url }))
+    },
+    async delete(req) {
+      return store.delete(cacheKey(req))
+    },
+    async addAll(reqs) {
+      for (const r of reqs) store.set(cacheKey(r), { ok: true })
+    },
+  })
+  return {
+    _stores: stores,
+    async open(name) {
+      if (!stores.has(name)) stores.set(name, new Map())
+      return wrap(stores.get(name))
+    },
+    async match(req) {
+      for (const store of stores.values()) {
+        const hit = store.get(cacheKey(req))
+        if (hit) return hit
+      }
+      return undefined
+    },
+    async keys() {
+      return [...stores.keys()]
+    },
+    async delete(name) {
+      return stores.delete(name)
+    },
+  }
+}
+
+function makeResponse(tag, { contentType = 'text/html', ...extra } = {}) {
+  return {
+    ok: true,
+    _tag: tag,
+    headers: { get: n => (String(n).toLowerCase() === 'content-type' ? contentType : null) },
+    clone() {
+      return this
+    },
+    ...extra,
+  }
+}
+
+let handlers
+
+async function loadServiceWorker() {
+  handlers = {}
+  globalThis.self = {
+    addEventListener: (type, fn) => {
+      handlers[type] = fn
+    },
+    skipWaiting: vi.fn(),
+    clients: { claim: vi.fn() },
+    location: { origin: ORIGIN },
+  }
+  globalThis.caches = makeCacheStorage()
+  vi.resetModules()
+  await import('../../public/sw.js')
+}
+
+// Invoke the captured fetch handler with a duck-typed request and resolve the
+// promise passed to event.respondWith (undefined if the SW passed the request
+// through without responding).
+async function handleFetch(request) {
+  let responded
+  handlers.fetch({
+    request,
+    respondWith: p => {
+      responded = p
+    },
+  })
+  return responded ? await responded : undefined
+}
+
+function allCachedEntries() {
+  return [...globalThis.caches._stores.values()].reduce((n, s) => n + s.size, 0)
+}
+
+describe('service worker fetch routing', () => {
+  beforeEach(async () => {
+    await loadServiceWorker()
+  })
+
+  it('serves navigations network-first — returns the fresh shell even when this exact URL is cached', async () => {
+    // Pre-seed a STALE copy of the very URL being navigated to, so a cache-first
+    // strategy would return it. Network-first must return the fresh network copy.
+    const seeded = await globalThis.caches.open('seed')
+    await seeded.put(`${ORIGIN}/event/some-route`, makeResponse('STALE'))
+
+    globalThis.fetch = vi.fn(async () => makeResponse('FRESH'))
+
+    const res = await handleFetch({
+      url: `${ORIGIN}/event/some-route`,
+      method: 'GET',
+      mode: 'navigate',
+    })
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    expect(res._tag).toBe('FRESH')
+  })
+
+  it('falls back to the cached shell for a navigation when the network is offline', async () => {
+    const cache = await globalThis.caches.open('static')
+    await cache.put(`${ORIGIN}/index.html`, makeResponse('SHELL'))
+
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('offline')
+    })
+
+    const res = await handleFetch({
+      url: `${ORIGIN}/event/some-route`,
+      method: 'GET',
+      mode: 'navigate',
+    })
+
+    expect(res._tag).toBe('SHELL')
+  })
+
+  it('bounds the public API cache to a fixed number of entries (evicts oldest)', async () => {
+    globalThis.fetch = vi.fn(async req => makeResponse('api', { _url: req.url }))
+
+    for (let i = 0; i < API_CACHE_MAX_ENTRIES + 5; i++) {
+      await handleFetch({
+        url: `${ORIGIN}/api/schedule?e=${i}`,
+        method: 'GET',
+        mode: 'cors',
+      })
+    }
+
+    const largestCache = Math.max(...[...globalThis.caches._stores.values()].map(s => s.size))
+    expect(largestCache).toBeLessThanOrEqual(API_CACHE_MAX_ENTRIES)
+  })
+
+  it('never caches admin API responses', async () => {
+    globalThis.fetch = vi.fn(async () => makeResponse('admin'))
+
+    await handleFetch({
+      url: `${ORIGIN}/api/admin/users`,
+      method: 'GET',
+      mode: 'cors',
+    })
+
+    expect(allCachedEntries()).toBe(0)
+  })
+
+  it('networkFirstStrategy: serves cache when offline, re-throws when cache is empty', async () => {
+    // Part A — warm cache: a successful fetch populates the API cache; a
+    // subsequent fetch that throws (offline) must return the cached response.
+    globalThis.fetch = vi.fn(async () => makeResponse('FIRST'))
+    await handleFetch({
+      url: `${ORIGIN}/api/schedule?e=warm`,
+      method: 'GET',
+      mode: 'cors',
+    })
+
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('offline')
+    })
+
+    const res = await handleFetch({
+      url: `${ORIGIN}/api/schedule?e=warm`,
+      method: 'GET',
+      mode: 'cors',
+    })
+    expect(res._tag).toBe('FIRST')
+
+    // Part B — cold cache: network throws and nothing is cached → must re-throw.
+    await expect(
+      handleFetch({
+        url: `${ORIGIN}/api/schedule?e=cold`,
+        method: 'GET',
+        mode: 'cors',
+      })
+    ).rejects.toThrow()
+  })
+
+  it('navigation to an /api/ URL does not poison the /index.html shell (reorder guard)', async () => {
+    // Regression: before the routing reorder, a navigate-mode request to any
+    // /api/ path flowed into navigationStrategy and overwrote /index.html.
+    globalThis.fetch = vi.fn(async () => makeResponse('ICS', { contentType: 'text/calendar' }))
+
+    await handleFetch({
+      url: `${ORIGIN}/api/feeds/ical`,
+      method: 'GET',
+      mode: 'navigate',
+    })
+
+    // After the fix this is routed to networkFirstStrategy (api-v4), not
+    // navigationStrategy, so the static cache must stay empty.
+    expect(await globalThis.caches.match('/index.html')).toBeUndefined()
+    // The response should be cached under its own URL in the API cache.
+    const apiStore = globalThis.caches._stores.get('api-v4')
+    expect(apiStore?.has(`${ORIGIN}/api/feeds/ical`)).toBe(true)
+  })
+
+  it('navigation to /api/…/confirm-follow (text/html) does not overwrite /index.html', async () => {
+    // The confirm-follow and unfollow endpoints return a friendly HTML page.
+    // Without the reorder fix a content-type guard alone would not save us
+    // because navigationStrategy would still be invoked.
+    globalThis.fetch = vi.fn(async () => makeResponse('CONFIRM'))
+
+    await handleFetch({
+      url: `${ORIGIN}/api/bands/test/confirm-follow`,
+      method: 'GET',
+      mode: 'navigate',
+    })
+
+    expect(await globalThis.caches.match('/index.html')).toBeUndefined()
+  })
+
+  it('navigation to a non-HTML non-API resource does not overwrite /index.html (content-type guard)', async () => {
+    // /sitemap.xml is a navigation (user opens it in a tab) but returns XML.
+    // The content-type guard in navigationStrategy must suppress the shell write.
+    globalThis.fetch = vi.fn(async () => makeResponse('SITEMAP', { contentType: 'application/xml' }))
+
+    await handleFetch({
+      url: `${ORIGIN}/sitemap.xml`,
+      method: 'GET',
+      mode: 'navigate',
+    })
+
+    expect(await globalThis.caches.match('/index.html')).toBeUndefined()
+  })
+
+  it('FIFO eviction: oldest entries are evicted first, newest entry is retained', async () => {
+    globalThis.fetch = vi.fn(async req => makeResponse('api', { _url: req.url }))
+
+    for (let i = 0; i < API_CACHE_MAX_ENTRIES + 3; i++) {
+      await handleFetch({
+        url: `${ORIGIN}/api/schedule?e=${i}`,
+        method: 'GET',
+        mode: 'cors',
+      })
+    }
+
+    // The API cache is the largest store after these fetches.
+    const largestStore = [...globalThis.caches._stores.values()].reduce(
+      (max, s) => (s.size > max.size ? s : max),
+      new Map()
+    )
+
+    // Oldest 3 entries (e=0, e=1, e=2) must have been evicted.
+    expect(largestStore.has(`${ORIGIN}/api/schedule?e=0`)).toBe(false)
+    expect(largestStore.has(`${ORIGIN}/api/schedule?e=1`)).toBe(false)
+    expect(largestStore.has(`${ORIGIN}/api/schedule?e=2`)).toBe(false)
+    // Newest entry (e=52) must still be present.
+    expect(largestStore.has(`${ORIGIN}/api/schedule?e=${API_CACHE_MAX_ENTRIES + 2}`)).toBe(true)
+    expect(largestStore.size).toBe(API_CACHE_MAX_ENTRIES)
+  })
+})
+
+describe('service worker activate', () => {
+  beforeEach(async () => {
+    await loadServiceWorker()
+  })
+
+  it('activate deletes old-version caches and leaves current and unrelated caches intact', async () => {
+    // Pre-populate old and current versioned caches, plus an unrelated one.
+    await globalThis.caches.open('schedule-v3')
+    await globalThis.caches.open('api-v3')
+    await globalThis.caches.open('schedule-v4')
+    await globalThis.caches.open('api-v4')
+    await globalThis.caches.open('some-other-cache')
+
+    const promises = []
+    handlers.activate({ waitUntil: p => promises.push(p) })
+    await Promise.all(promises)
+
+    // Old-version schedule-/api- families must be gone.
+    expect(globalThis.caches._stores.has('schedule-v3')).toBe(false)
+    expect(globalThis.caches._stores.has('api-v3')).toBe(false)
+    // Current-version caches and unrelated cache must survive.
+    expect(globalThis.caches._stores.has('schedule-v4')).toBe(true)
+    expect(globalThis.caches._stores.has('api-v4')).toBe(true)
+    expect(globalThis.caches._stores.has('some-other-cache')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
Closes #407. The service worker served the HTML document **cache-first** (pinning a stale `index.html` that referenced purged hashed chunks after a deploy → `ChunkLoadError` / blank screen) and cached **every** public `/api/` GET with **no size cap** (unbounded growth, worst on event day).

## Fix
- **Navigations are network-first** (`navigationStrategy`): a deploy's fresh shell — referencing the current hashed chunks — is always used when online; offline falls back to cached `/index.html` → `/` → `/offline.html` → `503`.
- **Public API responses move to a separate bounded cache** (`api-v4`, max **50** entries, FIFO eviction via `trimCache`), distinct from the static cache (`schedule-v4`). `activate` cleans up both `schedule-*` and `api-*` families. Admin API stays network-only.
- **Shell-poisoning guard:** `/api/` is routed **before** the navigate check, and the shell is only written when `Content-Type: text/html`. So a navigation to an `/api/` URL — e.g. an email `confirm-follow` link (which returns HTML) or `/api/feeds/ical` / `/sitemap.xml` opened in a tab — can never overwrite the `/index.html` shell.

## Tests
Adds the **first service-worker test suite** (`frontend/src/test/sw.test.js`, 10 tests): network-first navigation, offline shell fallback, bounded + FIFO API eviction, `networkFirst` offline fallback / cold re-throw, admin-never-cache, `activate` cleanup, and three shell-poisoning regressions (`/api/feeds/ical`, `/api/…/confirm-follow` HTML, `/sitemap.xml`).

## Verification
Frontend **214 tests pass** (32 files), `build` ✓, `lint` 0 errors, `format:check` clean.

## Process note
Implemented via TDD; the shell-poisoning bug was caught by a code-review pass on the first cut and fixed before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)