### PR TITLE
feat(follow): batch follow-all backend — endpoints + migration (Part of #447)

### DIFF
--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -368,10 +368,12 @@ CREATE TABLE IF NOT EXISTS band_follows (
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   consent_ip TEXT,
   consent_method TEXT NOT NULL DEFAULT 'web_form',
+  batch_token TEXT,
   UNIQUE(email, band_profile_id)
 );
 CREATE INDEX IF NOT EXISTS idx_band_follows_band ON band_follows(band_profile_id);
 CREATE INDEX IF NOT EXISTS idx_band_follows_email ON band_follows(email);
+CREATE INDEX IF NOT EXISTS idx_band_follows_batch_token ON band_follows(batch_token);
 
 CREATE TABLE IF NOT EXISTS band_follow_notifications (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -90,6 +90,8 @@ Following a band is **double opt-in**: a follow is created unverified and only a
 | `/api/bands/{name}/follow`         | `POST` | Body: `{ email, turnstileToken? }`. Bot-protected by Turnstile. Always returns `200` for valid input (no enumeration). `confirmUrl` is returned only when email is unconfigured (dev). |
 | `/api/bands/{name}/confirm-follow` | `GET`  | Verifies a pending follow via `?token=` and renders an HTML page. Idempotent; messaging is generic to avoid leaking token validity.                                                    |
 | `/api/bands/{name}/unfollow`       | `GET`  | Deletes the follow tied to the unsubscribe `?token=` and renders an HTML page. Returns `200` whether or not the token existed.                                                         |
+| `/api/bands/follow-batch`          | `POST` | Body: `{ email, performance_ids: number[], turnstileToken? }`. Resolves performance IDs to bands; inserts one `verified=0` row per band (INSERT OR IGNORE), all sharing a `batch_token`. Sends **exactly one** combined confirmation email (amplification mitigation). Always returns `200` for valid input; `confirmUrl` only in dev. |
+| `/api/bands/confirm-follow-batch`  | `GET`  | `?token=<batch_token>` — flips all rows sharing that token to `verified=1` and clears the token (idempotent). Generic HTML page; no enumeration of token validity.                    |
 
 ### Public request notes
 

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -603,6 +603,84 @@ paths:
               schema:
                 type: string
 
+  /api/bands/follow-batch:
+    post:
+      tags:
+        - Public
+      summary: Batch follow bands (double opt-in)
+      description: |
+        Registers an email to be notified when any of the given bands joins a
+        lineup. `performance_ids` is resolved to distinct `band_profile_ids`;
+        one `band_follows` row per band is inserted (`verified=0`,
+        `INSERT OR IGNORE`). All rows share a single `batch_token` so that
+        **exactly one** combined confirmation email is sent — one Turnstile
+        solve → one email, regardless of how many bands are in the batch
+        (amplification mitigation). A confirmed address receives announcement
+        emails only after clicking the confirm link (`verify=1`). Always
+        returns `200` for valid input (no enumeration of existing follows).
+        `confirmUrl` is returned only when email delivery is unconfigured
+        (local/dev).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BandFollowBatchRequest"
+      responses:
+        "200":
+          description: Batch accepted (one confirmation email sent if any follow was new)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BandFollowResponse"
+        "400":
+          description: Invalid email, failed bot verification, or invalid performance_ids
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /api/bands/confirm-follow-batch:
+    get:
+      tags:
+        - Public
+      summary: Confirm a pending batch band follow
+      description: |
+        Verifies all pending (`verified=0`) `band_follows` rows that share the
+        given `batch_token`, setting `verified=1` and clearing the token in one
+        statement. Idempotent: a second click finds no matching rows (token is
+        `NULL` after the first confirm) and returns the same success page.
+        Messaging is generic to avoid revealing whether the token was valid.
+      parameters:
+        - name: token
+          in: query
+          required: true
+          description: Shared batch_token from the confirmation email link
+          schema:
+            type: string
+            maxLength: 256
+      responses:
+        "200":
+          description: HTML confirmation page (success or already-confirmed)
+          content:
+            text/html:
+              schema:
+                type: string
+        "400":
+          description: Missing or oversized token
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Server error
+          content:
+            text/plain:
+              schema:
+                type: string
+
   /api/feeds/ical:
     get:
       tags:
@@ -3508,6 +3586,28 @@ components:
         confirmUrl:
           type: string
           description: Returned only when email delivery is unconfigured (local/dev)
+
+    BandFollowBatchRequest:
+      type: object
+      required:
+        - email
+        - performance_ids
+      properties:
+        email:
+          type: string
+          format: email
+          maxLength: 320
+        performance_ids:
+          type: array
+          description: Performance IDs to follow; resolved to distinct band_profile_ids
+          minItems: 1
+          maxItems: 30
+          items:
+            type: integer
+            minimum: 1
+        turnstileToken:
+          type: string
+          description: Cloudflare Turnstile token; required in production
 
     ScheduleShareRequest:
       type: object

--- a/functions/api/bands/__tests__/follow-batch.test.js
+++ b/functions/api/bands/__tests__/follow-batch.test.js
@@ -1,0 +1,369 @@
+import { describe, it, expect } from 'vitest'
+import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
+import * as followBatchHandler from '../follow-batch.js'
+import * as confirmBatchHandler from '../confirm-follow-batch.js'
+
+// waitUntil in tests: run the promise synchronously so email side-effects
+// execute before assertions (mirrors follow.test.js pattern).
+const waitUntil = (p) => p
+
+describe('POST /api/bands/follow-batch', () => {
+  it('inserts N verified=0 rows all sharing one batch_token', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-batch' })
+    const b1 = insertBand(rawDb, { name: 'Alpha', event_id: ev.id })
+    const b2 = insertBand(rawDb, { name: 'Beta', event_id: ev.id })
+    const b3 = insertBand(rawDb, { name: 'Gamma', event_id: ev.id })
+
+    const req = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'fan@example.com',
+        performance_ids: [b1.id, b2.id, b3.id],
+      }),
+    })
+    const res = await followBatchHandler.onRequestPost({
+      request: req,
+      env,
+      waitUntil,
+    })
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.success).toBe(true)
+
+    const rows = rawDb
+      .prepare('SELECT * FROM band_follows WHERE email = ? ORDER BY id')
+      .all('fan@example.com')
+
+    // Three rows — one per band
+    expect(rows).toHaveLength(3)
+
+    // Security invariant: every row must be unverified
+    for (const row of rows) {
+      expect(row.verified).toBe(0)
+      expect(row.verification_token).toBeTruthy()
+      expect(row.unsubscribe_token).toBeTruthy()
+      expect(row.consent_method).toBe('web_form')
+    }
+
+    // All three rows share the same batch_token
+    const tokens = new Set(rows.map((r) => r.batch_token))
+    expect(tokens.size).toBe(1)
+    expect([...tokens][0]).toBeTruthy()
+  })
+
+  it('returns confirmUrl in dev (email unconfigured) instead of sending email', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-confirmurl' })
+    const b1 = insertBand(rawDb, { name: 'Dev Band A', event_id: ev.id })
+    const b2 = insertBand(rawDb, { name: 'Dev Band B', event_id: ev.id })
+
+    const req = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'dev@example.com',
+        performance_ids: [b1.id, b2.id],
+      }),
+    })
+    const res = await followBatchHandler.onRequestPost({
+      request: req,
+      env,
+      waitUntil,
+    })
+
+    const data = await res.json()
+    expect(data.success).toBe(true)
+    // Dev env: email not configured → confirmUrl included
+    expect(data.confirmUrl).toMatch(/\/api\/bands\/confirm-follow-batch\?token=/)
+  })
+
+  it('is idempotent — re-submitting the same email returns 200 with no duplicate rows', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-idempotent' })
+    const b1 = insertBand(rawDb, { name: 'Idem Band', event_id: ev.id })
+
+    const makeReq = () =>
+      new Request('https://example.test/api/bands/follow-batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'idem@example.com',
+          performance_ids: [b1.id],
+        }),
+      })
+
+    const r1 = await followBatchHandler.onRequestPost({ request: makeReq(), env, waitUntil })
+    const r2 = await followBatchHandler.onRequestPost({ request: makeReq(), env, waitUntil })
+
+    expect(r1.status).toBe(200)
+    expect(r2.status).toBe(200)
+
+    const rows = rawDb
+      .prepare('SELECT * FROM band_follows WHERE email = ?')
+      .all('idem@example.com')
+    // INSERT OR IGNORE: no duplicate rows
+    expect(rows).toHaveLength(1)
+  })
+
+  it('no-enumeration: existing follows return 200 without leaking state', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-noenum' })
+    const band = insertBand(rawDb, { name: 'Existing Band', event_id: ev.id })
+
+    // Pre-seed a verified follow
+    rawDb
+      .prepare(
+        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)',
+      )
+      .run('existing@example.com', band.band_profile_id, 'existing-unsub')
+
+    const req = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'existing@example.com',
+        performance_ids: [band.id],
+      }),
+    })
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.success).toBe(true)
+    // No confirmUrl leaked — no new row was created
+    expect(data.confirmUrl).toBeUndefined()
+
+    // Original verified row untouched; no duplicate
+    const rows = rawDb
+      .prepare('SELECT * FROM band_follows WHERE email = ?')
+      .all('existing@example.com')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].verified).toBe(1)
+  })
+
+  it('returns 400 for an invalid email', async () => {
+    const { env } = createTestEnv()
+
+    const req = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'not-an-email', performance_ids: [1] }),
+    })
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.error).toMatch(/email/i)
+  })
+
+  it('returns 400 when performance_ids is missing', async () => {
+    const { env } = createTestEnv()
+
+    const req = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com' }),
+    })
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when performance_ids is empty', async () => {
+    const { env } = createTestEnv()
+
+    const req = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com', performance_ids: [] }),
+    })
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
+    expect(res.status).toBe(400)
+  })
+
+  it(`returns 400 when performance_ids exceeds MAX_BATCH_SIZE (30)`, async () => {
+    const { env } = createTestEnv()
+    const tooMany = Array.from({ length: 31 }, (_, i) => i + 1)
+
+    const req = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com', performance_ids: tooMany }),
+    })
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when performance_ids contains non-integers', async () => {
+    const { env } = createTestEnv()
+
+    const req = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com', performance_ids: ['one', 2] }),
+    })
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 silently when all performance_ids are unknown (no enumeration)', async () => {
+    const { env } = createTestEnv()
+
+    const req = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'fan@example.com', performance_ids: [99999, 99998] }),
+    })
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.success).toBe(true)
+  })
+
+  it('records consent_ip from CF-Connecting-IP', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-ip' })
+    const band = insertBand(rawDb, { name: 'IP Band Batch', event_id: ev.id })
+
+    const req = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-Connecting-IP': '203.0.113.10',
+      },
+      body: JSON.stringify({ email: 'ip@example.com', performance_ids: [band.id] }),
+    })
+    await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
+
+    const row = rawDb
+      .prepare('SELECT consent_ip FROM band_follows WHERE email = ?')
+      .get('ip@example.com')
+    expect(row.consent_ip).toBe('203.0.113.10')
+  })
+})
+
+describe('GET /api/bands/confirm-follow-batch', () => {
+  it('verifies all pending follows in the batch and clears batch_token', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-confirm-batch' })
+    const b1 = insertBand(rawDb, { name: 'Confirm A', event_id: ev.id })
+    const b2 = insertBand(rawDb, { name: 'Confirm B', event_id: ev.id })
+
+    // Create the batch follows
+    const followReq = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'confirmbatch@example.com',
+        performance_ids: [b1.id, b2.id],
+      }),
+    })
+    const followRes = await followBatchHandler.onRequestPost({
+      request: followReq,
+      env,
+      waitUntil,
+    })
+    const { confirmUrl } = await followRes.json()
+    expect(confirmUrl).toBeTruthy()
+
+    const batchToken = new URL(confirmUrl).searchParams.get('token')
+    expect(batchToken).toBeTruthy()
+
+    // Verify both rows are pending before confirm
+    const pending = rawDb
+      .prepare('SELECT verified FROM band_follows WHERE email = ?')
+      .all('confirmbatch@example.com')
+    expect(pending.every((r) => r.verified === 0)).toBe(true)
+
+    // Confirm the batch
+    const confirmReq = new Request(
+      `https://example.test/api/bands/confirm-follow-batch?token=${batchToken}`,
+    )
+    const confirmRes = await confirmBatchHandler.onRequestGet({
+      request: confirmReq,
+      env,
+    })
+    expect(confirmRes.status).toBe(200)
+    const html = await confirmRes.text()
+    expect(html).toMatch(/you're all set/i)
+
+    // All rows now verified=1, batch_token cleared
+    const confirmed = rawDb
+      .prepare('SELECT verified, batch_token FROM band_follows WHERE email = ?')
+      .all('confirmbatch@example.com')
+    expect(confirmed).toHaveLength(2)
+    for (const row of confirmed) {
+      expect(row.verified).toBe(1)
+      expect(row.batch_token).toBeNull()
+    }
+  })
+
+  it('is idempotent — a second click on a used token still returns 200', async () => {
+    const { env, rawDb } = createTestEnv()
+    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-idem-confirm' })
+    const band = insertBand(rawDb, { name: 'Idem Confirm', event_id: ev.id })
+
+    const followReq = new Request('https://example.test/api/bands/follow-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'idem2@example.com',
+        performance_ids: [band.id],
+      }),
+    })
+    const followRes = await followBatchHandler.onRequestPost({
+      request: followReq,
+      env,
+      waitUntil,
+    })
+    const { confirmUrl } = await followRes.json()
+    const batchToken = new URL(confirmUrl).searchParams.get('token')
+
+    const makeConfirmReq = () =>
+      new Request(
+        `https://example.test/api/bands/confirm-follow-batch?token=${batchToken}`,
+      )
+
+    const first = await confirmBatchHandler.onRequestGet({ request: makeConfirmReq(), env })
+    const second = await confirmBatchHandler.onRequestGet({ request: makeConfirmReq(), env })
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+
+    // Row still verified=1 after both clicks
+    const row = rawDb
+      .prepare('SELECT verified FROM band_follows WHERE email = ?')
+      .get('idem2@example.com')
+    expect(row.verified).toBe(1)
+  })
+
+  it('returns 400 for a missing token', async () => {
+    const { env } = createTestEnv()
+    const req = new Request('https://example.test/api/bands/confirm-follow-batch')
+    const res = await confirmBatchHandler.onRequestGet({ request: req, env })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for an oversized token', async () => {
+    const { env } = createTestEnv()
+    const longToken = 'a'.repeat(257)
+    const req = new Request(
+      `https://example.test/api/bands/confirm-follow-batch?token=${longToken}`,
+    )
+    const res = await confirmBatchHandler.onRequestGet({ request: req, env })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 for an unknown token (no enumeration)', async () => {
+    const { env } = createTestEnv()
+    const req = new Request(
+      'https://example.test/api/bands/confirm-follow-batch?token=nonexistent-batch-token',
+    )
+    const res = await confirmBatchHandler.onRequestGet({ request: req, env })
+    // Unknown token: changes=0, but we still show the success page (generic/no-enumeration)
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toMatch(/you're all set/i)
+  })
+})

--- a/functions/api/bands/confirm-follow-batch.js
+++ b/functions/api/bands/confirm-follow-batch.js
@@ -1,0 +1,58 @@
+// GET /api/bands/confirm-follow-batch?token=<batch_token>
+// Confirms all pending (verified=0) band follows that share the given batch_token.
+//
+// The batch_token is shared across every band_follows row created by a single
+// POST /api/bands/follow-batch request. One click here verifies all of them.
+//
+// Idempotent: the UPDATE clears batch_token to NULL on first click, so a second
+// click finds no matching rows and changes nothing — the fan still sees a success
+// page without any error. Messaging is generic to avoid revealing whether a given
+// token was valid (no enumeration).
+
+const htmlPage = (heading, body) =>
+  new Response(
+    `<html><body style="font-family:sans-serif;padding:2rem"><h2>${heading}</h2><p>${body}</p></body></html>`,
+    {
+      status: 200,
+      headers: { "Content-Type": "text/html", "Cache-Control": "no-store" },
+    },
+  );
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+  const { DB } = env;
+
+  try {
+    const url = new URL(request.url);
+    const token = url.searchParams.get("token");
+
+    if (!token || token.length > 256) {
+      return new Response("Invalid token.", {
+        status: 400,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+
+    // Verify all pending follows in this batch and clear the shared token in one
+    // statement. Idempotent: on a second click the batch_token is already NULL so
+    // no rows match, changes=0, and the fan still sees the success page.
+    await DB.prepare(
+      `UPDATE band_follows
+       SET verified = 1, verification_token = NULL, batch_token = NULL
+       WHERE batch_token = ? AND verified = 0`,
+    )
+      .bind(token)
+      .run();
+
+    return htmlPage(
+      "You're all set!",
+      "We'll email you when your bands join a lineup. You can unsubscribe anytime from those emails.",
+    );
+  } catch (err) {
+    console.error("[band-confirm-follow-batch] Error:", err);
+    return new Response("An error occurred.", {
+      status: 500,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+}

--- a/functions/api/bands/follow-batch.js
+++ b/functions/api/bands/follow-batch.js
@@ -1,0 +1,195 @@
+// POST /api/bands/follow-batch
+// Batch double opt-in band follow.
+//
+// Body: { email, performance_ids: number[], turnstileToken? }
+//
+// Resolves performance_ids → unique band_profile_ids, inserts one band_follows
+// row per band (verified=0, INSERT OR IGNORE), all sharing a single batch_token.
+// Sends EXACTLY ONE combined confirmation email regardless of how many bands are
+// in the batch — this is the amplification mitigation: one Turnstile solve → one
+// email to the submitted address, not N emails.
+//
+// Security invariants:
+//   • All rows inserted with verified=0 — announcement emails reach verified=1
+//     followers only, so an unconfirmed address is never enrolled in the stream.
+//   • INSERT OR IGNORE: idempotent — re-submitting the same email returns 200
+//     without leaking follow state.
+//   • One email per submit, not per band.
+//   • N capped at MAX_BATCH_SIZE to limit per-request DB write overhead.
+//   • Turnstile verified before any DB write.
+//   • Rate-limited fail-closed via D1 (BATCH_FOLLOW_RE in rateLimit.js) by the
+//     global middleware — no explicit call needed here.
+
+import { isValidEmail } from "../../utils/validation.js";
+import { generateToken } from "../../utils/tokens.js";
+import { sendEmail, isEmailConfigured } from "../../utils/email.js";
+import { verifyTurnstile } from "../../utils/turnstile.js";
+import { escapeHtml } from "../../utils/html.js";
+
+const MAX_EMAIL_LENGTH = 320;
+const MAX_BATCH_SIZE = 30;
+
+export async function onRequestPost(context) {
+  const { request, env, waitUntil } = context;
+  const { DB } = env;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const email =
+      typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    const turnstileToken = body.turnstileToken;
+    const performanceIds = body.performance_ids;
+
+    if (!email || email.length > MAX_EMAIL_LENGTH || !isValidEmail(email)) {
+      return new Response(JSON.stringify({ error: "Invalid email address" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (
+      !Array.isArray(performanceIds) ||
+      performanceIds.length === 0 ||
+      performanceIds.length > MAX_BATCH_SIZE ||
+      !performanceIds.every((id) => Number.isInteger(id) && id > 0)
+    ) {
+      return new Response(
+        JSON.stringify({
+          error: `performance_ids must be a non-empty array of up to ${MAX_BATCH_SIZE} positive integers`,
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const turnstileValid = await verifyTurnstile(request, env, turnstileToken);
+    if (!turnstileValid) {
+      return new Response(
+        JSON.stringify({ error: "Bot verification failed" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Resolve performance_ids → distinct band_profile_ids + band names.
+    // Unknown performance IDs are silently dropped. If none resolve, return
+    // success anyway (no enumeration of which IDs are valid).
+    const placeholders = performanceIds.map(() => "?").join(",");
+    const bands = await DB.prepare(
+      `SELECT DISTINCT p.band_profile_id, bp.name AS band_name
+       FROM performances p
+       JOIN band_profiles bp ON bp.id = p.band_profile_id
+       WHERE p.id IN (${placeholders})`,
+    )
+      .bind(...performanceIds)
+      .all();
+
+    if (!bands.results || bands.results.length === 0) {
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const consentIp = request.headers.get("CF-Connecting-IP") ?? null;
+    // One shared batch_token ties all the rows together so a single confirm link
+    // can flip all of them to verified=1.
+    const batchToken = generateToken();
+    const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
+    const confirmUrl = `${publicUrl}/api/bands/confirm-follow-batch?token=${batchToken}`;
+
+    // Build one INSERT OR IGNORE per band. Each row gets a unique per-row
+    // verification_token and unsubscribe_token (both have UNIQUE constraints),
+    // plus the shared batch_token. DB.batch() is atomic: if any write fails, all
+    // are rolled back.
+    //
+    // Known edge (fails safe): a pre-existing *pending* single-follow for a band
+    // (verified=0, batch_token=NULL, from /api/bands/:name/follow) is left untouched
+    // by INSERT OR IGNORE, so it is NOT adopted into this batch_token — it stays
+    // confirmable via its own earlier email. This errs toward not-verifying, never
+    // toward over-verifying, so it carries no email-amplification or consent risk.
+    const stmts = bands.results.map(({ band_profile_id }) => {
+      const verificationToken = generateToken();
+      const unsubscribeToken = generateToken();
+      return DB.prepare(
+        `INSERT OR IGNORE INTO band_follows
+           (email, band_profile_id, verified, verification_token, unsubscribe_token,
+            consent_ip, consent_method, batch_token)
+         VALUES (?, ?, 0, ?, ?, ?, 'web_form', ?)`,
+      ).bind(
+        email,
+        band_profile_id,
+        verificationToken,
+        unsubscribeToken,
+        consentIp,
+        batchToken,
+      );
+    });
+
+    const results = await DB.batch(stmts);
+    // True when at least one new follow row was inserted (not an existing duplicate).
+    const isNewBatch = results.some((r) => r.meta.changes > 0);
+
+    if (isNewBatch && isEmailConfigured(env)) {
+      const bandListText = bands.results
+        .map((b) => `• ${b.band_name}`)
+        .join("\n");
+      const bandListHtml = bands.results
+        .map((b) => `<li>${escapeHtml(b.band_name)}</li>`)
+        .join("");
+
+      // ONE email for the whole batch — the core amplification mitigation.
+      waitUntil(
+        sendEmail(env, {
+          to: email,
+          subject: "Confirm your lineup — SetTimes",
+          text: [
+            "Someone (hopefully you) asked to follow this lineup on SetTimes:",
+            "",
+            bandListText,
+            "",
+            `Confirm to get an email the moment set times drop:\n${confirmUrl}`,
+            "",
+            "If this wasn't you, ignore this email — you won't be subscribed.",
+          ].join("\n"),
+          html: [
+            "<p>Someone (hopefully you) asked to follow this lineup on SetTimes:</p>",
+            `<ul>${bandListHtml}</ul>`,
+            `<p><a href="${confirmUrl}">Confirm your lineup</a> to get an email the moment set times drop.</p>`,
+            "<p>If this wasn't you, just ignore this email — you won't be subscribed.</p>",
+          ].join(""),
+        })
+          .then((emailResult) => {
+            if (!emailResult?.delivered) {
+              console.warn(
+                "[band-follow-batch] Confirmation email not delivered:",
+                emailResult?.reason,
+              );
+            }
+          })
+          .catch((err) => {
+            console.error(
+              "[band-follow-batch] Failed to send confirmation email:",
+              err,
+            );
+          }),
+      );
+    }
+
+    const responseBody = { success: true };
+    // In local/dev (email unconfigured), surface the confirmUrl inline so the
+    // follow can still be completed — mirrors follow.js behaviour.
+    if (isNewBatch && !isEmailConfigured(env)) {
+      responseBody.confirmUrl = confirmUrl;
+    }
+
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("[band-follow-batch] Error:", err);
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -231,8 +231,10 @@ export function createTestDB() {
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       consent_ip TEXT,
       consent_method TEXT NOT NULL DEFAULT 'web_form',
+      batch_token TEXT,
       UNIQUE(email, band_profile_id)
     );
+    CREATE INDEX IF NOT EXISTS idx_band_follows_batch_token ON band_follows(batch_token);
 
     CREATE TABLE band_follow_notifications (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/functions/utils/rateLimit.js
+++ b/functions/utils/rateLimit.js
@@ -21,6 +21,11 @@ const RATE_LIMIT_PREFIX = "rate-limit:";
 const BAND_ACTION_RE =
   /^\/api\/bands\/[^/]+\/(follow|unfollow|confirm-follow)$/;
 
+// Batch follow endpoints — flat paths under /api/bands/ (not nested under {name}).
+// Same fail-closed treatment as BAND_ACTION_RE: they send email, so D1-backed
+// globally-consistent rate limiting applies.
+const BATCH_FOLLOW_RE = /^\/api\/bands\/(follow-batch|confirm-follow-batch)$/;
+
 // Rate limit configurations by endpoint pattern.
 // Order matters: more-specific prefixes must appear before less-specific ones.
 const RATE_LIMITS = {
@@ -63,6 +68,7 @@ const FAIL_CLOSED_PATTERNS = [
 function shouldFailClosed(pathname) {
   return (
     BAND_ACTION_RE.test(pathname) ||
+    BATCH_FOLLOW_RE.test(pathname) ||
     FAIL_CLOSED_PATTERNS.some((pattern) => pathname.startsWith(pattern))
   );
 }
@@ -86,6 +92,10 @@ function getRateLimitConfig(pathname) {
   // Band action endpoints (follow/unfollow/confirm-follow) — checked before the
   // prefix loop so that the tight fail-closed limit takes precedence over 'default'.
   if (BAND_ACTION_RE.test(pathname)) return { requests: 5, window: 300 };
+
+  // Batch follow endpoints — tighter than single-band follow (3/5min) because a
+  // single request can cover up to 30 bands and triggers an email send.
+  if (BATCH_FOLLOW_RE.test(pathname)) return { requests: 3, window: 300 };
 
   // Find matching config
   for (const [pattern, config] of Object.entries(RATE_LIMITS)) {

--- a/migrations/0047_band_follow_batch_token.sql
+++ b/migrations/0047_band_follow_batch_token.sql
@@ -1,0 +1,15 @@
+-- Migration: 0047_band_follow_batch_token
+-- Description: Add batch_token to band_follows to support batch follow confirmation.
+--   A single shared batch_token ties the band_follows rows from one batch-follow
+--   request together. Sending ONE confirmation email per submit (not per band)
+--   mitigates amplification: one Turnstile solve → one email, regardless of how
+--   many bands are in the batch. Non-unique so all rows in a batch can share the
+--   same token; nullable so existing single-band follows (batch_token=NULL) are
+--   unaffected. The per-row verification_token UNIQUE constraint is kept; it is
+--   NULL for batch-confirmed rows after confirmation.
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+ALTER TABLE band_follows ADD COLUMN batch_token TEXT;
+CREATE INDEX IF NOT EXISTS idx_band_follows_batch_token ON band_follows(batch_token);


### PR DESCRIPTION
## Summary
Backend for **#447 "Lock In Your Lineup"** — follow every band in your route from one submit, with **one** confirmation email. (Frontend — the "Lock in your lineup" panel on My Route + the share-import flow — ships as a separate PR.)

## Changes
- **`migrations/0047_band_follow_batch_token.sql`** — nullable/non-unique/indexed `batch_token` on `band_follows` (mirrored into `database/setup-complete.sql` + `test-utils.js`). Existing single-follows (`batch_token=NULL`) unaffected.
- **`POST /api/bands/follow-batch`** — `{ email, performance_ids[], turnstileToken? }` → resolve to distinct `band_profile_id`s, `INSERT OR IGNORE` one `verified=0` row per band sharing a `batch_token` (+ per-row tokens, `consent_ip`), and send **exactly ONE** combined confirmation email via `waitUntil`. One Turnstile solve → one email (the amplification mitigation). N capped at 30.
- **`GET /api/bands/confirm-follow-batch?token=`** — idempotent `UPDATE … WHERE batch_token=? AND verified=0`, flips the whole batch to `verified=1`, clears the token. Generic page, no enumeration.
- **Rate limit** — `BATCH_FOLLOW_RE` (3 req/5 min, fail-closed via D1, distinct bucket per endpoint).
- **14 endpoint tests** + `docs/api-spec.yaml` + `docs/API_DOCUMENTATION.md`.

## Security review (Cass — clean bill, 9/10)
Traced both handlers, migration, rate-limit wiring, Turnstile, escaping, and the tests. All 7 invariants PASS: double opt-in (`verified=0`, never auto-verify), email-count bounded by distinct bands (not N), Turnstile before any write, **rate-limit buckets verified isolated**, no enumeration (response/timing constant; `confirmUrl` dev-only), HTML escaped + SQL parameterized, batch-token confirm cryptographically scoped + idempotent, CASL consent recorded. One **non-security, fails-safe** edge documented in-code (a pre-existing *pending* single-follow isn't adopted into a later batch token).

## Verification
Backend **535 tests** pass, `validate:openapi` **no drift** (71 route files). Built by Sonny, reviewed by Cass + Theo.

Part of #447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)