### PR TITLE
security(auth): isDevRequest defaults to secure when ENVIRONMENT is unset (Closes #425)

### DIFF
--- a/.github/workflows/e2e-a11y-visual.yml
+++ b/.github/workflows/e2e-a11y-visual.yml
@@ -72,7 +72,7 @@ jobs:
                   E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD  }}
                   E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL  }}
               run: |
-                  printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\n' > .dev.vars
+                  printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\nENVIRONMENT="development"\n' > .dev.vars
 
                   echo "Initializing D1 database with schema..."
                   ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/setup-complete.sql

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -83,7 +83,7 @@ jobs:
                   E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
                   E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
               run: |
-                  printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\n' > .dev.vars
+                  printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\nENVIRONMENT="development"\n' > .dev.vars
 
                   echo "Initializing D1 database with schema..."
                   ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/setup-complete.sql

--- a/.github/workflows/update-visual-snapshots.yml
+++ b/.github/workflows/update-visual-snapshots.yml
@@ -70,7 +70,7 @@ jobs:
                   E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD  }}
                   E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL  }}
               run: |
-                  printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\n' > .dev.vars
+                  printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\nENVIRONMENT="development"\n' > .dev.vars
 
                   ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/setup-complete.sql
                   ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/seed-test-data.sql

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,10 @@ cp .dev.vars.example .dev.vars   # then fill in CSRF_SECRET, etc.
 npm run migrate:local
 
 # 5. Start the local full-stack server (Pages Functions + Vite HMR)
-cd frontend && npx wrangler pages dev --port 8788
+npm run pages:dev
 ```
+
+> **`ENVIRONMENT=development` is required for local dev.** Without it, `isDevRequest()` defaults to production-secure behavior and the session cookie is set with the `Secure` flag, which browsers reject over plain `http://localhost`. `npm run pages:dev` passes `--binding ENVIRONMENT=development` automatically, so you do not need to set it manually.
 
 The admin panel is at `http://localhost:8788/admin`. Create a first admin user with:
 

--- a/functions/api/subscriptions/__tests__/helpers.js
+++ b/functions/api/subscriptions/__tests__/helpers.js
@@ -16,7 +16,11 @@ export function createMockContext(mockDB) {
   return {
     env: {
       DB: mockDB,
-      PUBLIC_URL: 'https://example.com'
+      PUBLIC_URL: 'https://example.com',
+      // Required so isDevRequest() returns true and Turnstile/CSRF skip in
+      // unit tests.  Without an explicit ENVIRONMENT the security default is
+      // now "production" (secure/closed), not localhost-sniffing. (#425)
+      ENVIRONMENT: 'test',
     }
   }
 }

--- a/functions/utils/__tests__/auth.test.js
+++ b/functions/utils/__tests__/auth.test.js
@@ -1,7 +1,7 @@
 // functions/utils/__tests__/auth.test.js
 import { describe, test, expect, beforeEach } from 'vitest';
 import { createTestDB, createDBEnv, mockUsers } from '../../api/test-utils.js';
-import { initializeLucia } from '../auth.js';
+import { initializeLucia, isDevRequest } from '../auth.js';
 
 function makeEnv(rawDb, opts = {}) {
   return {
@@ -15,6 +15,54 @@ function makeRequest(opts = {}) {
     headers: opts.headers ?? {},
   });
 }
+
+describe('isDevRequest', () => {
+  const localhostRequest = new Request('http://localhost:8788/api/x', {
+    headers: { Host: 'localhost:8788' },
+  });
+  const prodRequest = new Request('https://settimes.ca/api/x', {
+    headers: { Host: 'settimes.ca' },
+  });
+
+  test('returns false when ENVIRONMENT is "production"', () => {
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'production' })).toBe(false);
+  });
+
+  test('returns true when ENVIRONMENT is "development"', () => {
+    expect(isDevRequest(localhostRequest, { ENVIRONMENT: 'development' })).toBe(true);
+  });
+
+  test('returns true when ENVIRONMENT is "test"', () => {
+    expect(isDevRequest(localhostRequest, { ENVIRONMENT: 'test' })).toBe(true);
+  });
+
+  test('returns false for a deployed non-allowlisted ENVIRONMENT like "staging" (secure by default)', () => {
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'staging' })).toBe(false);
+  });
+
+  test('fails CLOSED (secure) for a typo / case / whitespace variant of "production"', () => {
+    // A misconfigured prod ENVIRONMENT value must never downgrade to insecure dev mode.
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'Production' })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'PRODUCTION' })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'prod' })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'production\n' })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: '  production  ' })).toBe(false);
+  });
+
+  test('returns false when ENVIRONMENT is unset ({}), even for a localhost Host/url (#425 security)', () => {
+    // The Host header is client-controlled — trusting it when env is unset would let
+    // an attacker coerce a misconfigured deploy into dev (insecure) cookie behavior.
+    expect(isDevRequest(localhostRequest, {})).toBe(false);
+  });
+
+  test('returns false when env is null, even for a localhost request', () => {
+    expect(isDevRequest(localhostRequest, null)).toBe(false);
+  });
+
+  test('returns false when called without env argument (isDevRequest(request))', () => {
+    expect(isDevRequest(localhostRequest)).toBe(false);
+  });
+});
 
 describe('initializeLucia / session manager', () => {
   let rawDb;

--- a/functions/utils/auth.js
+++ b/functions/utils/auth.js
@@ -6,12 +6,18 @@ export const SESSION_CONFIG = {
 };
 
 export function isDevRequest(request, env = null) {
-  if (env?.ENVIRONMENT === 'production') return false;
-  if (env?.ENVIRONMENT && env.ENVIRONMENT !== 'production') return true;
-  if (!request) return false;
-  const host = request.headers.get('Host') || '';
-  const url = request.url || '';
-  return host.includes('localhost') || url.includes('localhost');
+  // Secure by default: dev (insecure-over-http cookie / CSRF / Turnstile)
+  // behavior is enabled ONLY for an explicit, known dev ENVIRONMENT value.
+  // Everything else fails CLOSED to secure — production, a typo/case/whitespace
+  // variant of the prod value ("Production", "prod", " production\n"), an
+  // unexpected value, or unset. We never trust the client-controlled Host
+  // header to decide this. (#425)
+  const environment = (env?.ENVIRONMENT ?? "").trim().toLowerCase();
+  return (
+    environment === "development" ||
+    environment === "dev" ||
+    environment === "test"
+  );
 }
 
 const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "SetTimes.ca - Event Schedule & Performance Management Platform",
   "scripts": {
-    "pages:dev": "./frontend/node_modules/.bin/wrangler pages dev frontend/dist --port 8788 --persist-to .wrangler/state",
+    "pages:dev": "./frontend/node_modules/.bin/wrangler pages dev frontend/dist --port 8788 --persist-to .wrangler/state --binding ENVIRONMENT=development",
     "pages:dev:public": "npm run pages:dev -- --binding PUBLIC_DATA_PUBLISH_ENABLED=true",
     "migrate:local": "bash scripts/migrate-local-db.sh",
     "validate:schema": "node scripts/validate-db-schema.js",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,7 +4,7 @@ import { defineConfig, devices } from '@playwright/test';
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8788';
 const useWrangler = process.env.PLAYWRIGHT_USE_WRANGLER !== 'false';
 const webServerCommand = useWrangler
-  ? 'npx wrangler pages dev frontend/dist --port 8788'
+  ? 'npx wrangler pages dev frontend/dist --port 8788 --binding ENVIRONMENT=development'
   : 'npm run dev --prefix frontend';
 const storageStatePath = 'e2e/.auth/admin.json';
 const skipA11yVisual = process.env.PLAYWRIGHT_SKIP_A11Y_VISUAL === 'true';


### PR DESCRIPTION
## Summary
Closes #425. `isDevRequest()` fell back to sniffing the **client-controlled** `Host`/URL for `localhost` when `env.ENVIRONMENT` was unset — so a deploy that forgot `ENVIRONMENT=production` could be coerced into dev cookie / CSRF / Turnstile behavior via a spoofed `Host` header. Now **secure by default**.

## Change
- `functions/utils/auth.js` — `isDevRequest` enables dev behavior **only** for an explicit, normalized (trim + lowercase) dev value: `development` / `dev` / `test`. Everything else — unset, `production`, a **typo/case/whitespace variant** of the prod value (`"Production"`, `"prod"`, `"production\n"`), or any unexpected value — **fails closed to secure**. The Host header is never trusted.
  - *(Allowlist form per the security review: the original `!== "production"` rule treated any non-prod value as dev, so a typo'd prod `ENVIRONMENT` would silently downgrade cookies. The allowlist fails closed instead.)*
- **Coordinated dev/E2E config** so local + CI keep dev cookies over `http://localhost`:
  - `--binding ENVIRONMENT=development` on the `pages:dev` npm script and the Playwright local `webServer` command.
  - `ENVIRONMENT="development"` added to the `.dev.vars` printf in `e2e-tests.yml`, `e2e-a11y-visual.yml`, `update-visual-snapshots.yml`.
  - `CONTRIBUTING.md` note.
- `functions/api/subscriptions/__tests__/helpers.js` — explicit `ENVIRONMENT: 'test'` (it had been relying on the removed Host sniff).
- 8 `isDevRequest` unit tests, incl. the **Host-not-trusted** and **fail-closed-on-typo** invariants.

## Security review (Cass)
Full audit of `isDevRequest` + all four callers, the deploy pipeline, and every other `Host`/`Origin`/`ENVIRONMENT` gate. Verdict: **net security improvement, merge-ready**. Confirmed: no `ENVIRONMENT=development` leak into production (`wrangler pages deploy` doesn't read `.dev.vars`; prod env is set in the CF dashboard), Turnstile now fails **closed** in prod (the old `Host: localhost` bypass is gone), and `__Host-`/`Secure`/`SameSite` cookie attributes are intact. The allowlist hardening above is from her one in-scope recommendation.

A sibling finding (email/security-link base-URL falls back to `new URL(request.url).origin` when `PUBLIC_URL` is unset — reset-link poisoning) is a different code path and is filed as a **follow-up issue**.

## Verification
Full backend suite **518 passed**. E2E auth is validated by this PR's CI (the three workflows now set `ENVIRONMENT=development` for the local wrangler dev server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)