### PR TITLE
fix(events): show all future published events in timeline "upcoming" (Vol-17 not appearing)

### DIFF
--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -649,3 +649,40 @@ describe("Timeline real-DB — reveal_mode JOIN gate (SQL exercise)", () => {
     expect(found.bands).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Real-DB regression — "upcoming" must NOT be capped to a fixed day-window.
+// A flagship event published weeks out (e.g. the Vol-17 crawl ~6 weeks ahead)
+// must appear in "upcoming" the moment it's published — not only once it falls
+// inside an arbitrary horizon. Regression for the old `AND date <= date(?,
+// '+30 days')` cap, which hid Vol-17 (~33 days out when published) entirely.
+// ---------------------------------------------------------------------------
+describe("Timeline real-DB — upcoming has no fixed day-window cap (SQL exercise)", () => {
+  test("a published event more than 30 days out appears in 'upcoming'", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 45 days out — comfortably past the old 30-day horizon.
+    const farFuture = new Date(Date.now() + 45 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split("T")[0];
+
+    const event = insertEvent(rawDb, {
+      name: "Flagship Crawl",
+      slug: "timeline-realdb-far-future",
+      date: farFuture,
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const found = data.upcoming.find((e) => e.id === event.id);
+    expect(found).toBeDefined();
+    expect(found.slug).toBe("timeline-realdb-far-future");
+  });
+});

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -184,7 +184,11 @@ export async function onRequestGet(context) {
       );
     }
 
-    // "Upcoming" events (future events, next 30 days) - single JOIN query
+    // "Upcoming" events (all future published events, soonest first) - single
+    // JOIN query. No fixed day-window cap: a flagship event weeks out (e.g. the
+    // Vol-17 crawl ~6 weeks ahead) must be visible the moment it's published, not
+    // only once it falls inside an arbitrary 30-day horizon. The LIMIT 10 in the
+    // subquery bounds the result size, matching the cap-free /api/events/public.
     if (includeUpcoming) {
       slots.upcoming = statements.length;
       statements.push(
@@ -221,18 +225,16 @@ export async function onRequestGet(context) {
         LEFT JOIN venues v ON p.venue_id = v.id
         WHERE e.is_published = 1
         AND e.date > ?
-        AND e.date <= date(?, '+30 days')
         AND e.id IN (
           SELECT id FROM events
           WHERE is_published = 1
           AND date > ?
-          AND date <= date(?, '+30 days')
           ORDER BY date ASC
           LIMIT 10
         )
         ORDER BY e.date ASC, p.start_time, v.name
       `,
-        ).bind(today, today, today, today),
+        ).bind(today, today),
       );
     }
 


### PR DESCRIPTION
## The bug
**Vol-17 was published (`is_published=1`, `2026-08-02`) but not showing on the homepage.**

The homepage (`EventTimeline.jsx`) reads `/api/events/timeline`, which splits events into now/upcoming/past. The **"upcoming" query capped to the next 30 days**:
```sql
AND e.date <= date(?, '+30 days')
```
Today is ~2026-06-30; +30 days = 2026-07-30. Vol-17 is **2026-08-02 (~33 days out)** — past the window. So it fell in a gap: not "now" (not today), not "upcoming" (>30 days away), not "past". **Invisible**, despite being correctly published.

## Diagnosis (localized against prod, not guessed)
- DB: Vol-17 row is `is_published=1`, `status='published'`, future date. ✅ data fine.
- `GET /api/events/public` → returned Vol-17. ✅ that endpoint has no day-cap.
- `GET /api/events/timeline` → `upcoming: []`. ❌ the 30-day cap.

## The fix
Remove the 30-day upper bound from the upcoming query (main query + the `IN (...)` subquery). The subquery's `LIMIT 10` still bounds result size, matching the already-cap-free `/api/events/public`. A flagship event published weeks out is now visible immediately — the full promo runway.

## Test
Added a **real-DB regression test**: a published event **45 days out** must appear in `upcoming`. Confirmed it **fails on the old cap** and **passes on the fix**.

## Verification
Backend **552 tests** (25 timeline, incl. the new regression), `validate:openapi` no drift.

Fixes the Vol-17 visibility report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)