### PR TITLE
fix(legal): resolve public [TODO] placeholders on live Terms + Privacy pages

### DIFF
--- a/frontend/src/pages/PrivacyPage.jsx
+++ b/frontend/src/pages/PrivacyPage.jsx
@@ -166,10 +166,11 @@ export default function PrivacyPage() {
             <h2 className="text-text-primary text-lg font-semibold mb-3">CASL and commercial email</h2>
             <p>
               All email communications require your express consent (double opt-in). Every email includes a one-click
-              unsubscribe link. Our sender identity and mailing address are:{' '}
-              <strong className="text-text-secondary">
-                [TODO: legal — operator legal name + mailing address required by CASL]
-              </strong>
+              unsubscribe link and identifies the sender as <strong className="text-text-secondary">SetTimes</strong>.
+              You can reach us at{' '}
+              <a href="mailto:hello@settimes.ca" className="text-accent-400 hover:text-accent-500 transition-colors">
+                hello@settimes.ca
+              </a>
               .
             </p>
           </section>

--- a/frontend/src/pages/TermsPage.jsx
+++ b/frontend/src/pages/TermsPage.jsx
@@ -26,7 +26,7 @@ export default function TermsPage() {
         </Link>
 
         <h1 className="text-text-primary text-3xl font-bold mb-2">Terms of Service</h1>
-        <p className="text-text-tertiary text-sm mb-4">Last updated: [DATE]</p>
+        <p className="text-text-tertiary text-sm mb-4">Last updated: June 2026</p>
 
         {/* Draft banner — visible until legal review is complete */}
         <div className="border border-border bg-surface rounded-lg px-4 py-3 mb-10 text-sm text-text-secondary">
@@ -41,9 +41,7 @@ export default function TermsPage() {
             <p>
               settimes.ca (&ldquo;SetTimes&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;, &ldquo;our&rdquo;) is a free,
               community-run event-schedule tool for live-music events in Waterloo Region, Ontario, Canada. It is
-              operated by{' '}
-              <strong className="text-text-secondary">[TODO: legal — legal name of operator / sole proprietor]</strong>,
-              based in <strong className="text-text-secondary">[TODO: legal — city], Ontario, Canada</strong>. You can
+              operated from <strong className="text-text-secondary">Waterloo Region, Ontario, Canada</strong>. You can
               reach us at{' '}
               <a href="mailto:hello@settimes.ca" className="text-accent-400 hover:text-accent-500 transition-colors">
                 hello@settimes.ca


### PR DESCRIPTION
## Summary
The merged legal pages (#456) left `[TODO: legal]` placeholders **publicly visible** on the live `/terms` and `/privacy` pages. This resolves them — with **no personal information** exposed (brand + region + `hello@settimes.ca` only).

- **Terms "Who we are":** `operated by [legal name], based in [city]` → **"operated from Waterloo Region, Ontario, Canada"** (no operator residence). `Last updated: [DATE]` → **June 2026**.
- **Privacy CASL section:** the `[TODO: operator legal name + mailing address]` placeholder → identifies the sender as **SetTimes** with contact **hello@settimes.ca**.

## On the CASL mailing address
CASL requires a valid mailing address in *commercial email footers* — **not your home address**, and a **PO box / virtual mailbox** satisfies it. That's deferred to the email templates (pending a PO box) + final legal review; the "draft — pending legal review" banner stays on both pages.

## Verification
Frontend **228 tests**, lint 0 errors, build green. No `[TODO]`/`[DATE]` placeholders remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)