### PR TITLE
feat(legal): "Download PDF" + community-project banner on Terms/Privacy

### DIFF
--- a/frontend/src/components/DownloadPdfButton.jsx
+++ b/frontend/src/components/DownloadPdfButton.jsx
@@ -1,0 +1,26 @@
+import { Download } from 'lucide-react'
+
+/**
+ * DownloadPdfButton — "Download PDF" for the legal pages (Terms / Privacy).
+ *
+ * Triggers the browser print dialog (window.print()); the print stylesheet in
+ * index.css (@media print) isolates the `.legal-document` content so the saved
+ * PDF is a clean, text-selectable copy of just the legal text — no app chrome.
+ * This keeps the legal content single-source in the React page (no duplicated
+ * text to drift) and adds no PDF-library bundle weight.
+ *
+ * The button itself is marked `no-print` so it never appears in the output.
+ */
+export default function DownloadPdfButton({ className = '' }) {
+  return (
+    <button
+      type="button"
+      onClick={() => window.print()}
+      aria-label="Download this page as a PDF — opens your browser print dialog; choose Save as PDF"
+      className={`no-print inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-border bg-surface px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500 ${className}`}
+    >
+      <Download size={16} aria-hidden="true" />
+      Download PDF
+    </button>
+  )
+}

--- a/frontend/src/components/__tests__/DownloadPdfButton.test.jsx
+++ b/frontend/src/components/__tests__/DownloadPdfButton.test.jsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import DownloadPdfButton from '../DownloadPdfButton'
+
+describe('DownloadPdfButton', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders a Download PDF button', () => {
+    render(<DownloadPdfButton />)
+    expect(screen.getByRole('button', { name: /download this page as a pdf/i })).toBeInTheDocument()
+    expect(screen.getByText('Download PDF')).toBeInTheDocument()
+  })
+
+  it('calls window.print() when clicked', () => {
+    const printSpy = vi.spyOn(window, 'print').mockImplementation(() => {})
+    render(<DownloadPdfButton />)
+    fireEvent.click(screen.getByRole('button', { name: /download this page as a pdf/i }))
+    expect(printSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is marked no-print so it never appears in the saved PDF', () => {
+    render(<DownloadPdfButton />)
+    expect(screen.getByRole('button')).toHaveClass('no-print')
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -644,3 +644,60 @@ body {
 .ghost-bob {
   animation: ghost-bob 1.6s ease-in-out infinite;
 }
+
+/* Print / Save-as-PDF for the legal pages (Terms, Privacy). The "Download PDF"
+   button calls window.print(); these rules isolate the .legal-document content
+   into a clean dark-on-white document and hide all app chrome (nav, footer,
+   gradient background, the button itself). The legal text stays single-source in
+   the React page — no duplicated content, no PDF library. */
+@page {
+  margin: 2cm;
+}
+
+@media print {
+  html,
+  body {
+    background: #fff !important;
+  }
+
+  /* Hide everything, then reveal only the legal document. */
+  body * {
+    visibility: hidden;
+  }
+  .legal-document,
+  .legal-document * {
+    visibility: visible;
+  }
+  .legal-document {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    padding: 0;
+  }
+
+  /* Force legible dark-on-white (the on-screen theme is light-on-dark). */
+  .legal-document,
+  .legal-document * {
+    color: #1a1a1a !important;
+    background: transparent !important;
+    box-shadow: none !important;
+  }
+  .legal-document a {
+    color: #1a1a1a !important;
+    text-decoration: underline;
+  }
+
+  /* Elements excluded from the printed output (back link, the button itself). */
+  .no-print {
+    display: none !important;
+  }
+
+  /* Keep headings with their content; don't split sections across pages. */
+  .legal-document h1,
+  .legal-document h2 {
+    page-break-after: avoid;
+  }
+  .legal-document section {
+    break-inside: avoid;
+  }
+}

--- a/frontend/src/pages/PrivacyPage.jsx
+++ b/frontend/src/pages/PrivacyPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { Link } from 'react-router-dom'
+import DownloadPdfButton from '../components/DownloadPdfButton'
 
 export default function PrivacyPage() {
   // react-helmet-async does not reliably set document.title in React 19 — set it
@@ -17,10 +18,13 @@ export default function PrivacyPage() {
         <link rel="canonical" href="https://settimes.ca/privacy" />
       </Helmet>
 
-      <div className="container mx-auto px-4 max-w-2xl py-12">
-        <Link to="/" className="text-accent-400 hover:text-accent-500 text-sm mb-8 inline-block transition-colors">
-          ← Back to SetTimes
-        </Link>
+      <div className="container mx-auto px-4 max-w-2xl py-12 legal-document">
+        <div className="no-print mb-8 flex items-center justify-between gap-3">
+          <Link to="/" className="text-accent-400 hover:text-accent-500 text-sm transition-colors">
+            ← Back to SetTimes
+          </Link>
+          <DownloadPdfButton />
+        </div>
 
         <h1 className="text-text-primary text-3xl font-bold mb-2">Privacy Policy</h1>
         <p className="text-text-tertiary text-sm mb-10">Last updated: June 2026</p>

--- a/frontend/src/pages/TermsPage.jsx
+++ b/frontend/src/pages/TermsPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { Link } from 'react-router-dom'
+import DownloadPdfButton from '../components/DownloadPdfButton'
 
 export default function TermsPage() {
   // react-helmet-async does not reliably set document.title in React 19 — set it
@@ -20,10 +21,13 @@ export default function TermsPage() {
         <link rel="canonical" href="https://settimes.ca/terms" />
       </Helmet>
 
-      <div className="container mx-auto px-4 max-w-2xl py-12">
-        <Link to="/" className="text-accent-400 hover:text-accent-500 text-sm mb-8 inline-block transition-colors">
-          ← Back to SetTimes
-        </Link>
+      <div className="container mx-auto px-4 max-w-2xl py-12 legal-document">
+        <div className="no-print mb-8 flex items-center justify-between gap-3">
+          <Link to="/" className="text-accent-400 hover:text-accent-500 text-sm transition-colors">
+            ← Back to SetTimes
+          </Link>
+          <DownloadPdfButton />
+        </div>
 
         <h1 className="text-text-primary text-3xl font-bold mb-2">Terms of Service</h1>
         <p className="text-text-tertiary text-sm mb-4">Last updated: June 2026</p>

--- a/frontend/src/pages/TermsPage.jsx
+++ b/frontend/src/pages/TermsPage.jsx
@@ -32,11 +32,13 @@ export default function TermsPage() {
         <h1 className="text-text-primary text-3xl font-bold mb-2">Terms of Service</h1>
         <p className="text-text-tertiary text-sm mb-4">Last updated: June 2026</p>
 
-        {/* Draft banner — visible until legal review is complete */}
+        {/* Good-faith notice for a free community project (not legal advice). */}
         <div className="border border-border bg-surface rounded-lg px-4 py-3 mb-10 text-sm text-text-secondary">
-          <strong className="text-text-primary">Draft for legal review.</strong> This is a first draft prepared by the
-          settimes.ca team, not legal advice. A qualified Ontario lawyer should review it before publication. Bracketed{' '}
-          <code className="text-accent-400 text-sm">[…]</code> items must be filled in.
+          <strong className="text-text-primary">SetTimes is a free, community-run project.</strong> These terms are
+          provided in good faith to be clear and fair — not legal advice. Questions?{' '}
+          <a href="mailto:hello@settimes.ca" className="text-accent-400 hover:text-accent-500 transition-colors">
+            hello@settimes.ca
+          </a>
         </div>
 
         <div className="space-y-8 text-text-secondary leading-relaxed">


### PR DESCRIPTION
## Summary
Two legal-page touches (both public, theme-following surfaces):

### 1. "Download PDF" on /terms and /privacy
Triggers the browser's print dialog (→ "Save as PDF"); a print stylesheet renders just the legal content as a clean, **text-selectable** document — useful for handing a reviewer a markup-able copy, and a nice touch for users.
- **`DownloadPdfButton`** (new) — `no-print`, accessible (real `<button>`, 44px target, focus-visible ring, `aria-label` clarifying it opens the print dialog). Beside the "← Back" link on both pages.
- **`@media print`** in `index.css` — isolates `.legal-document`, hides app chrome (nav, footer, gradient bg, the button + back link), forces legible **dark-on-white**, avoids splitting headings/sections across pages, `@page { margin: 2cm }`.
- Print-to-PDF keeps the legal text **single-source** in the React page — no duplicated content to drift, no PDF-library bundle weight.

### 2. Terms banner reframed for a free community project
With the `[TODO]` brackets gone (#458), the *"Draft for legal review — bracketed items must be filled in"* banner was stale and read corporate. Replaced with a good-faith community-project notice + `hello@settimes.ca` contact — fitting a free, non-commercial tool.

## Verification
Frontend **231 tests** pass (incl. 3 new `DownloadPdfButton` tests), lint 0 errors, build green. No duplicated legal text; no `text-white`/`bg-white` on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)