### PR TITLE
feat(legal): real one-click PDF download (jsPDF) + remove internal open-items section

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@tiptap/react": "^3.27.1",
         "@tiptap/starter-kit": "^3.27.1",
         "dompurify": "^3.4.11",
+        "jspdf": "^4.2.1",
         "lucide-react": "^1.22.0",
         "prop-types": "^15.8.1",
         "qrcode.react": "^4.2.0",
@@ -332,10 +333,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3756,6 +3756,19 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -4410,6 +4423,16 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.40",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
@@ -4656,6 +4679,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -5021,6 +5064,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5052,6 +5107,16 @@
       "integrity": "sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -6409,6 +6474,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -6418,6 +6494,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "2.0.0",
@@ -6927,6 +7009,20 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7206,6 +7302,12 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -8126,6 +8228,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -9513,6 +9632,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -9589,6 +9724,13 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -10025,6 +10167,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -10173,6 +10325,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -10248,6 +10407,16 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/robots-parser": {
       "version": "3.0.1",
@@ -10998,6 +11167,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -11193,6 +11372,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -11350,6 +11539,16 @@
         "react-native-b4a": {
           "optional": true
         }
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/third-party-web": {
@@ -11778,6 +11977,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "@tiptap/react": "^3.27.1",
     "@tiptap/starter-kit": "^3.27.1",
     "dompurify": "^3.4.11",
+    "jspdf": "^4.2.1",
     "lucide-react": "^1.22.0",
     "prop-types": "^15.8.1",
     "qrcode.react": "^4.2.0",

--- a/frontend/src/components/DownloadPdfButton.jsx
+++ b/frontend/src/components/DownloadPdfButton.jsx
@@ -1,26 +1,185 @@
+import { useState } from 'react'
 import { Download } from 'lucide-react'
 
 /**
- * DownloadPdfButton — "Download PDF" for the legal pages (Terms / Privacy).
+ * DownloadPdfButton — one-click PDF download for the legal pages (Terms / Privacy).
  *
- * Triggers the browser print dialog (window.print()); the print stylesheet in
- * index.css (@media print) isolates the `.legal-document` content so the saved
- * PDF is a clean, text-selectable copy of just the legal text — no app chrome.
- * This keeps the legal content single-source in the React page (no duplicated
- * text to drift) and adds no PDF-library bundle weight.
+ * Dynamically imports jsPDF on click (separate chunk, not in the main bundle) and
+ * generates a text-selectable PDF directly from the rendered `.legal-document` DOM.
+ * Legal prose stays single-source in the React page — no duplicated text to drift.
  *
- * The button itself is marked `no-print` so it never appears in the output.
+ * DOM traversal rules:
+ *  - Skip any element with the `no-print` class (back link, this button).
+ *  - h1/h2/h3 → bold headings at decreasing font sizes.
+ *  - p         → body paragraph.
+ *  - ul/ol     → bullet / numbered list items.
+ *  - table     → "Data type — Retention" rows (privacy table).
+ *  - div/section/article → recurse. If a container has no block-level children
+ *    (e.g. a notice div whose only children are <strong> and <a>) its full
+ *    textContent is emitted as a paragraph.
+ *
+ * The filename is derived from document.title so the same component works on
+ * both /terms and /privacy without extra props.
  */
+
+const BLOCK_TAGS = new Set([
+  'h1',
+  'h2',
+  'h3',
+  'p',
+  'ul',
+  'ol',
+  'table',
+  'div',
+  'section',
+  'article',
+  'aside',
+  'blockquote',
+])
+
+function deriveFilename() {
+  const title = (document.title || '').toLowerCase()
+  if (title.includes('privacy')) return 'settimes-privacy-policy.pdf'
+  return 'settimes-terms-of-service.pdf'
+}
+
+function extractItems(container) {
+  const items = []
+
+  function processNode(node) {
+    if (!node || node.nodeType !== 1) return
+    if (node.classList?.contains('no-print')) return
+
+    const tag = node.tagName?.toLowerCase()
+
+    if (tag === 'h1') {
+      items.push({ type: 'h1', text: node.textContent.trim() })
+    } else if (tag === 'h2') {
+      items.push({ type: 'h2', text: node.textContent.trim() })
+    } else if (tag === 'h3') {
+      items.push({ type: 'h3', text: node.textContent.trim() })
+    } else if (tag === 'p') {
+      const text = node.textContent.trim()
+      if (text) items.push({ type: 'p', text })
+    } else if (tag === 'ul' || tag === 'ol') {
+      Array.from(node.querySelectorAll(':scope > li')).forEach((li, i) => {
+        const prefix = tag === 'ul' ? '• ' : `${i + 1}. `
+        const text = li.textContent.trim()
+        if (text) items.push({ type: 'li', text: prefix + text })
+      })
+    } else if (tag === 'table') {
+      Array.from(node.querySelectorAll('tr')).forEach(row => {
+        const cells = row.querySelectorAll('th, td')
+        if (cells.length >= 2) {
+          const label = cells[0].textContent.trim()
+          const value = cells[1].textContent.trim()
+          if (label || value) items.push({ type: 'table-row', text: `${label} — ${value}` })
+        }
+      })
+    } else {
+      // Container element: recurse if it has block-level children; otherwise
+      // treat its full text content as a paragraph (handles notice divs etc.)
+      const hasBlockChild = Array.from(node.children || []).some(c => BLOCK_TAGS.has(c.tagName?.toLowerCase()))
+      if (hasBlockChild) {
+        Array.from(node.childNodes).forEach(child => processNode(child))
+      } else {
+        const text = node.textContent?.trim()
+        if (text) items.push({ type: 'p', text })
+      }
+    }
+  }
+
+  Array.from(container.childNodes).forEach(child => processNode(child))
+  return items
+}
+
+async function generatePdf() {
+  const container = document.querySelector('.legal-document')
+  if (!container) return
+
+  const { jsPDF } = await import('jspdf')
+  const items = extractItems(container)
+
+  const margin = 20 // mm
+  const pageWidth = 210 // A4
+  const pageHeight = 297 // A4
+  const contentWidth = pageWidth - margin * 2
+  const bottomMargin = 25
+
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' })
+  let y = margin
+
+  function checkPageBreak(neededMm) {
+    if (y + neededMm > pageHeight - bottomMargin) {
+      doc.addPage()
+      y = margin
+    }
+  }
+
+  function addBlock(text, fontSize, bold, spacingAfter = 4) {
+    doc.setFontSize(fontSize)
+    doc.setFont('helvetica', bold ? 'bold' : 'normal')
+    const lines = doc.splitTextToSize(text, contentWidth)
+    // 1pt = 0.352778mm; use 1.25 line-height factor
+    const lineH = fontSize * 0.352778 * 1.25
+    const blockH = lines.length * lineH
+    checkPageBreak(blockH + spacingAfter)
+    doc.text(lines, margin, y)
+    y += blockH + spacingAfter
+  }
+
+  for (const item of items) {
+    switch (item.type) {
+      case 'h1':
+        if (y > margin) y += 5
+        addBlock(item.text, 18, true, 6)
+        break
+      case 'h2':
+        if (y > margin) y += 7
+        addBlock(item.text, 13, true, 4)
+        break
+      case 'h3':
+        if (y > margin) y += 4
+        addBlock(item.text, 11, true, 3)
+        break
+      case 'p':
+        addBlock(item.text, 10, false, 4)
+        break
+      case 'li':
+        addBlock(item.text, 10, false, 2)
+        break
+      case 'table-row':
+        addBlock(item.text, 10, false, 2)
+        break
+    }
+  }
+
+  doc.save(deriveFilename())
+}
+
 export default function DownloadPdfButton({ className = '' }) {
+  const [isGenerating, setIsGenerating] = useState(false)
+
+  async function handleClick() {
+    if (isGenerating) return
+    setIsGenerating(true)
+    try {
+      await generatePdf()
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
   return (
     <button
       type="button"
-      onClick={() => window.print()}
-      aria-label="Download this page as a PDF — opens your browser print dialog; choose Save as PDF"
-      className={`no-print inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-border bg-surface px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500 ${className}`}
+      onClick={handleClick}
+      disabled={isGenerating}
+      aria-label="Download this page as a PDF file"
+      className={`no-print inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-border bg-surface px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500 disabled:cursor-not-allowed disabled:opacity-60 ${className}`}
     >
       <Download size={16} aria-hidden="true" />
-      Download PDF
+      {isGenerating ? 'Generating…' : 'Download PDF'}
     </button>
   )
 }

--- a/frontend/src/components/__tests__/DownloadPdfButton.test.jsx
+++ b/frontend/src/components/__tests__/DownloadPdfButton.test.jsx
@@ -1,11 +1,45 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import DownloadPdfButton from '../DownloadPdfButton'
+
+// Hoist mock references so they are available inside the vi.mock() factory,
+// which is hoisted to the top of the module by Vitest before any imports.
+const { mockSave, mockSplitTextToSize } = vi.hoisted(() => ({
+  mockSave: vi.fn(),
+  mockSplitTextToSize: vi.fn(text => [text]),
+}))
+
+vi.mock('jspdf', () => ({
+  // Must use a regular constructor function (not an arrow function) so that
+  // `new jsPDF()` works correctly in Vitest 4.x — arrow functions can't be
+  // called as constructors and the vi.fn() wrapper does not override that.
+  jsPDF: vi.fn(function () {
+    this.save = mockSave
+    this.text = vi.fn()
+    this.setFont = vi.fn()
+    this.setFontSize = vi.fn()
+    this.addPage = vi.fn()
+    this.splitTextToSize = mockSplitTextToSize
+  }),
+}))
 
 describe('DownloadPdfButton', () => {
   afterEach(() => {
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
+    // Remove any .legal-document nodes injected for individual tests
+    document.querySelectorAll('.legal-document').forEach(el => el.remove())
   })
+
+  function injectLegalDocument(titleContains = 'Terms') {
+    document.title = titleContains.includes('Privacy') ? 'Privacy Policy | SetTimes' : 'Terms of Service | SetTimes'
+    const div = document.createElement('div')
+    div.className = 'legal-document'
+    const h1 = document.createElement('h1')
+    h1.textContent = titleContains.includes('Privacy') ? 'Privacy Policy' : 'Terms of Service'
+    div.appendChild(h1)
+    document.body.appendChild(div)
+    return div
+  }
 
   it('renders a Download PDF button', () => {
     render(<DownloadPdfButton />)
@@ -13,15 +47,60 @@ describe('DownloadPdfButton', () => {
     expect(screen.getByText('Download PDF')).toBeInTheDocument()
   })
 
-  it('calls window.print() when clicked', () => {
-    const printSpy = vi.spyOn(window, 'print').mockImplementation(() => {})
-    render(<DownloadPdfButton />)
-    fireEvent.click(screen.getByRole('button', { name: /download this page as a pdf/i }))
-    expect(printSpy).toHaveBeenCalledTimes(1)
-  })
-
-  it('is marked no-print so it never appears in the saved PDF', () => {
+  it('is marked no-print so it never appears in the generated PDF', () => {
     render(<DownloadPdfButton />)
     expect(screen.getByRole('button')).toHaveClass('no-print')
+  })
+
+  it('calls doc.save() with a .pdf filename when clicked', async () => {
+    injectLegalDocument('Terms')
+    render(<DownloadPdfButton />)
+    fireEvent.click(screen.getByRole('button', { name: /download this page as a pdf/i }))
+    await waitFor(() => {
+      expect(mockSave).toHaveBeenCalledTimes(1)
+      expect(mockSave).toHaveBeenCalledWith(expect.stringMatching(/\.pdf$/))
+    })
+  })
+
+  it('uses the privacy filename when document.title contains "Privacy"', async () => {
+    injectLegalDocument('Privacy')
+    render(<DownloadPdfButton />)
+    fireEvent.click(screen.getByRole('button', { name: /download this page as a pdf/i }))
+    await waitFor(() => {
+      expect(mockSave).toHaveBeenCalledWith('settimes-privacy-policy.pdf')
+    })
+  })
+
+  it('uses the terms filename when document.title contains "Terms"', async () => {
+    injectLegalDocument('Terms')
+    render(<DownloadPdfButton />)
+    fireEvent.click(screen.getByRole('button', { name: /download this page as a pdf/i }))
+    await waitFor(() => {
+      expect(mockSave).toHaveBeenCalledWith('settimes-terms-of-service.pdf')
+    })
+  })
+
+  it('does NOT call window.print()', async () => {
+    const printSpy = vi.spyOn(window, 'print').mockImplementation(() => {})
+    injectLegalDocument('Terms')
+    render(<DownloadPdfButton />)
+    fireEvent.click(screen.getByRole('button', { name: /download this page as a pdf/i }))
+    await waitFor(() => {
+      expect(mockSave).toHaveBeenCalledTimes(1)
+    })
+    expect(printSpy).not.toHaveBeenCalled()
+  })
+
+  it('disables the button while generating and re-enables after', async () => {
+    injectLegalDocument('Terms')
+    render(<DownloadPdfButton />)
+    const btn = screen.getByRole('button', { name: /download this page as a pdf/i })
+    fireEvent.click(btn)
+    // Immediately after click the button should be disabled
+    expect(btn).toBeDisabled()
+    // After the async generation completes it should be enabled again
+    await waitFor(() => {
+      expect(btn).not.toBeDisabled()
+    })
   })
 })

--- a/frontend/src/pages/TermsPage.jsx
+++ b/frontend/src/pages/TermsPage.jsx
@@ -237,31 +237,6 @@ export default function TermsPage() {
               .
             </p>
           </section>
-
-          <section className="border-t border-border pt-8">
-            <h2 className="text-text-primary text-lg font-semibold mb-3">Open items flagged for the lawyer</h2>
-            <ol className="list-decimal list-outside pl-5 space-y-2 text-text-tertiary text-sm">
-              <li>
-                <strong className="text-text-secondary">Operator identity / mailing address.</strong> CASL requires a
-                valid sender identity and mailing address in every commercial email; a sole-proprietor name + Ontario
-                mailing address (or PO box) should be confirmed and added here and in email footers.
-              </li>
-              <li>
-                <strong className="text-text-secondary">Minors.</strong> Events may be 19+, but the website and its
-                email signup are open to all ages. Consider whether to restrict email collection to 16+/18+ and add an
-                age statement (CASL/PIPEDA consent from minors is a known grey area).
-              </li>
-              <li>
-                <strong className="text-text-secondary">&ldquo;Commercial activity&rdquo; / liability cap.</strong> A
-                free, non-commercial tool may not need a damages cap or may want a different one; confirm the cap and
-                indemnity posture for a hobby/community project vs. a business.
-              </li>
-              <li>
-                <strong className="text-text-secondary">Ticketing/third-party links.</strong> If affiliate or paid
-                ticket links are ever added, revisit Sections 2, 5, and 7.
-              </li>
-            </ol>
-          </section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Real PDF download** — replaces `window.print()` with a client-side jsPDF generation flow. On click the component dynamically imports jsPDF (lazy chunk, not in the main bundle), walks the live `.legal-document` DOM to extract headings/paragraphs/lists/tables, and calls `doc.save()` to trigger a direct file download — no print dialog.
- **Text-selectable output** — DOM text is fed to jsPDF as strings, producing a proper searchable/copyable PDF. Headings are bold at decreasing sizes; list items get bullet/number prefixes; the Privacy retention table renders as "Data type — Retention" rows.
- **Single source of truth** — no prose duplicated in JS; content stays in the React pages.
- **Filename auto-detected** from `document.title` — `settimes-terms-of-service.pdf` or `settimes-privacy-policy.pdf`.
- **Loading state** — button shows "Generating…" and is `disabled` while the async import + generation runs; re-enables on completion or error.
- **Open-items section removed** — the "Open items flagged for the lawyer" section in TermsPage (internal review notes: operator identity/CASL, minors, liability cap, ticketing links) is deleted. Internal notes don't belong on a live public page.
- **Test updated** — drops `window.print()` spy; adds `vi.hoisted` jsPDF constructor mock (regular function, not arrow, per Vitest 4.x constructor requirement) and asserts `doc.save()` is called with the correct `.pdf` filename for both pages.

## Bundle impact

| Chunk | Size | Gzip |
|---|---|---|
| `jspdf.es.min-*.js` | 403.92 kB | **129.33 kB** |

Downloaded only on first click — zero impact on initial page load.

## Test plan

- [ ] All 235 unit tests pass (`npm test -- --run`)
- [ ] 0 ESLint errors
- [ ] Build green (`npm run build`)
- [ ] No `text-white`/`bg-white` violations on `/terms` or `/privacy`
- [ ] Click "Download PDF" on `/terms` → browser downloads `settimes-terms-of-service.pdf` (no print dialog)
- [ ] Click "Download PDF" on `/privacy` → browser downloads `settimes-privacy-policy.pdf`
- [ ] Button shows "Generating…" disabled state during generation
- [ ] PDF is text-selectable and contains all section content
- [ ] Privacy retention table appears as "Data type — Retention" rows in PDF
- [ ] "Open items flagged for the lawyer" section is gone from `/terms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)