### PR TITLE
feat(follow): "Lock in your lineup" batch-follow UI on My Route + share import (Part of #447)

### DIFF
--- a/frontend/src/components/LockInLineupPanel.jsx
+++ b/frontend/src/components/LockInLineupPanel.jsx
@@ -1,0 +1,180 @@
+import { Bell, Check } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+
+const TURNSTILE_SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+
+/**
+ * LockInLineupPanel — Batch follow CTA for "My Route" and shared-route import.
+ *
+ * One submit → POST /api/bands/follow-batch → one combined double-opt-in
+ * confirmation email for all N bands. The backend inserts each row as
+ * verified=0 (double opt-in invariant preserved) and sends exactly one email
+ * so one Turnstile solve can't fan-out to N separate emails.
+ *
+ * Props:
+ *   performanceIds  — array of numeric performance IDs (the bands to follow)
+ *   bandCount       — number shown in CTA copy (usually performanceIds.length,
+ *                     but let the caller decide if they want a different label)
+ */
+export default function LockInLineupPanel({ performanceIds, bandCount }) {
+  const [followEmail, setFollowEmail] = useState('')
+  const [followStatus, setFollowStatus] = useState('idle') // 'idle' | 'loading' | 'success' | 'error'
+  const [followError, setFollowError] = useState('')
+  const turnstileContainerRef = useRef(null)
+  const turnstileWidgetIdRef = useRef(null)
+  const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY || ''
+  const turnstileEnabled = Boolean(turnstileSiteKey)
+  const [turnstileToken, setTurnstileToken] = useState('')
+  const hasPerformances = Array.isArray(performanceIds) && performanceIds.length > 0
+
+  // Mirror the Turnstile setup from BandProfilePage — explicit render, interaction-only
+  // appearance (invisible unless a human challenge fires), cleanup on unmount/re-run.
+  // Gate on hasPerformances so we don't try to render into a null container ref when
+  // the component returns null early.
+  useEffect(() => {
+    if (!turnstileEnabled || !hasPerformances) return undefined
+
+    let cancelled = false
+    let scriptElement = document.querySelector('script[data-turnstile-script="true"]')
+
+    const renderTurnstile = () => {
+      if (cancelled || !window.turnstile || !turnstileContainerRef.current) return
+      if (turnstileWidgetIdRef.current !== null) return
+
+      turnstileWidgetIdRef.current = window.turnstile.render(turnstileContainerRef.current, {
+        sitekey: turnstileSiteKey,
+        appearance: 'interaction-only',
+        callback: token => setTurnstileToken(token),
+        'expired-callback': () => setTurnstileToken(''),
+        'error-callback': () => setTurnstileToken(''),
+      })
+    }
+
+    if (scriptElement) {
+      if (window.turnstile) {
+        renderTurnstile()
+      } else {
+        scriptElement.addEventListener('load', renderTurnstile)
+      }
+    } else {
+      const script = document.createElement('script')
+      script.src = TURNSTILE_SCRIPT_SRC
+      script.async = true
+      script.defer = true
+      script.setAttribute('data-turnstile-script', 'true')
+      script.addEventListener('load', renderTurnstile)
+      document.head.appendChild(script)
+      scriptElement = script
+    }
+
+    return () => {
+      cancelled = true
+      if (scriptElement) scriptElement.removeEventListener('load', renderTurnstile)
+      if (window.turnstile && turnstileWidgetIdRef.current !== null) {
+        window.turnstile.remove(turnstileWidgetIdRef.current)
+        turnstileWidgetIdRef.current = null
+      }
+    }
+  }, [turnstileEnabled, turnstileSiteKey, hasPerformances])
+
+  // Early return after hooks (React rules of hooks: no conditional hook calls)
+  if (!hasPerformances) return null
+
+  const n = bandCount ?? performanceIds.length
+
+  const handleSubmit = async e => {
+    e.preventDefault()
+    if (!followEmail.trim()) return
+    if (turnstileEnabled && !turnstileToken) {
+      setFollowStatus('error')
+      setFollowError('Please complete the bot verification challenge.')
+      return
+    }
+    setFollowStatus('loading')
+    setFollowError('')
+    try {
+      const res = await fetch('/api/bands/follow-batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: followEmail.trim(),
+          performance_ids: performanceIds,
+          turnstileToken,
+        }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error || 'Something went wrong — please try again.')
+      }
+      setFollowStatus('success')
+      setTurnstileToken('')
+      if (turnstileEnabled && window.turnstile && turnstileWidgetIdRef.current !== null) {
+        window.turnstile.reset(turnstileWidgetIdRef.current)
+      }
+    } catch (err) {
+      setFollowStatus('error')
+      setFollowError(err.message)
+      setTurnstileToken('')
+      if (turnstileEnabled && window.turnstile && turnstileWidgetIdRef.current !== null) {
+        window.turnstile.reset(turnstileWidgetIdRef.current)
+      }
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-accent-500/30 bg-surface/50 p-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="sm:flex-1">
+          <div className="mb-1 flex items-center gap-2">
+            <Bell size={16} className="shrink-0 text-accent-400" aria-hidden="true" />
+            <h2 className="text-sm font-semibold text-text-primary">Lock in your lineup</h2>
+          </div>
+          <p className="text-xs text-text-secondary">
+            Get an email the moment set times drop, plus a heads-up before each of your{' '}
+            <span className="font-semibold text-text-primary">{n}</span> {n === 1 ? 'band' : 'bands'} plays. One click
+            confirms {n === 1 ? 'it' : 'all of them'}.
+          </p>
+        </div>
+
+        {followStatus === 'success' ? (
+          <p className="inline-flex items-start gap-1.5 text-sm text-success-500 sm:max-w-xs">
+            <Check size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+            Check your email to confirm — one click locks in all {n} {n === 1 ? 'band' : 'bands'}.
+          </p>
+        ) : (
+          <form onSubmit={handleSubmit} className="w-full sm:w-auto">
+            <label htmlFor="lineup-follow-email" className="sr-only">
+              Your email address
+            </label>
+            <div className="flex gap-2 sm:w-80">
+              <input
+                id="lineup-follow-email"
+                type="email"
+                value={followEmail}
+                onChange={e => setFollowEmail(e.target.value)}
+                placeholder="your@email.com"
+                required
+                disabled={followStatus === 'loading'}
+                className="min-w-0 flex-1 rounded border border-text-primary/20 bg-bg-navy px-3 py-2 text-sm text-text-primary placeholder:text-text-disabled focus:border-accent-500 focus:outline-none disabled:opacity-60"
+              />
+              <button
+                type="submit"
+                disabled={followStatus === 'loading' || (turnstileEnabled && !turnstileToken)}
+                className="shrink-0 min-h-[44px] rounded-lg bg-accent-500 px-4 py-2 text-sm font-semibold text-bg-navy transition-all hover:bg-accent-400 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500"
+              >
+                {followStatus === 'loading' ? 'Saving…' : 'Notify me'}
+              </button>
+            </div>
+            {turnstileEnabled && <div ref={turnstileContainerRef} className="mt-2" />}
+          </form>
+        )}
+      </div>
+
+      {followStatus === 'error' && (
+        <p className="mt-2 text-xs text-error-500" role="alert">
+          {followError}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -24,6 +24,7 @@ import { HIGHLIGHTED_BANDS, getHighlightMessage } from '../config/highlights.jsx
 import { copyToClipboard } from '../utils/clipboard'
 import { formatTimeRange } from '../utils/timeFormat'
 import BandCard from './BandCard'
+import LockInLineupPanel from './LockInLineupPanel'
 import { walkMinutesBetween } from '../utils/walkTime'
 
 // Label a break between two sets at the same venue.
@@ -229,6 +230,17 @@ function MySchedule({
 
   const bandById = useMemo(() => new Map(visibleBands.map(b => [b.id, b])), [visibleBands])
   const bandNameById = useMemo(() => new Map(visibleBands.map(b => [b.id, b.name])), [visibleBands])
+
+  // Extract numeric performance IDs from band composite IDs (e.g. "event-slug-perf-42" → 42).
+  // Mirrors the same split used in handleShareSchedule so the two stay in sync.
+  const performanceIds = useMemo(() => {
+    return bands.reduce((acc, band) => {
+      const parts = band.id.split('-')
+      const id = parseInt(parts[parts.length - 1], 10)
+      if (Number.isFinite(id) && id > 0) acc.push(id)
+      return acc
+    }, [])
+  }, [bands])
 
   // Detect overlaps and conflicts
   const { conflicts, overlaps, overlapCount } = useMemo(() => {
@@ -650,6 +662,10 @@ function MySchedule({
             </div>
           )
         })}
+      </div>
+
+      <div className="max-w-5xl mx-auto">
+        <LockInLineupPanel performanceIds={performanceIds} bandCount={performanceIds.length} />
       </div>
 
       <div className="max-w-5xl mx-auto mt-8 text-center text-xs text-text-tertiary">

--- a/frontend/src/components/__tests__/LockInLineupPanel.test.jsx
+++ b/frontend/src/components/__tests__/LockInLineupPanel.test.jsx
@@ -1,0 +1,212 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import LockInLineupPanel from '../LockInLineupPanel'
+
+// Turnstile is not available in jsdom — ensure the env var is empty so the
+// component treats Turnstile as disabled (no site key = bot protection off).
+// This lets us exercise the full submit path without mocking the Turnstile API.
+vi.stubEnv('VITE_TURNSTILE_SITE_KEY', '')
+
+const PERFORMANCE_IDS = [10, 20, 30]
+const BAND_COUNT = 3
+
+function renderPanel(props = {}) {
+  return render(<LockInLineupPanel performanceIds={PERFORMANCE_IDS} bandCount={BAND_COUNT} {...props} />)
+}
+
+describe('LockInLineupPanel', () => {
+  let fetchMock
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  // ── Render guard ───────────────────────────────────────────────────────────
+
+  it('renders nothing when performanceIds is empty', () => {
+    const { container } = render(<LockInLineupPanel performanceIds={[]} bandCount={0} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when performanceIds is undefined', () => {
+    // Defensive: callers might not pass the prop during initial load
+    const { container } = render(<LockInLineupPanel performanceIds={undefined} bandCount={0} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  // ── Idle render ────────────────────────────────────────────────────────────
+
+  it('renders the "Lock in your lineup" heading', () => {
+    renderPanel()
+    expect(screen.getByRole('heading', { name: /lock in your lineup/i })).toBeInTheDocument()
+  })
+
+  it('shows the correct band count in the CTA copy', () => {
+    renderPanel({ bandCount: 5 })
+    expect(screen.getByText(/5/)).toBeInTheDocument()
+    expect(screen.getByText(/bands/)).toBeInTheDocument()
+  })
+
+  it('uses singular "band" copy when bandCount is 1', () => {
+    renderPanel({ performanceIds: [42], bandCount: 1 })
+    // Should say "1 band plays" (singular)
+    expect(screen.getByText(/1/)).toBeInTheDocument()
+    // "bands" should NOT appear in the description
+    const desc = screen.getByText(/plays\. One click confirms/i)
+    expect(desc.textContent).toMatch(/\b1\b/)
+    expect(desc.textContent).not.toMatch(/bands/)
+  })
+
+  it('renders the email input and Notify me button', () => {
+    renderPanel()
+    expect(screen.getByLabelText(/your email address/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /notify me/i })).toBeInTheDocument()
+  })
+
+  it('button is enabled when Turnstile is disabled (no site key)', () => {
+    renderPanel()
+    expect(screen.getByRole('button', { name: /notify me/i })).not.toBeDisabled()
+  })
+
+  // ── Submit ─────────────────────────────────────────────────────────────────
+
+  it('POST /api/bands/follow-batch with the right body on submit', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    })
+
+    renderPanel()
+    fireEvent.change(screen.getByLabelText(/your email address/i), {
+      target: { value: 'fan@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /notify me/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/bands/follow-batch')
+    expect(opts.method).toBe('POST')
+    const body = JSON.parse(opts.body)
+    expect(body.email).toBe('fan@example.com')
+    expect(body.performance_ids).toEqual(PERFORMANCE_IDS)
+    // turnstileToken should be '' (disabled in test env)
+    expect(body.turnstileToken).toBe('')
+  })
+
+  it('shows the success state after a successful submit', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    })
+
+    renderPanel()
+    fireEvent.change(screen.getByLabelText(/your email address/i), {
+      target: { value: 'fan@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /notify me/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/check your email to confirm/i)).toBeInTheDocument()
+    })
+    // Form should be gone
+    expect(screen.queryByRole('button', { name: /notify me/i })).not.toBeInTheDocument()
+  })
+
+  it('success copy mentions the correct band count', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    })
+
+    renderPanel({ bandCount: 7 })
+    fireEvent.change(screen.getByLabelText(/your email address/i), {
+      target: { value: 'fan@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /notify me/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/7 bands/i)).toBeInTheDocument()
+    })
+  })
+
+  // ── Error handling ─────────────────────────────────────────────────────────
+
+  it('shows an error message when the API returns a non-ok response', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Rate limit exceeded' }),
+    })
+
+    renderPanel()
+    fireEvent.change(screen.getByLabelText(/your email address/i), {
+      target: { value: 'fan@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /notify me/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+      expect(screen.getByRole('alert')).toHaveTextContent('Rate limit exceeded')
+    })
+    // Form should still be visible so the user can retry
+    expect(screen.getByRole('button', { name: /notify me/i })).toBeInTheDocument()
+  })
+
+  it('shows a fallback error when the API response has no error field', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    })
+
+    renderPanel()
+    fireEvent.change(screen.getByLabelText(/your email address/i), {
+      target: { value: 'fan@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /notify me/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('shows an error message when fetch itself throws (network error)', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('Network failure'))
+
+    renderPanel()
+    fireEvent.change(screen.getByLabelText(/your email address/i), {
+      target: { value: 'fan@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /notify me/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Network failure')
+    })
+  })
+
+  // ── Loading state ──────────────────────────────────────────────────────────
+
+  it('shows "Saving…" while the request is in flight', async () => {
+    let resolve
+    fetchMock.mockReturnValueOnce(new Promise(res => (resolve = res)))
+
+    renderPanel()
+    fireEvent.change(screen.getByLabelText(/your email address/i), {
+      target: { value: 'fan@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /notify me/i }))
+
+    expect(await screen.findByText('Saving…')).toBeInTheDocument()
+
+    // Clean up: resolve the pending fetch so no state updates leak
+    resolve({ ok: true, json: async () => ({ success: true }) })
+    await waitFor(() => expect(screen.queryByText('Saving…')).not.toBeInTheDocument())
+  })
+})

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -2,6 +2,7 @@ import { ArrowLeft } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { Link, useNavigate, useParams } from 'react-router-dom'
+import LockInLineupPanel from '../components/LockInLineupPanel'
 import { Alert, BandCardSkeleton } from '../components/ui'
 import { fetchPublicJson } from '../utils/publicApi'
 
@@ -138,6 +139,8 @@ export default function SharePreviewPage() {
           Add {shareData.band_names.length} stop{shareData.band_names.length !== 1 ? 's' : ''} to my route for{' '}
           {shareData.event_name}
         </button>
+
+        <LockInLineupPanel performanceIds={shareData.performance_ids} bandCount={shareData.band_names.length} />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
Frontend for **#447 "Lock In Your Lineup"** — the UI that lets a fan follow every band in their route from one submit. Pairs with the backend in **#452** (merge both to ship the feature).

## Changes
- **`LockInLineupPanel`** (new) — email input + Cloudflare Turnstile (reuses `BandProfilePage`'s explicit-render, `interaction-only` pattern + shared script tag + cleanup) → `POST /api/bands/follow-batch` with `{ email, performance_ids, turnstileToken }`. States: idle → loading → **success** ("Check your email to confirm — one click locks in all N bands") / error. Returns `null` when the route has no bands (safe to render unconditionally). Accessible: `sr-only` label, `role="alert"`, 44px tap target, focus-visible ring, pluralized copy.
- **Theme tokens only** — zero `text-white`/`bg-white` on these public, theme-following surfaces (verified across all changed files).
- **Wired into My Route** (`MySchedule.jsx`) — `performance_ids` parsed from band composite IDs (same logic as the existing `handleShareSchedule`) — and the **shared-route import** (`SharePreviewPage.jsx`) via `shareData.performance_ids`.
- **11 component tests** (render/empty, copy + pluralization, POST body shape, success/error/loading, Turnstile gating).

## Verification
Frontend **228 tests** pass, ESLint **0 errors**, format clean, build ✓. Reviewed by Theo (theme-token gate + component review).

## Dependency
Requires **#452** (backend `/api/bands/follow-batch`) — merge #452 first (or together) so the UI's request resolves. Together they **complete #447**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)