### PR TITLE
feat(legal): Terms of Service page + Privacy Policy accuracy corrections (Part of #444, #448)

### DIFF
--- a/frontend/public/_routes.json
+++ b/frontend/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "include": ["/api/*", "/s/*", "/sitemap.xml", "/event/*", "/band/*", "/venue/*"],
-  "exclude": ["/", "/admin/*", "/privacy", "/assets/*", "/favicon.ico", "/favicon.svg", "/favicon-*.png", "/apple-touch-icon.png", "/android-chrome-*.png", "/manifest.json", "/robots.txt", "/sw.js", "/offline.html"]
+  "exclude": ["/", "/admin/*", "/privacy", "/terms", "/assets/*", "/favicon.ico", "/favicon.svg", "/favicon-*.png", "/apple-touch-icon.png", "/android-chrome-*.png", "/manifest.json", "/robots.txt", "/sw.js", "/offline.html"]
 }

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -18,6 +18,9 @@ function Footer() {
             <Link to="/privacy" className="text-text-tertiary hover:text-accent-400 transition-colors">
               Privacy Policy
             </Link>
+            <Link to="/terms" className="text-text-tertiary hover:text-accent-400 transition-colors">
+              Terms of Service
+            </Link>
           </div>
 
           <p className="text-text-tertiary text-xs">Times are subject to change - late starts happen!</p>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,6 +10,7 @@ import SubscribePage from './pages/SubscribePage.jsx'
 import ResetPasswordPage from './pages/ResetPasswordPage.jsx'
 import ActivatePage from './pages/ActivatePage.jsx'
 import PrivacyPage from './pages/PrivacyPage.jsx'
+import TermsPage from './pages/TermsPage.jsx'
 import NotFoundPage from './pages/NotFoundPage.jsx'
 import ErrorBoundary from './components/ErrorBoundary.jsx'
 import { measurePageLoad } from './utils/performance'
@@ -86,6 +87,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
               <Route path="/reset-password" element={<ResetPasswordPage />} />
               <Route path="/activate" element={<ActivatePage />} />
               <Route path="/privacy" element={<PrivacyPage />} />
+              <Route path="/terms" element={<TermsPage />} />
 
               {/* Event recap: Lazy loaded */}
               <Route

--- a/frontend/src/pages/PrivacyPage.jsx
+++ b/frontend/src/pages/PrivacyPage.jsx
@@ -23,15 +23,15 @@ export default function PrivacyPage() {
         </Link>
 
         <h1 className="text-text-primary text-3xl font-bold mb-2">Privacy Policy</h1>
-        <p className="text-text-tertiary text-sm mb-10">Last updated: April 2026</p>
+        <p className="text-text-tertiary text-sm mb-10">Last updated: June 2026</p>
 
         <div className="space-y-8 text-text-secondary leading-relaxed">
           <section>
             <h2 className="text-text-primary text-lg font-semibold mb-3">What SetTimes is</h2>
             <p>
               SetTimes (settimes.ca) is a free, community-run schedule tool for Waterloo region music festivals. It
-              helps festival-goers plan their evening. There is no advertising, no tracking pixels, and no third-party
-              analytics. This site is operated by a single developer in the Waterloo region.
+              helps festival-goers plan their evening. This site is operated by a single developer in the Waterloo
+              region.
             </p>
           </section>
 
@@ -40,18 +40,26 @@ export default function PrivacyPage() {
 
             <h3 className="text-text-secondary font-medium mb-2 mt-4">If you just browse</h3>
             <p>
-              We do not use advertising trackers, tracking pixels, or persistent cookies for public browsing. We count
-              anonymous page views and artist profile visits to understand which features are useful. Limited request
-              metadata may be processed briefly for security and abuse prevention, but public browsing is not tied to a
-              persistent account or profiling identifier in our application data.
+              We count anonymous page views and artist profile visits (including social link clicks, ticket link clicks,
+              event views, and schedule builds) to understand which features are useful. These metrics are aggregated
+              and do not identify individual visitors. We use Cloudflare Analytics Engine — a privacy-safe, aggregate,
+              first-party metrics sink on our infrastructure provider (Cloudflare) — rather than third-party tracking
+              scripts or tracking pixels. Limited request metadata may be processed briefly by Cloudflare for security
+              and abuse prevention, but public browsing is not tied to a persistent account or profiling identifier in
+              our application data.
             </p>
 
-            <h3 className="text-text-secondary font-medium mb-2 mt-4">If you subscribe to email updates</h3>
+            <h3 className="text-text-secondary font-medium mb-2 mt-4">
+              If you subscribe to email updates or follow a band
+            </h3>
             <p>
-              We store your email address, your city/genre preferences, and a verification timestamp. We do not store
-              your IP address in the subscription record itself. Limited request metadata may still be processed
-              transiently for abuse prevention and rate limiting. Your email is only used to send the updates you
-              subscribed to, and the one-click unsubscribe in every email removes the active subscription immediately.
+              We store your email address, your city/genre preferences (for subscribers), and a verification timestamp.
+              As a record of your CASL express consent, we also store the IP address from which you subscribed or
+              confirmed your follow, and the consent method (<code className="text-accent-400 text-sm">web_form</code>).
+              This consent record is held for as long as your subscription or follow is active and deleted when you
+              unsubscribe. Limited request metadata may be processed transiently for abuse prevention and rate limiting.
+              Your email is only used to send the updates you subscribed to, and the one-click unsubscribe in every
+              email removes the active subscription immediately.
             </p>
 
             <h3 className="text-text-secondary font-medium mb-2 mt-4">If you are an organiser with admin access</h3>
@@ -59,24 +67,88 @@ export default function PrivacyPage() {
               We store your email address, hashed password (PBKDF2-SHA256, 100,000 iterations), and session tokens.
               Login attempts and admin actions may include security metadata such as IP address and user agent for
               account protection, abuse investigation, and session management. These records are retained for limited
-              periods and deleted automatically according to our retention rules.
+              periods and deleted automatically according to our retention rules (see below).
             </p>
           </section>
 
           <section>
-            <h2 className="text-text-primary text-lg font-semibold mb-3">Your browser storage</h2>
-            <p>
-              We use <code className="text-accent-400 text-sm">localStorage</code> to remember the bands you have added
-              to your personal schedule. This data never leaves your device and is not sent to our servers.
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Data retention</h2>
+            <p className="mb-3">
+              We apply the following automatic retention windows. Records are deleted on the schedule below; no manual
+              request is needed.
             </p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="text-left text-text-primary font-medium py-2 pr-4">Data type</th>
+                    <th className="text-left text-text-primary font-medium py-2">Retention</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  <tr>
+                    <td className="py-2 pr-4">
+                      Sessions, MFA challenges, OTP codes, password-reset tokens, trusted devices
+                    </td>
+                    <td className="py-2">Deleted at expiry</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4">Rate-limit counters</td>
+                    <td className="py-2">~30 minutes</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4">Login attempt log (IPs, emails)</td>
+                    <td className="py-2">30 days</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4">Security audit log (IPs, events)</td>
+                    <td className="py-2">90 days</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4">Admin action log</td>
+                    <td className="py-2">1 year</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4">Email subscribers / band followers (incl. consent IP)</td>
+                    <td className="py-2">Until unsubscribe / unfollow</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Your browser storage</h2>
+            <p className="mb-3">
+              We use <code className="text-accent-400 text-sm">localStorage</code> on your device for:
+            </p>
+            <ul className="list-disc list-outside pl-5 space-y-1">
+              <li>
+                <code className="text-accent-400 text-sm">selectedBandsByEvent</code> — bands you have added to your
+                personal schedule (never sent to our servers)
+              </li>
+              <li>
+                <code className="text-accent-400 text-sm">theme</code> — your preferred colour theme
+              </li>
+              <li>
+                <code className="text-accent-400 text-sm">scheduleSessionId</code> — an anonymous session identifier
+                used to associate your schedule share links
+              </li>
+              <li>Saved route state used for navigation continuity</li>
+              <li>Privacy banner acknowledgement</li>
+            </ul>
+            <p className="mt-3">This data is stored only on your device and is not transmitted to our servers.</p>
           </section>
 
           <section>
             <h2 className="text-text-primary text-lg font-semibold mb-3">Cookies</h2>
             <p>
-              Admin accounts use a secure, HTTP-only session cookie. Public visitors receive no cookies. The privacy
-              banner acknowledgement is stored in <code className="text-accent-400 text-sm">localStorage</code>, not a
-              cookie.
+              Admin accounts use a secure, HTTP-only session cookie. Public pages use a{' '}
+              <code className="text-accent-400 text-sm">csrf_token</code> cookie for cross-site request forgery
+              protection when you interact with forms. Cloudflare (our hosting provider) and Turnstile (our bot
+              protection service) may also set security and anti-abuse cookies as part of their infrastructure and
+              challenge flow. The privacy banner acknowledgement is stored in{' '}
+              <code className="text-accent-400 text-sm">localStorage</code>, not a cookie.
             </p>
           </section>
 
@@ -91,9 +163,22 @@ export default function PrivacyPage() {
           </section>
 
           <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">CASL and commercial email</h2>
+            <p>
+              All email communications require your express consent (double opt-in). Every email includes a one-click
+              unsubscribe link. Our sender identity and mailing address are:{' '}
+              <strong className="text-text-secondary">
+                [TODO: legal — operator legal name + mailing address required by CASL]
+              </strong>
+              .
+            </p>
+          </section>
+
+          <section>
             <h2 className="text-text-primary text-lg font-semibold mb-3">Your rights</h2>
             <p className="mb-3">
-              If you are an email subscriber, the unsubscribe link in every email deletes your subscription immediately.
+              If you are an email subscriber or band follower, the unsubscribe link in every email deletes your
+              subscription immediately.
             </p>
             <p>
               For all other requests — access, correction, erasure, or questions — email{' '}
@@ -109,6 +194,17 @@ export default function PrivacyPage() {
             <p>
               If we make material changes to this policy, we will update the date at the top of this page. We will not
               retroactively weaken privacy protections for data already collected.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Terms of Service</h2>
+            <p>
+              Your use of the Service is also governed by our{' '}
+              <Link to="/terms" className="text-accent-400 hover:text-accent-500 transition-colors">
+                Terms of Service
+              </Link>
+              .
             </p>
           </section>
         </div>

--- a/frontend/src/pages/TermsPage.jsx
+++ b/frontend/src/pages/TermsPage.jsx
@@ -1,0 +1,265 @@
+import { useEffect } from 'react'
+import { Helmet } from 'react-helmet-async'
+import { Link } from 'react-router-dom'
+
+export default function TermsPage() {
+  // react-helmet-async does not reliably set document.title in React 19 — set it
+  // directly to match the <Helmet> title below. See BandProfilePage.jsx.
+  useEffect(() => {
+    document.title = 'Terms of Service | SetTimes'
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple">
+      <Helmet>
+        <title>Terms of Service | SetTimes</title>
+        <meta
+          name="description"
+          content="Terms of Service for SetTimes — Waterloo region live music event scheduling tool."
+        />
+        <link rel="canonical" href="https://settimes.ca/terms" />
+      </Helmet>
+
+      <div className="container mx-auto px-4 max-w-2xl py-12">
+        <Link to="/" className="text-accent-400 hover:text-accent-500 text-sm mb-8 inline-block transition-colors">
+          ← Back to SetTimes
+        </Link>
+
+        <h1 className="text-text-primary text-3xl font-bold mb-2">Terms of Service</h1>
+        <p className="text-text-tertiary text-sm mb-4">Last updated: [DATE]</p>
+
+        {/* Draft banner — visible until legal review is complete */}
+        <div className="border border-border bg-surface rounded-lg px-4 py-3 mb-10 text-sm text-text-secondary">
+          <strong className="text-text-primary">Draft for legal review.</strong> This is a first draft prepared by the
+          settimes.ca team, not legal advice. A qualified Ontario lawyer should review it before publication. Bracketed{' '}
+          <code className="text-accent-400 text-sm">[…]</code> items must be filled in.
+        </div>
+
+        <div className="space-y-8 text-text-secondary leading-relaxed">
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">1. Who we are</h2>
+            <p>
+              settimes.ca (&ldquo;SetTimes&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;, &ldquo;our&rdquo;) is a free,
+              community-run event-schedule tool for live-music events in Waterloo Region, Ontario, Canada. It is
+              operated by{' '}
+              <strong className="text-text-secondary">[TODO: legal — legal name of operator / sole proprietor]</strong>,
+              based in <strong className="text-text-secondary">[TODO: legal — city], Ontario, Canada</strong>. You can
+              reach us at{' '}
+              <a href="mailto:hello@settimes.ca" className="text-accent-400 hover:text-accent-500 transition-colors">
+                hello@settimes.ca
+              </a>
+              .
+            </p>
+            <p className="mt-3">
+              By accessing or using settimes.ca (the &ldquo;Service&rdquo;), you agree to these Terms of Service (the
+              &ldquo;Terms&rdquo;). If you do not agree, please do not use the Service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">2. The Service</h2>
+            <p>
+              SetTimes lets visitors browse event lineups, set times, venues, and artist information, build a personal
+              schedule (stored on your own device), share schedules, and optionally subscribe by email to event or
+              artist updates. The Service is provided free of charge.
+            </p>
+            <p className="mt-3">
+              We do not sell tickets, admit attendees, run venues, or organize the events listed. Ticketing, entry, age
+              restrictions (events may be <strong className="text-text-secondary">19+</strong>), and the events
+              themselves are the responsibility of the venues, promoters, and artists involved.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">3. Acceptable use</h2>
+            <p className="mb-3">You agree not to:</p>
+            <ul className="list-disc list-outside pl-5 space-y-2">
+              <li>use the Service for any unlawful purpose or in violation of these Terms;</li>
+              <li>submit email addresses you do not own or control, or sign others up without their consent;</li>
+              <li>
+                scrape, harvest, or bulk-extract data, or use bots, except as permitted by our{' '}
+                <code className="text-accent-400 text-sm">robots.txt</code>;
+              </li>
+              <li>
+                attempt to gain unauthorized access to any account, admin area, server, or data, or probe, scan, or test
+                the security of the Service without our written permission;
+              </li>
+              <li>
+                interfere with or disrupt the Service (including denial-of-service attempts or circumventing rate
+                limiting or bot protection);
+              </li>
+              <li>
+                upload content that is unlawful, infringing, defamatory, hateful, or that you do not have the right to
+                share;
+              </li>
+              <li>impersonate any person, band, venue, or organization, or misrepresent your affiliation.</li>
+            </ul>
+            <p className="mt-3">
+              We may suspend or block access (including by IP) to protect the Service or other users.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">4. User-submitted content</h2>
+            <p className="mb-3">
+              Some features let you or event organizers submit content — for example, band/artist information, photos,
+              links, and email addresses for follows and subscriptions (&ldquo;Submissions&rdquo;).
+            </p>
+            <ul className="list-disc list-outside pl-5 space-y-2">
+              <li>
+                <strong className="text-text-primary">Your responsibility.</strong> You represent that you have the
+                right to submit the content and that it does not infringe anyone&apos;s rights (including copyright,
+                trademark, privacy, or publicity rights) and is accurate to the best of your knowledge.
+              </li>
+              <li>
+                <strong className="text-text-primary">Band photos and profiles.</strong> If you submit a photo or artist
+                information, you confirm you own it or have permission to use it and to allow us to display it on the
+                Service.
+              </li>
+              <li>
+                <strong className="text-text-primary">Licence to us.</strong> You grant SetTimes a non-exclusive,
+                royalty-free, worldwide licence to host, store, reproduce, and display your Submissions for the purpose
+                of operating and promoting the Service. You retain ownership of your content.
+              </li>
+              <li>
+                <strong className="text-text-primary">Email addresses.</strong> When you submit an email to follow a
+                band or subscribe to updates, you confirm it is your own address. We use a double opt-in confirmation
+                step, and you can unsubscribe at any time (see the Privacy Policy).
+              </li>
+              <li>
+                <strong className="text-text-primary">Takedown.</strong> If you believe content on the Service infringes
+                your rights or is inaccurate, email{' '}
+                <a href="mailto:hello@settimes.ca" className="text-accent-400 hover:text-accent-500 transition-colors">
+                  hello@settimes.ca
+                </a>{' '}
+                and we will review and, where appropriate, remove or correct it. We may remove any Submission at our
+                discretion.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">
+              5. Third-party event, venue, and artist information — accuracy disclaimer
+            </h2>
+            <p>
+              Event details on SetTimes — including{' '}
+              <strong className="text-text-secondary">
+                set times, venue listings, line-ups, age restrictions, and ticketing
+              </strong>{' '}
+              — come from organizers, venues, and artists, and{' '}
+              <strong className="text-text-secondary">change frequently and on short notice</strong>. Late starts and
+              last-minute changes are common.
+            </p>
+            <p className="mt-3">
+              SetTimes provides this information &ldquo;as is&rdquo; for convenience and planning only.{' '}
+              <strong className="text-text-secondary">
+                We do not guarantee that any listing is accurate, complete, or current.
+              </strong>{' '}
+              Always confirm timing, venue, age requirements, and ticket details directly with the venue or organizer
+              before relying on them. Links to third-party sites (venues, ticket sellers, social media) are provided for
+              convenience; we are not responsible for third-party sites or services.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">6. No warranty</h2>
+            <p>
+              The Service is provided &ldquo;as is&rdquo; and &ldquo;as available&rdquo;, without warranties of any
+              kind, whether express or implied, including implied warranties of merchantability, fitness for a
+              particular purpose, and non-infringement. We do not warrant that the Service will be uninterrupted,
+              error-free, or secure. Some jurisdictions do not allow the exclusion of certain warranties, so some of the
+              above may not apply to you.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">7. Limitation of liability</h2>
+            <p>
+              To the fullest extent permitted by law, SetTimes and its operator will not be liable for any indirect,
+              incidental, special, consequential, or punitive damages, or for any loss arising from: (a) your use of or
+              inability to use the Service; (b) reliance on any event, venue, set-time, or artist information; (c) any
+              missed event, denied entry, or ticketing issue; or (d) any third-party content or website.
+            </p>
+            <p className="mt-3">
+              To the extent any liability cannot be excluded, our total aggregate liability to you for all claims
+              relating to the Service is limited to <strong className="text-text-secondary">CAD $100</strong>. Nothing
+              in these Terms limits liability that cannot be limited under applicable Ontario or Canadian law (for
+              example, liability for fraud or for death or personal injury caused by negligence).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">8. Privacy</h2>
+            <p>
+              Your use of the Service is also governed by our{' '}
+              <Link to="/privacy" className="text-accent-400 hover:text-accent-500 transition-colors">
+                Privacy Policy
+              </Link>
+              , which explains what personal information we collect, how we use it, and your rights under Canadian
+              privacy law (PIPEDA) and Canada&apos;s Anti-Spam Legislation (CASL).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">9. Changes to these Terms</h2>
+            <p>
+              We may update these Terms from time to time. When we do, we will change the &ldquo;Last updated&rdquo;
+              date above. Material changes take effect when posted; continuing to use the Service after changes are
+              posted means you accept the updated Terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">10. Governing law and venue</h2>
+            <p>
+              These Terms are governed by the laws of the{' '}
+              <strong className="text-text-secondary">Province of Ontario</strong> and the federal laws of{' '}
+              <strong className="text-text-secondary">Canada</strong> applicable there, without regard to
+              conflict-of-laws rules. You agree that the{' '}
+              <strong className="text-text-secondary">courts located in Ontario, Canada</strong> have exclusive
+              jurisdiction over any dispute arising out of or relating to these Terms or the Service, subject to any
+              non-waivable rights you have under applicable consumer-protection law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">11. Contact</h2>
+            <p>
+              Questions about these Terms? Email{' '}
+              <a href="mailto:hello@settimes.ca" className="text-accent-400 hover:text-accent-500 transition-colors">
+                hello@settimes.ca
+              </a>
+              .
+            </p>
+          </section>
+
+          <section className="border-t border-border pt-8">
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Open items flagged for the lawyer</h2>
+            <ol className="list-decimal list-outside pl-5 space-y-2 text-text-tertiary text-sm">
+              <li>
+                <strong className="text-text-secondary">Operator identity / mailing address.</strong> CASL requires a
+                valid sender identity and mailing address in every commercial email; a sole-proprietor name + Ontario
+                mailing address (or PO box) should be confirmed and added here and in email footers.
+              </li>
+              <li>
+                <strong className="text-text-secondary">Minors.</strong> Events may be 19+, but the website and its
+                email signup are open to all ages. Consider whether to restrict email collection to 16+/18+ and add an
+                age statement (CASL/PIPEDA consent from minors is a known grey area).
+              </li>
+              <li>
+                <strong className="text-text-secondary">&ldquo;Commercial activity&rdquo; / liability cap.</strong> A
+                free, non-commercial tool may not need a damages cap or may want a different one; confirm the cap and
+                indemnity posture for a hobby/community project vs. a business.
+              </li>
+              <li>
+                <strong className="text-text-secondary">Ticketing/third-party links.</strong> If affiliate or paid
+                ticket links are ever added, revisit Sections 2, 5, and 7.
+              </li>
+            </ol>
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## ⚠️ HOLD — pending legal review
**Do not merge until:** (1) a lawyer reviews, and (2) the `[TODO: legal]` placeholders are filled (operator **legal name + mailing address** — CASL requires sender identity in commercial email). This PR is the review gate. The Privacy Policy is a **live** page, so the CASL-sender placeholder must be filled before merge.

## #444 — Terms of Service page
- New `frontend/src/pages/TermsPage.jsx` rendering the legal-pass ToS draft **verbatim** (11 sections + the "open items for the lawyer" list), behind its visible **"Draft for legal review"** banner.
- `/terms` route, footer link beside Privacy, `/terms` in `_routes.json`. Theme tokens, React-19 `document.title` workaround, escaped entities. `[TODO: legal]` for operator legal name + city.

## #448 — Privacy Policy corrections (live page)
1. **CRITICAL** — removed the **false** "we do not store your IP address" sentence; replaced with an accurate CASL express-consent disclosure (we *do* store `consent_ip` + `consent_method`).
2. **Retention table** from `retention.js` (auth_attempts 30d, auth_audit 90d, audit_log 1y, sessions/MFA/OTP/reset/trusted-devices at expiry, rate_limits ~30min) + subscriber/follower records kept until unsubscribe.
3. **Analytics** corrected — full event list; reconciled "no third-party analytics" with the first-party Cloudflare Analytics Engine sink.
4. **Cookies/localStorage** broadened (`csrf_token`, `scheduleSessionId`, theme, saved route, Turnstile/Cloudflare security cookies).
5. `[TODO: legal]` placeholder for the CASL sender mailing address. "Last updated" bumped.

## Verification
Frontend **228 tests** pass, build green, lint 0 errors, **zero `text-white`/`bg-white`** on these theme-following pages. Built by Sonny from Portia's specs; reviewed by Theo for theme tokens + factual accuracy of the corrections.

Part of #444 and #448 (these close once a lawyer reviews + the placeholders are filled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)