### PR TITLE
ci: Dependabot major-version guard + E2E on schema changes + Playwright cache (Part of #451)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,15 @@ jobs:
         if: github.actor == 'dependabot[bot]'
 
         steps:
+            - name: Fetch Dependabot metadata
+              id: fetch-metadata
+              uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Enable auto-merge
+              # Skip major-version bumps — they require human review
+              if: steps.fetch-metadata.outputs.update-type != 'version-update:semver-major'
               env:
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-a11y-visual.yml
+++ b/.github/workflows/e2e-a11y-visual.yml
@@ -6,6 +6,8 @@ on:
         paths:
             - 'e2e/accessibility/**'
             - 'e2e/visual-regression.spec.js'
+            - 'migrations/**'
+            - 'database/**'
     schedule:
         - cron: '0 7 * * 1'
 
@@ -53,6 +55,8 @@ jobs:
               with:
                   path: ~/.cache/ms-playwright
                   key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+                  restore-keys: |
+                      playwright-${{ runner.os }}-
 
             - name: Install Playwright browsers
               run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,26 +44,31 @@ jobs:
                       frontend: 'frontend/**'
                       e2e: 'e2e/**'
                       functions: 'functions/**'
+                      schema: |
+                          migrations/**
+                          database/**
 
             - name: Install dependencies
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true'
+              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
               run: npm ci
 
             - name: Install frontend dependencies
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true'
+              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
               working-directory: frontend
               run: npm ci
 
             - name: Cache Playwright browsers
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true'
+              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
               id: playwright-cache
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   path: ~/.cache/ms-playwright
                   key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+                  restore-keys: |
+                      playwright-${{ runner.os }}-
 
             - name: Install Playwright browsers
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true'
+              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
               run: |
                   if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
                       npx playwright install-deps chromium
@@ -73,12 +78,12 @@ jobs:
                   fi
 
             - name: Build frontend
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true'
+              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
               working-directory: frontend
               run: npm run build
 
             - name: Initialize D1 database with schema
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true'
+              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
               env:
                   E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
                   E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
@@ -106,7 +111,7 @@ jobs:
                   echo "✓ Database initialization complete"
 
             - name: Start Pages Functions server
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true'
+              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
               timeout-minutes: 5
               run: |
                   ./frontend/node_modules/.bin/wrangler pages dev frontend/dist --port 8788 --persist-to .wrangler/state > /tmp/wrangler.log 2>&1 &
@@ -141,7 +146,7 @@ jobs:
                   exit 1
 
             - name: Run Playwright tests
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true'
+              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
               env:
                   ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
                   ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -21,10 +21,6 @@ jobs:
   gitleaks:
     name: Detect Secrets (gitleaks)
     runs-on: ubuntu-latest
-    env:
-      # gitleaks-action v2.3.9 declares Node 20 but runs fine on Node 24.
-      # Opt in early before GitHub forces the switch on 2026-06-02.
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/update-visual-snapshots.yml
+++ b/.github/workflows/update-visual-snapshots.yml
@@ -49,6 +49,8 @@ jobs:
               with:
                   path: ~/.cache/ms-playwright
                   key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+                  restore-keys: |
+                      playwright-${{ runner.os }}-
 
             - name: Install Playwright browsers
               env:


### PR DESCRIPTION
## Summary
The low-risk **quick wins** from the CI audit (#451):

- **Dependabot major-version guard** (`dependabot-auto-merge.yml`) — adds `dependabot/fetch-metadata` (SHA-pinned **v3.1.0**, verified) and gates the auto-merge step on `update-type != 'version-update:semver-major'`. A major React/Vite/wrangler bump no longer auto-merges on green — it waits for a human; non-major bumps still auto-merge.
- **E2E on schema changes** (`e2e-tests.yml`) — adds `migrations/**` + `database/**` to the `dorny/paths-filter` (new `schema` filter) so a PR touching migrations or `setup-complete.sql` actually runs E2E. Closes the documented `setup-complete.sql`-drift→500 blind spot. `e2e-a11y-visual.yml` gets the paths on its trigger too.
- **Playwright cache `restore-keys`** on all three E2E workflows — a lockfile bump warms a partial browser cache instead of a full re-download.
- **`secret-scan.yml`** — drops the now-expired `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env (2026-06-02 cutoff passed).

## Deferred (own PR)
#451 **#1** (ESLint for `functions/`) and **#2** (prettier for `functions/`+`scripts/`) — the "under-gated backend" items — need a backend reformat/config pass first, so a blind check step doesn't turn CI red immediately. Plus the medium items (#4 composite-action dedupe, #7–#9).

## Verification
All 5 changed workflows parse (js-yaml); `fetch-metadata` SHA confirmed = `v3.1.0` via `git ls-remote`; the `if:` guard is on the auto-merge step (so metadata always runs). Built by Sonny, reviewed by Theo.

Part of #451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)