### PR TITLE
fix(metrics): stop page_views_daily double-count + drop dead artist_daily_stats columns (Closes #445, #446)

### DIFF
--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -131,9 +131,7 @@ CREATE TABLE IF NOT EXISTS artist_daily_stats (
   band_profile_id INTEGER NOT NULL,
   date TEXT NOT NULL,
   page_views INTEGER DEFAULT 0,
-  profile_clicks INTEGER DEFAULT 0,
   social_clicks INTEGER DEFAULT 0,
-  share_count INTEGER DEFAULT 0,
   created_at TEXT DEFAULT (datetime('now')),
   UNIQUE(band_profile_id, date),
   FOREIGN KEY (band_profile_id) REFERENCES band_profiles(id) ON DELETE CASCADE

--- a/database/setup-local-dev.sql
+++ b/database/setup-local-dev.sql
@@ -91,9 +91,7 @@ CREATE TABLE IF NOT EXISTS artist_daily_stats (
   band_profile_id INTEGER NOT NULL,
   date TEXT NOT NULL,
   page_views INTEGER DEFAULT 0,
-  profile_clicks INTEGER DEFAULT 0,
   social_clicks INTEGER DEFAULT 0,
-  share_count INTEGER DEFAULT 0,
   created_at TEXT DEFAULT (datetime('now')),
   UNIQUE(band_profile_id, date),
   FOREIGN KEY (band_profile_id) REFERENCES band_profiles(id) ON DELETE CASCADE

--- a/functions/api/__tests__/metrics.test.js
+++ b/functions/api/__tests__/metrics.test.js
@@ -1,6 +1,7 @@
 // Tests for POST /api/metrics
-// Covers: break-removal (all event_view counts written even above MAX_BATCH_STATEMENTS)
-// and catch-logging (swallowed page_views_daily failure now emits logger.warn).
+// Covers: event_view/ticket_click no longer written to page_views_daily (#445 fix),
+// page_view events still written as real path keys, and catch-logging (swallowed
+// page_views_daily failure now emits logger.warn).
 import { describe, expect, test, vi, afterEach } from "vitest";
 import { onRequestPost } from "../metrics.js";
 import * as loggerModule from "../../utils/logger.js";
@@ -19,11 +20,12 @@ describe("POST /api/metrics", () => {
     vi.restoreAllMocks();
   });
 
-  test("writes ALL event_view counts when count exceeds MAX_BATCH_STATEMENTS (break removed)", async () => {
+  test("event_view events do NOT write synthetic keys to page_views_daily (#445)", async () => {
     const { env, rawDb } = createTestEnv();
 
-    // Generate 25 unique event_view events — MAX_BATCH_STATEMENTS is 20, so without
-    // the fix the last 5 would have been silently dropped.
+    // 25 event_view events — before the fix these wrote 25 event:N rows; now they
+    // should write nothing to page_views_daily (the path page_view already captures
+    // the visit; storing synthetic keys caused double-counting).
     const events = Array.from({ length: 25 }, (_, i) => ({
       event: "event_view",
       props: { event_id: i + 1 },
@@ -33,12 +35,40 @@ describe("POST /api/metrics", () => {
     expect(res.status).toBe(200);
 
     const rows = rawDb.prepare("SELECT * FROM page_views_daily").all();
-    expect(rows).toHaveLength(25);
-    // Verify all 25 event IDs appear as keys
-    const pages = new Set(rows.map((r) => r.page));
-    for (let i = 1; i <= 25; i++) {
-      expect(pages.has(`event:${i}`)).toBe(true);
-    }
+    expect(rows).toHaveLength(0);
+  });
+
+  test("ticket_click events do NOT write synthetic keys to page_views_daily (#445)", async () => {
+    const { env, rawDb } = createTestEnv();
+
+    const events = [
+      { event: "ticket_click", props: { event_id: 1 } },
+      { event: "ticket_click", props: { event_id: 2 } },
+    ];
+
+    const res = await onRequestPost({ request: makeRequest(events), env });
+    expect(res.status).toBe(200);
+
+    const rows = rawDb.prepare("SELECT * FROM page_views_daily").all();
+    expect(rows).toHaveLength(0);
+  });
+
+  test("page_view events still write real path keys to page_views_daily", async () => {
+    const { env, rawDb } = createTestEnv();
+
+    const events = [
+      { event: "page_view", props: { page: "/event/lwbc16" } },
+      { event: "page_view", props: { page: "/event/lwbc16" } },
+      { event: "page_view", props: { page: "/bands/cool-band" } },
+    ];
+
+    const res = await onRequestPost({ request: makeRequest(events), env });
+    expect(res.status).toBe(200);
+
+    const rows = rawDb.prepare("SELECT page, views FROM page_views_daily ORDER BY page").all();
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.page === "/event/lwbc16").views).toBe(2);
+    expect(rows.find((r) => r.page === "/bands/cool-band").views).toBe(1);
   });
 
   test("returns 200 and logs a warning when page_views_daily batch fails", async () => {

--- a/functions/api/metrics.js
+++ b/functions/api/metrics.js
@@ -94,7 +94,6 @@ export async function onRequestPost(context) {
       const bandViewCounts = new Map();
       const socialClickCounts = new Map();
       const pageCounts = new Map(); // page path → count
-      const eventViewCounts = new Map(); // event_id → count
 
       for (const event of validEvents) {
         if (event.event === "artist_profile_view") {
@@ -117,15 +116,6 @@ export async function onRequestPost(context) {
         if (event.event === "page_view") {
           const page = String(event.props?.page || "/").slice(0, 255);
           pageCounts.set(page, (pageCounts.get(page) || 0) + 1);
-        }
-
-        if (event.event === "event_view" || event.event === "ticket_click") {
-          const eventId = parseInteger(event.props?.event_id);
-          const prefix = event.event === "ticket_click" ? "ticket" : "event";
-          if (eventId) {
-            const key = `${prefix}:${eventId}`;
-            eventViewCounts.set(key, (eventViewCounts.get(key) || 0) + 1);
-          }
         }
       }
 
@@ -154,8 +144,12 @@ export async function onRequestPost(context) {
         await executeInChunks(env.DB, stmts);
       }
 
-      // Store page views and event views in a separate batch so a missing
-      // page_views_daily table doesn't break artist_daily_stats writes
+      // Store page views in a separate batch so a missing
+      // page_views_daily table doesn't break artist_daily_stats writes.
+      // Only real path keys (page_view events) are written here — event_view and
+      // ticket_click synthetic keys (event:N / ticket:N) are intentionally not
+      // stored: the page_view for the same page already captures the visit, and
+      // the synthetic rows caused double-counting under two key formats (#445).
       const pvStmts = [];
       for (const [page, count] of pageCounts) {
         pvStmts.push(
@@ -165,17 +159,6 @@ export async function onRequestPost(context) {
              ON CONFLICT (page, date)
              DO UPDATE SET views = views + ?`,
           ).bind(page, today, count, count),
-        );
-      }
-
-      for (const [key, count] of eventViewCounts) {
-        pvStmts.push(
-          env.DB.prepare(
-            `INSERT INTO page_views_daily (page, date, views)
-             VALUES (?, ?, ?)
-             ON CONFLICT (page, date)
-             DO UPDATE SET views = views + ?`,
-          ).bind(key, today, count, count),
         );
       }
 

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -142,9 +142,7 @@ export function createTestDB() {
       band_profile_id INTEGER NOT NULL,
       date TEXT NOT NULL,
       page_views INTEGER DEFAULT 0,
-      profile_clicks INTEGER DEFAULT 0,
       social_clicks INTEGER DEFAULT 0,
-      share_count INTEGER DEFAULT 0,
       created_at TEXT DEFAULT (datetime('now')),
       UNIQUE(band_profile_id, date),
       FOREIGN KEY (band_profile_id) REFERENCES band_profiles(id) ON DELETE CASCADE

--- a/functions/scheduled/__tests__/aggregate-stats.test.js
+++ b/functions/scheduled/__tests__/aggregate-stats.test.js
@@ -19,10 +19,10 @@ describe('aggregate-stats scheduled job (P1-P3)', () => {
       'INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)'
     ).run('Stat Band', 'statband')
 
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks, share_count) VALUES (?, ?, ?, ?, ?)')
-      .run(profileId, '2026-05-01', 100, 5, 2)
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks, share_count) VALUES (?, ?, ?, ?, ?)')
-      .run(profileId, '2026-05-02', 200, 10, 3)
+    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)')
+      .run(profileId, '2026-05-01', 100, 5)
+    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)')
+      .run(profileId, '2026-05-02', 200, 10)
 
     await runScheduled(env)
 
@@ -55,19 +55,19 @@ describe('aggregate-stats scheduled job (P1-P3)', () => {
     ).run('Trending Band', 'trendingband')
 
     // Recent row — should count toward popularity
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks, share_count) VALUES (?, ?, ?, ?, ?)')
-      .run(profileId, daysAgo(5), 10, 4, 1)
+    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)')
+      .run(profileId, daysAgo(5), 10, 4)
     // Old row — should NOT count toward popularity (> 30 days ago)
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks, share_count) VALUES (?, ?, ?, ?, ?)')
-      .run(profileId, daysAgo(60), 1000, 500, 200)
+    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)')
+      .run(profileId, daysAgo(60), 1000, 500)
 
     await runScheduled(env)
 
     const profile = rawDb.prepare('SELECT total_views, popularity_score FROM band_profiles WHERE id = ?').get(profileId)
     // total_views sums ALL history
     expect(profile.total_views).toBe(1010)
-    // popularity_score only counts recent: 10*1 + 4*3 + 1*5 = 27
-    expect(profile.popularity_score).toBeCloseTo(27, 1)
+    // popularity_score only counts recent: 10*1 + 4*3 = 22
+    expect(profile.popularity_score).toBeCloseTo(22, 1)
   })
 
   it('deletes artist_daily_stats older than 90 days', async () => {

--- a/functions/scheduled/aggregate-stats.js
+++ b/functions/scheduled/aggregate-stats.js
@@ -28,7 +28,7 @@ export async function scheduled(_event, env, _ctx) {
              SUM(social_clicks) AS total_social_clicks,
              SUM(
                CASE WHEN date >= date('now', '-30 days')
-                    THEN page_views * 1.0 + social_clicks * 3.0 + share_count * 5.0
+                    THEN page_views * 1.0 + social_clicks * 3.0
                     ELSE 0 END
              ) AS popularity_score
            FROM artist_daily_stats

--- a/migrations/0048_drop_dead_artist_daily_stats_columns.sql
+++ b/migrations/0048_drop_dead_artist_daily_stats_columns.sql
@@ -1,0 +1,15 @@
+-- Migration: 0048_drop_dead_artist_daily_stats_columns.sql
+-- Description: Drop profile_clicks and share_count from artist_daily_stats.
+--
+-- profile_clicks: no event in the metrics allowlist ever writes it; always 0 in prod.
+--
+-- share_count: referenced by the aggregate-stats popularity formula
+--   (page_views*1 + social_clicks*3 + share_count*5) but never written, so the 5×
+--   weight was silently inert. The column is dropped and the formula updated to
+--   page_views*1 + social_clicks*3. Share-link counts (from share_links.view_count)
+--   as a popularity signal is tracked as a deferred enhancement.
+--
+-- D1 / modern SQLite supports ALTER TABLE … DROP COLUMN directly.
+
+ALTER TABLE artist_daily_stats DROP COLUMN profile_clicks;
+ALTER TABLE artist_daily_stats DROP COLUMN share_count;


### PR DESCRIPTION
## Summary
Two small metrics data-quality fixes found in the analytics baseline pass.

### #445 — `page_views_daily` double-count
`page_view` events store the real path (`/event/lwbc16`) while `event_view`/`ticket_click` stored **synthetic keys** (`event:{id}` / `ticket:{id}`) in the **same** table — counting one event view twice under two formats. **Consumer check: nothing in `functions/` reads the synthetic keys** (the only reader was a test of the old write behavior). So we stop writing them — the path `page_view` (fired on the same load) already records the event page. Minimal change, **no migration, no schema change**.

### #446 — dead `artist_daily_stats` columns
- `profile_clicks` — no writer, no reader → dropped.
- `share_count` — read by the popularity formula's `* 5.0` weight but **never written**, so the 5× weight was silently inert. Dropped, and the inert term removed: the score is now the honest `page_views*1 + social_clicks*3`.
- **Migration 0048** (`ALTER TABLE … DROP COLUMN`, per the 0027 precedent), mirrored into `setup-complete.sql` / `setup-local-dev.sql` / `test-utils.js` (drift gate). `aggregate-stats.js` + its tests updated.
- *Shares as a popularity signal — sourced properly from `share_links` — is a deferred enhancement, intentionally not a broken weight here.*

## Verification
Backend **537 tests** pass, `validate:openapi` no drift. Built by Sonny (who confirmed the synthetic keys are unused before choosing the #445 fix); reviewed + verified by Theo.

Closes #445, Closes #446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)