### PR TITLE
security: build emailed security links from PUBLIC_URL, never the client Host (Closes #443)

### DIFF
--- a/functions/api/admin/auth/signup.js
+++ b/functions/api/admin/auth/signup.js
@@ -13,6 +13,7 @@ import {
   writeAuthAttempt,
 } from "../../../utils/authAttempts.js";
 import { logger } from "../../../utils/logger.js";
+import { getPublicBaseUrl } from "../../../utils/publicUrl.js";
 
 export async function onRequestPost(context) {
   const { request, env } = context;
@@ -277,7 +278,7 @@ export async function onRequestPost(context) {
       userId: user.id,
     });
 
-    const baseUrl = env.PUBLIC_URL || new URL(request.url).origin;
+    const baseUrl = getPublicBaseUrl(env);
     const activationUrl = new URL("/activate", baseUrl);
     activationUrl.searchParams.set("token", activationToken);
 

--- a/functions/api/admin/users.js
+++ b/functions/api/admin/users.js
@@ -11,6 +11,7 @@ import {
 import { getClientIP } from '../../utils/request.js';
 import { sendEmail, isEmailConfigured } from '../../utils/email.js';
 import { buildInviteEmail } from '../../utils/emailTemplates.js';
+import { getPublicBaseUrl } from '../../utils/publicUrl.js';
 
 // GET - List all users (admin only)
 export async function onRequestGet(context) {
@@ -137,7 +138,7 @@ export async function onRequestPost(context) {
       .bind(inviteCode, email, role, currentUser.userId, expiresAt)
       .first();
 
-    const baseUrl = env.PUBLIC_URL || new URL(request.url).origin;
+    const baseUrl = getPublicBaseUrl(env);
     const inviteUrl = new URL('/admin/signup', baseUrl);
     inviteUrl.searchParams.set('code', inviteCode);
 

--- a/functions/api/admin/users/[id]/reset-password.js
+++ b/functions/api/admin/users/[id]/reset-password.js
@@ -10,6 +10,7 @@ import { getClientIP } from '../../../../utils/request.js';
 import { sendEmail, isEmailConfigured } from '../../../../utils/email.js';
 import { buildResetPasswordEmail } from '../../../../utils/emailTemplates.js';
 import { revokeAllTrustedDevices } from '../../../../utils/trustedDevice.js';
+import { getPublicBaseUrl } from '../../../../utils/publicUrl.js';
 
 export async function onRequestPost(context) {
   const { request, env, params } = context;
@@ -96,7 +97,7 @@ export async function onRequestPost(context) {
 
     await revokeAllTrustedDevices(DB, userId);
 
-    const baseUrl = env.PUBLIC_URL || new URL(request.url).origin;
+    const baseUrl = getPublicBaseUrl(env);
     // Use a hash fragment so the token is never sent to the server, logged by
     // Cloudflare access logs, stored in browser history, or leaked via Referer.
     const resetUrl = `${baseUrl}/reset-password#token=${resetToken.token}`;

--- a/functions/api/auth/resend-activation.js
+++ b/functions/api/auth/resend-activation.js
@@ -1,6 +1,7 @@
 import { isValidEmail } from "../../utils/validation.js";
 import { isEmailConfigured, sendEmail } from "../../utils/email.js";
 import { buildActivationEmail } from "../../utils/emailTemplates.js";
+import { getPublicBaseUrl } from "../../utils/publicUrl.js";
 
 export async function onRequestPost(context) {
   const { request, env } = context;
@@ -100,7 +101,7 @@ export async function onRequestPost(context) {
       return genericResponse;
     }
 
-    const baseUrl = env.PUBLIC_URL || new URL(request.url).origin;
+    const baseUrl = getPublicBaseUrl(env);
     const activationUrl = new URL("/activate", baseUrl);
     activationUrl.searchParams.set("token", activationToken);
 

--- a/functions/api/bands/[name]/follow.js
+++ b/functions/api/bands/[name]/follow.js
@@ -5,6 +5,7 @@ import { verifyTurnstile } from "../../../utils/turnstile.js";
 import { normalizeBandName } from "../../../utils/bandName.js";
 
 import { escapeHtml } from "../../../utils/html.js";
+import { getPublicBaseUrl } from "../../../utils/publicUrl.js";
 
 const MAX_EMAIL_LENGTH = 320;
 
@@ -77,7 +78,7 @@ export async function onRequestPost(context) {
     // changes=0 → this email already follows the band (verified or pending). Say
     // nothing further: don't leak follow state and don't re-send on every POST.
     const isNewFollow = result.meta.changes > 0;
-    const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
+    const publicUrl = getPublicBaseUrl(env);
     const confirmUrl = `${publicUrl}/api/bands/${band.id}/confirm-follow?token=${verificationToken}`;
 
     if (isNewFollow && isEmailConfigured(env)) {

--- a/functions/api/bands/follow-batch.js
+++ b/functions/api/bands/follow-batch.js
@@ -25,6 +25,7 @@ import { generateToken } from "../../utils/tokens.js";
 import { sendEmail, isEmailConfigured } from "../../utils/email.js";
 import { verifyTurnstile } from "../../utils/turnstile.js";
 import { escapeHtml } from "../../utils/html.js";
+import { getPublicBaseUrl } from "../../utils/publicUrl.js";
 
 const MAX_EMAIL_LENGTH = 320;
 const MAX_BATCH_SIZE = 30;
@@ -93,7 +94,7 @@ export async function onRequestPost(context) {
     // One shared batch_token ties all the rows together so a single confirm link
     // can flip all of them to verified=1.
     const batchToken = generateToken();
-    const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
+    const publicUrl = getPublicBaseUrl(env);
     const confirmUrl = `${publicUrl}/api/bands/confirm-follow-batch?token=${batchToken}`;
 
     // Build one INSERT OR IGNORE per band. Each row gets a unique per-row

--- a/functions/api/subscriptions/subscribe.js
+++ b/functions/api/subscriptions/subscribe.js
@@ -6,6 +6,7 @@ import { sendEmail, isEmailConfigured } from "../../utils/email.js";
 import { isValidEmail } from "../../utils/validation.js";
 import { verifyTurnstile } from "../../utils/turnstile.js";
 import { escapeHtml } from "../../utils/html.js";
+import { getPublicBaseUrl } from "../../utils/publicUrl.js";
 
 const FREQUENCY_OPTIONS = new Set(["daily", "weekly", "monthly"]);
 const MAX_EMAIL_LENGTH = 320;
@@ -219,7 +220,7 @@ export async function onRequestPost(context) {
 }
 
 async function sendVerificationEmail(env, email, city, genre, token) {
-  const baseUrl = env.PUBLIC_URL || "http://localhost:5173";
+  const baseUrl = getPublicBaseUrl(env);
   const verifyUrl = `${baseUrl}/verify?token=${token}`;
   const subject = "Confirm your SetTimes subscription";
   const safeCity = escapeHtml(city);

--- a/functions/api/subscriptions/verify.js
+++ b/functions/api/subscriptions/verify.js
@@ -1,6 +1,8 @@
 // Email verification endpoint
 // GET /api/subscriptions/verify?token=xxx
 
+import { getPublicBaseUrl } from "../../utils/publicUrl.js";
+
 export async function onRequestGet(context) {
   const { request, env } = context;
   const url = new URL(request.url);
@@ -63,7 +65,7 @@ export async function onRequestGet(context) {
     }
 
     // Redirect to success page
-    const baseUrl = env.PUBLIC_URL || new URL(request.url).origin;
+    const baseUrl = getPublicBaseUrl(env);
     return Response.redirect(`${baseUrl}/subscribe?verified=true`, 302);
   } catch (error) {
     console.error("Verification error:", error);

--- a/functions/utils/__tests__/publicUrl.test.js
+++ b/functions/utils/__tests__/publicUrl.test.js
@@ -1,0 +1,103 @@
+// Tests for getPublicBaseUrl — verifies that emailed security links never
+// derive their host from the client-controlled request (Host-header poisoning).
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getPublicBaseUrl } from "../publicUrl.js";
+
+const SAFE_DEFAULT = "https://settimes.ca";
+
+describe("getPublicBaseUrl", () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when PUBLIC_URL is set", () => {
+    it("returns PUBLIC_URL as-is when it has no trailing slash", () => {
+      expect(getPublicBaseUrl({ PUBLIC_URL: "https://example.com" })).toBe(
+        "https://example.com",
+      );
+    });
+
+    it("strips a single trailing slash from PUBLIC_URL", () => {
+      expect(getPublicBaseUrl({ PUBLIC_URL: "https://example.com/" })).toBe(
+        "https://example.com",
+      );
+    });
+
+    it("strips multiple trailing slashes from PUBLIC_URL", () => {
+      expect(getPublicBaseUrl({ PUBLIC_URL: "https://example.com///" })).toBe(
+        "https://example.com",
+      );
+    });
+
+    it("trims surrounding whitespace from PUBLIC_URL before using it", () => {
+      expect(
+        getPublicBaseUrl({ PUBLIC_URL: "  https://example.com  " }),
+      ).toBe("https://example.com");
+    });
+
+    it("does not emit a warning when PUBLIC_URL is set", () => {
+      getPublicBaseUrl({ PUBLIC_URL: "https://example.com" });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns PUBLIC_URL unchanged for staging/preview URLs", () => {
+      const staging = "https://staging.settimes.ca";
+      expect(getPublicBaseUrl({ PUBLIC_URL: staging })).toBe(staging);
+    });
+  });
+
+  describe("when PUBLIC_URL is unset or empty", () => {
+    it("returns the safe production default when PUBLIC_URL is undefined", () => {
+      expect(getPublicBaseUrl({})).toBe(SAFE_DEFAULT);
+    });
+
+    it("returns the safe production default when PUBLIC_URL is null", () => {
+      expect(getPublicBaseUrl({ PUBLIC_URL: null })).toBe(SAFE_DEFAULT);
+    });
+
+    it("returns the safe production default when PUBLIC_URL is an empty string", () => {
+      expect(getPublicBaseUrl({ PUBLIC_URL: "" })).toBe(SAFE_DEFAULT);
+    });
+
+    it("returns the safe production default when PUBLIC_URL is whitespace-only", () => {
+      expect(getPublicBaseUrl({ PUBLIC_URL: "   " })).toBe(SAFE_DEFAULT);
+    });
+
+    it("emits a console.warn when falling back to the safe default", () => {
+      getPublicBaseUrl({});
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0][0]).toMatch(/PUBLIC_URL/);
+    });
+
+    it("emits a warn even when env is null or undefined", () => {
+      expect(getPublicBaseUrl(null)).toBe(SAFE_DEFAULT);
+      expect(getPublicBaseUrl(undefined)).toBe(SAFE_DEFAULT);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("security: result is never derived from request", () => {
+    it("ignores any request object passed alongside env", () => {
+      // Simulates a call site that might accidentally pass request context.
+      // getPublicBaseUrl only accepts env; the result must still be the safe default.
+      const fakeEnv = {};
+      const result = getPublicBaseUrl(fakeEnv);
+      expect(result).toBe(SAFE_DEFAULT);
+      // Must not contain any hostname that could come from request.url
+      expect(result).not.toContain("attacker.example");
+      expect(result).not.toContain("evil.com");
+    });
+
+    it("the safe default is always https://settimes.ca regardless of env content", () => {
+      // Belt-and-suspenders: test the constant value directly
+      expect(getPublicBaseUrl({})).toBe("https://settimes.ca");
+      expect(getPublicBaseUrl({ PUBLIC_URL: "" })).toBe("https://settimes.ca");
+    });
+  });
+});

--- a/functions/utils/announceDigest.js
+++ b/functions/utils/announceDigest.js
@@ -15,11 +15,12 @@
 import { sendEmail } from "./email.js";
 import { logger } from "./logger.js";
 import { escapeHtml } from "./html.js";
+import { getPublicBaseUrl } from "./publicUrl.js";
 
 const SEND_CONCURRENCY = 8;
 
 export async function flushAnnounceDigest(env, DB) {
-  const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
+  const publicUrl = getPublicBaseUrl(env);
 
   // Fetch every pending entry, joining band_follows for email + unsubscribe_token.
   const { results: queue } = await DB.prepare(

--- a/functions/utils/bandFollowNotify.js
+++ b/functions/utils/bandFollowNotify.js
@@ -8,6 +8,7 @@
 // endpoint (bands/[id]/resend-announcement.js).
 import { sendEmail } from "./email.js";
 import { logger } from "./logger.js";
+import { getPublicBaseUrl } from "./publicUrl.js";
 import { escapeHtml } from "./html.js";
 
 export async function notifyBandFollowers(
@@ -15,7 +16,7 @@ export async function notifyBandFollowers(
   DB,
   { performanceId, bandProfileId, bandName, eventName, followers },
 ) {
-  const publicUrl = env.PUBLIC_URL || "https://settimes.ca";
+  const publicUrl = getPublicBaseUrl(env);
 
   const results = await Promise.allSettled(
     followers.map(async (follower) => {

--- a/functions/utils/publicUrl.js
+++ b/functions/utils/publicUrl.js
@@ -1,0 +1,38 @@
+// publicUrl.js — safe base-URL resolution for security-bearing emails
+//
+// The only safe source for the public base URL is a server-side environment
+// variable. Deriving it from request.url (or the Host header) lets an attacker
+// send a victim a password-reset link pointing at an attacker-controlled host
+// (reset-link / Host-header poisoning).
+//
+// Usage:
+//   import { getPublicBaseUrl } from "../../utils/publicUrl.js";
+//   const baseUrl = getPublicBaseUrl(env);
+
+const PROD_BASE_URL = "https://settimes.ca";
+
+/**
+ * Returns the public base URL to use in outbound security-bearing links
+ * (password-reset, activation, invite, verification).
+ *
+ * Prefers env.PUBLIC_URL when set and non-empty. Falls back to the hardcoded
+ * production default — NEVER to request.url — so the link host is never
+ * attacker-controllable via the Host header.
+ *
+ * @param {object} env  Cloudflare Workers env binding
+ * @returns {string}    Base URL with no trailing slash
+ */
+export function getPublicBaseUrl(env) {
+  const url = env?.PUBLIC_URL?.trim();
+  if (url) {
+    return url.replace(/\/+$/, "");
+  }
+  // PUBLIC_URL is documented as required in production. If it is unset the
+  // runtime is mis-configured; log a warning so ops can detect and fix it.
+  // We still return the safe prod default so the flow continues rather than
+  // crashing — but crucially, the host is never derived from the request.
+  console.warn(
+    "[publicUrl] PUBLIC_URL is unset; falling back to the safe production default. Set PUBLIC_URL in the environment.",
+  );
+  return PROD_BASE_URL;
+}


### PR DESCRIPTION
## Summary
Closes #443. Password-reset / activation / invite / verification links were built as `env.PUBLIC_URL || new URL(request.url).origin` — so with `PUBLIC_URL` unset, the link host came from the **client-controlled `Host` header**, letting an attacker have a victim emailed an attacker-controlled reset URL.

## Fix
- **New `functions/utils/publicUrl.js` → `getPublicBaseUrl(env)`** — returns `PUBLIC_URL` (trimmed, trailing-slash stripped) or a hardcoded **safe production default**, **never** the request. Warns on the fallback so a misconfigured `PUBLIC_URL` is alertable. The flow keeps working; the host is just never attacker-controllable.
- **Replaced the Host-trusting fallback at all 5 sites** (reset-password, signup, users invite, resend-activation, subscriptions/verify) + unified **5 more** link builders already using a string default onto the helper — including `subscribe.js`, which had fallen back to a dev `"http://localhost:5173"` URL (a latent prod bug).
- **Left correct request-origin uses untouched:** `csrf.js` (Origin validation) and `ssrMeta.js` (same-origin SPA-shell asset fetch; SEO canonicals are pinned separately in #449).
- **14 helper tests**, including explicit assertions the result is never request-derived.

## Bug class
Same root cause as **#425** (cookies) and **#449** (SEO canonicals): *don't fall through to client-controlled request data when an env var is unset.* This one was surfaced by Cass's #425 security review.

## Verification
Backend **549 tests** pass, `validate:openapi` no drift. Reviewed + verified by Theo (the only remaining request-origin uses confirmed legitimate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)