### PR TITLE
fix(admin): editing a band on a venue-less performance no longer fails with "Venue not found"

### DIFF
--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -272,7 +272,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
       const originDisplay = [formData.origin_city, formData.origin_region].filter(Boolean).join(', ') || ''
       const payload = {
         eventId: Number(formData.event_id),
-        venueId: Number(formData.venue_id),
+        venueId: formData.venue_id ? Number(formData.venue_id) : null,
         name: formData.name,
         startTime: formData.start_time,
         endTime: formData.end_time,

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -143,6 +143,16 @@ export async function onRequestPut(context) {
       photo_alt_text,
       social_links,
     } = body;
+
+    // Normalize venueId: treat "", 0, "0" as null (no venue assigned).
+    // Guards against the frontend sending Number("") = 0 when no venue is selected,
+    // which would otherwise pass the !== null check and then 404 on "Venue not found".
+    const normalizedVenueId =
+      venueId === undefined
+        ? undefined
+        : !venueId || Number(venueId) <= 0
+          ? null
+          : Number(venueId);
     let resolvedPhotoUrl;
     try {
       resolvedPhotoUrl =
@@ -211,7 +221,7 @@ export async function onRequestPut(context) {
       // events the band has played. Only block when a performance field is the
       // thing actually being changed.
       const editsPerformanceFields =
-        venueId !== undefined ||
+        normalizedVenueId !== undefined ||
         startTime !== undefined ||
         endTime !== undefined;
       if (linkedEvent?.status === "archived" && editsPerformanceFields) {
@@ -341,7 +351,7 @@ export async function onRequestPut(context) {
     const actualEndTime =
       endTime !== undefined ? endTime : performance.end_time;
     const actualVenueId =
-      venueId !== undefined ? venueId : performance.venue_id;
+      normalizedVenueId !== undefined ? normalizedVenueId : performance.venue_id;
 
     // Validate times (allow sets that cross midnight; prevent zero-length sets)
     if (actualStartTime && actualEndTime && actualStartTime === actualEndTime) {
@@ -357,14 +367,14 @@ export async function onRequestPut(context) {
       );
     }
 
-    // Check if venue exists (only if venueId is being changed)
-    if (venueId !== undefined && venueId !== null) {
+    // Check if venue exists (only when a specific positive venue id was provided)
+    if (normalizedVenueId != null) {
       const venue = await DB.prepare(
         `
         SELECT id FROM venues WHERE id = ?
       `,
       )
-        .bind(venueId)
+        .bind(normalizedVenueId)
         .first();
 
       if (!venue) {
@@ -560,9 +570,9 @@ export async function onRequestPut(context) {
 
     // Handle performance updates (ONLY if it's a real performance)
     if (!isProfileUpdate) {
-      if (venueId !== undefined) {
+      if (normalizedVenueId !== undefined) {
         updates.push("venue_id = ?");
-        params.push(venueId);
+        params.push(normalizedVenueId);
       }
       if (startTime !== undefined) {
         updates.push("start_time = ?");

--- a/functions/api/admin/bands/__tests__/bands.test.js
+++ b/functions/api/admin/bands/__tests__/bands.test.js
@@ -1077,6 +1077,101 @@ describe('Admin bands API - bulk-preview after-midnight conflict detection (T2/V
   })
 })
 
+describe('Admin bands API - venue-optional PUT (Closes #407)', () => {
+  it('PUT with venueId: 0 on a venue-less performance returns 200 and keeps venue NULL', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'NullVenuePut0', slug: 'null-venue-put0' })
+    // insertBand default: venue_id = null
+    const band = insertBand(rawDb, { name: 'No Venue Band 0', event_id: ev.id })
+
+    const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        venueId: 0,
+        social_links: JSON.stringify({ website: 'https://example.com' }),
+      }),
+    })
+
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
+    expect(res.status).toBe(200)
+    const row = rawDb.prepare('SELECT venue_id FROM performances WHERE id = ?').get(band.id)
+    expect(row.venue_id).toBeNull()
+  })
+
+  it('PUT with venueId: "" on a venue-less performance returns 200 and keeps venue NULL', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'NullVenuePutEmpty', slug: 'null-venue-put-empty' })
+    const band = insertBand(rawDb, { name: 'No Venue Band Empty', event_id: ev.id })
+
+    const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        venueId: '',
+        social_links: JSON.stringify({ instagram: '@testband' }),
+      }),
+    })
+
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
+    expect(res.status).toBe(200)
+    const row = rawDb.prepare('SELECT venue_id FROM performances WHERE id = ?').get(band.id)
+    expect(row.venue_id).toBeNull()
+  })
+
+  it('PUT without venueId on a venue-less performance returns 200 and keeps venue NULL', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'NullVenuePutOmit', slug: 'null-venue-put-omit' })
+    const band = insertBand(rawDb, { name: 'No Venue Band Omit', event_id: ev.id })
+
+    const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ social_links: JSON.stringify({ bandcamp: 'https://band.bandcamp.com' }) }),
+    })
+
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
+    expect(res.status).toBe(200)
+    const row = rawDb.prepare('SELECT venue_id FROM performances WHERE id = ?').get(band.id)
+    expect(row.venue_id).toBeNull()
+  })
+
+  it('PUT with a positive invalid venueId still returns 404 (guard still fires)', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'InvalidVenuePut', slug: 'invalid-venue-put' })
+    const band = insertBand(rawDb, { name: 'Invalid Venue Band', event_id: ev.id })
+
+    const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ venueId: 99999 }),
+    })
+
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
+    expect(res.status).toBe(404)
+    const data = await res.json()
+    expect(data.message).toBe('Venue not found')
+  })
+
+  it('PUT with venueId: null clears an existing venue assignment', async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+    const ev = insertEvent(rawDb, { name: 'ClearVenuePut', slug: 'clear-venue-put' })
+    const venue = insertVenue(rawDb, { name: 'Clear Test Venue' })
+    const band = insertBand(rawDb, { name: 'Clear Venue Band', event_id: ev.id, venue_id: venue.id })
+
+    const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ venueId: null }),
+    })
+
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
+    expect(res.status).toBe(200)
+    const row = rawDb.prepare('SELECT venue_id FROM performances WHERE id = ?').get(band.id)
+    expect(row.venue_id).toBeNull()
+  })
+})
+
 describe('Admin bands API - PUT conflict self-exclusion (T3)', () => {
   it('PUT update does not conflict with the band being updated (self-exclusion)', async () => {
     const { env, rawDb, headers } = createTestEnv({ role: 'editor' })


### PR DESCRIPTION
## Summary

- **Root cause (confirmed):** `LineupTab.jsx` sends `venueId: Number(formData.venue_id)` in every update payload. When a performance has `venue_id = NULL` (all 22 Vol-17 bands), `formData.venue_id` is `""` and `Number("") = 0`. The backend guard `venueId !== undefined && venueId !== null` passes for `0`, then `SELECT id FROM venues WHERE id = 0` finds nothing and returns 404 "Venue not found".
- **Frontend fix** (`LineupTab.jsx`): send `null` instead of `0` when the venue field is blank (`formData.venue_id ? Number(formData.venue_id) : null`).
- **Backend fix** (`functions/api/admin/bands/[id].js`): normalize `venueId` from the request body immediately after destructuring — treat `0`, `""`, and `"0"` as `null` (no venue). Only a positive integer passes through to the venue-exists check. The DB write follows the same normalization so no junk `0` value ever reaches `venue_id`.

## Changed files

| File | Change |
|---|---|
| `frontend/src/admin/LineupTab.jsx` | `venueId: formData.venue_id ? Number(...) : null` — sends `null` when blank |
| `functions/api/admin/bands/[id].js` | Normalizes `venueId` after body parse; replaces all downstream uses with `normalizedVenueId` |
| `functions/api/admin/bands/__tests__/bands.test.js` | 5 new regression tests |

## Test plan

- [x] `venueId: 0` on a venue-less performance → 200, `venue_id` stays NULL
- [x] `venueId: ""` on a venue-less performance → 200, `venue_id` stays NULL
- [x] omitted `venueId` on a venue-less performance → 200, `venue_id` stays NULL
- [x] positive invalid `venueId` (99999) still → 404 "Venue not found" (guard still fires)
- [x] `venueId: null` clears an existing venue assignment → 200, `venue_id` is NULL
- [x] All 551 backend tests pass, all 231 frontend tests pass, 0 lint errors, build clean

## Security note

This endpoint requires `editor` role and a valid session+CSRF token (unchanged). The normalization is defense-in-depth and does not expand the attack surface — it only prevents a frontend-originated `0` from being treated as a venue id to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)