### PR TITLE
perf(api): batch the 4 sequential D1 reads in admin event-metrics (Closes #410)

### DIFF
--- a/functions/api/admin/events/[id]/metrics.js
+++ b/functions/api/admin/events/[id]/metrics.js
@@ -16,69 +16,45 @@ export async function onRequestGet(context) {
   }
 
   try {
-    // Get event metrics
-    const metrics = await DB.prepare(
-      `
-      SELECT
-        COUNT(*) as total_schedule_builds,
-        COUNT(DISTINCT user_session) as unique_visitors,
-        MAX(created_at) as last_updated
-      FROM schedule_builds
-      WHERE event_id = ?
-    `,
-    )
-      .bind(eventId)
-      .first();
+    const [metricsRes, popularBandsRes, shareStatsRes, topRoutesRes] = await DB.batch([
+      DB.prepare(
+        `SELECT COUNT(*) as total_schedule_builds,
+                COUNT(DISTINCT user_session) as unique_visitors,
+                MAX(created_at) as last_updated
+         FROM schedule_builds WHERE event_id = ?`,
+      ).bind(eventId),
+      DB.prepare(
+        `SELECT bp.id as band_id, bp.name as band_name,
+                COUNT(sb.performance_id) as schedule_count
+         FROM schedule_builds sb
+         JOIN performances p ON sb.performance_id = p.id
+         JOIN band_profiles bp ON p.band_profile_id = bp.id
+         WHERE sb.event_id = ?
+         GROUP BY bp.id, bp.name
+         ORDER BY schedule_count DESC
+         LIMIT 10`,
+      ).bind(eventId),
+      DB.prepare(
+        `SELECT COUNT(*) AS total_shares,
+                COALESCE(SUM(view_count), 0) AS total_share_views
+         FROM share_links WHERE event_id = ?`,
+      ).bind(eventId),
+      DB.prepare(
+        `SELECT slug, view_count FROM share_links
+         WHERE event_id = ?
+         ORDER BY view_count DESC, created_at DESC
+         LIMIT 10`,
+      ).bind(eventId),
+    ]);
 
-    // Get most popular bands
-    let popularBands;
-    try {
-      popularBands = await DB.prepare(
-        `
-        SELECT
-          bp.id as band_id,
-          bp.name as band_name,
-          COUNT(sb.performance_id) as schedule_count
-        FROM schedule_builds sb
-        JOIN performances p ON sb.performance_id = p.id
-        JOIN band_profiles bp ON p.band_profile_id = bp.id
-        WHERE sb.event_id = ?
-        GROUP BY bp.id, bp.name
-        ORDER BY schedule_count DESC
-        LIMIT 10
-      `,
-      )
-        .bind(eventId)
-        .all();
-    } catch (error) {
-      if (!String(error).includes("performance_id")) {
-        throw error;
-      }
-
-      popularBands = { results: [] };
-    }
+    const metrics = metricsRes.results?.[0];
+    const popularBands = popularBandsRes.results || [];
+    const shareStats = shareStatsRes.results?.[0];
+    const topSharedRoutes = topRoutesRes.results || [];
 
     // Share-link analytics: shares created + total views + top routes by views.
     // Derived directly from share_links (creates are rows; views are view_count),
     // so no separate share telemetry path is needed.
-    const shareStats = await DB.prepare(
-      `SELECT COUNT(*) AS total_shares,
-              COALESCE(SUM(view_count), 0) AS total_share_views
-       FROM share_links WHERE event_id = ?`,
-    )
-      .bind(eventId)
-      .first();
-
-    const topSharedRoutes = await DB.prepare(
-      `SELECT slug, view_count
-       FROM share_links
-       WHERE event_id = ?
-       ORDER BY view_count DESC, created_at DESC
-       LIMIT 10`,
-    )
-      .bind(eventId)
-      .all();
-
     return new Response(
       JSON.stringify({
         success: true,
@@ -86,10 +62,10 @@ export async function onRequestGet(context) {
           totalScheduleBuilds: metrics?.total_schedule_builds || 0,
           uniqueVisitors: metrics?.unique_visitors || 0,
           lastUpdated: metrics?.last_updated,
-          popularBands: popularBands.results || [],
+          popularBands: popularBands,
           totalShares: shareStats?.total_shares || 0,
           totalShareViews: shareStats?.total_share_views || 0,
-          topSharedRoutes: topSharedRoutes.results || [],
+          topSharedRoutes: topSharedRoutes,
         },
       }),
       {

--- a/functions/api/admin/events/__tests__/metrics.test.js
+++ b/functions/api/admin/events/__tests__/metrics.test.js
@@ -22,7 +22,7 @@ vi.mock('../../_middleware.js', () => ({
 }))
 
 import { onRequestGet } from '../[id]/metrics.js'
-import { createTestEnv, insertEvent, insertShareLink } from '../../../test-utils.js'
+import { createTestEnv, insertEvent, insertShareLink, insertBand } from '../../../test-utils.js'
 
 describe('GET /api/admin/events/[id]/metrics', () => {
   function call(env, eventId) {
@@ -68,5 +68,37 @@ describe('GET /api/admin/events/[id]/metrics', () => {
     expect(body.metrics.totalShareViews).toBe(7)
     expect(body.metrics.topSharedRoutes[0].slug).toBe('routeaaa')
     expect(body.metrics.topSharedRoutes[0].view_count).toBe(5)
+  })
+
+  test('popularBands is ordered by schedule_count desc and totalScheduleBuilds/uniqueVisitors reflect inserted rows', async () => {
+    const { env, rawDb } = createTestEnv()
+    const event = insertEvent(rawDb, { name: 'Band Fest', slug: 'band-fest' })
+
+    const perfA = insertBand(rawDb, { name: 'Alpha Band', event_id: event.id })
+    const perfB = insertBand(rawDb, { name: 'Beta Band', event_id: event.id })
+
+    // Alpha Band: 3 schedule builds across 2 sessions
+    rawDb.prepare('INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)').run(event.id, perfA.id, 'session-1')
+    rawDb.prepare('INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)').run(event.id, perfA.id, 'session-2')
+    rawDb.prepare('INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)').run(event.id, perfA.id, 'session-2')
+    // Beta Band: 1 schedule build in a new session
+    rawDb.prepare('INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)').run(event.id, perfB.id, 'session-3')
+
+    const res = await call(env, event.id)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    // popularBands should be a non-empty array ordered by schedule_count desc
+    expect(Array.isArray(body.metrics.popularBands)).toBe(true)
+    expect(body.metrics.popularBands.length).toBeGreaterThan(0)
+    expect(body.metrics.popularBands[0].band_name).toBe('Alpha Band')
+    expect(body.metrics.popularBands[0].schedule_count).toBe(3)
+    expect(body.metrics.popularBands[1].band_name).toBe('Beta Band')
+    expect(body.metrics.popularBands[1].schedule_count).toBe(1)
+
+    // totalScheduleBuilds: 4 rows inserted
+    expect(body.metrics.totalScheduleBuilds).toBe(4)
+    // uniqueVisitors: 3 distinct sessions
+    expect(body.metrics.uniqueVisitors).toBe(3)
   })
 })


### PR DESCRIPTION
## Summary
Closes #410. The admin event-metrics endpoint ran **4 independent D1 reads** (event metrics, popular bands, share stats, top shared routes) as separate `await`s — ~4 round-trips per dashboard load. They're now a single **`DB.batch([...])`** (1 round-trip). The JSON response shape is byte-for-byte identical.

## Changes
- `functions/api/admin/events/[id]/metrics.js` — four `await DB.prepare(...).first()/.all()` calls → one `DB.batch([...])`. The two `.first()` reads map to `batch[i].results[0]`, the two `.all()` reads to `batch[i].results`.
- **Removed the dead `popularBands` try/catch** that swallowed a "missing `schedule_builds.performance_id` column" error. That column has been `NOT NULL` since the table's original migration (`0007_migration-metrics.sql`), so the tolerated error cannot occur; genuine errors already 500 via the outer try/catch, and `DB.batch()` is atomic (a per-query catch isn't possible inside it anyway).
- Added a test covering the previously-untested `popularBands` path (ordering by `schedule_count`, plus `totalScheduleBuilds` / `uniqueVisitors`).

## Verification
Full backend suite **510 passed** (66 files); metrics test file 2 passed. Response shape unchanged → no OpenAPI/contract impact.

## Process
Designed by Opus (batch shape + the safety analysis for removing the try/catch), implemented by a Sonnet agent from that spec, reviewed + re-verified by Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)