### PR TITLE
ci: enforce prettier on functions/ + scripts/ (Closes #451 item 2)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -67,6 +67,29 @@ jobs:
       - name: Check code formatting
         run: npm run format:check
 
+  format-check-backend:
+    name: Format Check (backend)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Check backend code formatting
+        run: npm run format:check
+
   accessibility-tests:
     name: Accessibility Tests
     runs-on: ubuntu-latest

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "endOfLine": "lf"
+}

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,19 +1,15 @@
 // Shared middleware for Cloudflare Pages Functions
 // Handles CORS, rate limiting, error handling, and common headers
 
-import {
-  checkRateLimit,
-  rateLimitHeaders,
-  rateLimitResponse,
-} from './utils/rateLimit.js';
-import { createRequestLogger } from './utils/logger.js';
+import { checkRateLimit, rateLimitHeaders, rateLimitResponse } from "./utils/rateLimit.js";
+import { createRequestLogger } from "./utils/logger.js";
 
 export async function onRequest(context) {
   const { request, env } = context;
 
   // Only process API routes - let static files pass through without middleware
   const url = new URL(request.url);
-  if (!url.pathname.startsWith('/api/')) {
+  if (!url.pathname.startsWith("/api/")) {
     return context.next();
   }
 
@@ -21,52 +17,48 @@ export async function onRequest(context) {
 
   // Allowed origins for CORS (production and development)
   const baseAllowedOrigins = [
-    'https://settimes.ca',
-    'https://www.settimes.ca',
-    'https://dev.settimesdotca.pages.dev',
-    'https://settimesdotca.pages.dev',
-    'https://dev.settimes.ca',
-    'http://localhost:5173',
-    'http://localhost:3000',
-    'http://localhost:8788',
-    'http://127.0.0.1:5173',
-    'http://127.0.0.1:3000',
-    'http://127.0.0.1:8788',
+    "https://settimes.ca",
+    "https://www.settimes.ca",
+    "https://dev.settimesdotca.pages.dev",
+    "https://settimesdotca.pages.dev",
+    "https://dev.settimes.ca",
+    "http://localhost:5173",
+    "http://localhost:3000",
+    "http://localhost:8788",
+    "http://127.0.0.1:5173",
+    "http://127.0.0.1:3000",
+    "http://127.0.0.1:8788",
   ];
-  const envAllowedOrigins = (env?.CORS_ALLOWED_ORIGINS || '')
-    .split(',')
+  const envAllowedOrigins = (env?.CORS_ALLOWED_ORIGINS || "")
+    .split(",")
     .map((origin) => origin.trim())
     .filter(Boolean);
-  const ALLOWED_ORIGINS = Array.from(
-    new Set([...baseAllowedOrigins, ...envAllowedOrigins])
-  );
+  const ALLOWED_ORIGINS = Array.from(new Set([...baseAllowedOrigins, ...envAllowedOrigins]));
 
   // SECURITY: Check if origin is allowed
-  const origin = request.headers.get('Origin');
+  const origin = request.headers.get("Origin");
 
   // Only set CORS headers if origin is explicitly allowed
   const corsHeaders = {};
   if (ALLOWED_ORIGINS.includes(origin)) {
-    corsHeaders['Access-Control-Allow-Origin'] = origin;
-    corsHeaders['Access-Control-Allow-Methods'] =
-      'GET, POST, PUT, DELETE, OPTIONS';
-    corsHeaders['Access-Control-Allow-Headers'] =
-      'Content-Type, Authorization, X-CSRF-Token';
-    corsHeaders['Access-Control-Max-Age'] = '86400';
-    corsHeaders['Access-Control-Allow-Credentials'] = 'true';
+    corsHeaders["Access-Control-Allow-Origin"] = origin;
+    corsHeaders["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS";
+    corsHeaders["Access-Control-Allow-Headers"] = "Content-Type, Authorization, X-CSRF-Token";
+    corsHeaders["Access-Control-Max-Age"] = "86400";
+    corsHeaders["Access-Control-Allow-Credentials"] = "true";
   } else if (!origin) {
     // Same-origin request (no Origin header) - allow
     // Browser will handle same-origin policy
   } else {
     // Origin provided but not in allowed list - reject
-    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
+    return new Response(JSON.stringify({ error: "Origin not allowed" }), {
       status: 403,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 
   // Handle preflight requests
-  if (request.method === 'OPTIONS') {
+  if (request.method === "OPTIONS") {
     return new Response(null, {
       status: 204,
       headers: corsHeaders,
@@ -80,22 +72,22 @@ export async function onRequest(context) {
   }
 
   // Basic request size guard for non-upload API requests (1MB)
-  if (['POST', 'PUT', 'PATCH'].includes(request.method)) {
-    const contentType = request.headers.get('Content-Type') || '';
-    const isMultipart = contentType.includes('multipart/form-data');
-    const contentLength = Number(request.headers.get('Content-Length') || 0);
+  if (["POST", "PUT", "PATCH"].includes(request.method)) {
+    const contentType = request.headers.get("Content-Type") || "";
+    const isMultipart = contentType.includes("multipart/form-data");
+    const contentLength = Number(request.headers.get("Content-Length") || 0);
     if (!isMultipart && contentLength > 1_000_000) {
-      return new Response(JSON.stringify({ error: 'Payload too large' }), {
+      return new Response(JSON.stringify({ error: "Payload too large" }), {
         status: 413,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+        headers: { "Content-Type": "application/json", ...corsHeaders },
       });
     }
   }
 
   const cspEnforce =
     env?.CSP_ENFORCE !== undefined && env?.CSP_ENFORCE !== null
-      ? env?.CSP_ENFORCE === 'true'
-      : env?.ENVIRONMENT === 'production';
+      ? env?.CSP_ENFORCE === "true"
+      : env?.ENVIRONMENT === "production";
 
   // Single source of truth for the Content-Security-Policy (reused on both the
   // success and error responses below).
@@ -121,7 +113,7 @@ export async function onRequest(context) {
     "worker-src 'self'",
     "base-uri 'self'",
     "frame-ancestors 'none'",
-  ].join('; ');
+  ].join("; ");
 
   // Enable FK enforcement for this D1 session. SQLite disables it by default;
   // this must be set per-connection so it applies to every handler in this request.
@@ -134,10 +126,9 @@ export async function onRequest(context) {
   // page). The guard is a strict allowlist of read-only methods — anything else
   // (POST/PUT/PATCH/DELETE or an unknown method) still gets FK enforcement, so
   // the invariant holds for every mutation. Do NOT widen this to skip writes.
-  const isReadOnlyMethod =
-    request.method === 'GET' || request.method === 'HEAD';
+  const isReadOnlyMethod = request.method === "GET" || request.method === "HEAD";
   if (env.DB && !isReadOnlyMethod) {
-    await env.DB.prepare('PRAGMA foreign_keys = ON').run();
+    await env.DB.prepare("PRAGMA foreign_keys = ON").run();
   }
 
   try {
@@ -164,26 +155,20 @@ export async function onRequest(context) {
     });
 
     // Traceability: Add Request ID to response headers
-    newHeaders.set('X-Request-ID', log.getRequestId());
+    newHeaders.set("X-Request-ID", log.getRequestId());
 
     // Security headers
-    newHeaders.set('X-Content-Type-Options', 'nosniff');
-    newHeaders.set('X-Frame-Options', 'DENY');
-    newHeaders.set('Referrer-Policy', 'no-referrer');
-    newHeaders.set(
-      'Permissions-Policy',
-      'geolocation=(), microphone=(), camera=()'
-    );
+    newHeaders.set("X-Content-Type-Options", "nosniff");
+    newHeaders.set("X-Frame-Options", "DENY");
+    newHeaders.set("Referrer-Policy", "no-referrer");
+    newHeaders.set("Permissions-Policy", "geolocation=(), microphone=(), camera=()");
     if (cspEnforce) {
-      newHeaders.set('Content-Security-Policy', csp);
+      newHeaders.set("Content-Security-Policy", csp);
     } else {
-      newHeaders.set('Content-Security-Policy-Report-Only', csp);
+      newHeaders.set("Content-Security-Policy-Report-Only", csp);
     }
-    if (request.url.startsWith('https://')) {
-      newHeaders.set(
-        'Strict-Transport-Security',
-        'max-age=63072000; includeSubDomains; preload'
-      );
+    if (request.url.startsWith("https://")) {
+      newHeaders.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
     }
 
     return new Response(response.body, {
@@ -192,26 +177,24 @@ export async function onRequest(context) {
       headers: newHeaders,
     });
   } catch (error) {
-    log.error('Middleware error', { error });
+    log.error("Middleware error", { error });
 
     return new Response(
       JSON.stringify({
-        error: 'Internal server error',
+        error: "Internal server error",
       }),
       {
         status: 500,
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
           ...corsHeaders,
-          'X-Content-Type-Options': 'nosniff',
-          'X-Frame-Options': 'DENY',
-          'Referrer-Policy': 'no-referrer',
-          'Permissions-Policy': 'geolocation=(), microphone=(), camera=()',
-          ...(cspEnforce
-            ? { 'Content-Security-Policy': csp }
-            : { 'Content-Security-Policy-Report-Only': csp }),
+          "X-Content-Type-Options": "nosniff",
+          "X-Frame-Options": "DENY",
+          "Referrer-Policy": "no-referrer",
+          "Permissions-Policy": "geolocation=(), microphone=(), camera=()",
+          ...(cspEnforce ? { "Content-Security-Policy": csp } : { "Content-Security-Policy-Report-Only": csp }),
         },
-      }
+      },
     );
   }
 }

--- a/functions/api/__tests__/artists.test.js
+++ b/functions/api/__tests__/artists.test.js
@@ -1,10 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  createTestEnv,
-  insertEvent,
-  insertBand,
-  insertVenue,
-} from "../test-utils";
+import { createTestEnv, insertEvent, insertBand, insertVenue } from "../test-utils";
 import * as artists from "../artists.js";
 
 function seedEnv() {

--- a/functions/api/__tests__/schedule-reveal.test.js
+++ b/functions/api/__tests__/schedule-reveal.test.js
@@ -1,56 +1,56 @@
-import { describe, it, expect } from 'vitest'
-import { createTestEnv, insertEvent, insertVenue, insertBand } from '../test-utils'
-import * as scheduleHandler from '../schedule.js'
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../test-utils";
+import * as scheduleHandler from "../schedule.js";
 
-describe('GET /api/schedule - reveal mode', () => {
-  it('returns all bands when reveal_mode is off', async () => {
-    const { env, rawDb } = createTestEnv()
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal-off', status: 'draft' })
-    rawDb.prepare('UPDATE events SET is_published=1 WHERE id=?').run(ev.id)
-    const venue = insertVenue(rawDb, { name: 'Venue A' })
-    insertBand(rawDb, { name: 'Announced Band', event_id: ev.id, venue_id: venue.id })
-    const unannounced = insertBand(rawDb, { name: 'Hidden Band', event_id: ev.id, venue_id: venue.id })
-    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(unannounced.id)
+describe("GET /api/schedule - reveal mode", () => {
+  it("returns all bands when reveal_mode is off", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-reveal-off", status: "draft" });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    const venue = insertVenue(rawDb, { name: "Venue A" });
+    insertBand(rawDb, { name: "Announced Band", event_id: ev.id, venue_id: venue.id });
+    const unannounced = insertBand(rawDb, { name: "Hidden Band", event_id: ev.id, venue_id: venue.id });
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(unannounced.id);
 
-    const req = new Request('https://example.test/api/schedule?event=vol6-reveal-off')
-    const res = await scheduleHandler.onRequestGet({ request: req, env })
-    expect(res.status).toBe(200)
-    const data = await res.json()
+    const req = new Request("https://example.test/api/schedule?event=vol6-reveal-off");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
     // reveal_mode=0: all bands returned regardless of is_announced
-    expect(data.bands.length).toBe(2)
-    expect(data.event.reveal_mode).toBe(0)
-  })
+    expect(data.bands.length).toBe(2);
+    expect(data.event.reveal_mode).toBe(0);
+  });
 
-  it('filters unannounced bands when reveal_mode is on', async () => {
-    const { env, rawDb } = createTestEnv()
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal-on' })
-    rawDb.prepare('UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?').run(ev.id)
-    const venue = insertVenue(rawDb, { name: 'Venue B' })
-    const announced = insertBand(rawDb, { name: 'Visible Band', event_id: ev.id, venue_id: venue.id })
-    rawDb.prepare('UPDATE performances SET is_announced=1 WHERE id=?').run(announced.id)
-    const hidden = insertBand(rawDb, { name: 'Hidden Band', event_id: ev.id, venue_id: venue.id })
-    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(hidden.id)
+  it("filters unannounced bands when reveal_mode is on", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-reveal-on" });
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(ev.id);
+    const venue = insertVenue(rawDb, { name: "Venue B" });
+    const announced = insertBand(rawDb, { name: "Visible Band", event_id: ev.id, venue_id: venue.id });
+    rawDb.prepare("UPDATE performances SET is_announced=1 WHERE id=?").run(announced.id);
+    const hidden = insertBand(rawDb, { name: "Hidden Band", event_id: ev.id, venue_id: venue.id });
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(hidden.id);
 
-    const req = new Request('https://example.test/api/schedule?event=vol6-reveal-on')
-    const res = await scheduleHandler.onRequestGet({ request: req, env })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.bands.length).toBe(1)
-    expect(data.bands[0].name).toBe('Visible Band')
-    expect(data.event.reveal_mode).toBe(1)
-  })
+    const req = new Request("https://example.test/api/schedule?event=vol6-reveal-on");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.bands.length).toBe(1);
+    expect(data.bands[0].name).toBe("Visible Band");
+    expect(data.event.reveal_mode).toBe(1);
+  });
 
-  it('includes reveal_mode in event metadata', async () => {
-    const { env, rawDb } = createTestEnv()
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-meta' })
-    rawDb.prepare('UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?').run(ev.id)
+  it("includes reveal_mode in event metadata", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-meta" });
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(ev.id);
 
-    const req = new Request('https://example.test/api/schedule?event=vol6-meta')
-    const res = await scheduleHandler.onRequestGet({ request: req, env })
-    const data = await res.json()
-    expect(data.event.reveal_mode).toBe(1)
-  })
-})
+    const req = new Request("https://example.test/api/schedule?event=vol6-meta");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    const data = await res.json();
+    expect(data.event.reveal_mode).toBe(1);
+  });
+});

--- a/functions/api/__tests__/venues.test.js
+++ b/functions/api/__tests__/venues.test.js
@@ -1,10 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  createTestEnv,
-  insertEvent,
-  insertBand,
-  insertVenue,
-} from "../test-utils";
+import { createTestEnv, insertEvent, insertBand, insertVenue } from "../test-utils";
 import * as venues from "../venues.js";
 import * as venueDetail from "../venues/[id].js";
 

--- a/functions/api/admin/__tests__/audit-log.test.js
+++ b/functions/api/admin/__tests__/audit-log.test.js
@@ -17,10 +17,7 @@ describe("Admin audit log API", () => {
       )
       .run(1, "event.updated", "event", 11, JSON.stringify({ name: "B" }), "127.0.0.1");
 
-    const req = new Request(
-      "https://example.test/api/admin/audit-log?limit=1&offset=0",
-      { headers },
-    );
+    const req = new Request("https://example.test/api/admin/audit-log?limit=1&offset=0", { headers });
     const res = await auditLogHandler.onRequestGet({ request: req, env });
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -45,10 +42,7 @@ describe("Admin audit log API", () => {
       )
       .run(2, "user.updated", "user", 98, JSON.stringify({ email: "y@test" }), "127.0.0.1");
 
-    const req = new Request(
-      "https://example.test/api/admin/audit-log?user_id=1&action=user.created",
-      { headers },
-    );
+    const req = new Request("https://example.test/api/admin/audit-log?user_id=1&action=user.created", { headers });
     const res = await auditLogHandler.onRequestGet({ request: req, env });
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -60,10 +54,7 @@ describe("Admin audit log API", () => {
   it("rejects limit over 100", async () => {
     const { env, headers } = createTestEnv({ role: "admin" });
 
-    const req = new Request(
-      "https://example.test/api/admin/audit-log?limit=250",
-      { headers },
-    );
+    const req = new Request("https://example.test/api/admin/audit-log?limit=250", { headers });
     const res = await auditLogHandler.onRequestGet({ request: req, env });
     expect(res.status).toBe(400);
   });

--- a/functions/api/admin/__tests__/bands-follower-count.test.js
+++ b/functions/api/admin/__tests__/bands-follower-count.test.js
@@ -1,64 +1,55 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from "vitest";
 
-vi.mock('../_middleware.js', () => ({
+vi.mock("../_middleware.js", () => ({
   checkPermission: async (context) => {
-    const role =
-      context?.data?.user?.role || context?.request?.headers?.get('x-test-role')
+    const role = context?.data?.user?.role || context?.request?.headers?.get("x-test-role");
     if (!role) {
       return {
         error: true,
-        response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        response: new Response(JSON.stringify({ error: "Unauthorized" }), {
           status: 401,
-          headers: { 'Content-Type': 'application/json' },
+          headers: { "Content-Type": "application/json" },
         }),
-      }
+      };
     }
-    return { error: false, user: { userId: 1, role }, userId: 1 }
+    return { error: false, user: { userId: 1, role }, userId: 1 };
   },
   auditLog: vi.fn(async () => {}),
-}))
+}));
 
-import { onRequestGet } from '../bands.js'
-import { createTestEnv } from '../../test-utils.js'
+import { onRequestGet } from "../bands.js";
+import { createTestEnv } from "../../test-utils.js";
 
-describe('GET /api/admin/bands — follower_count', () => {
-  test('includes the verified follower count per band', async () => {
-    const { env, rawDb } = createTestEnv()
+describe("GET /api/admin/bands — follower_count", () => {
+  test("includes the verified follower count per band", async () => {
+    const { env, rawDb } = createTestEnv();
     const profileId = rawDb
-      .prepare(
-        'INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)'
-      )
-      .run('The Reverbs', 'thereverbs').lastInsertRowid
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("The Reverbs", "thereverbs").lastInsertRowid;
 
     // 2 verified followers + 1 unverified (should not count)
     rawDb
-      .prepare(
-        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
-      )
-      .run('a@x.co', profileId, 'tk-a')
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("a@x.co", profileId, "tk-a");
     rawDb
-      .prepare(
-        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
-      )
-      .run('b@x.co', profileId, 'tk-b')
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("b@x.co", profileId, "tk-b");
     rawDb
-      .prepare(
-        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 0, ?)'
-      )
-      .run('c@x.co', profileId, 'tk-c')
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 0, ?)")
+      .run("c@x.co", profileId, "tk-c");
 
     const res = await onRequestGet({
-      request: new Request('https://example.test/api/admin/bands', {
-        headers: { 'x-test-role': 'viewer' },
+      request: new Request("https://example.test/api/admin/bands", {
+        headers: { "x-test-role": "viewer" },
       }),
       env,
-      data: { user: { userId: 1, role: 'viewer' } },
-    })
+      data: { user: { userId: 1, role: "viewer" } },
+    });
 
-    expect(res.status).toBe(200)
-    const body = await res.json()
-    const band = (body.bands || []).find((b) => b.name === 'The Reverbs')
-    expect(band).toBeTruthy()
-    expect(band.follower_count).toBe(2)
-  })
-})
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const band = (body.bands || []).find((b) => b.name === "The Reverbs");
+    expect(band).toBeTruthy();
+    expect(band.follower_count).toBe(2);
+  });
+});

--- a/functions/api/admin/__tests__/login.test.js
+++ b/functions/api/admin/__tests__/login.test.js
@@ -43,16 +43,7 @@ async function postLogin(env, { email, password }) {
   return onRequestPost({ request, env });
 }
 
-function insertUser(
-  rawDb,
-  {
-    email,
-    hash,
-    isActive = 1,
-    activatedAt = "2025-01-01 00:00:00",
-    role = "editor",
-  } = {},
-) {
+function insertUser(rawDb, { email, hash, isActive = 1, activatedAt = "2025-01-01 00:00:00", role = "editor" } = {}) {
   rawDb
     .prepare(
       `INSERT INTO users

--- a/functions/api/admin/__tests__/middleware.test.js
+++ b/functions/api/admin/__tests__/middleware.test.js
@@ -1,21 +1,21 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test } from "vitest";
 
-import { onRequest } from '../_middleware.js';
-import { createTestEnv } from '../../test-utils.js';
+import { onRequest } from "../_middleware.js";
+import { createTestEnv } from "../../test-utils.js";
 
-const BASE_URL = 'https://example.test/api/admin/me';
+const BASE_URL = "https://example.test/api/admin/me";
 
-describe('admin auth middleware', () => {
-  test('reports remaining idle time instead of the full idle timeout', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' });
-    const sessionId = headers.Authorization.replace('Bearer ', '');
+describe("admin auth middleware", () => {
+  test("reports remaining idle time instead of the full idle timeout", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const sessionId = headers.Authorization.replace("Bearer ", "");
 
     rawDb
       .prepare(
         `UPDATE lucia_sessions
          SET created_at = datetime('now', '-1 hour'),
              last_activity_at = datetime('now', '-14 minutes')
-         WHERE id = ?`
+         WHERE id = ?`,
       )
       .run(sessionId);
 
@@ -26,22 +26,20 @@ describe('admin auth middleware', () => {
       next: async () =>
         new Response(JSON.stringify({ ok: true }), {
           status: 200,
-          headers: { 'Content-Type': 'application/json' },
+          headers: { "Content-Type": "application/json" },
         }),
     });
 
     expect(response.status).toBe(200);
 
-    const idleRemaining = Number(response.headers.get('X-Session-Idle-Expires-In'));
-    const timeRemaining = Number(response.headers.get('X-Session-Expires-In'));
-    const absoluteRemaining = Number(
-      response.headers.get('X-Session-Absolute-Expires-In')
-    );
+    const idleRemaining = Number(response.headers.get("X-Session-Idle-Expires-In"));
+    const timeRemaining = Number(response.headers.get("X-Session-Expires-In"));
+    const absoluteRemaining = Number(response.headers.get("X-Session-Absolute-Expires-In"));
 
     expect(idleRemaining).toBeGreaterThan(0);
     expect(idleRemaining).toBeLessThan(120);
     expect(timeRemaining).toBe(idleRemaining);
     expect(absoluteRemaining).toBeGreaterThan(6 * 60 * 60);
-    expect(response.headers.get('X-Session-Warning')).toBe('true');
+    expect(response.headers.get("X-Session-Warning")).toBe("true");
   });
 });

--- a/functions/api/admin/__tests__/sessions.test.js
+++ b/functions/api/admin/__tests__/sessions.test.js
@@ -1,42 +1,35 @@
-import { describe, expect, test } from 'vitest';
-import { createTestEnv, mockUsers } from '../../test-utils.js';
-import { onRequestGet, onRequestDelete } from '../sessions.js';
+import { describe, expect, test } from "vitest";
+import { createTestEnv, mockUsers } from "../../test-utils.js";
+import { onRequestGet, onRequestDelete } from "../sessions.js";
 
-const BASE_URL = 'https://example.test/api/admin/sessions';
+const BASE_URL = "https://example.test/api/admin/sessions";
 
-function insertSession(
-  rawDb,
-  { userId, ipAddress = '127.0.0.1', userAgent = 'test-agent' } = {}
-) {
+function insertSession(rawDb, { userId, ipAddress = "127.0.0.1", userAgent = "test-agent" } = {}) {
   const sessionId = crypto.randomUUID();
   const expiresAt = Math.floor(Date.now() / 1000) + 60 * 60;
 
   rawDb
-    .prepare(
-      'INSERT INTO lucia_sessions (id, user_id, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)'
-    )
+    .prepare("INSERT INTO lucia_sessions (id, user_id, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)")
     .run(sessionId, userId, expiresAt, ipAddress, userAgent);
 
-  return rawDb
-    .prepare('SELECT * FROM lucia_sessions WHERE id = ?')
-    .get(sessionId);
+  return rawDb.prepare("SELECT * FROM lucia_sessions WHERE id = ?").get(sessionId);
 }
 
-describe('GET /api/admin/sessions', () => {
-  test('returns safe session metadata without exposing raw session identifiers', async () => {
-    const { env, rawDb } = createTestEnv({ role: 'editor' });
+describe("GET /api/admin/sessions", () => {
+  test("returns safe session metadata without exposing raw session identifiers", async () => {
+    const { env, rawDb } = createTestEnv({ role: "editor" });
     const currentSession = rawDb
-      .prepare('SELECT id FROM lucia_sessions WHERE user_id = ? LIMIT 1')
+      .prepare("SELECT id FROM lucia_sessions WHERE user_id = ? LIMIT 1")
       .get(mockUsers.editor.id);
 
     insertSession(rawDb, {
       userId: mockUsers.editor.id,
-      ipAddress: '10.0.0.2',
-      userAgent: 'secondary-agent',
+      ipAddress: "10.0.0.2",
+      userAgent: "secondary-agent",
     });
     insertSession(rawDb, {
       userId: mockUsers.admin.id,
-      ipAddress: '10.0.0.99',
+      ipAddress: "10.0.0.99",
     });
 
     const response = await onRequestGet({
@@ -45,7 +38,7 @@ describe('GET /api/admin/sessions', () => {
       data: {
         user: {
           userId: String(mockUsers.editor.id),
-          role: 'editor',
+          role: "editor",
           email: mockUsers.editor.email,
         },
         session: { id: currentSession.id },
@@ -55,46 +48,28 @@ describe('GET /api/admin/sessions', () => {
     expect(response.status).toBe(200);
 
     const payload = await response.json();
-    expect(payload).not.toHaveProperty('currentSessionId');
+    expect(payload).not.toHaveProperty("currentSessionId");
     expect(payload.sessions).toHaveLength(2);
-    expect(payload.sessions.filter((session) => session.current)).toHaveLength(
-      1
-    );
+    expect(payload.sessions.filter((session) => session.current)).toHaveLength(1);
     // Raw session identifiers must not be exposed
-    expect(
-      payload.sessions.every((session) => !Object.hasOwn(session, 'id'))
-    ).toBe(true);
-    expect(
-      payload.sessions.every(
-        (session) => !Object.hasOwn(session, 'session_token')
-      )
-    ).toBe(true);
+    expect(payload.sessions.every((session) => !Object.hasOwn(session, "id"))).toBe(true);
+    expect(payload.sessions.every((session) => !Object.hasOwn(session, "session_token"))).toBe(true);
     // Opaque revocation token must be present for each session
-    expect(
-      payload.sessions.every((session) =>
-        /^[0-9a-f]{64}$/.test(session.revocationToken)
-      )
-    ).toBe(true);
-    expect(
-      payload.sessions.some((session) => session.ip_address === '10.0.0.2')
-    ).toBe(true);
-    expect(
-      payload.sessions.every(
-        (session) => typeof session.expires_at === 'string'
-      )
-    ).toBe(true);
+    expect(payload.sessions.every((session) => /^[0-9a-f]{64}$/.test(session.revocationToken))).toBe(true);
+    expect(payload.sessions.some((session) => session.ip_address === "10.0.0.2")).toBe(true);
+    expect(payload.sessions.every((session) => typeof session.expires_at === "string")).toBe(true);
   });
 });
 
-describe('DELETE /api/admin/sessions', () => {
-  test('revokes a specific session using its opaque revocation token', async () => {
-    const { env, rawDb } = createTestEnv({ role: 'editor' });
+describe("DELETE /api/admin/sessions", () => {
+  test("revokes a specific session using its opaque revocation token", async () => {
+    const { env, rawDb } = createTestEnv({ role: "editor" });
 
     // Insert a second session to be revoked
     const sessionToRevoke = insertSession(rawDb, {
       userId: mockUsers.editor.id,
-      ipAddress: '10.0.0.5',
-      userAgent: 'other-browser',
+      ipAddress: "10.0.0.5",
+      userAgent: "other-browser",
     });
 
     // Obtain the revocation token via the GET endpoint
@@ -104,14 +79,14 @@ describe('DELETE /api/admin/sessions', () => {
       data: {
         user: {
           userId: String(mockUsers.editor.id),
-          role: 'editor',
+          role: "editor",
           email: mockUsers.editor.email,
         },
         session: { id: crypto.randomUUID() }, // different from both, so neither is "current"
       },
     });
     const { sessions } = await getResponse.json();
-    const target = sessions.find((s) => s.user_agent === 'other-browser');
+    const target = sessions.find((s) => s.user_agent === "other-browser");
     expect(target).toBeDefined();
     expect(target.revocationToken).toMatch(/^[0-9a-f]{64}$/);
 
@@ -120,8 +95,8 @@ describe('DELETE /api/admin/sessions', () => {
 
     const deleteResponse = await onRequestDelete({
       request: new Request(BASE_URL, {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ revocationToken: target.revocationToken }),
       }),
       env,
@@ -138,15 +113,15 @@ describe('DELETE /api/admin/sessions', () => {
     expect(invalidated[0]).toBe(sessionToRevoke.id);
   });
 
-  test('returns 404 when revocation token does not match any session', async () => {
-    const { env } = createTestEnv({ role: 'editor' });
+  test("returns 404 when revocation token does not match any session", async () => {
+    const { env } = createTestEnv({ role: "editor" });
     const mockLucia = { invalidateSession: async () => {} };
 
     const response = await onRequestDelete({
       request: new Request(BASE_URL, {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ revocationToken: 'a'.repeat(64) }),
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ revocationToken: "a".repeat(64) }),
       }),
       env,
       data: {
@@ -158,14 +133,14 @@ describe('DELETE /api/admin/sessions', () => {
     expect(response.status).toBe(404);
   });
 
-  test('returns 400 when revocation token is missing', async () => {
-    const { env } = createTestEnv({ role: 'editor' });
+  test("returns 400 when revocation token is missing", async () => {
+    const { env } = createTestEnv({ role: "editor" });
     const mockLucia = { invalidateSession: async () => {} };
 
     const response = await onRequestDelete({
       request: new Request(BASE_URL, {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
       }),
       env,
@@ -177,6 +152,6 @@ describe('DELETE /api/admin/sessions', () => {
 
     expect(response.status).toBe(400);
     const payload = await response.json();
-    expect(payload.error).toContain('Revocation token');
+    expect(payload.error).toContain("Revocation token");
   });
 });

--- a/functions/api/admin/__tests__/trusted-devices.test.js
+++ b/functions/api/admin/__tests__/trusted-devices.test.js
@@ -9,9 +9,7 @@ function makeCtx(env, userId) {
 }
 
 function insertDevice(rawDb, { userId, expired = false } = {}) {
-  const expiresExpr = expired
-    ? "datetime('now', '-1 day')"
-    : "datetime('now', '+30 days')";
+  const expiresExpr = expired ? "datetime('now', '-1 day')" : "datetime('now', '+30 days')";
   const info = rawDb
     .prepare(
       `INSERT INTO trusted_devices (user_id, token, device_fingerprint, ip_address, user_agent, expires_at, last_used_at)
@@ -27,7 +25,7 @@ describe("GET /api/admin/trusted-devices", () => {
     insertDevice(rawDb, { userId: mockUsers.editor.id });
     insertDevice(rawDb, { userId: mockUsers.editor.id });
     insertDevice(rawDb, { userId: mockUsers.editor.id, expired: true }); // should not appear
-    insertDevice(rawDb, { userId: mockUsers.admin.id });                 // another user's device
+    insertDevice(rawDb, { userId: mockUsers.admin.id }); // another user's device
 
     const response = await onRequestGet({
       request: new Request(BASE_URL),

--- a/functions/api/admin/_middleware.js
+++ b/functions/api/admin/_middleware.js
@@ -16,8 +16,7 @@ function parseSessionDate(value) {
 
 function normalizeUser(user) {
   if (!user) return null;
-  const displayName =
-    user.name || [user.firstName, user.lastName].filter(Boolean).join(" ") || null;
+  const displayName = user.name || [user.firstName, user.lastName].filter(Boolean).join(" ") || null;
   return {
     userId: user.id,
     email: user.email,
@@ -33,13 +32,10 @@ async function resolveSession(request, env) {
   const lucia = initializeLucia(env.DB, request, env);
   // SECURITY: Bearer token auth is for non-production environments only.
   // In production, only cookie-based sessions are accepted.
-  const allowHeaderAuth =
-    env?.ALLOW_HEADER_AUTH === "true" && env?.ENVIRONMENT !== "production";
+  const allowHeaderAuth = env?.ALLOW_HEADER_AUTH === "true" && env?.ENVIRONMENT !== "production";
   const sessionId =
     lucia.readSessionCookie(request.headers.get("Cookie") ?? "") ||
-    (allowHeaderAuth
-      ? request.headers.get("Authorization")?.replace("Bearer ", "")
-      : null);
+    (allowHeaderAuth ? request.headers.get("Authorization")?.replace("Bearer ", "") : null);
 
   if (!sessionId) {
     return { lucia, sessionId: null, session: null, user: null, sessionMeta: null };
@@ -51,9 +47,7 @@ async function resolveSession(request, env) {
       return { lucia, sessionId, session: null, user: null, sessionMeta: null };
     }
 
-    const sessionMeta = await env.DB.prepare(
-      "SELECT created_at, last_activity_at FROM lucia_sessions WHERE id = ?"
-    )
+    const sessionMeta = await env.DB.prepare("SELECT created_at, last_activity_at FROM lucia_sessions WHERE id = ?")
       .bind(sessionId)
       .first();
 
@@ -74,20 +68,20 @@ async function enforceSession(request, env) {
       headers.append("Set-Cookie", lucia.createBlankSessionCookie().serialize());
     }
     return {
-      response: new Response(
-        JSON.stringify({ error: "Unauthorized", message: "Valid session required" }),
-        { status: 401, headers }
-      ),
+      response: new Response(JSON.stringify({ error: "Unauthorized", message: "Valid session required" }), {
+        status: 401,
+        headers,
+      }),
       result,
     };
   }
 
   if (!user.isActive) {
     return {
-      response: new Response(
-        JSON.stringify({ error: "Account deactivated" }),
-        { status: 403, headers: { "Content-Type": "application/json" } }
-      ),
+      response: new Response(JSON.stringify({ error: "Account deactivated" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      }),
       result,
     };
   }
@@ -96,14 +90,8 @@ async function enforceSession(request, env) {
   const createdAt = parseSessionDate(sessionMeta?.created_at) || now;
   const lastActivityAt = parseSessionDate(sessionMeta?.last_activity_at) || createdAt;
 
-  const idleTimeout =
-    user.role === "admin"
-      ? SESSION_CONFIG.adminIdleTimeout
-      : SESSION_CONFIG.idleTimeout;
-  const absoluteTimeout =
-    user.role === "admin"
-      ? SESSION_CONFIG.adminAbsoluteTimeout
-      : SESSION_CONFIG.absoluteTimeout;
+  const idleTimeout = user.role === "admin" ? SESSION_CONFIG.adminIdleTimeout : SESSION_CONFIG.idleTimeout;
+  const absoluteTimeout = user.role === "admin" ? SESSION_CONFIG.adminAbsoluteTimeout : SESSION_CONFIG.absoluteTimeout;
 
   const idleElapsed = now.getTime() - lastActivityAt.getTime();
   const absoluteElapsed = now.getTime() - createdAt.getTime();
@@ -119,15 +107,13 @@ async function enforceSession(request, env) {
           error: "Session expired",
           reason: idleElapsed > idleTimeout ? "inactivity" : "absolute",
         }),
-        { status: 401, headers }
+        { status: 401, headers },
       ),
       result,
     };
   }
 
-  await env.DB.prepare(
-    "UPDATE lucia_sessions SET last_activity_at = datetime('now') WHERE id = ?"
-  )
+  await env.DB.prepare("UPDATE lucia_sessions SET last_activity_at = datetime('now') WHERE id = ?")
     .bind(sessionId)
     .run();
 
@@ -166,7 +152,7 @@ export async function checkPermission(context, requiredRole) {
             error: "Forbidden",
             message: "Insufficient permissions",
           }),
-          { status: 403, headers: { "Content-Type": "application/json" } }
+          { status: 403, headers: { "Content-Type": "application/json" } },
         ),
       };
     }
@@ -192,7 +178,7 @@ export async function checkPermission(context, requiredRole) {
           error: "Forbidden",
           message: "Insufficient permissions",
         }),
-        { status: 403, headers: { "Content-Type": "application/json" } }
+        { status: 403, headers: { "Content-Type": "application/json" } },
       ),
     };
   }
@@ -201,22 +187,13 @@ export async function checkPermission(context, requiredRole) {
 }
 
 // Audit log function - logs all admin actions
-export async function auditLog(
-  env,
-  userId,
-  action,
-  resourceType,
-  resourceId,
-  details,
-  ipAddress,
-  log = null
-) {
+export async function auditLog(env, userId, action, resourceType, resourceId, details, ipAddress, log = null) {
   try {
     await env.DB.prepare(
       `
       INSERT INTO audit_log (user_id, action, resource_type, resource_id, details, ip_address)
       VALUES (?, ?, ?, ?, ?, ?)
-    `
+    `,
     )
       .bind(
         userId,
@@ -224,7 +201,7 @@ export async function auditLog(
         resourceType || null,
         resourceId || null,
         details ? JSON.stringify(details) : null,
-        ipAddress || "unknown"
+        ipAddress || "unknown",
       )
       .run();
   } catch (error) {
@@ -323,7 +300,7 @@ export async function onRequest(context) {
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 }

--- a/functions/api/admin/analytics/__tests__/subscriptions.test.js
+++ b/functions/api/admin/analytics/__tests__/subscriptions.test.js
@@ -7,28 +7,29 @@ describe("Admin analytics subscriptions API", () => {
     const { env, rawDb, headers } = createTestEnv({ role: "admin" });
 
     // Insert test subscription data
-    rawDb.prepare(
-      "INSERT INTO email_subscriptions (email, city, genre, unsubscribe_token, verified) VALUES (?, ?, ?, ?, ?)"
-    ).run("user1@test.com", "Portland", "punk", "token1", 1);
+    rawDb
+      .prepare(
+        "INSERT INTO email_subscriptions (email, city, genre, unsubscribe_token, verified) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run("user1@test.com", "Portland", "punk", "token1", 1);
 
-    rawDb.prepare(
-      "INSERT INTO email_subscriptions (email, city, genre, unsubscribe_token, verified) VALUES (?, ?, ?, ?, ?)"
-    ).run("user2@test.com", "Seattle", "indie", "token2", 1);
+    rawDb
+      .prepare(
+        "INSERT INTO email_subscriptions (email, city, genre, unsubscribe_token, verified) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run("user2@test.com", "Seattle", "indie", "token2", 1);
 
     // Get the second subscription ID to unsubscribe
     const sub2 = rawDb.prepare("SELECT id FROM email_subscriptions WHERE email = ?").get("user2@test.com");
 
     // Add an unsubscribe record
-    rawDb.prepare(
-      "INSERT INTO subscription_unsubscribes (subscription_id, reason) VALUES (?, ?)"
-    ).run(sub2.id, "Test unsubscribe");
+    rawDb
+      .prepare("INSERT INTO subscription_unsubscribes (subscription_id, reason) VALUES (?, ?)")
+      .run(sub2.id, "Test unsubscribe");
 
-    const request = new Request(
-      "https://example.test/api/admin/analytics/subscriptions",
-      {
-        headers,
-      }
-    );
+    const request = new Request("https://example.test/api/admin/analytics/subscriptions", {
+      headers,
+    });
 
     const response = await subscriptionsHandler.onRequestGet({ request, env });
     expect(response.status).toBe(200);
@@ -47,12 +48,9 @@ describe("Admin analytics subscriptions API", () => {
 
   test("non-admin requests are forbidden", async () => {
     const { env, headers } = createTestEnv({ role: "viewer" });
-    const request = new Request(
-      "https://example.test/api/admin/analytics/subscriptions",
-      {
-        headers,
-      }
-    );
+    const request = new Request("https://example.test/api/admin/analytics/subscriptions", {
+      headers,
+    });
 
     const response = await subscriptionsHandler.onRequestGet({ request, env });
     expect(response.status).toBe(403);

--- a/functions/api/admin/analytics/subscriptions.js
+++ b/functions/api/admin/analytics/subscriptions.js
@@ -18,7 +18,6 @@ export async function onRequestGet(context) {
   const ipAddress = getClientIP(request);
 
   try {
-
     // Total subscriptions
     const { results: total } = await DB.prepare(
       `
@@ -99,10 +98,7 @@ export async function onRequestGet(context) {
         by_frequency: byFrequency,
         growth_30_days: growth,
         total_unsubscribes: unsubscribes[0].count,
-        unsubscribe_rate:
-          total[0].count > 0
-            ? ((unsubscribes[0].count / total[0].count) * 100).toFixed(2) + "%"
-            : "0%",
+        unsubscribe_rate: total[0].count > 0 ? ((unsubscribes[0].count / total[0].count) * 100).toFixed(2) + "%" : "0%",
       }),
       {
         headers: { "Content-Type": "application/json" },
@@ -110,12 +106,9 @@ export async function onRequestGet(context) {
     );
   } catch (error) {
     console.error("Analytics error:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to fetch analytics" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return new Response(JSON.stringify({ error: "Failed to fetch analytics" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/admin/audit-log.js
+++ b/functions/api/admin/audit-log.js
@@ -76,8 +76,7 @@ export async function onRequestGet(context) {
       params.push(resourceType);
     }
 
-    const whereClause =
-      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
     // Get total count
     const countQuery = `
@@ -144,12 +143,9 @@ export async function onRequestGet(context) {
     );
   } catch (error) {
     console.error("Get audit log error:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to fetch audit log" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return new Response(JSON.stringify({ error: "Failed to fetch audit log" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/admin/auth/__tests__/mfa.test.js
+++ b/functions/api/admin/auth/__tests__/mfa.test.js
@@ -1,11 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createTestEnv } from "../../../test-utils";
 import { hashPassword } from "../../../../utils/crypto.js";
-import {
-  generateTotpCode,
-  generateTotpSecret,
-  hashBackupCode,
-} from "../../../../utils/totp.js";
+import { generateTotpCode, generateTotpSecret, hashBackupCode } from "../../../../utils/totp.js";
 import { AUTH_ATTEMPT_TYPES } from "../../../../utils/authAttempts.js";
 import { encryptTotpSecret, isEncryptedTotpSecret } from "../../../../utils/mfaSecrets.js";
 import * as loginHandler from "../login.js";
@@ -16,9 +12,7 @@ describe("admin mfa", () => {
     const { env, rawDb } = createTestEnv({ role: "admin" });
     const passwordHash = await hashPassword("StrongPass1!");
     rawDb
-      .prepare(
-        "UPDATE users SET password_hash = ?, totp_secret = ?, totp_enabled = 1 WHERE id = 1"
-      )
+      .prepare("UPDATE users SET password_hash = ?, totp_secret = ?, totp_enabled = 1 WHERE id = 1")
       .run(passwordHash, "JBSWY3DPEHPK3PXP");
 
     const request = new Request("https://example.test/api/admin/auth/login", {
@@ -36,14 +30,10 @@ describe("admin mfa", () => {
     expect(payload.mfaRequired).toBe(true);
     expect(payload.mfaToken).toBeTruthy();
 
-    const challenge = rawDb
-      .prepare("SELECT * FROM mfa_challenges WHERE token = ?")
-      .get(payload.mfaToken);
+    const challenge = rawDb.prepare("SELECT * FROM mfa_challenges WHERE token = ?").get(payload.mfaToken);
     expect(challenge).toBeTruthy();
 
-    const user = rawDb
-      .prepare("SELECT totp_secret FROM users WHERE id = ?")
-      .get(1);
+    const user = rawDb.prepare("SELECT totp_secret FROM users WHERE id = ?").get(1);
     expect(isEncryptedTotpSecret(user.totp_secret)).toBe(true);
   });
 
@@ -51,48 +41,37 @@ describe("admin mfa", () => {
     const { env, rawDb } = createTestEnv({ role: "admin" });
     const secret = generateTotpSecret();
     const encryptedSecret = await encryptTotpSecret(secret, env);
-    rawDb
-      .prepare(
-        "UPDATE users SET totp_secret = ?, totp_enabled = 1 WHERE id = 1"
-      )
-      .run(encryptedSecret);
+    rawDb.prepare("UPDATE users SET totp_secret = ?, totp_enabled = 1 WHERE id = 1").run(encryptedSecret);
 
     const mfaToken = crypto.randomUUID();
     const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
     rawDb
       .prepare(
         `INSERT INTO mfa_challenges (token, user_id, ip_address, user_agent, expires_at)
-         VALUES (?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?)`,
       )
       .run(mfaToken, 1, "127.0.0.1", "test-agent", expiresAt);
 
     const code = await generateTotpCode(secret);
-    const request = new Request(
-      "https://example.test/api/admin/auth/mfa/verify",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "CF-Connecting-IP": "127.0.0.1",
-          "User-Agent": "test-agent",
-        },
-        body: JSON.stringify({ mfaToken, code }),
-      }
-    );
+    const request = new Request("https://example.test/api/admin/auth/mfa/verify", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "CF-Connecting-IP": "127.0.0.1",
+        "User-Agent": "test-agent",
+      },
+      body: JSON.stringify({ mfaToken, code }),
+    });
 
     const response = await mfaVerifyHandler.onRequestPost({ request, env });
     expect(response.status).toBe(200);
     const payload = await response.json();
     expect(payload.success).toBe(true);
 
-    const session = rawDb
-      .prepare("SELECT * FROM lucia_sessions WHERE user_id = ?")
-      .get(1);
+    const session = rawDb.prepare("SELECT * FROM lucia_sessions WHERE user_id = ?").get(1);
     expect(session).toBeTruthy();
 
-    const challenge = rawDb
-      .prepare("SELECT used FROM mfa_challenges WHERE token = ?")
-      .get(mfaToken);
+    const challenge = rawDb.prepare("SELECT used FROM mfa_challenges WHERE token = ?").get(mfaToken);
     expect(challenge.used).toBe(1);
   });
 
@@ -103,9 +82,7 @@ describe("admin mfa", () => {
     const backupCode = "ABCD-12";
     const backupCodes = [await hashBackupCode(backupCode)];
     rawDb
-      .prepare(
-        "UPDATE users SET totp_secret = ?, totp_enabled = 1, backup_codes = ? WHERE id = 1"
-      )
+      .prepare("UPDATE users SET totp_secret = ?, totp_enabled = 1, backup_codes = ? WHERE id = 1")
       .run(encryptedSecret, JSON.stringify(backupCodes));
 
     const mfaToken = crypto.randomUUID();
@@ -113,29 +90,24 @@ describe("admin mfa", () => {
     rawDb
       .prepare(
         `INSERT INTO mfa_challenges (token, user_id, ip_address, user_agent, expires_at)
-         VALUES (?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?)`,
       )
       .run(mfaToken, 1, "127.0.0.1", "test-agent", expiresAt);
 
-    const request = new Request(
-      "https://example.test/api/admin/auth/mfa/verify",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "CF-Connecting-IP": "127.0.0.1",
-          "User-Agent": "test-agent",
-        },
-        body: JSON.stringify({ mfaToken, code: backupCode }),
-      }
-    );
+    const request = new Request("https://example.test/api/admin/auth/mfa/verify", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "CF-Connecting-IP": "127.0.0.1",
+        "User-Agent": "test-agent",
+      },
+      body: JSON.stringify({ mfaToken, code: backupCode }),
+    });
 
     const response = await mfaVerifyHandler.onRequestPost({ request, env });
     expect(response.status).toBe(200);
 
-    const user = rawDb
-      .prepare("SELECT backup_codes FROM users WHERE id = ?")
-      .get(1);
+    const user = rawDb.prepare("SELECT backup_codes FROM users WHERE id = ?").get(1);
     expect(user.backup_codes).toBeNull();
   });
 
@@ -146,9 +118,7 @@ describe("admin mfa", () => {
     const backupCode = "ABCD-34";
     const backupCodes = [await hashBackupCode(backupCode)];
     rawDb
-      .prepare(
-        "UPDATE users SET totp_secret = ?, totp_enabled = 1, backup_codes = ? WHERE id = 1"
-      )
+      .prepare("UPDATE users SET totp_secret = ?, totp_enabled = 1, backup_codes = ? WHERE id = 1")
       .run(encryptedSecret, JSON.stringify(backupCodes));
 
     const mfaToken = crypto.randomUUID();
@@ -156,36 +126,29 @@ describe("admin mfa", () => {
     rawDb
       .prepare(
         `INSERT INTO mfa_challenges (token, user_id, ip_address, user_agent, expires_at)
-         VALUES (?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?)`,
       )
       .run(mfaToken, 1, "127.0.0.1", "test-agent", expiresAt);
 
     env.MFA_TOTP_ENCRYPTION_KEY = "";
 
-    const request = new Request(
-      "https://example.test/api/admin/auth/mfa/verify",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "CF-Connecting-IP": "127.0.0.1",
-          "User-Agent": "test-agent",
-        },
-        body: JSON.stringify({ mfaToken, code: backupCode }),
-      }
-    );
+    const request = new Request("https://example.test/api/admin/auth/mfa/verify", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "CF-Connecting-IP": "127.0.0.1",
+        "User-Agent": "test-agent",
+      },
+      body: JSON.stringify({ mfaToken, code: backupCode }),
+    });
 
     const response = await mfaVerifyHandler.onRequestPost({ request, env });
     expect(response.status).toBe(200);
 
-    const session = rawDb
-      .prepare("SELECT * FROM lucia_sessions WHERE user_id = ? ORDER BY created_at DESC")
-      .get(1);
+    const session = rawDb.prepare("SELECT * FROM lucia_sessions WHERE user_id = ? ORDER BY created_at DESC").get(1);
     expect(session).toBeTruthy();
 
-    const user = rawDb
-      .prepare("SELECT backup_codes FROM users WHERE id = ?")
-      .get(1);
+    const user = rawDb.prepare("SELECT backup_codes FROM users WHERE id = ?").get(1);
     expect(user.backup_codes).toBeNull();
   });
 
@@ -193,9 +156,7 @@ describe("admin mfa", () => {
     const { env, rawDb } = createTestEnv({ role: "admin" });
     const passwordHash = await hashPassword("StrongPass1!");
     rawDb
-      .prepare(
-        "UPDATE users SET password_hash = ?, totp_secret = ?, totp_enabled = 1 WHERE id = 1"
-      )
+      .prepare("UPDATE users SET password_hash = ?, totp_secret = ?, totp_enabled = 1 WHERE id = 1")
       .run(passwordHash, "JBSWY3DPEHPK3PXP");
 
     const staleToken = crypto.randomUUID();
@@ -203,7 +164,7 @@ describe("admin mfa", () => {
     rawDb
       .prepare(
         `INSERT INTO mfa_challenges (token, user_id, ip_address, user_agent, expires_at)
-         VALUES (?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?)`,
       )
       .run(staleToken, 1, "127.0.0.1", "test-agent", expiresAt);
 
@@ -220,54 +181,57 @@ describe("admin mfa", () => {
     expect(response.status).toBe(200);
     const payload = await response.json();
 
-    const activeChallenges = rawDb
-      .prepare("SELECT token FROM mfa_challenges WHERE user_id = ? AND used = 0")
-      .all(1);
+    const activeChallenges = rawDb.prepare("SELECT token FROM mfa_challenges WHERE user_id = ? AND used = 0").all(1);
     expect(activeChallenges).toHaveLength(1);
     expect(activeChallenges[0].token).toBe(payload.mfaToken);
 
-    const staleChallenge = rawDb
-      .prepare("SELECT COUNT(*) as c FROM mfa_challenges WHERE token = ?")
-      .get(staleToken);
+    const staleChallenge = rawDb.prepare("SELECT COUNT(*) as c FROM mfa_challenges WHERE token = ?").get(staleToken);
     expect(staleChallenge.c).toBe(0);
   });
 
   it("rate limits invalid or expired MFA tokens by IP before challenge lookup", async () => {
     const { env, rawDb } = createTestEnv({ role: "admin" });
 
-    rawDb.prepare(
-      `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
-    ).run(null, null, "127.0.0.1", "test-agent", AUTH_ATTEMPT_TYPES.mfa, 0, "invalid_or_expired_token");
-    rawDb.prepare(
-      `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
-    ).run(null, null, "127.0.0.1", "test-agent", AUTH_ATTEMPT_TYPES.mfa, 0, "invalid_or_expired_token");
-    rawDb.prepare(
-      `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
-    ).run(null, null, "127.0.0.1", "test-agent", AUTH_ATTEMPT_TYPES.mfa, 0, "invalid_or_expired_token");
-    rawDb.prepare(
-      `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
-    ).run(null, null, "127.0.0.1", "test-agent", AUTH_ATTEMPT_TYPES.mfa, 0, "invalid_or_expired_token");
-    rawDb.prepare(
-      `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
-    ).run(null, null, "127.0.0.1", "test-agent", AUTH_ATTEMPT_TYPES.mfa, 0, "invalid_or_expired_token");
+    rawDb
+      .prepare(
+        `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(null, null, "127.0.0.1", "test-agent", AUTH_ATTEMPT_TYPES.mfa, 0, "invalid_or_expired_token");
+    rawDb
+      .prepare(
+        `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(null, null, "127.0.0.1", "test-agent", AUTH_ATTEMPT_TYPES.mfa, 0, "invalid_or_expired_token");
+    rawDb
+      .prepare(
+        `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(null, null, "127.0.0.1", "test-agent", AUTH_ATTEMPT_TYPES.mfa, 0, "invalid_or_expired_token");
+    rawDb
+      .prepare(
+        `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(null, null, "127.0.0.1", "test-agent", AUTH_ATTEMPT_TYPES.mfa, 0, "invalid_or_expired_token");
+    rawDb
+      .prepare(
+        `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(null, null, "127.0.0.1", "test-agent", AUTH_ATTEMPT_TYPES.mfa, 0, "invalid_or_expired_token");
 
-    const request = new Request(
-      "https://example.test/api/admin/auth/mfa/verify",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "CF-Connecting-IP": "127.0.0.1",
-          "User-Agent": "test-agent",
-        },
-        body: JSON.stringify({ mfaToken: "invalid-token", code: "123456" }),
-      }
-    );
+    const request = new Request("https://example.test/api/admin/auth/mfa/verify", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "CF-Connecting-IP": "127.0.0.1",
+        "User-Agent": "test-agent",
+      },
+      body: JSON.stringify({ mfaToken: "invalid-token", code: "123456" }),
+    });
 
     const response = await mfaVerifyHandler.onRequestPost({ request, env });
     expect(response.status).toBe(429);

--- a/functions/api/admin/auth/__tests__/signup.test.js
+++ b/functions/api/admin/auth/__tests__/signup.test.js
@@ -6,14 +6,14 @@ describe("admin signup", () => {
   it("creates an inactive user and requires activation", async () => {
     const { env, rawDb } = createTestEnv({ role: "editor" });
     env.ALLOW_ADMIN_SIGNUP = "true";
-    
+
     // Create a valid invite code for the test
     const inviteCode = "TEST-INVITE-CODE-123";
     const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
-    rawDb.prepare(
-      "INSERT INTO invite_codes (code, role, expires_at, is_active) VALUES (?, ?, ?, ?)"
-    ).run(inviteCode, "editor", expiresAt, 1);
-    
+    rawDb
+      .prepare("INSERT INTO invite_codes (code, role, expires_at, is_active) VALUES (?, ?, ?, ?)")
+      .run(inviteCode, "editor", expiresAt, 1);
+
     const request = new Request("https://example.test/api/admin/auth/signup", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -32,17 +32,15 @@ describe("admin signup", () => {
     expect(payload.success).toBe(true);
     expect(payload.requiresActivation).toBe(true);
     expect(payload.user).toBeUndefined();
-    
+
     // Verify the invite code was marked as used
-    const usedInvite = rawDb
-      .prepare("SELECT * FROM invite_codes WHERE code = ?")
-      .get(inviteCode);
+    const usedInvite = rawDb.prepare("SELECT * FROM invite_codes WHERE code = ?").get(inviteCode);
     expect(usedInvite.used_by_user_id).toBeDefined();
     expect(usedInvite.used_at).toBeDefined();
 
     const createdUser = rawDb
       .prepare(
-        "SELECT email, is_active, activation_token, activation_token_expires_at, activated_at FROM users WHERE email = ?"
+        "SELECT email, is_active, activation_token, activation_token_expires_at, activated_at FROM users WHERE email = ?",
       )
       .get("new.user@example.com");
     expect(createdUser).toBeDefined();
@@ -58,9 +56,9 @@ describe("admin signup", () => {
 
     const expiredCode = "EXPIRED-CODE-123";
     const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-    rawDb.prepare(
-      "INSERT INTO invite_codes (code, role, expires_at, is_active) VALUES (?, ?, ?, ?)"
-    ).run(expiredCode, "editor", yesterday, 1);
+    rawDb
+      .prepare("INSERT INTO invite_codes (code, role, expires_at, is_active) VALUES (?, ?, ?, ?)")
+      .run(expiredCode, "editor", yesterday, 1);
 
     const request = new Request("https://example.test/api/admin/auth/signup", {
       method: "POST",
@@ -85,13 +83,13 @@ describe("admin signup", () => {
     const usedCode = "USED-CODE-456";
     const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
     // Insert existing user to reference as used_by_user_id
-    rawDb.prepare("INSERT INTO users (email, password_hash, name, role, is_active) VALUES (?, ?, ?, ?, ?)").run(
-      "existing@example.com", "hash", "Existing", "editor", 1
-    );
+    rawDb
+      .prepare("INSERT INTO users (email, password_hash, name, role, is_active) VALUES (?, ?, ?, ?, ?)")
+      .run("existing@example.com", "hash", "Existing", "editor", 1);
     const existingUser = rawDb.prepare("SELECT id FROM users WHERE email = ?").get("existing@example.com");
-    rawDb.prepare(
-      "INSERT INTO invite_codes (code, role, expires_at, is_active, used_by_user_id) VALUES (?, ?, ?, ?, ?)"
-    ).run(usedCode, "editor", futureDate, 1, existingUser.id);
+    rawDb
+      .prepare("INSERT INTO invite_codes (code, role, expires_at, is_active, used_by_user_id) VALUES (?, ?, ?, ?, ?)")
+      .run(usedCode, "editor", futureDate, 1, existingUser.id);
 
     const request = new Request("https://example.test/api/admin/auth/signup", {
       method: "POST",
@@ -114,9 +112,9 @@ describe("admin signup", () => {
 
     const inviteCode = "INVITE-S6-TEST";
     const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
-    rawDb.prepare(
-      "INSERT INTO invite_codes (code, role, expires_at, is_active) VALUES (?, ?, ?, ?)"
-    ).run(inviteCode, "editor", expiresAt, 1);
+    rawDb
+      .prepare("INSERT INTO invite_codes (code, role, expires_at, is_active) VALUES (?, ?, ?, ?)")
+      .run(inviteCode, "editor", expiresAt, 1);
 
     const request = new Request("https://example.test/api/admin/auth/signup", {
       method: "POST",

--- a/functions/api/admin/auth/login.js
+++ b/functions/api/admin/auth/login.js
@@ -7,16 +7,9 @@ import { verifyPassword, hashPassword } from "../../../utils/crypto.js";
 import { generateCSRFToken, setCSRFCookie } from "../../../utils/csrf.js";
 import { getClientIP } from "../../../utils/request.js";
 import { initializeLucia } from "../../../utils/auth.js";
-import {
-  AUTH_ATTEMPT_TYPES,
-  checkAuthRateLimit,
-  writeAuthAttempt,
-} from "../../../utils/authAttempts.js";
+import { AUTH_ATTEMPT_TYPES, checkAuthRateLimit, writeAuthAttempt } from "../../../utils/authAttempts.js";
 import { loadTotpSecret } from "../../../utils/mfaSecrets.js";
-import {
-  getTrustedDeviceToken,
-  validateTrustedDevice,
-} from "../../../utils/trustedDevice.js";
+import { getTrustedDeviceToken, validateTrustedDevice } from "../../../utils/trustedDevice.js";
 import { logger } from "../../../utils/logger.js";
 
 export async function onRequestPost(context) {
@@ -157,9 +150,7 @@ export async function onRequestPost(context) {
       const storedIterations = Number(user.password_hash.split("$")[1]);
       if (storedIterations && storedIterations < 600000) {
         const newHash = await hashPassword(password);
-        await DB.prepare("UPDATE users SET password_hash = ? WHERE id = ?")
-          .bind(newHash, user.id)
-          .run();
+        await DB.prepare("UPDATE users SET password_hash = ? WHERE id = ?").bind(newHash, user.id).run();
       }
     } catch (rehashError) {
       logger.warn("opportunistic password rehash failed (login not affected)", {
@@ -228,12 +219,7 @@ export async function onRequestPost(context) {
       try {
         const trustedDeviceToken = getTrustedDeviceToken(request);
         if (trustedDeviceToken) {
-          const trustedUserId = await validateTrustedDevice(
-            DB,
-            trustedDeviceToken,
-            ipAddress,
-            userAgent,
-          );
+          const trustedUserId = await validateTrustedDevice(DB, trustedDeviceToken, ipAddress, userAgent);
           if (trustedUserId === user.id) {
             logger.debug("trusted device validated, skipping MFA", {
               userId: user.id,
@@ -247,10 +233,7 @@ export async function onRequestPost(context) {
         }
       } catch (trustedDeviceError) {
         // Don't fail login if trusted device check fails - just require MFA
-        console.error(
-          "[Login] Trusted device check failed:",
-          trustedDeviceError?.message || trustedDeviceError,
-        );
+        console.error("[Login] Trusted device check failed:", trustedDeviceError?.message || trustedDeviceError);
         skipMfa = false;
       }
     }
@@ -260,15 +243,11 @@ export async function onRequestPost(context) {
       try {
         totpSecretState = await loadTotpSecret(user.totp_secret, env);
       } catch (error) {
-        console.error(
-          "[Login] Failed to decrypt TOTP secret:",
-          error?.message || error,
-        );
+        console.error("[Login] Failed to decrypt TOTP secret:", error?.message || error);
         return new Response(
           JSON.stringify({
             error: "MFA configuration error",
-            message:
-              "Multi-factor authentication is not configured correctly. Contact an administrator.",
+            message: "Multi-factor authentication is not configured correctly. Contact an administrator.",
           }),
           {
             status: 500,
@@ -294,8 +273,7 @@ export async function onRequestPost(context) {
         return new Response(
           JSON.stringify({
             error: "MFA configuration error",
-            message:
-              "Multi-factor authentication is not configured correctly. Contact an administrator.",
+            message: "Multi-factor authentication is not configured correctly. Contact an administrator.",
           }),
           {
             status: 500,
@@ -309,10 +287,7 @@ export async function onRequestPost(context) {
       // against datetime('now') are lexicographically correct. ISO 8601 with 'T'
       // sorts greater than the space-separated SQLite format at the same instant,
       // which would allow expired challenges to pass the verify query.
-      const expiresAt = new Date(Date.now() + 5 * 60 * 1000)
-        .toISOString()
-        .replace("T", " ")
-        .slice(0, 19);
+      const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString().replace("T", " ").slice(0, 19);
 
       await DB.prepare(
         `INSERT INTO mfa_challenges (token, user_id, ip_address, user_agent, expires_at, used, used_at)
@@ -344,10 +319,7 @@ export async function onRequestPost(context) {
           mfaToken,
           user: {
             email: user.email,
-            name:
-              user.name ||
-              [user.first_name, user.last_name].filter(Boolean).join(" ") ||
-              null,
+            name: user.name || [user.first_name, user.last_name].filter(Boolean).join(" ") || null,
             firstName: user.first_name || null,
             lastName: user.last_name || null,
             role: user.role,
@@ -373,11 +345,7 @@ export async function onRequestPost(context) {
       .run();
 
     // Update last login
-    await DB.prepare(
-      "UPDATE users SET last_login = datetime('now') WHERE id = ?",
-    )
-      .bind(user.id)
-      .run();
+    await DB.prepare("UPDATE users SET last_login = datetime('now') WHERE id = ?").bind(user.id).run();
 
     // Log successful login
     await writeAuthAttempt(DB, {
@@ -396,10 +364,7 @@ export async function onRequestPost(context) {
     const headers = new Headers({
       "Content-Type": "application/json",
     });
-    headers.append(
-      "Set-Cookie",
-      lucia.createSessionCookie(session.id).serialize(),
-    );
+    headers.append("Set-Cookie", lucia.createSessionCookie(session.id).serialize());
     headers.append("Set-Cookie", setCSRFCookie(csrfToken, request));
 
     return new Response(
@@ -408,10 +373,7 @@ export async function onRequestPost(context) {
         user: {
           id: user.id,
           email: user.email,
-          name:
-            user.name ||
-            [user.first_name, user.last_name].filter(Boolean).join(" ") ||
-            null,
+          name: user.name || [user.first_name, user.last_name].filter(Boolean).join(" ") || null,
           firstName: user.first_name || null,
           lastName: user.last_name || null,
           role: user.role,

--- a/functions/api/admin/auth/logout.js
+++ b/functions/api/admin/auth/logout.js
@@ -17,21 +17,14 @@ export async function onRequestPost(context) {
     // (handles __Host-session_token in production vs session_token in dev).
     // SECURITY: Bearer token auth is for non-production environments only.
     const lucia = initializeLucia(DB, request, env);
-    const allowHeaderAuth =
-      env?.ALLOW_HEADER_AUTH === "true" && env?.ENVIRONMENT !== "production";
+    const allowHeaderAuth = env?.ALLOW_HEADER_AUTH === "true" && env?.ENVIRONMENT !== "production";
     const sessionToken =
       lucia.readSessionCookie(request.headers.get("Cookie") ?? "") ||
-      (allowHeaderAuth
-        ? request.headers.get("Authorization")?.replace("Bearer ", "")
-        : null);
+      (allowHeaderAuth ? request.headers.get("Authorization")?.replace("Bearer ", "") : null);
 
     if (sessionToken) {
       // Get user ID from session before deleting
-      const session = await DB.prepare(
-        `SELECT user_id FROM lucia_sessions WHERE id = ?`,
-      )
-        .bind(sessionToken)
-        .first();
+      const session = await DB.prepare(`SELECT user_id FROM lucia_sessions WHERE id = ?`).bind(sessionToken).first();
 
       await lucia.invalidateSession(sessionToken);
 

--- a/functions/api/admin/auth/mfa/verify.js
+++ b/functions/api/admin/auth/mfa/verify.js
@@ -8,10 +8,7 @@ import { getClientIP } from "../../../../utils/request.js";
 import { initializeLucia } from "../../../../utils/auth.js";
 import { AUTH_ATTEMPT_TYPES, checkAuthRateLimit, writeAuthAttempt } from "../../../../utils/authAttempts.js";
 import { loadTotpSecret } from "../../../../utils/mfaSecrets.js";
-import {
-  createTrustedDevice,
-  createTrustedDeviceCookie,
-} from "../../../../utils/trustedDevice.js";
+import { createTrustedDevice, createTrustedDeviceCookie } from "../../../../utils/trustedDevice.js";
 
 function parseBackupCodes(raw) {
   if (!raw) return [];
@@ -43,7 +40,7 @@ export async function onRequestPost(context) {
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -63,7 +60,7 @@ export async function onRequestPost(context) {
       FROM mfa_challenges c
       INNER JOIN users u ON u.id = c.user_id
       WHERE c.token = ? AND c.used = 0 AND c.expires_at > datetime('now')
-    `
+    `,
     )
       .bind(mfaToken)
       .first();
@@ -83,7 +80,7 @@ export async function onRequestPost(context) {
           {
             status: 429,
             headers: { "Content-Type": "application/json" },
-          }
+          },
         );
       }
 
@@ -103,7 +100,7 @@ export async function onRequestPost(context) {
         {
           status: 401,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -113,10 +110,7 @@ export async function onRequestPost(context) {
       ipAddress !== "unknown" &&
       challenge.ip_address !== ipAddress;
     const uaMismatch =
-      challenge.user_agent &&
-      userAgent &&
-      challenge.user_agent !== "unknown" &&
-      challenge.user_agent !== userAgent;
+      challenge.user_agent && userAgent && challenge.user_agent !== "unknown" && challenge.user_agent !== userAgent;
 
     if (ipMismatch || uaMismatch) {
       await writeAuthAttempt(DB, {
@@ -137,7 +131,7 @@ export async function onRequestPost(context) {
         {
           status: 401,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -160,7 +154,7 @@ export async function onRequestPost(context) {
         {
           status: 403,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -179,7 +173,7 @@ export async function onRequestPost(context) {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -226,7 +220,7 @@ export async function onRequestPost(context) {
         {
           status: 500,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -249,7 +243,7 @@ export async function onRequestPost(context) {
         {
           status: 401,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -258,7 +252,7 @@ export async function onRequestPost(context) {
     const markUsed = await DB.prepare(
       `UPDATE mfa_challenges
        SET used = 1, used_at = datetime('now')
-       WHERE id = ? AND used = 0`
+       WHERE id = ? AND used = 0`,
     )
       .bind(challenge.challenge_id)
       .run();
@@ -272,7 +266,7 @@ export async function onRequestPost(context) {
         {
           status: 401,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -287,9 +281,7 @@ export async function onRequestPost(context) {
 
       if (usedBackupCode) {
         const nextCodes =
-          remainingBackupCodes && remainingBackupCodes.length > 0
-            ? JSON.stringify(remainingBackupCodes)
-            : null;
+          remainingBackupCodes && remainingBackupCodes.length > 0 ? JSON.stringify(remainingBackupCodes) : null;
         setClauses.push("backup_codes = ?");
         bindValues.push(nextCodes);
       }
@@ -297,7 +289,7 @@ export async function onRequestPost(context) {
       await DB.prepare(
         `UPDATE users
          SET ${setClauses.join(", ")}
-         WHERE id = ?`
+         WHERE id = ?`,
       )
         .bind(...bindValues, challenge.user_id)
         .run();
@@ -310,16 +302,12 @@ export async function onRequestPost(context) {
     await DB.prepare(
       `UPDATE lucia_sessions
        SET ip_address = ?, user_agent = ?, remember_me = ?
-       WHERE id = ?`
+       WHERE id = ?`,
     )
       .bind(ipAddress, userAgent, 0, session.id)
       .run();
 
-    await DB.prepare(
-      "UPDATE users SET last_login = datetime('now') WHERE id = ?"
-    )
-      .bind(challenge.user_id)
-      .run();
+    await DB.prepare("UPDATE users SET last_login = datetime('now') WHERE id = ?").bind(challenge.user_id).run();
 
     await writeAuthAttempt(DB, {
       attemptType: AUTH_ATTEMPT_TYPES.mfa,
@@ -340,16 +328,8 @@ export async function onRequestPost(context) {
     // Create trusted device if requested
     if (rememberDevice) {
       try {
-        const trustedDevice = await createTrustedDevice(
-          DB,
-          challenge.user_id,
-          ipAddress,
-          userAgent
-        );
-        headers.append(
-          "Set-Cookie",
-          createTrustedDeviceCookie(trustedDevice.token, request, env)
-        );
+        const trustedDevice = await createTrustedDevice(DB, challenge.user_id, ipAddress, userAgent);
+        headers.append("Set-Cookie", createTrustedDeviceCookie(trustedDevice.token, request, env));
       } catch (err) {
         // Don't fail login if trusted device creation fails
         console.error("[MFA Verify] Failed to create trusted device:", err);
@@ -369,7 +349,7 @@ export async function onRequestPost(context) {
       {
         status: 200,
         headers,
-      }
+      },
     );
   } catch (error) {
     console.error("MFA verify error:", error);
@@ -382,7 +362,7 @@ export async function onRequestPost(context) {
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 }

--- a/functions/api/admin/auth/signup.js
+++ b/functions/api/admin/auth/signup.js
@@ -1,17 +1,9 @@
 import { hashPassword } from "../../../utils/crypto.js";
-import {
-  isValidEmail,
-  validatePassword,
-  FIELD_LIMITS,
-} from "../../../utils/validation.js";
+import { isValidEmail, validatePassword, FIELD_LIMITS } from "../../../utils/validation.js";
 import { getClientIP } from "../../../utils/request.js";
 import { isEmailConfigured, sendEmail } from "../../../utils/email.js";
 import { buildActivationEmail } from "../../../utils/emailTemplates.js";
-import {
-  AUTH_ATTEMPT_TYPES,
-  checkAuthRateLimit,
-  writeAuthAttempt,
-} from "../../../utils/authAttempts.js";
+import { AUTH_ATTEMPT_TYPES, checkAuthRateLimit, writeAuthAttempt } from "../../../utils/authAttempts.js";
 import { logger } from "../../../utils/logger.js";
 import { getPublicBaseUrl } from "../../../utils/publicUrl.js";
 
@@ -21,8 +13,7 @@ export async function onRequestPost(context) {
   const ipAddress = getClientIP(request);
 
   try {
-    const { email, password, name, firstName, lastName, role, inviteCode } =
-      await request.json();
+    const { email, password, name, firstName, lastName, role, inviteCode } = await request.json();
 
     // SECURITY: Require invite code for all signups
     if (!inviteCode) {
@@ -134,8 +125,7 @@ export async function onRequestPost(context) {
       return new Response(
         JSON.stringify({
           error: "Invalid invite code",
-          message:
-            "The invite code is invalid, expired, or has already been used",
+          message: "The invite code is invalid, expired, or has already been used",
         }),
         {
           status: 403,
@@ -158,8 +148,7 @@ export async function onRequestPost(context) {
       return new Response(
         JSON.stringify({
           error: "Email mismatch",
-          message:
-            "This invite code is restricted to a different email address",
+          message: "This invite code is restricted to a different email address",
         }),
         {
           status: 403,
@@ -174,17 +163,11 @@ export async function onRequestPost(context) {
 
     // Ignore any role parameter passed by client to prevent privilege escalation
     if (role === "admin") {
-      console.warn(
-        `Signup attempt with admin role blocked for email: ${email}`,
-      );
+      console.warn(`Signup attempt with admin role blocked for email: ${email}`);
     }
 
     // Check if user already exists
-    const existingUser = await DB.prepare(
-      "SELECT id FROM users WHERE email = ?",
-    )
-      .bind(email)
-      .first();
+    const existingUser = await DB.prepare("SELECT id FROM users WHERE email = ?").bind(email).first();
 
     if (existingUser) {
       return new Response(
@@ -199,16 +182,9 @@ export async function onRequestPost(context) {
       );
     }
 
-    const fallbackName =
-      name !== undefined && name !== null ? String(name).trim() : "";
-    let resolvedFirstName =
-      firstName !== undefined && firstName !== null
-        ? String(firstName).trim()
-        : "";
-    let resolvedLastName =
-      lastName !== undefined && lastName !== null
-        ? String(lastName).trim()
-        : "";
+    const fallbackName = name !== undefined && name !== null ? String(name).trim() : "";
+    let resolvedFirstName = firstName !== undefined && firstName !== null ? String(firstName).trim() : "";
+    let resolvedLastName = lastName !== undefined && lastName !== null ? String(lastName).trim() : "";
 
     if ((!resolvedFirstName || !resolvedLastName) && fallbackName) {
       const parts = fallbackName.split(/\s+/).filter(Boolean);
@@ -238,11 +214,8 @@ export async function onRequestPost(context) {
     // Hash password
     const passwordHash = await hashPassword(password);
 
-    const activationToken =
-      crypto.randomUUID() + crypto.randomUUID().replace(/-/g, "");
-    const activationExpires = new Date(
-      Date.now() + 24 * 60 * 60 * 1000,
-    ).toISOString();
+    const activationToken = crypto.randomUUID() + crypto.randomUUID().replace(/-/g, "");
+    const activationExpires = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
 
     // Create user (inactive until activation)
     const user = await DB.prepare(
@@ -262,9 +235,7 @@ export async function onRequestPost(context) {
       .first();
 
     // Mark invite code as used
-    await DB.prepare(
-      "UPDATE invite_codes SET used_by_user_id = ?, used_at = datetime('now') WHERE code = ?",
-    )
+    await DB.prepare("UPDATE invite_codes SET used_by_user_id = ?, used_at = datetime('now') WHERE code = ?")
       .bind(user.id, inviteCode)
       .run();
 
@@ -304,16 +275,13 @@ export async function onRequestPost(context) {
       });
       logger.debug("activation email delivery attempted", { userId: user.id });
     } else {
-      console.warn(
-        "[Signup] Email not configured; activation email was not sent.",
-      );
+      console.warn("[Signup] Email not configured; activation email was not sent.");
     }
 
     return new Response(
       JSON.stringify({
         success: true,
-        message:
-          "Account created. Please check your email to activate your account.",
+        message: "Account created. Please check your email to activate your account.",
         requiresActivation: true,
         email: { delivered: !!emailResult?.delivered },
       }),

--- a/functions/api/admin/bands.js
+++ b/functions/api/admin/bands.js
@@ -17,9 +17,7 @@ import { normalizeBandName } from "../../utils/bandName.js";
 async function getEventStatus(DB, eventId) {
   if (!eventId) return null;
 
-  const event = await DB.prepare(`SELECT id, status FROM events WHERE id = ?`)
-    .bind(eventId)
-    .first();
+  const event = await DB.prepare(`SELECT id, status FROM events WHERE id = ?`).bind(eventId).first();
 
   return event || null;
 }
@@ -33,10 +31,7 @@ function unpackSocialLinks(band) {
   } catch (_e) {
     social = {};
   }
-  const origin =
-    [band.origin_city, band.origin_region].filter(Boolean).join(", ") ||
-    band.origin ||
-    "";
+  const origin = [band.origin_city, band.origin_region].filter(Boolean).join(", ") || band.origin || "";
   return {
     ...band,
     origin,
@@ -51,14 +46,7 @@ function unpackSocialLinks(band) {
   };
 }
 
-async function checkConflicts(
-  DB,
-  eventId,
-  venueId,
-  startTime,
-  endTime,
-  excludePerformanceId = null,
-) {
+async function checkConflicts(DB, eventId, venueId, startTime, endTime, excludePerformanceId = null) {
   let query = `
     SELECT p.id, p.start_time, p.end_time, bp.name
     FROM performances p
@@ -80,19 +68,14 @@ async function checkConflicts(
   for (const perf of existingPerformances) {
     if (!perf.start_time || !perf.end_time) continue;
     const perfIntervals = buildIntervals(perf.start_time, perf.end_time);
-    const hasOverlap = perfIntervals.some((b) =>
-      newIntervals.some((a) => intervalsOverlap(a, b)),
-    );
+    const hasOverlap = perfIntervals.some((b) => newIntervals.some((a) => intervalsOverlap(a, b)));
     if (hasOverlap) {
       conflicts.push({
         id: perf.id,
         name: perf.name,
         startTime: perf.start_time,
         endTime: perf.end_time,
-        type:
-          perf.start_time === startTime && perf.end_time === endTime
-            ? "conflict"
-            : "overlap",
+        type: perf.start_time === startTime && perf.end_time === endTime ? "conflict" : "overlap",
       });
     }
   }
@@ -113,20 +96,10 @@ export async function onRequestGet(context) {
 
   const url = new URL(request.url);
   const eventId = url.searchParams.get("event_id");
-  const requestedLimit = Number.parseInt(
-    url.searchParams.get("limit") || "200",
-    10,
-  );
-  const requestedOffset = Number.parseInt(
-    url.searchParams.get("offset") || "0",
-    10,
-  );
-  const limit = Number.isFinite(requestedLimit)
-    ? Math.min(Math.max(requestedLimit, 1), 500)
-    : 200;
-  const offset = Number.isFinite(requestedOffset)
-    ? Math.max(requestedOffset, 0)
-    : 0;
+  const requestedLimit = Number.parseInt(url.searchParams.get("limit") || "200", 10);
+  const requestedOffset = Number.parseInt(url.searchParams.get("offset") || "0", 10);
+  const limit = Number.isFinite(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 500) : 200;
+  const offset = Number.isFinite(requestedOffset) ? Math.max(requestedOffset, 0) : 0;
 
   try {
     let result;
@@ -259,29 +232,19 @@ export async function onRequestPost(context) {
 
     const resolvedName = sanitizeString(name || "");
     const resolvedVenueId = venueId ? Number(venueId) : null;
-    const resolvedDescription =
-      description !== undefined ? sanitizeString(description) || null : null;
-    const resolvedGenre =
-      genre !== undefined ? sanitizeString(genre) || null : null;
+    const resolvedDescription = description !== undefined ? sanitizeString(description) || null : null;
+    const resolvedGenre = genre !== undefined ? sanitizeString(genre) || null : null;
     let resolvedPhotoUrl;
     let resolvedWebsite;
 
     try {
-      resolvedPhotoUrl = sanitizeOptionalHttpUrl(
-        photo_url,
-        FIELD_LIMITS.bandUrl.max,
-        "Photo URL",
-      );
-      resolvedWebsite = sanitizeOptionalHttpUrl(
-        url,
-        FIELD_LIMITS.bandUrl.max,
-        "Website URL",
-      );
+      resolvedPhotoUrl = sanitizeOptionalHttpUrl(photo_url, FIELD_LIMITS.bandUrl.max, "Photo URL");
+      resolvedWebsite = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");
     } catch (error) {
-      return new Response(
-        JSON.stringify({ error: "Validation error", message: error.message }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Validation error", message: error.message }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     if (contact_email && !isValidEmail(contact_email)) {
@@ -320,18 +283,17 @@ export async function onRequestPost(context) {
 
       const event = await getEventStatus(DB, eventId);
       if (!event) {
-        return new Response(
-          JSON.stringify({ error: "Not found", message: "Event not found" }),
-          { status: 404, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ error: "Not found", message: "Event not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       if (event.status === "archived") {
         return new Response(
           JSON.stringify({
             error: "Validation error",
-            message:
-              "Cannot add performances to an archived event. Copy it as a template instead.",
+            message: "Cannot add performances to an archived event. Copy it as a template instead.",
           }),
           { status: 400, headers: { "Content-Type": "application/json" } },
         );
@@ -339,10 +301,7 @@ export async function onRequestPost(context) {
     }
 
     // Validate time format (only if schedule is provided)
-    if (
-      (startTime && !/^\d{2}:\d{2}$/.test(startTime)) ||
-      (endTime && !/^\d{2}:\d{2}$/.test(endTime))
-    ) {
+    if ((startTime && !/^\d{2}:\d{2}$/.test(startTime)) || (endTime && !/^\d{2}:\d{2}$/.test(endTime))) {
       return new Response(
         JSON.stringify({
           error: "Validation error",
@@ -386,13 +345,7 @@ export async function onRequestPost(context) {
 
     // Check for conflicts (only if times are provided)
     if (!isGlobalAdd && resolvedVenueId && startTime && endTime) {
-      const conflicts = await checkConflicts(
-        DB,
-        eventId,
-        resolvedVenueId,
-        startTime,
-        endTime,
-      );
+      const conflicts = await checkConflicts(DB, eventId, resolvedVenueId, startTime, endTime);
       if (conflicts.length > 0) {
         return new Response(
           JSON.stringify({
@@ -408,21 +361,12 @@ export async function onRequestPost(context) {
     // 1. Find or Create Band Profile
     const nameNormalized = normalizeBandName(resolvedName);
     const parsedOrigin = parseOrigin(origin?.trim());
-    const trimmedOriginCity = origin_city
-      ? origin_city.trim()
-      : parsedOrigin.city;
-    const trimmedOriginRegion = origin_region
-      ? origin_region.trim()
-      : parsedOrigin.region;
+    const trimmedOriginCity = origin_city ? origin_city.trim() : parsedOrigin.city;
+    const trimmedOriginRegion = origin_region ? origin_region.trim() : parsedOrigin.region;
     const computedOrigin =
-      origin?.trim() ||
-      [trimmedOriginCity, trimmedOriginRegion].filter(Boolean).join(", ") ||
-      null;
-    const resolvedIsActive =
-      is_active === undefined ? 1 : Number(is_active) === 1 ? 1 : 0;
-    const existingProfile = await DB.prepare(
-      "SELECT id FROM band_profiles WHERE name_normalized = ?",
-    )
+      origin?.trim() || [trimmedOriginCity, trimmedOriginRegion].filter(Boolean).join(", ") || null;
+    const resolvedIsActive = is_active === undefined ? 1 : Number(is_active) === 1 ? 1 : 0;
+    const existingProfile = await DB.prepare("SELECT id FROM band_profiles WHERE name_normalized = ?")
       .bind(nameNormalized)
       .first();
 
@@ -434,14 +378,13 @@ export async function onRequestPost(context) {
       let socialLinksJson;
       try {
         socialLinksJson = sanitizeBandSocialLinks(
-          social_links ||
-            (resolvedWebsite ? { website: resolvedWebsite } : null),
+          social_links || (resolvedWebsite ? { website: resolvedWebsite } : null),
         );
       } catch (error) {
-        return new Response(
-          JSON.stringify({ error: "Validation error", message: error.message }),
-          { status: 400, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ error: "Validation error", message: error.message }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       bandProfile = await DB.prepare(
@@ -492,29 +435,19 @@ export async function onRequestPost(context) {
            VALUES (?, ?, ?, ?, ?)
            RETURNING id`,
         )
-          .bind(
-            eventId,
-            resolvedVenueId,
-            bandProfile.id,
-            startTime || null,
-            endTime || null,
-          )
+          .bind(eventId, resolvedVenueId, bandProfile.id, startTime || null, endTime || null)
           .first();
       } catch (perfError) {
         // Compensating delete: only undo profiles we just created, not pre-existing ones
         if (createdNewProfile) {
-          await DB.prepare("DELETE FROM band_profiles WHERE id = ?")
-            .bind(bandProfile.id)
-            .run();
+          await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(bandProfile.id).run();
         }
         throw perfError;
       }
 
       if (!perfResult) {
         if (createdNewProfile) {
-          await DB.prepare("DELETE FROM band_profiles WHERE id = ?")
-            .bind(bandProfile.id)
-            .run();
+          await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(bandProfile.id).run();
         }
         throw new Error("performances INSERT returned null");
       }
@@ -531,10 +464,10 @@ export async function onRequestPost(context) {
     );
   } catch (error) {
     console.error("Failed to create band:", error);
-    return new Response(
-      JSON.stringify({ success: false, error: "Failed to create band" }),
-      { status: 500, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ success: false, error: "Failed to create band" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }
 

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -11,10 +11,7 @@ import {
   sanitizeString,
 } from "../../../utils/validation.js";
 import { getClientIP } from "../../../utils/request.js";
-import {
-  buildIntervals,
-  intervalsOverlap,
-} from "../../../utils/timeConflicts.js";
+import { buildIntervals, intervalsOverlap } from "../../../utils/timeConflicts.js";
 import { parseOrigin } from "../../../utils/parseOrigin.js";
 import { normalizeBandName } from "../../../utils/bandName.js";
 
@@ -41,14 +38,7 @@ async function getEventForPerformance(DB, performanceId) {
     .first();
 }
 
-async function checkConflicts(
-  DB,
-  eventId,
-  venueId,
-  startTime,
-  endTime,
-  excludePerformanceId = null,
-) {
+async function checkConflicts(DB, eventId, venueId, startTime, endTime, excludePerformanceId = null) {
   const query = excludePerformanceId
     ? `SELECT p.id, p.start_time, p.end_time, bp.name
        FROM performances p
@@ -59,9 +49,7 @@ async function checkConflicts(
        JOIN band_profiles bp ON p.band_profile_id = bp.id
        WHERE p.event_id = ? AND p.venue_id = ?`;
 
-  const bindings = excludePerformanceId
-    ? [eventId, venueId, excludePerformanceId]
-    : [eventId, venueId];
+  const bindings = excludePerformanceId ? [eventId, venueId, excludePerformanceId] : [eventId, venueId];
 
   const { results: existingBands } = await DB.prepare(query)
     .bind(...bindings)
@@ -72,19 +60,14 @@ async function checkConflicts(
   for (const band of existingBands) {
     if (!band.start_time || !band.end_time) continue;
     const bandIntervals = buildIntervals(band.start_time, band.end_time);
-    const hasOverlap = bandIntervals.some((b) =>
-      newIntervals.some((a) => intervalsOverlap(a, b)),
-    );
+    const hasOverlap = bandIntervals.some((b) => newIntervals.some((a) => intervalsOverlap(a, b)));
     if (hasOverlap) {
       conflicts.push({
         id: band.id,
         name: band.name,
         startTime: band.start_time,
         endTime: band.end_time,
-        type:
-          band.start_time === startTime && band.end_time === endTime
-            ? "conflict"
-            : "overlap",
+        type: band.start_time === startTime && band.end_time === endTime ? "conflict" : "overlap",
       });
     }
   }
@@ -148,26 +131,16 @@ export async function onRequestPut(context) {
     // Guards against the frontend sending Number("") = 0 when no venue is selected,
     // which would otherwise pass the !== null check and then 404 on "Venue not found".
     const normalizedVenueId =
-      venueId === undefined
-        ? undefined
-        : !venueId || Number(venueId) <= 0
-          ? null
-          : Number(venueId);
+      venueId === undefined ? undefined : !venueId || Number(venueId) <= 0 ? null : Number(venueId);
     let resolvedPhotoUrl;
     try {
       resolvedPhotoUrl =
-        photo_url !== undefined
-          ? sanitizeOptionalHttpUrl(
-              photo_url,
-              FIELD_LIMITS.bandUrl.max,
-              "Photo URL",
-            )
-          : undefined;
+        photo_url !== undefined ? sanitizeOptionalHttpUrl(photo_url, FIELD_LIMITS.bandUrl.max, "Photo URL") : undefined;
     } catch (error) {
-      return new Response(
-        JSON.stringify({ error: "Validation error", message: error.message }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Validation error", message: error.message }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
     let realPerformanceId = performanceId;
     let bandProfileId = null;
@@ -221,26 +194,19 @@ export async function onRequestPut(context) {
       // events the band has played. Only block when a performance field is the
       // thing actually being changed.
       const editsPerformanceFields =
-        normalizedVenueId !== undefined ||
-        startTime !== undefined ||
-        endTime !== undefined;
+        normalizedVenueId !== undefined || startTime !== undefined || endTime !== undefined;
       if (linkedEvent?.status === "archived" && editsPerformanceFields) {
         return new Response(
           JSON.stringify({
             error: "Validation error",
-            message:
-              "Archived event set times cannot be edited. Copy the event as a template instead.",
+            message: "Archived event set times cannot be edited. Copy the event as a template instead.",
           }),
           { status: 400, headers: { "Content-Type": "application/json" } },
         );
       }
     } else {
       // Fetch profile directly
-      const profile = await DB.prepare(
-        "SELECT * FROM band_profiles WHERE id = ?",
-      )
-        .bind(bandProfileId)
-        .first();
+      const profile = await DB.prepare("SELECT * FROM band_profiles WHERE id = ?").bind(bandProfileId).first();
 
       if (!profile) {
         return new Response(
@@ -282,9 +248,7 @@ export async function onRequestPut(context) {
       // For now, let's just update the profile name if it's unique, or switch if it exists.
 
       const nameNormalized = normalizeBandName(name);
-      const existingProfile = await DB.prepare(
-        `SELECT id FROM band_profiles WHERE name_normalized = ? AND id != ?`,
-      )
+      const existingProfile = await DB.prepare(`SELECT id FROM band_profiles WHERE name_normalized = ? AND id != ?`)
         .bind(nameNormalized, performance.band_profile_id)
         .first();
 
@@ -293,11 +257,7 @@ export async function onRequestPut(context) {
       }
     }
 
-    if (
-      contact_email !== undefined &&
-      contact_email &&
-      !isValidEmail(contact_email)
-    ) {
+    if (contact_email !== undefined && contact_email && !isValidEmail(contact_email)) {
       return new Response(
         JSON.stringify({
           error: "Validation error",
@@ -311,11 +271,7 @@ export async function onRequestPut(context) {
     }
 
     // Validate time format (only if a non-empty time is provided; empty string = TBD)
-    if (
-      startTime !== undefined &&
-      startTime !== "" &&
-      !/^\d{2}:\d{2}$/.test(startTime)
-    ) {
+    if (startTime !== undefined && startTime !== "" && !/^\d{2}:\d{2}$/.test(startTime)) {
       return new Response(
         JSON.stringify({
           error: "Validation error",
@@ -328,11 +284,7 @@ export async function onRequestPut(context) {
       );
     }
 
-    if (
-      endTime !== undefined &&
-      endTime !== "" &&
-      !/^\d{2}:\d{2}$/.test(endTime)
-    ) {
+    if (endTime !== undefined && endTime !== "" && !/^\d{2}:\d{2}$/.test(endTime)) {
       return new Response(
         JSON.stringify({
           error: "Validation error",
@@ -346,12 +298,9 @@ export async function onRequestPut(context) {
     }
 
     // Determine actual times to use (provided or existing)
-    const actualStartTime =
-      startTime !== undefined ? startTime : performance.start_time;
-    const actualEndTime =
-      endTime !== undefined ? endTime : performance.end_time;
-    const actualVenueId =
-      normalizedVenueId !== undefined ? normalizedVenueId : performance.venue_id;
+    const actualStartTime = startTime !== undefined ? startTime : performance.start_time;
+    const actualEndTime = endTime !== undefined ? endTime : performance.end_time;
+    const actualVenueId = normalizedVenueId !== undefined ? normalizedVenueId : performance.venue_id;
 
     // Validate times (allow sets that cross midnight; prevent zero-length sets)
     if (actualStartTime && actualEndTime && actualStartTime === actualEndTime) {
@@ -393,12 +342,7 @@ export async function onRequestPut(context) {
 
     // Check for conflicts only if we have all required scheduling fields
     let conflicts = [];
-    if (
-      actualVenueId &&
-      actualStartTime &&
-      actualEndTime &&
-      performance.event_id
-    ) {
+    if (actualVenueId && actualStartTime && actualEndTime && performance.event_id) {
       conflicts = await checkConflicts(
         DB,
         performance.event_id,
@@ -459,20 +403,13 @@ export async function onRequestPut(context) {
         profileUpdates.push("genre = ?");
         profileParams.push(sanitizeString(genre) || null);
       }
-      const parsedOrigin =
-        origin !== undefined
-          ? parseOrigin(origin)
-          : { city: null, region: null };
-      const resolvedOriginCity =
-        origin_city !== undefined ? origin_city : parsedOrigin.city;
-      const resolvedOriginRegion =
-        origin_region !== undefined ? origin_region : parsedOrigin.region;
+      const parsedOrigin = origin !== undefined ? parseOrigin(origin) : { city: null, region: null };
+      const resolvedOriginCity = origin_city !== undefined ? origin_city : parsedOrigin.city;
+      const resolvedOriginRegion = origin_region !== undefined ? origin_region : parsedOrigin.region;
       const computedOrigin =
         origin !== undefined
           ? origin
-          : [resolvedOriginCity, resolvedOriginRegion]
-              .filter(Boolean)
-              .join(", ") || undefined;
+          : [resolvedOriginCity, resolvedOriginRegion].filter(Boolean).join(", ") || undefined;
 
       if (origin !== undefined || origin_city !== undefined) {
         profileUpdates.push("origin_city = ?");
@@ -528,19 +465,13 @@ export async function onRequestPut(context) {
         // Legacy update of just website
         let existingLinks = {};
         try {
-          const profile = await DB.prepare(
-            "SELECT social_links FROM band_profiles WHERE id = ?",
-          )
+          const profile = await DB.prepare("SELECT social_links FROM band_profiles WHERE id = ?")
             .bind(performance.band_profile_id)
             .first();
           existingLinks = JSON.parse(profile.social_links || "{}");
         } catch (e) {}
         try {
-          existingLinks.website = sanitizeOptionalHttpUrl(
-            url,
-            FIELD_LIMITS.bandUrl.max,
-            "Website URL",
-          );
+          existingLinks.website = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");
           newSocialLinks = sanitizeBandSocialLinks(existingLinks);
         } catch (error) {
           return new Response(
@@ -560,9 +491,7 @@ export async function onRequestPut(context) {
 
       if (profileUpdates.length > 0) {
         profileParams.push(performance.band_profile_id);
-        await DB.prepare(
-          `UPDATE band_profiles SET ${profileUpdates.join(", ")} WHERE id = ?`,
-        )
+        await DB.prepare(`UPDATE band_profiles SET ${profileUpdates.join(", ")} WHERE id = ?`)
           .bind(...profileParams)
           .run();
       }
@@ -628,11 +557,7 @@ export async function onRequestPut(context) {
         .bind(realPerformanceId)
         .first();
     } else {
-      const profile = await DB.prepare(
-        "SELECT * FROM band_profiles WHERE id = ?",
-      )
-        .bind(bandProfileId)
-        .first();
+      const profile = await DB.prepare("SELECT * FROM band_profiles WHERE id = ?").bind(bandProfileId).first();
       result = {
         id: `profile_${profile.id}`,
         name: profile.name,
@@ -652,10 +577,7 @@ export async function onRequestPut(context) {
       social = JSON.parse(result.social_links || "{}");
     } catch (e) {}
     result.url = social.website || "";
-    result.origin =
-      [result.origin_city, result.origin_region].filter(Boolean).join(", ") ||
-      result.origin ||
-      "";
+    result.origin = [result.origin_city, result.origin_region].filter(Boolean).join(", ") || result.origin || "";
 
     // Audit log the update
     await auditLog(
@@ -739,9 +661,7 @@ export async function onRequestPatch(context) {
       );
     }
 
-    const performance = await DB.prepare(
-      "SELECT id, is_announced, band_follow_notified FROM performances WHERE id = ?",
-    )
+    const performance = await DB.prepare("SELECT id, is_announced, band_follow_notified FROM performances WHERE id = ?")
       .bind(performanceId)
       .first();
 
@@ -767,20 +687,14 @@ export async function onRequestPatch(context) {
     }
 
     const newValue = body.is_announced ? 1 : 0;
-    await DB.prepare(
-      "UPDATE performances SET is_announced = ?, updated_at = datetime('now') WHERE id = ?",
-    )
+    await DB.prepare("UPDATE performances SET is_announced = ?, updated_at = datetime('now') WHERE id = ?")
       .bind(newValue, performanceId)
       .run();
 
     // Queue band-follower notifications on first 0 → 1 transition.
     // Followers are batched into band_announce_queue; POST /api/admin/flush-announce-digest
     // groups them by (email, event) and sends one digest per fan per event.
-    if (
-      newValue === 1 &&
-      performance.is_announced === 0 &&
-      !performance.band_follow_notified
-    ) {
+    if (newValue === 1 && performance.is_announced === 0 && !performance.band_follow_notified) {
       const perf = await DB.prepare(
         `SELECT p.band_profile_id, bp.name as band_name,
                 e.id as event_id, e.name as event_name, e.slug as event_slug
@@ -842,9 +756,7 @@ export async function onRequestPatch(context) {
       ipAddress,
     );
 
-    const updated = await DB.prepare(
-      "SELECT band_follow_notified FROM performances WHERE id = ?",
-    )
+    const updated = await DB.prepare("SELECT band_follow_notified FROM performances WHERE id = ?")
       .bind(performanceId)
       .first();
 
@@ -916,9 +828,7 @@ export async function onRequestDelete(context) {
         );
       }
       // Check if any performances exist
-      const perfCount = await DB.prepare(
-        "SELECT COUNT(*) as count FROM performances WHERE band_profile_id = ?",
-      )
+      const perfCount = await DB.prepare("SELECT COUNT(*) as count FROM performances WHERE band_profile_id = ?")
         .bind(bandProfileId)
         .first();
 
@@ -926,8 +836,7 @@ export async function onRequestDelete(context) {
         return new Response(
           JSON.stringify({
             error: "Conflict",
-            message:
-              "Cannot delete band profile because it has associated performances. Delete performances first.",
+            message: "Cannot delete band profile because it has associated performances. Delete performances first.",
           }),
           {
             status: 409,
@@ -948,9 +857,7 @@ export async function onRequestDelete(context) {
       );
 
       // Delete profile
-      await DB.prepare("DELETE FROM band_profiles WHERE id = ?")
-        .bind(bandProfileId)
-        .run();
+      await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(bandProfileId).run();
 
       return new Response(
         JSON.stringify({
@@ -991,8 +898,7 @@ export async function onRequestDelete(context) {
       return new Response(
         JSON.stringify({
           error: "Validation error",
-          message:
-            "Archived event performances cannot be deleted. Copy the event as a template instead.",
+          message: "Archived event performances cannot be deleted. Copy the event as a template instead.",
         }),
         {
           status: 400,

--- a/functions/api/admin/bands/[id]/resend-announcement.js
+++ b/functions/api/admin/bands/[id]/resend-announcement.js
@@ -29,10 +29,7 @@ export async function onRequestPost(context) {
   const ipAddress = getClientIP(request);
 
   if (!isEmailConfigured(env)) {
-    return json(
-      { error: "Email not configured", message: "Email is not configured" },
-      400,
-    );
+    return json({ error: "Email not configured", message: "Email is not configured" }, 400);
   }
 
   const perf = await DB.prepare(
@@ -50,10 +47,7 @@ export async function onRequestPost(context) {
   }
 
   if (!perf.is_announced) {
-    return json(
-      { error: "Bad request", message: "Performance has not been announced" },
-      400,
-    );
+    return json({ error: "Bad request", message: "Performance has not been announced" }, 400);
   }
 
   // Verified followers WITHOUT a notification row for this performance.

--- a/functions/api/admin/bands/__tests__/announce-digest.test.js
+++ b/functions/api/admin/bands/__tests__/announce-digest.test.js
@@ -1,10 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import {
-  createTestEnv,
-  insertEvent,
-  insertVenue,
-  insertBand,
-} from "../../../test-utils.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils.js";
 import { flushAnnounceDigest } from "../../../../utils/announceDigest.js";
 
 vi.mock("../../../../utils/email.js", () => ({
@@ -30,14 +25,8 @@ describe("flushAnnounceDigest", () => {
     });
 
     const followId = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
-      .run(
-        "fan@example.com",
-        perf.band_profile_id,
-        "tok-unsub",
-      ).lastInsertRowid;
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("fan@example.com", perf.band_profile_id, "tok-unsub").lastInsertRowid;
 
     rawDb
       .prepare(
@@ -45,15 +34,7 @@ describe("flushAnnounceDigest", () => {
        (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(
-        followId,
-        perf.id,
-        ev.id,
-        "The Band",
-        "Fest",
-        "fest-single",
-        perf.band_profile_id,
-      );
+      .run(followId, perf.id, ev.id, "The Band", "Fest", "fest-single", perf.band_profile_id);
 
     const stats = await flushAnnounceDigest(env, env.DB);
 
@@ -67,9 +48,7 @@ describe("flushAnnounceDigest", () => {
     const remaining = rawDb.prepare("SELECT * FROM band_announce_queue").all();
     expect(remaining).toHaveLength(0);
     // Notification row recorded
-    const notif = rawDb
-      .prepare("SELECT * FROM band_follow_notifications")
-      .all();
+    const notif = rawDb.prepare("SELECT * FROM band_follow_notifications").all();
     expect(notif).toHaveLength(1);
   });
 
@@ -90,15 +69,11 @@ describe("flushAnnounceDigest", () => {
     });
 
     const fanFollowA = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fan@example.com", perfA.band_profile_id, "tok-a").lastInsertRowid;
 
     const fanFollowB = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fan@example.com", perfB.band_profile_id, "tok-b").lastInsertRowid;
 
     rawDb
@@ -107,15 +82,7 @@ describe("flushAnnounceDigest", () => {
        (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(
-        fanFollowA,
-        perfA.id,
-        ev.id,
-        "Band A",
-        "Crawl",
-        "crawl-digest",
-        perfA.band_profile_id,
-      );
+      .run(fanFollowA, perfA.id, ev.id, "Band A", "Crawl", "crawl-digest", perfA.band_profile_id);
 
     rawDb
       .prepare(
@@ -123,15 +90,7 @@ describe("flushAnnounceDigest", () => {
        (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(
-        fanFollowB,
-        perfB.id,
-        ev.id,
-        "Band B",
-        "Crawl",
-        "crawl-digest",
-        perfB.band_profile_id,
-      );
+      .run(fanFollowB, perfB.id, ev.id, "Band B", "Crawl", "crawl-digest", perfB.band_profile_id);
 
     const stats = await flushAnnounceDigest(env, env.DB);
 
@@ -142,12 +101,8 @@ describe("flushAnnounceDigest", () => {
     expect(subject).toBe("2 bands you follow are playing Crawl!");
 
     // Both queue entries consumed, both notification rows written
-    expect(
-      rawDb.prepare("SELECT * FROM band_announce_queue").all(),
-    ).toHaveLength(0);
-    expect(
-      rawDb.prepare("SELECT * FROM band_follow_notifications").all(),
-    ).toHaveLength(2);
+    expect(rawDb.prepare("SELECT * FROM band_announce_queue").all()).toHaveLength(0);
+    expect(rawDb.prepare("SELECT * FROM band_follow_notifications").all()).toHaveLength(2);
   });
 
   it("sends separate digests for different fans", async () => {
@@ -161,15 +116,11 @@ describe("flushAnnounceDigest", () => {
     });
 
     const f1 = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fan1@example.com", perf.band_profile_id, "tok-f1").lastInsertRowid;
 
     const f2 = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fan2@example.com", perf.band_profile_id, "tok-f2").lastInsertRowid;
 
     for (const [followId, token] of [
@@ -182,15 +133,7 @@ describe("flushAnnounceDigest", () => {
          (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
         )
-        .run(
-          followId,
-          perf.id,
-          ev.id,
-          "Band X",
-          "Fest",
-          "fest-fans",
-          perf.band_profile_id,
-        );
+        .run(followId, perf.id, ev.id, "Band X", "Fest", "fest-fans", perf.band_profile_id);
     }
 
     const stats = await flushAnnounceDigest(env, env.DB);
@@ -222,9 +165,7 @@ describe("flushAnnounceDigest", () => {
     });
 
     const followId = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fail@example.com", perf.band_profile_id, "tok-z").lastInsertRowid;
 
     rawDb
@@ -233,27 +174,15 @@ describe("flushAnnounceDigest", () => {
        (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(
-        followId,
-        perf.id,
-        ev.id,
-        "Band Z",
-        "Fest",
-        "fest-fail",
-        perf.band_profile_id,
-      );
+      .run(followId, perf.id, ev.id, "Band Z", "Fest", "fest-fail", perf.band_profile_id);
 
     const stats = await flushAnnounceDigest(env, env.DB);
 
     expect(stats.failed).toBe(1);
     // Queue consumed (won't retry via digest; resend-announcement handles recovery)
-    expect(
-      rawDb.prepare("SELECT * FROM band_announce_queue").all(),
-    ).toHaveLength(0);
+    expect(rawDb.prepare("SELECT * FROM band_announce_queue").all()).toHaveLength(0);
     // Claim released so resend-announcement can recover
-    expect(
-      rawDb.prepare("SELECT * FROM band_follow_notifications").all(),
-    ).toHaveLength(0);
+    expect(rawDb.prepare("SELECT * FROM band_follow_notifications").all()).toHaveLength(0);
   });
 
   it("skips entries already claimed by a concurrent flush or resend", async () => {
@@ -267,9 +196,7 @@ describe("flushAnnounceDigest", () => {
     });
 
     const followId = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("skip@example.com", perf.band_profile_id, "tok-q").lastInsertRowid;
 
     rawDb
@@ -278,21 +205,11 @@ describe("flushAnnounceDigest", () => {
        (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(
-        followId,
-        perf.id,
-        ev.id,
-        "Band Q",
-        "Fest",
-        "fest-skip",
-        perf.band_profile_id,
-      );
+      .run(followId, perf.id, ev.id, "Band Q", "Fest", "fest-skip", perf.band_profile_id);
 
     // Simulate a concurrent resend that already claimed the notification row
     rawDb
-      .prepare(
-        "INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)",
-      )
+      .prepare("INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)")
       .run(perf.id, followId);
 
     const stats = await flushAnnounceDigest(env, env.DB);
@@ -301,9 +218,7 @@ describe("flushAnnounceDigest", () => {
     expect(stats.sent).toBe(0);
     expect(sendEmail).not.toHaveBeenCalled();
     // Queue entry still cleaned up
-    expect(
-      rawDb.prepare("SELECT * FROM band_announce_queue").all(),
-    ).toHaveLength(0);
+    expect(rawDb.prepare("SELECT * FROM band_announce_queue").all()).toHaveLength(0);
   });
 
   it("correctly tallies sent/failed/skipped across multiple groups when some sends fail", async () => {
@@ -329,23 +244,17 @@ describe("flushAnnounceDigest", () => {
 
     // fan1 follows Band A — send will succeed
     const f1 = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fan1@example.com", perfA.band_profile_id, "tok1").lastInsertRowid;
 
     // fan2 follows Band B — send will fail
     const f2 = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fan2@example.com", perfB.band_profile_id, "tok2").lastInsertRowid;
 
     // fan3 follows Band C — already claimed (skipped)
     const f3 = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fan3@example.com", perfC.band_profile_id, "tok3").lastInsertRowid;
 
     for (const [followId, perf] of [
@@ -359,22 +268,12 @@ describe("flushAnnounceDigest", () => {
          (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
         )
-        .run(
-          followId,
-          perf.id,
-          ev.id,
-          perf.name ?? "Band",
-          "Multi",
-          "multi-mixed",
-          perf.band_profile_id,
-        );
+        .run(followId, perf.id, ev.id, perf.name ?? "Band", "Multi", "multi-mixed", perf.band_profile_id);
     }
 
     // Pre-claim fan3's slot to simulate concurrent flush
     rawDb
-      .prepare(
-        "INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)",
-      )
+      .prepare("INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)")
       .run(perfC.id, f3);
 
     // First call succeeds (fan1), second fails (fan2)
@@ -389,16 +288,10 @@ describe("flushAnnounceDigest", () => {
     expect(stats.skipped).toBe(1);
 
     // All queue entries consumed
-    expect(
-      rawDb.prepare("SELECT * FROM band_announce_queue").all(),
-    ).toHaveLength(0);
+    expect(rawDb.prepare("SELECT * FROM band_announce_queue").all()).toHaveLength(0);
 
     // fan1's notification row kept; fan2's released; fan3's pre-existing row kept
-    const notifs = rawDb
-      .prepare(
-        "SELECT band_follow_id FROM band_follow_notifications ORDER BY band_follow_id",
-      )
-      .all();
+    const notifs = rawDb.prepare("SELECT band_follow_id FROM band_follow_notifications ORDER BY band_follow_id").all();
     const followIds = notifs.map((n) => n.band_follow_id);
     expect(followIds).toContain(Number(f1));
     expect(followIds).not.toContain(Number(f2)); // released on failure
@@ -422,24 +315,12 @@ describe("flushAnnounceDigest", () => {
     });
 
     const f1 = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
-      .run(
-        "release@example.com",
-        perfA.band_profile_id,
-        "tok-r1",
-      ).lastInsertRowid;
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("release@example.com", perfA.band_profile_id, "tok-r1").lastInsertRowid;
 
     const f2 = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
-      .run(
-        "release@example.com",
-        perfB.band_profile_id,
-        "tok-r2",
-      ).lastInsertRowid;
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("release@example.com", perfB.band_profile_id, "tok-r2").lastInsertRowid;
 
     for (const [followId, perf] of [
       [f1, perfA],
@@ -451,15 +332,7 @@ describe("flushAnnounceDigest", () => {
          (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
         )
-        .run(
-          followId,
-          perf.id,
-          ev.id,
-          perf.name ?? "Band",
-          "Fest",
-          "fest-release",
-          perf.band_profile_id,
-        );
+        .run(followId, perf.id, ev.id, perf.name ?? "Band", "Fest", "fest-release", perf.band_profile_id);
     }
 
     sendEmail.mockResolvedValueOnce({ delivered: false });
@@ -470,12 +343,8 @@ describe("flushAnnounceDigest", () => {
     expect(stats.sent).toBe(0);
 
     // Both claims for the failed digest group must be released
-    expect(
-      rawDb.prepare("SELECT * FROM band_follow_notifications").all(),
-    ).toHaveLength(0);
+    expect(rawDb.prepare("SELECT * FROM band_follow_notifications").all()).toHaveLength(0);
     // Queue entries consumed regardless of send outcome
-    expect(
-      rawDb.prepare("SELECT * FROM band_announce_queue").all(),
-    ).toHaveLength(0);
+    expect(rawDb.prepare("SELECT * FROM band_announce_queue").all()).toHaveLength(0);
   });
 });

--- a/functions/api/admin/bands/__tests__/announce.test.js
+++ b/functions/api/admin/bands/__tests__/announce.test.js
@@ -1,176 +1,176 @@
-import { describe, it, expect } from 'vitest'
-import { createTestEnv, insertEvent, insertVenue, insertBand } from '../../../test-utils'
-import * as bandIdHandler from '../[id].js'
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils";
+import * as bandIdHandler from "../[id].js";
 
-describe('PATCH /api/admin/bands/:id - announce toggle', () => {
-  it('announces a performance (sets is_announced=1)', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-announce' })
-    const venue = insertVenue(rawDb, { name: 'Venue X' })
-    const band = insertBand(rawDb, { name: 'Test Band', event_id: ev.id, venue_id: venue.id })
-    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(band.id)
+describe("PATCH /api/admin/bands/:id - announce toggle", () => {
+  it("announces a performance (sets is_announced=1)", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-announce" });
+    const venue = insertVenue(rawDb, { name: "Venue X" });
+    const band = insertBand(rawDb, { name: "Test Band", event_id: ev.id, venue_id: venue.id });
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(band.id);
 
     const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ is_announced: true }),
-    })
+    });
     const res = await bandIdHandler.onRequestPatch({
       request: req,
       env,
-      data: { user: { role: 'editor', id: 2 } },
-    })
+      data: { user: { role: "editor", id: 2 } },
+    });
 
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.performance.is_announced).toBe(1)
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.performance.is_announced).toBe(1);
 
-    const row = rawDb.prepare('SELECT is_announced FROM performances WHERE id=?').get(band.id)
-    expect(row.is_announced).toBe(1)
-  })
+    const row = rawDb.prepare("SELECT is_announced FROM performances WHERE id=?").get(band.id);
+    expect(row.is_announced).toBe(1);
+  });
 
-  it('unannounces a performance (sets is_announced=0)', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-unannounce' })
-    const venue = insertVenue(rawDb, { name: 'Venue Y' })
-    const band = insertBand(rawDb, { name: 'Visible Band', event_id: ev.id, venue_id: venue.id })
+  it("unannounces a performance (sets is_announced=0)", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-unannounce" });
+    const venue = insertVenue(rawDb, { name: "Venue Y" });
+    const band = insertBand(rawDb, { name: "Visible Band", event_id: ev.id, venue_id: venue.id });
 
     const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ is_announced: false }),
-    })
+    });
     const res = await bandIdHandler.onRequestPatch({
       request: req,
       env,
-      data: { user: { role: 'editor', id: 2 } },
-    })
+      data: { user: { role: "editor", id: 2 } },
+    });
 
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.performance.is_announced).toBe(0)
-  })
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.performance.is_announced).toBe(0);
+  });
 
-  it('returns 400 if is_announced is missing from body', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-bad' })
-    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+  it("returns 400 if is_announced is missing from body", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-bad" });
+    const band = insertBand(rawDb, { name: "Band", event_id: ev.id });
 
     const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ unrelated: true }),
-    })
+    });
     const res = await bandIdHandler.onRequestPatch({
       request: req,
       env,
-      data: { user: { role: 'editor', id: 2 } },
-    })
+      data: { user: { role: "editor", id: 2 } },
+    });
 
-    expect(res.status).toBe(400)
-  })
+    expect(res.status).toBe(400);
+  });
 
-  it('requires at least editor role', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'viewer' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-auth' })
-    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+  it("requires at least editor role", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "viewer" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-auth" });
+    const band = insertBand(rawDb, { name: "Band", event_id: ev.id });
 
     const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ is_announced: true }),
-    })
+    });
     const res = await bandIdHandler.onRequestPatch({
       request: req,
       env,
-      data: { user: { role: 'viewer', id: 3 } },
-    })
+      data: { user: { role: "viewer", id: 3 } },
+    });
 
-    expect(res.status).toBe(403)
-  })
+    expect(res.status).toBe(403);
+  });
 
-  it('queues followers in band_announce_queue when band is announced', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-notify' })
-    rawDb.prepare('UPDATE events SET reveal_mode=1 WHERE id=?').run(ev.id)
-    const venue = insertVenue(rawDb, { name: 'Venue N' })
-    const band = insertBand(rawDb, { name: 'Notify Band', event_id: ev.id, venue_id: venue.id })
-    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(band.id)
+  it("queues followers in band_announce_queue when band is announced", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-notify" });
+    rawDb.prepare("UPDATE events SET reveal_mode=1 WHERE id=?").run(ev.id);
+    const venue = insertVenue(rawDb, { name: "Venue N" });
+    const band = insertBand(rawDb, { name: "Notify Band", event_id: ev.id, venue_id: venue.id });
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(band.id);
 
-    const followId = rawDb.prepare(
-      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
-    ).run('follower@example.com', band.band_profile_id, 'unsub-token-1').lastInsertRowid
+    const followId = rawDb
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("follower@example.com", band.band_profile_id, "unsub-token-1").lastInsertRowid;
 
     const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ is_announced: true }),
-    })
+    });
     await bandIdHandler.onRequestPatch({
       request: req,
       env,
-      data: { user: { role: 'editor', id: 2 } },
-    })
+      data: { user: { role: "editor", id: 2 } },
+    });
 
     // Latch is set so a repeat announce does not re-queue.
-    const perfRow = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
-    expect(perfRow.band_follow_notified).toBe(1)
+    const perfRow = rawDb.prepare("SELECT band_follow_notified FROM performances WHERE id=?").get(band.id);
+    expect(perfRow.band_follow_notified).toBe(1);
 
     // Follower is queued for digest delivery, not emailed immediately.
-    const queued = rawDb.prepare('SELECT * FROM band_announce_queue WHERE band_follow_id=?').all(followId)
-    expect(queued).toHaveLength(1)
-    expect(queued[0].band_name).toBe('Notify Band')
-    expect(queued[0].event_name).toBe('Vol6')
-    expect(queued[0].performance_id).toBe(band.id)
-  })
+    const queued = rawDb.prepare("SELECT * FROM band_announce_queue WHERE band_follow_id=?").all(followId);
+    expect(queued).toHaveLength(1);
+    expect(queued[0].band_name).toBe("Notify Band");
+    expect(queued[0].event_name).toBe("Vol6");
+    expect(queued[0].performance_id).toBe(band.id);
+  });
 
-  it('does not set band_follow_notified when no followers exist', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-nofollowers' })
-    const band = insertBand(rawDb, { name: 'No Followers Band', event_id: ev.id })
-    rawDb.prepare('UPDATE performances SET is_announced=0 WHERE id=?').run(band.id)
+  it("does not set band_follow_notified when no followers exist", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-nofollowers" });
+    const band = insertBand(rawDb, { name: "No Followers Band", event_id: ev.id });
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(band.id);
     // No rows in band_follows for this band
 
     const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ is_announced: true }),
-    })
+    });
     const res = await bandIdHandler.onRequestPatch({
       request: req,
       env,
-      data: { user: { role: 'editor', id: 2 } },
-    })
+      data: { user: { role: "editor", id: 2 } },
+    });
 
-    expect(res.status).toBe(200)
-    const row = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
+    expect(res.status).toBe(200);
+    const row = rawDb.prepare("SELECT band_follow_notified FROM performances WHERE id=?").get(band.id);
     // Flag should remain 0 since there were no followers — future followers will still be notified
-    expect(row.band_follow_notified).toBe(0)
-  })
+    expect(row.band_follow_notified).toBe(0);
+  });
 
-  it('does not set band_follow_notified again if band was already notified', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-renotify' })
-    const band = insertBand(rawDb, { name: 'Already Notified', event_id: ev.id })
-    rawDb.prepare('UPDATE performances SET is_announced=0, band_follow_notified=1 WHERE id=?').run(band.id)
+  it("does not set band_follow_notified again if band was already notified", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-renotify" });
+    const band = insertBand(rawDb, { name: "Already Notified", event_id: ev.id });
+    rawDb.prepare("UPDATE performances SET is_announced=0, band_follow_notified=1 WHERE id=?").run(band.id);
 
-    rawDb.prepare(
-      'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
-    ).run('follower2@example.com', band.band_profile_id, 'unsub-token-2')
+    rawDb
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("follower2@example.com", band.band_profile_id, "unsub-token-2");
 
     const req = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ is_announced: true }),
-    })
+    });
     const res = await bandIdHandler.onRequestPatch({
       request: req,
       env,
-      data: { user: { role: 'editor', id: 2 } },
-    })
+      data: { user: { role: "editor", id: 2 } },
+    });
 
-    expect(res.status).toBe(200)
-    const row = rawDb.prepare('SELECT band_follow_notified FROM performances WHERE id=?').get(band.id)
-    expect(row.band_follow_notified).toBe(1)
-  })
-})
+    expect(res.status).toBe(200);
+    const row = rawDb.prepare("SELECT band_follow_notified FROM performances WHERE id=?").get(band.id);
+    expect(row.band_follow_notified).toBe(1);
+  });
+});

--- a/functions/api/admin/bands/__tests__/bands.test.js
+++ b/functions/api/admin/bands/__tests__/bands.test.js
@@ -1,288 +1,292 @@
-import { describe, it, expect } from 'vitest'
-import { createTestEnv, insertEvent, insertVenue, insertBand } from '../../../test-utils'
-import * as bandsHandler from '../../bands.js'
-import * as bandIdHandler from '../[id].js'
-import * as bulkHandler from '../bulk.js'
-import * as bulkPreviewHandler from '../bulk-preview.js'
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils";
+import * as bandsHandler from "../../bands.js";
+import * as bandIdHandler from "../[id].js";
+import * as bulkHandler from "../bulk.js";
+import * as bulkPreviewHandler from "../bulk-preview.js";
 
-describe('Admin bands API - CRUD operations', () => {
-  it('can create a band for an event', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'BandEvent', slug: 'band-event' })
-    const venue = insertVenue(rawDb, { name: 'Main Venue' })
-    const body = { eventId: ev.id, venueId: venue.id, name: 'New Band', startTime: '18:00', endTime: '19:00' }
+describe("Admin bands API - CRUD operations", () => {
+  it("can create a band for an event", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "BandEvent", slug: "band-event" });
+    const venue = insertVenue(rawDb, { name: "Main Venue" });
+    const body = { eventId: ev.id, venueId: venue.id, name: "New Band", startTime: "18:00", endTime: "19:00" };
 
-    const request = new Request('https://example.test/api/admin/bands', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
     });
 
-    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(201)
-    const data = await res.json()
-    expect(data.band).toHaveProperty('id')
-    expect(data.band.name).toBe('New Band')
-  })
+    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.band).toHaveProperty("id");
+    expect(data.band.name).toBe("New Band");
+  });
 
-  it('GET /api/admin/bands?event_id returns bands with venue and event names', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ListEvent', slug: 'list-event' })
-    const venue = insertVenue(rawDb, { name: 'List Venue' })
-    const band = insertBand(rawDb, { name: 'List Band', event_id: ev.id, venue_id: venue.id })
+  it("GET /api/admin/bands?event_id returns bands with venue and event names", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ListEvent", slug: "list-event" });
+    const venue = insertVenue(rawDb, { name: "List Venue" });
+    const band = insertBand(rawDb, { name: "List Band", event_id: ev.id, venue_id: venue.id });
 
-    const getReq = new Request(`https://example.test/api/admin/bands?event_id=${ev.id}`, { headers })
-    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: 'editor' } } })
-    expect(getRes.status).toBe(200)
-    const list = await getRes.json()
-    expect(list.bands.length).toBeGreaterThan(0)
-    expect(list.bands[0]).toHaveProperty('venue_name')
-    expect(list.bands[0]).toHaveProperty('event_name')
-  })
+    const getReq = new Request(`https://example.test/api/admin/bands?event_id=${ev.id}`, { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    expect(getRes.status).toBe(200);
+    const list = await getRes.json();
+    expect(list.bands.length).toBeGreaterThan(0);
+    expect(list.bands[0]).toHaveProperty("venue_name");
+    expect(list.bands[0]).toHaveProperty("event_name");
+  });
 
-  it('PUT /api/admin/bands/{id} updates band name', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'UpdateEvent', slug: 'update-event' })
-    const venue = insertVenue(rawDb, { name: 'Update Venue' })
-    const band = insertBand(rawDb, { name: 'Old Name', event_id: ev.id, venue_id: venue.id })
+  it("PUT /api/admin/bands/{id} updates band name", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "UpdateEvent", slug: "update-event" });
+    const venue = insertVenue(rawDb, { name: "Update Venue" });
+    const band = insertBand(rawDb, { name: "Old Name", event_id: ev.id, venue_id: venue.id });
 
-    const body = { name: 'New Name' }
+    const body = { name: "New Name" };
     const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.band.name).toBe('New Name')
-  })
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.band.name).toBe("New Name");
+  });
 
-  it('DELETE /api/admin/bands/{id} removes band', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'DeleteEvent', slug: 'delete-event' })
-    const venue = insertVenue(rawDb, { name: 'Delete Venue' })
-    const band = insertBand(rawDb, { name: 'Delete Me', event_id: ev.id, venue_id: venue.id })
+  it("DELETE /api/admin/bands/{id} removes band", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "DeleteEvent", slug: "delete-event" });
+    const venue = insertVenue(rawDb, { name: "Delete Venue" });
+    const band = insertBand(rawDb, { name: "Delete Me", event_id: ev.id, venue_id: venue.id });
 
     const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'DELETE',
+      method: "DELETE",
       headers: { ...headers },
-    })
+    });
 
-    const res = await bandIdHandler.onRequestDelete({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.success).toBeTruthy()
-  })
+    const res = await bandIdHandler.onRequestDelete({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBeTruthy();
+  });
 
-  it('PUT /api/admin/bands/{id} persists photo_alt_text and GET returns it', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'AltEvent', slug: 'alt-event' })
-    const venue = insertVenue(rawDb, { name: 'Alt Venue' })
-    const band = insertBand(rawDb, { name: 'Alt Band', event_id: ev.id, venue_id: venue.id })
+  it("PUT /api/admin/bands/{id} persists photo_alt_text and GET returns it", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "AltEvent", slug: "alt-event" });
+    const venue = insertVenue(rawDb, { name: "Alt Venue" });
+    const band = insertBand(rawDb, { name: "Alt Band", event_id: ev.id, venue_id: venue.id });
 
     const body = {
-      photo_url: 'https://band-photos.settimes.ca/band-photos/x.jpg',
-      photo_alt_text: 'Alt Band performing under red stage lights',
-    }
+      photo_url: "https://band-photos.settimes.ca/band-photos/x.jpg",
+      photo_alt_text: "Alt Band performing under red stage lights",
+    };
     const putReq = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
-    const putRes = await bandIdHandler.onRequestPut({ request: putReq, env, data: { user: { role: 'editor' } } })
-    expect(putRes.status).toBe(200)
+    });
+    const putRes = await bandIdHandler.onRequestPut({ request: putReq, env, data: { user: { role: "editor" } } });
+    expect(putRes.status).toBe(200);
 
-    const getReq = new Request(`https://example.test/api/admin/bands?event_id=${ev.id}`, { headers })
-    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: 'editor' } } })
-    const list = await getRes.json()
-    const updated = list.bands.find(b => b.name === 'Alt Band')
-    expect(updated.photo_alt_text).toBe('Alt Band performing under red stage lights')
-  })
+    const getReq = new Request(`https://example.test/api/admin/bands?event_id=${ev.id}`, { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    const list = await getRes.json();
+    const updated = list.bands.find((b) => b.name === "Alt Band");
+    expect(updated.photo_alt_text).toBe("Alt Band performing under red stage lights");
+  });
 
-  it('PUT /api/admin/bands/{id} allows band-profile edits (is_active) for a performance in an archived event', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ArchivedEdit', slug: 'archived-edit', status: 'archived', is_published: 0 })
-    const venue = insertVenue(rawDb, { name: 'Archived Edit Venue' })
-    const band = insertBand(rawDb, { name: 'Filthy Kitty', event_id: ev.id, venue_id: venue.id })
+  it("PUT /api/admin/bands/{id} allows band-profile edits (is_active) for a performance in an archived event", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ArchivedEdit", slug: "archived-edit", status: "archived", is_published: 0 });
+    const venue = insertVenue(rawDb, { name: "Archived Edit Venue" });
+    const band = insertBand(rawDb, { name: "Filthy Kitty", event_id: ev.id, venue_id: venue.id });
 
     const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ is_active: 0 }),
-    })
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
+    });
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
     // Band status is band-wide, not event-specific — must not be blocked by archive.
-    expect(res.status).toBe(200)
-    const row = rawDb.prepare('SELECT is_active FROM band_profiles WHERE id = ?').get(band.band_profile_id)
-    expect(row.is_active).toBe(0)
-  })
+    expect(res.status).toBe(200);
+    const row = rawDb.prepare("SELECT is_active FROM band_profiles WHERE id = ?").get(band.band_profile_id);
+    expect(row.is_active).toBe(0);
+  });
 
-  it('GET without event_id excludes inactive bands from the lineup-builder picker', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
+  it("GET without event_id excludes inactive bands from the lineup-builder picker", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
 
-    rawDb.prepare('INSERT INTO band_profiles (name, name_normalized, is_active) VALUES (?, ?, ?)').run('Active Band', 'activeband', 1)
-    rawDb.prepare('INSERT INTO band_profiles (name, name_normalized, is_active) VALUES (?, ?, ?)').run('Inactive Band', 'inactiveband', 0)
+    rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized, is_active) VALUES (?, ?, ?)")
+      .run("Active Band", "activeband", 1);
+    rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized, is_active) VALUES (?, ?, ?)")
+      .run("Inactive Band", "inactiveband", 0);
 
-    const getReq = new Request('https://example.test/api/admin/bands', { headers })
-    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: 'editor' } } })
-    expect(getRes.status).toBe(200)
-    const data = await getRes.json()
+    const getReq = new Request("https://example.test/api/admin/bands", { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    expect(getRes.status).toBe(200);
+    const data = await getRes.json();
 
-    const names = data.bands.map((b) => b.name)
-    expect(names).toContain('Active Band')
-    expect(names).not.toContain('Inactive Band')
-  })
+    const names = data.bands.map((b) => b.name);
+    expect(names).toContain("Active Band");
+    expect(names).not.toContain("Inactive Band");
+  });
 
-  it('PUT /api/admin/bands/{id} still rejects set-time edits for a performance in an archived event', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ArchivedTime', slug: 'archived-time', status: 'archived', is_published: 0 })
-    const venue = insertVenue(rawDb, { name: 'Archived Time Venue' })
-    const band = insertBand(rawDb, { name: 'Frozen Set', event_id: ev.id, venue_id: venue.id })
+  it("PUT /api/admin/bands/{id} still rejects set-time edits for a performance in an archived event", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ArchivedTime", slug: "archived-time", status: "archived", is_published: 0 });
+    const venue = insertVenue(rawDb, { name: "Archived Time Venue" });
+    const band = insertBand(rawDb, { name: "Frozen Set", event_id: ev.id, venue_id: venue.id });
 
     const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ startTime: '20:00', endTime: '21:00' }),
-    })
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-  })
-})
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ startTime: "20:00", endTime: "21:00" }),
+    });
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+  });
+});
 
-describe('Admin bands API - Validation', () => {
-  it('create rejects performances for archived events', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ArchivedAdd', slug: 'archived-add', status: 'archived', is_published: 0 })
-    const venue = insertVenue(rawDb, { name: 'Archive Venue' })
+describe("Admin bands API - Validation", () => {
+  it("create rejects performances for archived events", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ArchivedAdd", slug: "archived-add", status: "archived", is_published: 0 });
+    const venue = insertVenue(rawDb, { name: "Archive Venue" });
 
-    const body = { eventId: ev.id, venueId: venue.id, name: 'Too Late Band', startTime: '18:00', endTime: '19:00' }
-    const request = new Request('https://example.test/api/admin/bands', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { eventId: ev.id, venueId: venue.id, name: "Too Late Band", startTime: "18:00", endTime: "19:00" };
+    const request = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toBe('Validation error')
-  })
+    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Validation error");
+  });
 
-  it('create validation fails when name is missing', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ValEvent', slug: 'val-event' })
-    const venue = insertVenue(rawDb, { name: 'Val Venue' })
+  it("create validation fails when name is missing", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ValEvent", slug: "val-event" });
+    const venue = insertVenue(rawDb, { name: "Val Venue" });
 
-    const body = { eventId: ev.id, venueId: venue.id, startTime: '18:00', endTime: '19:00' }
-    const request = new Request('https://example.test/api/admin/bands', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { eventId: ev.id, venueId: venue.id, startTime: "18:00", endTime: "19:00" };
+    const request = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toBe('Missing required fields')
-  })
+    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Missing required fields");
+  });
 
-  it('create succeeds for event band without venue or times (TBD lineup)', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'MissingEvent', slug: 'missing-event' })
+  it("create succeeds for event band without venue or times (TBD lineup)", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "MissingEvent", slug: "missing-event" });
 
-    const body = { eventId: ev.id, name: 'TBD Band' }
-    const request = new Request('https://example.test/api/admin/bands', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { eventId: ev.id, name: "TBD Band" };
+    const request = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(201)
-    const data = await res.json()
-    expect(data.band.name).toBe('TBD Band')
-  })
+    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.band.name).toBe("TBD Band");
+  });
 
-  it('create succeeds for event band with venue but no times', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'NoTimeEvent', slug: 'no-time-event' })
-    const venue = insertVenue(rawDb, { name: 'No Time Venue' })
+  it("create succeeds for event band with venue but no times", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "NoTimeEvent", slug: "no-time-event" });
+    const venue = insertVenue(rawDb, { name: "No Time Venue" });
 
-    const body = { eventId: ev.id, venueId: venue.id, name: 'No Time Band' }
-    const request = new Request('https://example.test/api/admin/bands', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { eventId: ev.id, venueId: venue.id, name: "No Time Band" };
+    const request = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(201)
-  })
+    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(201);
+  });
 
-  it('GET with event_id returns null-venue performances', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'NullVenueEvent', slug: 'null-venue-event' })
+  it("GET with event_id returns null-venue performances", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "NullVenueEvent", slug: "null-venue-event" });
 
     // Insert a band (performance) without a venue or times
-    const bandBody = { eventId: ev.id, name: 'TBD Venue Band' }
-    const postReq = new Request('https://example.test/api/admin/bands', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const bandBody = { eventId: ev.id, name: "TBD Venue Band" };
+    const postReq = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(bandBody),
-    })
-    await bandsHandler.onRequestPost({ request: postReq, env, data: { user: { role: 'editor' } } })
+    });
+    await bandsHandler.onRequestPost({ request: postReq, env, data: { user: { role: "editor" } } });
 
-    const getReq = new Request(`https://example.test/api/admin/bands?event_id=${ev.id}`, { headers })
-    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: 'editor' } } })
-    expect(getRes.status).toBe(200)
-    const list = await getRes.json()
-    expect(list.bands.length).toBe(1)
-    expect(list.bands[0].venue_name).toBeNull()
-    expect(list.bands[0].start_time).toBeNull()
-  })
+    const getReq = new Request(`https://example.test/api/admin/bands?event_id=${ev.id}`, { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    expect(getRes.status).toBe(200);
+    const list = await getRes.json();
+    expect(list.bands.length).toBe(1);
+    expect(list.bands[0].venue_name).toBeNull();
+    expect(list.bands[0].start_time).toBeNull();
+  });
 
-  it('create validation fails with invalid time format', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'TimeEvent', slug: 'time-event' })
-    const venue = insertVenue(rawDb, { name: 'Time Venue' })
+  it("create validation fails with invalid time format", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "TimeEvent", slug: "time-event" });
+    const venue = insertVenue(rawDb, { name: "Time Venue" });
 
-    const body = { eventId: ev.id, venueId: venue.id, name: 'Bad Time', startTime: '6pm', endTime: '19:00' }
-    const request = new Request('https://example.test/api/admin/bands', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { eventId: ev.id, venueId: venue.id, name: "Bad Time", startTime: "6pm", endTime: "19:00" };
+    const request = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.message).toContain('Time must be in HH:MM format')
-  })
+    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.message).toContain("Time must be in HH:MM format");
+  });
 
-  it('create validation fails when end time before start time', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'OrderEvent', slug: 'order-event' })
-    const venue = insertVenue(rawDb, { name: 'Order Venue' })
+  it("create validation fails when end time before start time", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "OrderEvent", slug: "order-event" });
+    const venue = insertVenue(rawDb, { name: "Order Venue" });
 
-    const body = { eventId: ev.id, venueId: venue.id, name: 'Bad Order', startTime: '19:00', endTime: '18:00' }
-    const request = new Request('https://example.test/api/admin/bands', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { eventId: ev.id, venueId: venue.id, name: "Bad Order", startTime: "19:00", endTime: "18:00" };
+    const request = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.message).toContain('End time must be after start time')
-  })
+    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.message).toContain("End time must be after start time");
+  });
 
-  it('duplicate band name returns 409', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'DupEvent', slug: 'dup-event' })
-    const venue = insertVenue(rawDb, { name: 'Dup Venue' })
+  it("duplicate band name returns 409", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "DupEvent", slug: "dup-event" });
+    const venue = insertVenue(rawDb, { name: "Dup Venue" });
 
     const body = {
       eventId: ev.id,
@@ -290,962 +294,1128 @@ describe('Admin bands API - Validation', () => {
       name: "SameBand",
       startTime: "18:00",
       endTime: "19:00",
-    }
+    };
     const req1 = new Request("https://example.test/api/admin/bands", {
       method: "POST",
       headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
-    const r1 = await bandsHandler.onRequestPost({ request: req1, env, data: { user: { role: 'editor' } } })
-    expect(r1.status).toBe(201)
+    });
+    const r1 = await bandsHandler.onRequestPost({ request: req1, env, data: { user: { role: "editor" } } });
+    expect(r1.status).toBe(201);
 
     const req2 = new Request("https://example.test/api/admin/bands", {
       method: "POST",
       headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
-    const r2 = await bandsHandler.onRequestPost({ request: req2, env, data: { user: { role: 'editor' } } })
-    expect(r2.status).toBe(409)
-  })
+    });
+    const r2 = await bandsHandler.onRequestPost({ request: req2, env, data: { user: { role: "editor" } } });
+    expect(r2.status).toBe(409);
+  });
 
-  it('update returns 404 for non-existent band', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+  it("update returns 404 for non-existent band", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const body = { name: 'Updated Name' }
-    const request = new Request('https://example.test/api/admin/bands/99999', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { name: "Updated Name" };
+    const request = new Request("https://example.test/api/admin/bands/99999", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(404)
-  })
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(404);
+  });
 
-  it('update allows band-profile fields (name) for a performance in an archived event', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ArchivedUpdate', slug: 'archived-update', status: 'archived', is_published: 0 })
-    const venue = insertVenue(rawDb, { name: 'Archive Update Venue' })
-    const band = insertBand(rawDb, { name: 'Frozen Band', event_id: ev.id, venue_id: venue.id })
+  it("update allows band-profile fields (name) for a performance in an archived event", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, {
+      name: "ArchivedUpdate",
+      slug: "archived-update",
+      status: "archived",
+      is_published: 0,
+    });
+    const venue = insertVenue(rawDb, { name: "Archive Update Venue" });
+    const band = insertBand(rawDb, { name: "Frozen Band", event_id: ev.id, venue_id: venue.id });
 
     const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ name: 'Renamed Frozen Band' }),
-    })
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ name: "Renamed Frozen Band" }),
+    });
 
     // Band name is band-wide profile data (one shared band_profiles row) — editable
     // regardless of event archive state. Only event-specific set times are frozen.
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const row = rawDb.prepare('SELECT name FROM band_profiles WHERE id = ?').get(band.band_profile_id)
-    expect(row.name).toBe('Renamed Frozen Band')
-  })
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const row = rawDb.prepare("SELECT name FROM band_profiles WHERE id = ?").get(band.band_profile_id);
+    expect(row.name).toBe("Renamed Frozen Band");
+  });
 
-  it('delete returns 404 for non-existent band', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+  it("delete returns 404 for non-existent band", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const request = new Request('https://example.test/api/admin/bands/99999', {
-      method: 'DELETE',
+    const request = new Request("https://example.test/api/admin/bands/99999", {
+      method: "DELETE",
       headers: { ...headers },
-    })
+    });
 
-    const res = await bandIdHandler.onRequestDelete({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(404)
-  })
+    const res = await bandIdHandler.onRequestDelete({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(404);
+  });
 
-  it('delete rejects performances for archived events', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ArchivedDelete', slug: 'archived-delete', status: 'archived', is_published: 0 })
-    const venue = insertVenue(rawDb, { name: 'Archive Delete Venue' })
-    const band = insertBand(rawDb, { name: 'Protected Band', event_id: ev.id, venue_id: venue.id })
+  it("delete rejects performances for archived events", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, {
+      name: "ArchivedDelete",
+      slug: "archived-delete",
+      status: "archived",
+      is_published: 0,
+    });
+    const venue = insertVenue(rawDb, { name: "Archive Delete Venue" });
+    const band = insertBand(rawDb, { name: "Protected Band", event_id: ev.id, venue_id: venue.id });
 
     const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'DELETE',
+      method: "DELETE",
       headers: { ...headers },
-    })
+    });
 
-    const res = await bandIdHandler.onRequestDelete({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toBe('Validation error')
-  })
-})
+    const res = await bandIdHandler.onRequestDelete({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Validation error");
+  });
+});
 
-describe('Admin bands API - Conflicts', () => {
-  it('conflict detection finds overlapping times at the same venue', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ConflictEvent', slug: 'conflict-event' })
-    const venue = insertVenue(rawDb, { name: 'Conflict Venue' })
+describe("Admin bands API - Conflicts", () => {
+  it("conflict detection finds overlapping times at the same venue", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ConflictEvent", slug: "conflict-event" });
+    const venue = insertVenue(rawDb, { name: "Conflict Venue" });
 
     // Existing band
-    const band1 = insertBand(rawDb, { name: 'Band One', event_id: ev.id, venue_id: venue.id, start_time: '18:00', end_time: '19:00' })
+    const band1 = insertBand(rawDb, {
+      name: "Band One",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
 
     // Overlapping band
-    const body2 = { eventId: ev.id, venueId: venue.id, name: 'Band Two', startTime: '18:30', endTime: '19:30' }
-    const req2 = new Request('https://example.test/api/admin/bands', {
-      method: 'POST', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify(body2)
-    })
-    const r2 = await bandsHandler.onRequestPost({ request: req2, env, data: { user: { role: 'editor' } } })
-    expect(r2.status).toBe(409)
-    const data2 = await r2.json()
-    expect(data2.conflicts).toBeDefined()
-    expect(data2.conflicts.length).toBeGreaterThan(0)
-  })
-})
+    const body2 = { eventId: ev.id, venueId: venue.id, name: "Band Two", startTime: "18:30", endTime: "19:30" };
+    const req2 = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body2),
+    });
+    const r2 = await bandsHandler.onRequestPost({ request: req2, env, data: { user: { role: "editor" } } });
+    expect(r2.status).toBe(409);
+    const data2 = await r2.json();
+    expect(data2.conflicts).toBeDefined();
+    expect(data2.conflicts.length).toBeGreaterThan(0);
+  });
+});
 
-describe('Admin bands API - Bulk operations', () => {
-  it('PATCH /api/admin/bands/bulk deletes multiple bands', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'BulkEvent', slug: 'bulk-event' })
-    const venue = insertVenue(rawDb, { name: 'Bulk Venue' })
-    const band1 = insertBand(rawDb, { name: 'Bulk1', event_id: ev.id, venue_id: venue.id })
-    const band2 = insertBand(rawDb, { name: 'Bulk2', event_id: ev.id, venue_id: venue.id })
+describe("Admin bands API - Bulk operations", () => {
+  it("PATCH /api/admin/bands/bulk deletes multiple bands", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "BulkEvent", slug: "bulk-event" });
+    const venue = insertVenue(rawDb, { name: "Bulk Venue" });
+    const band1 = insertBand(rawDb, { name: "Bulk1", event_id: ev.id, venue_id: venue.id });
+    const band2 = insertBand(rawDb, { name: "Bulk2", event_id: ev.id, venue_id: venue.id });
 
-    const body = { band_ids: [band1.id, band2.id], action: 'delete' }
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { band_ids: [band1.id, band2.id], action: "delete" };
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.success).toBeTruthy()
-    expect(data.updated).toBe(2)
-  })
+    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBeTruthy();
+    expect(data.updated).toBe(2);
+  });
 
-  it('PATCH /api/admin/bands/bulk rejects archived event performances', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Archived Bulk', slug: 'archived-bulk', status: 'archived', is_published: 0 })
-    const venue = insertVenue(rawDb, { name: 'Archived Bulk Venue' })
-    const band = insertBand(rawDb, { name: 'Locked Bulk Band', event_id: ev.id, venue_id: venue.id })
+  it("PATCH /api/admin/bands/bulk rejects archived event performances", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, {
+      name: "Archived Bulk",
+      slug: "archived-bulk",
+      status: "archived",
+      is_published: 0,
+    });
+    const venue = insertVenue(rawDb, { name: "Archived Bulk Venue" });
+    const band = insertBand(rawDb, { name: "Locked Bulk Band", event_id: ev.id, venue_id: venue.id });
 
-    const body = { band_ids: [band.id], action: 'delete' }
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { band_ids: [band.id], action: "delete" };
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toBe('Validation error')
-  })
+    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Validation error");
+  });
 
-  it('DELETE /api/admin/bands/bulk rejects archived event performances', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Archived Bulk Delete', slug: 'archived-bulk-delete', status: 'archived', is_published: 0 })
-    const venue = insertVenue(rawDb, { name: 'Archived Bulk Delete Venue' })
-    const band = insertBand(rawDb, { name: 'Locked Delete Band', event_id: ev.id, venue_id: venue.id })
+  it("DELETE /api/admin/bands/bulk rejects archived event performances", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, {
+      name: "Archived Bulk Delete",
+      slug: "archived-bulk-delete",
+      status: "archived",
+      is_published: 0,
+    });
+    const venue = insertVenue(rawDb, { name: "Archived Bulk Delete Venue" });
+    const band = insertBand(rawDb, { name: "Locked Delete Band", event_id: ev.id, venue_id: venue.id });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ band_ids: [band.id] }),
-    })
+    });
 
-    const res = await bulkHandler.onRequestDelete({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toBe('Validation error')
-  })
+    const res = await bulkHandler.onRequestDelete({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Validation error");
+  });
 
-  it('bulk preview returns changes and conflicts', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'PreviewEvent', slug: 'preview-event' })
-    const venue = insertVenue(rawDb, { name: 'Preview Venue' })
-    const band1 = insertBand(rawDb, { name: 'Preview1', event_id: ev.id, venue_id: venue.id })
+  it("bulk preview returns changes and conflicts", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "PreviewEvent", slug: "preview-event" });
+    const venue = insertVenue(rawDb, { name: "Preview Venue" });
+    const band1 = insertBand(rawDb, { name: "Preview1", event_id: ev.id, venue_id: venue.id });
 
-    const body = { band_ids: [band1.id], action: 'delete' }
-    const request = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { band_ids: [band1.id], action: "delete" };
+    const request = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.changes).toBeDefined()
-    expect(data.conflicts).toBeDefined()
-  })
+    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.changes).toBeDefined();
+    expect(data.conflicts).toBeDefined();
+  });
 
-  it('bulk preview flags archived event performances as conflicts', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Archived Preview', slug: 'archived-preview', status: 'archived', is_published: 0 })
-    const venue = insertVenue(rawDb, { name: 'Archived Preview Venue' })
-    const band = insertBand(rawDb, { name: 'Preview Locked Band', event_id: ev.id, venue_id: venue.id })
+  it("bulk preview flags archived event performances as conflicts", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, {
+      name: "Archived Preview",
+      slug: "archived-preview",
+      status: "archived",
+      is_published: 0,
+    });
+    const venue = insertVenue(rawDb, { name: "Archived Preview Venue" });
+    const band = insertBand(rawDb, { name: "Preview Locked Band", event_id: ev.id, venue_id: venue.id });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ band_ids: [band.id], action: 'delete' }),
-    })
+    const request = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ band_ids: [band.id], action: "delete" }),
+    });
 
-    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.conflicts.some(conflict => conflict.message.includes('archived event'))).toBe(true)
-    expect(data.changes).toHaveLength(0)
-  })
+    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.conflicts.some((conflict) => conflict.message.includes("archived event"))).toBe(true);
+    expect(data.changes).toHaveLength(0);
+  });
 
-  it('bulk preview change_time returns 400 for invalid start_time', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'PreviewValidateEvent', slug: 'preview-validate-event' })
-    const venue = insertVenue(rawDb, { name: 'Preview Validate Venue' })
-    const band = insertBand(rawDb, { name: 'Preview Validate Band', event_id: ev.id, venue_id: venue.id, start_time: '18:00', end_time: '19:00' })
+  it("bulk preview change_time returns 400 for invalid start_time", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "PreviewValidateEvent", slug: "preview-validate-event" });
+    const venue = insertVenue(rawDb, { name: "Preview Validate Venue" });
+    const band = insertBand(rawDb, {
+      name: "Preview Validate Band",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ band_ids: [band.id], action: 'change_time', start_time: '6pm' }),
-    })
+    const request = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ band_ids: [band.id], action: "change_time", start_time: "6pm" }),
+    });
 
-    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-  })
+    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+  });
 
-  it('bulk change_time preserves duration for after-midnight sets', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'MidnightEvent', slug: 'midnight-event' })
-    const venue = insertVenue(rawDb, { name: 'Midnight Venue' })
+  it("bulk change_time preserves duration for after-midnight sets", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "MidnightEvent", slug: "midnight-event" });
+    const venue = insertVenue(rawDb, { name: "Midnight Venue" });
     // 23:40–00:10 = 30 minute set crossing midnight
-    const band = insertBand(rawDb, { name: 'Midnight Band', event_id: ev.id, venue_id: venue.id, start_time: '23:40', end_time: '00:10' })
+    const band = insertBand(rawDb, {
+      name: "Midnight Band",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "23:40",
+      end_time: "00:10",
+    });
 
-    const body = { band_ids: [band.id], action: 'change_time', start_time: '23:00' }
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { band_ids: [band.id], action: "change_time", start_time: "23:00" };
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
+    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
 
     // Shifting 23:40 → 23:00 should shift end 00:10 → 23:30 (30 min duration preserved)
-    const updated = rawDb.prepare('SELECT start_time, end_time FROM performances WHERE id = ?').get(band.id)
-    expect(updated.start_time).toBe('23:00')
-    expect(updated.end_time).toBe('23:30')
-  })
+    const updated = rawDb.prepare("SELECT start_time, end_time FROM performances WHERE id = ?").get(band.id);
+    expect(updated.start_time).toBe("23:00");
+    expect(updated.end_time).toBe("23:30");
+  });
 
-  it('bulk change_time preserves duration for a set that shifts across midnight', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ShiftEvent', slug: 'shift-event' })
-    const venue = insertVenue(rawDb, { name: 'Shift Venue' })
+  it("bulk change_time preserves duration for a set that shifts across midnight", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ShiftEvent", slug: "shift-event" });
+    const venue = insertVenue(rawDb, { name: "Shift Venue" });
     // 22:00–23:00 = 60 minute same-day set
-    const band = insertBand(rawDb, { name: 'Shift Band', event_id: ev.id, venue_id: venue.id, start_time: '22:00', end_time: '23:00' })
+    const band = insertBand(rawDb, {
+      name: "Shift Band",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "22:00",
+      end_time: "23:00",
+    });
 
-    const body = { band_ids: [band.id], action: 'change_time', start_time: '23:30' }
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { band_ids: [band.id], action: "change_time", start_time: "23:30" };
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
+    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
 
     // Shifting 22:00 → 23:30 should end at 00:30 (60 min duration)
-    const updated = rawDb.prepare('SELECT start_time, end_time FROM performances WHERE id = ?').get(band.id)
-    expect(updated.start_time).toBe('23:30')
-    expect(updated.end_time).toBe('00:30')
-  })
+    const updated = rawDb.prepare("SELECT start_time, end_time FROM performances WHERE id = ?").get(band.id);
+    expect(updated.start_time).toBe("23:30");
+    expect(updated.end_time).toBe("00:30");
+  });
 
-  it('bulk change_time rejects invalid start_time format', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ValidateEvent', slug: 'validate-event' })
-    const venue = insertVenue(rawDb, { name: 'Validate Venue' })
-    const band = insertBand(rawDb, { name: 'Validate Band', event_id: ev.id, venue_id: venue.id, start_time: '18:00', end_time: '19:00' })
+  it("bulk change_time rejects invalid start_time format", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ValidateEvent", slug: "validate-event" });
+    const venue = insertVenue(rawDb, { name: "Validate Venue" });
+    const band = insertBand(rawDb, {
+      name: "Validate Band",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
 
-    const body = { band_ids: [band.id], action: 'change_time', start_time: '6pm' }
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { band_ids: [band.id], action: "change_time", start_time: "6pm" };
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-  })
+    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+  });
 
-  it('bulk move_venue rejects non-existent venue_id', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'VenueCheckEvent', slug: 'venue-check-event' })
-    const venue = insertVenue(rawDb, { name: 'Venue Check' })
-    const band = insertBand(rawDb, { name: 'Venue Check Band', event_id: ev.id, venue_id: venue.id })
+  it("bulk move_venue rejects non-existent venue_id", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "VenueCheckEvent", slug: "venue-check-event" });
+    const venue = insertVenue(rawDb, { name: "Venue Check" });
+    const band = insertBand(rawDb, { name: "Venue Check Band", event_id: ev.id, venue_id: venue.id });
 
-    const body = { band_ids: [band.id], action: 'move_venue', venue_id: 99999 }
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { band_ids: [band.id], action: "move_venue", venue_id: 99999 };
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(404)
-  })
+    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(404);
+  });
 
-  it('bulk PATCH returns 400 for malformed JSON body', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+  it("bulk PATCH returns 400 for malformed JSON body", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: 'not valid json{{{',
-    })
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: "not valid json{{{",
+    });
 
-    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-  })
+    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+  });
 
-  it('conflict detection returns type field distinguishing overlap from exact conflict', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'TypeEvent', slug: 'type-event' })
-    const venue = insertVenue(rawDb, { name: 'Type Venue' })
-    insertBand(rawDb, { name: 'Band Exact', event_id: ev.id, venue_id: venue.id, start_time: '18:00', end_time: '19:00' })
+  it("conflict detection returns type field distinguishing overlap from exact conflict", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "TypeEvent", slug: "type-event" });
+    const venue = insertVenue(rawDb, { name: "Type Venue" });
+    insertBand(rawDb, {
+      name: "Band Exact",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
 
     // Exact conflict — same time slot
-    const exactBody = { eventId: ev.id, venueId: venue.id, name: 'Band Exact Copy', startTime: '18:00', endTime: '19:00' }
-    const exactReq = new Request('https://example.test/api/admin/bands', {
-      method: 'POST', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify(exactBody)
-    })
-    const exactRes = await bandsHandler.onRequestPost({ request: exactReq, env, data: { user: { role: 'editor' } } })
-    expect(exactRes.status).toBe(409)
-    const exactData = await exactRes.json()
-    expect(exactData.conflicts[0].type).toBe('conflict')
+    const exactBody = {
+      eventId: ev.id,
+      venueId: venue.id,
+      name: "Band Exact Copy",
+      startTime: "18:00",
+      endTime: "19:00",
+    };
+    const exactReq = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(exactBody),
+    });
+    const exactRes = await bandsHandler.onRequestPost({ request: exactReq, env, data: { user: { role: "editor" } } });
+    expect(exactRes.status).toBe(409);
+    const exactData = await exactRes.json();
+    expect(exactData.conflicts[0].type).toBe("conflict");
 
     // Overlap — partial overlap
-    const overlapBody = { eventId: ev.id, venueId: venue.id, name: 'Band Overlapper', startTime: '18:30', endTime: '19:30' }
-    const overlapReq = new Request('https://example.test/api/admin/bands', {
-      method: 'POST', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify(overlapBody)
-    })
-    const overlapRes = await bandsHandler.onRequestPost({ request: overlapReq, env, data: { user: { role: 'editor' } } })
-    expect(overlapRes.status).toBe(409)
-    const overlapData = await overlapRes.json()
-    expect(overlapData.conflicts[0].type).toBe('overlap')
-  })
+    const overlapBody = {
+      eventId: ev.id,
+      venueId: venue.id,
+      name: "Band Overlapper",
+      startTime: "18:30",
+      endTime: "19:30",
+    };
+    const overlapReq = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(overlapBody),
+    });
+    const overlapRes = await bandsHandler.onRequestPost({
+      request: overlapReq,
+      env,
+      data: { user: { role: "editor" } },
+    });
+    expect(overlapRes.status).toBe(409);
+    const overlapData = await overlapRes.json();
+    expect(overlapData.conflicts[0].type).toBe("overlap");
+  });
 
-  it('move_venue preview detects overlap between two batch members moving to the same venue', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'BatchOverlapEvent', slug: 'batch-overlap-event' })
-    const sourceA = insertVenue(rawDb, { name: 'Source A' })
-    const sourceB = insertVenue(rawDb, { name: 'Source B' })
-    const target = insertVenue(rawDb, { name: 'Target Venue' })
+  it("move_venue preview detects overlap between two batch members moving to the same venue", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "BatchOverlapEvent", slug: "batch-overlap-event" });
+    const sourceA = insertVenue(rawDb, { name: "Source A" });
+    const sourceB = insertVenue(rawDb, { name: "Source B" });
+    const target = insertVenue(rawDb, { name: "Target Venue" });
     // Two bands at different venues, overlapping times — moving both to the same target venue
-    const bandA = insertBand(rawDb, { name: 'Batch A', event_id: ev.id, venue_id: sourceA.id, start_time: '21:00', end_time: '22:00' })
-    const bandB = insertBand(rawDb, { name: 'Batch B', event_id: ev.id, venue_id: sourceB.id, start_time: '21:30', end_time: '22:30' })
+    const bandA = insertBand(rawDb, {
+      name: "Batch A",
+      event_id: ev.id,
+      venue_id: sourceA.id,
+      start_time: "21:00",
+      end_time: "22:00",
+    });
+    const bandB = insertBand(rawDb, {
+      name: "Batch B",
+      event_id: ev.id,
+      venue_id: sourceB.id,
+      start_time: "21:30",
+      end_time: "22:30",
+    });
 
-    const req = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ band_ids: [bandA.id, bandB.id], action: 'move_venue', venue_id: target.id }),
-    })
-    const res = await bulkPreviewHandler.onRequestPost({ request: req, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
+    const req = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ band_ids: [bandA.id, bandB.id], action: "move_venue", venue_id: target.id }),
+    });
+    const res = await bulkPreviewHandler.onRequestPost({ request: req, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
 
     // One entry per pair — message must mention both band names
-    const overlap = data.conflicts.find(c => c.type === 'overlap')
-    expect(overlap).toBeDefined()
-    expect(overlap.message).toContain('Batch A')
-    expect(overlap.message).toContain('Batch B')
-  })
+    const overlap = data.conflicts.find((c) => c.type === "overlap");
+    expect(overlap).toBeDefined();
+    expect(overlap.message).toContain("Batch A");
+    expect(overlap.message).toContain("Batch B");
+  });
 
-  it('move_venue preview detects exact conflict when two batch members have identical times', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'BatchExactEvent', slug: 'batch-exact-event' })
-    const sourceA = insertVenue(rawDb, { name: 'Exact Source A' })
-    const sourceB = insertVenue(rawDb, { name: 'Exact Source B' })
-    const target = insertVenue(rawDb, { name: 'Exact Target' })
+  it("move_venue preview detects exact conflict when two batch members have identical times", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "BatchExactEvent", slug: "batch-exact-event" });
+    const sourceA = insertVenue(rawDb, { name: "Exact Source A" });
+    const sourceB = insertVenue(rawDb, { name: "Exact Source B" });
+    const target = insertVenue(rawDb, { name: "Exact Target" });
     // Same time slot at different venues — should become an exact conflict when co-located
-    const bandA = insertBand(rawDb, { name: 'Exact A', event_id: ev.id, venue_id: sourceA.id, start_time: '21:00', end_time: '22:00' })
-    const bandB = insertBand(rawDb, { name: 'Exact B', event_id: ev.id, venue_id: sourceB.id, start_time: '21:00', end_time: '22:00' })
+    const bandA = insertBand(rawDb, {
+      name: "Exact A",
+      event_id: ev.id,
+      venue_id: sourceA.id,
+      start_time: "21:00",
+      end_time: "22:00",
+    });
+    const bandB = insertBand(rawDb, {
+      name: "Exact B",
+      event_id: ev.id,
+      venue_id: sourceB.id,
+      start_time: "21:00",
+      end_time: "22:00",
+    });
 
-    const req = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ band_ids: [bandA.id, bandB.id], action: 'move_venue', venue_id: target.id }),
-    })
-    const res = await bulkPreviewHandler.onRequestPost({ request: req, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
+    const req = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ band_ids: [bandA.id, bandB.id], action: "move_venue", venue_id: target.id }),
+    });
+    const res = await bulkPreviewHandler.onRequestPost({ request: req, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
 
     // One entry per pair — message must mention both band names
-    const conflict = data.conflicts.find(c => c.type === 'conflict')
-    expect(conflict).toBeDefined()
-    expect(conflict.message).toContain('Exact A')
-    expect(conflict.message).toContain('Exact B')
-  })
+    const conflict = data.conflicts.find((c) => c.type === "conflict");
+    expect(conflict).toBeDefined();
+    expect(conflict.message).toContain("Exact A");
+    expect(conflict.message).toContain("Exact B");
+  });
 
-  it('change_time preview detects overlap between two batch members at the same venue+event after time shift', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ChangeTimeBatchEvent', slug: 'change-time-batch-event' })
-    const venue = insertVenue(rawDb, { name: 'Shared Venue' })
+  it("change_time preview detects overlap between two batch members at the same venue+event after time shift", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ChangeTimeBatchEvent", slug: "change-time-batch-event" });
+    const venue = insertVenue(rawDb, { name: "Shared Venue" });
     // Two bands at the same venue+event with different durations — moving both to the same start time
-    const bandA = insertBand(rawDb, { name: 'CT Band A', event_id: ev.id, venue_id: venue.id, start_time: '20:00', end_time: '21:00' })  // 60 min
-    const bandB = insertBand(rawDb, { name: 'CT Band B', event_id: ev.id, venue_id: venue.id, start_time: '20:00', end_time: '21:30' })  // 90 min
+    const bandA = insertBand(rawDb, {
+      name: "CT Band A",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    }); // 60 min
+    const bandB = insertBand(rawDb, {
+      name: "CT Band B",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:30",
+    }); // 90 min
 
     // Both shifted to 23:00 → A: 23:00-00:00, B: 23:00-00:30 → overlap
-    const req = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ band_ids: [bandA.id, bandB.id], action: 'change_time', start_time: '23:00' }),
-    })
-    const res = await bulkPreviewHandler.onRequestPost({ request: req, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
+    const req = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ band_ids: [bandA.id, bandB.id], action: "change_time", start_time: "23:00" }),
+    });
+    const res = await bulkPreviewHandler.onRequestPost({ request: req, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
 
     // One entry per pair — message must mention both band names
-    const entry = data.conflicts.find(c => c.type === 'overlap' || c.type === 'conflict')
-    expect(entry).toBeDefined()
-    expect(entry.message).toContain('CT Band A')
-    expect(entry.message).toContain('CT Band B')
-  })
-})
+    const entry = data.conflicts.find((c) => c.type === "overlap" || c.type === "conflict");
+    expect(entry).toBeDefined();
+    expect(entry.message).toContain("CT Band A");
+    expect(entry.message).toContain("CT Band B");
+  });
+});
 
-describe('Admin bands API - Atomicity (P0-B1, P1-B6)', () => {
-  it('cleans up newly created band_profile if performance insert fails', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'AtomicEvent', slug: 'atomic-event' })
-    const venue = insertVenue(rawDb, { name: 'Atomic Venue' })
+describe("Admin bands API - Atomicity (P0-B1, P1-B6)", () => {
+  it("cleans up newly created band_profile if performance insert fails", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "AtomicEvent", slug: "atomic-event" });
+    const venue = insertVenue(rawDb, { name: "Atomic Venue" });
 
     // Make the performance INSERT throw to simulate a DB failure mid-creation
-    const originalPrepare = env.DB.prepare.bind(env.DB)
-    env.DB.prepare = sql => {
-      if (sql.includes('INSERT INTO performances')) {
-        return { bind: () => ({ first: () => { throw new Error('simulated D1 constraint failure') } }) }
+    const originalPrepare = env.DB.prepare.bind(env.DB);
+    env.DB.prepare = (sql) => {
+      if (sql.includes("INSERT INTO performances")) {
+        return {
+          bind: () => ({
+            first: () => {
+              throw new Error("simulated D1 constraint failure");
+            },
+          }),
+        };
       }
-      return originalPrepare(sql)
-    }
+      return originalPrepare(sql);
+    };
 
-    const body = { eventId: ev.id, venueId: venue.id, name: 'NewOrphanBand', startTime: '18:00', endTime: '19:00' }
-    const request = new Request('https://example.test/api/admin/bands', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { eventId: ev.id, venueId: venue.id, name: "NewOrphanBand", startTime: "18:00", endTime: "19:00" };
+    const request = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(500)
+    const res = await bandsHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(500);
 
     // The newly created band_profile must have been cleaned up
-    const orphan = rawDb.prepare('SELECT id FROM band_profiles WHERE name_normalized = ?').get('neworphanband')
-    expect(orphan).toBeUndefined()
-  })
+    const orphan = rawDb.prepare("SELECT id FROM band_profiles WHERE name_normalized = ?").get("neworphanband");
+    expect(orphan).toBeUndefined();
+  });
 
-  it('does not delete an existing band_profile if performance insert fails', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ExistingProfileEvent', slug: 'existing-profile-event' })
-    const venue = insertVenue(rawDb, { name: 'EP Venue' })
+  it("does not delete an existing band_profile if performance insert fails", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ExistingProfileEvent", slug: "existing-profile-event" });
+    const venue = insertVenue(rawDb, { name: "EP Venue" });
 
     // Pre-create the band profile so it already exists when the POST runs
-    rawDb.prepare('INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)').run('ExistingArtist', 'existingartist')
+    rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("ExistingArtist", "existingartist");
 
     // Make the performance INSERT throw
-    const originalPrepare = env.DB.prepare.bind(env.DB)
-    env.DB.prepare = sql => {
-      if (sql.includes('INSERT INTO performances')) {
-        return { bind: () => ({ first: () => { throw new Error('simulated failure') } }) }
+    const originalPrepare = env.DB.prepare.bind(env.DB);
+    env.DB.prepare = (sql) => {
+      if (sql.includes("INSERT INTO performances")) {
+        return {
+          bind: () => ({
+            first: () => {
+              throw new Error("simulated failure");
+            },
+          }),
+        };
       }
-      return originalPrepare(sql)
-    }
+      return originalPrepare(sql);
+    };
 
-    const body = { eventId: ev.id, venueId: venue.id, name: 'ExistingArtist', startTime: '20:00', endTime: '21:00' }
-    const request = new Request('https://example.test/api/admin/bands', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { eventId: ev.id, venueId: venue.id, name: "ExistingArtist", startTime: "20:00", endTime: "21:00" };
+    const request = new Request("https://example.test/api/admin/bands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    await bandsHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
+    await bandsHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
 
     // Pre-existing profile must still be there — we must NOT delete profiles we didn't create
-    const profile = rawDb.prepare('SELECT id FROM band_profiles WHERE name_normalized = ?').get('existingartist')
-    expect(profile).toBeDefined()
-  })
-})
+    const profile = rawDb.prepare("SELECT id FROM band_profiles WHERE name_normalized = ?").get("existingartist");
+    expect(profile).toBeDefined();
+  });
+});
 
-describe('Admin bands API - Input validation (P1-S2)', () => {
-  it('bulk PATCH rejects non-integer band_ids (string injection)', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'InjEvent', slug: 'inj-event' })
-    const venue = insertVenue(rawDb, { name: 'InjVenue' })
+describe("Admin bands API - Input validation (P1-S2)", () => {
+  it("bulk PATCH rejects non-integer band_ids (string injection)", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "InjEvent", slug: "inj-event" });
+    const venue = insertVenue(rawDb, { name: "InjVenue" });
 
-    const body = { band_ids: ['1; DROP TABLE performances; --'], action: 'delete' }
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { band_ids: ["1; DROP TABLE performances; --"], action: "delete" };
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toMatch(/invalid/i)
-  })
+    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid/i);
+  });
 
-  it('bulk PATCH rejects floating-point band_ids', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+  it("bulk PATCH rejects floating-point band_ids", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const body = { band_ids: [1.5, 2.9], action: 'delete' }
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { band_ids: [1.5, 2.9], action: "delete" };
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-  })
+    const res = await bulkHandler.onRequestPatch({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+  });
 
-  it('bulk-preview rejects non-integer band_ids', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+  it("bulk-preview rejects non-integer band_ids", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const body = { band_ids: ['not-an-id'], action: 'delete' }
-    const request = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { band_ids: ["not-an-id"], action: "delete" };
+    const request = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-  })
-})
+    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+  });
+});
 
-describe('Admin bands API - Bulk DELETE profile IDs (P1-B4, P1-B7)', () => {
-  it('bulk DELETE correctly removes a profile that has no performances', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const profileInfo = rawDb.prepare('INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)').run('Orphan Artist', 'orphanartist')
-    const profileId = profileInfo.lastInsertRowid
+describe("Admin bands API - Bulk DELETE profile IDs (P1-B4, P1-B7)", () => {
+  it("bulk DELETE correctly removes a profile that has no performances", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const profileInfo = rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("Orphan Artist", "orphanartist");
+    const profileId = profileInfo.lastInsertRowid;
 
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ band_ids: [`profile_${profileId}`] }),
-    })
+    });
 
-    const res = await bulkHandler.onRequestDelete({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.deletedCount).toBe(1)
-    expect(rawDb.prepare('SELECT id FROM band_profiles WHERE id = ?').get(profileId)).toBeUndefined()
-  })
+    const res = await bulkHandler.onRequestDelete({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.deletedCount).toBe(1);
+    expect(rawDb.prepare("SELECT id FROM band_profiles WHERE id = ?").get(profileId)).toBeUndefined();
+  });
 
-  it('bulk DELETE blocks profile deletion when it has existing performances', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'HasPerfEvent', slug: 'has-perf-event' })
-    const band = insertBand(rawDb, { name: 'Busy Artist', event_id: ev.id })
-    const profileId = band.band_profile_id
+  it("bulk DELETE blocks profile deletion when it has existing performances", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "HasPerfEvent", slug: "has-perf-event" });
+    const band = insertBand(rawDb, { name: "Busy Artist", event_id: ev.id });
+    const profileId = band.band_profile_id;
 
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ band_ids: [`profile_${profileId}`] }),
-    })
+    });
 
-    const res = await bulkHandler.onRequestDelete({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.deletedCount).toBe(0)
-    expect(data.errors).toBeDefined()
-    expect(data.errors.length).toBeGreaterThan(0)
-    expect(rawDb.prepare('SELECT id FROM band_profiles WHERE id = ?').get(profileId)).toBeDefined()
-  })
+    const res = await bulkHandler.onRequestDelete({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.deletedCount).toBe(0);
+    expect(data.errors).toBeDefined();
+    expect(data.errors.length).toBeGreaterThan(0);
+    expect(rawDb.prepare("SELECT id FROM band_profiles WHERE id = ?").get(profileId)).toBeDefined();
+  });
 
-  it('bulk DELETE with non-integer profile ID reports an error instead of silently succeeding', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+  it("bulk DELETE with non-integer profile ID reports an error instead of silently succeeding", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ band_ids: ['profile_not_a_number'] }),
-    })
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ band_ids: ["profile_not_a_number"] }),
+    });
 
-    const res = await bulkHandler.onRequestDelete({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.deletedCount).toBe(0)
-    expect(data.errors).toBeDefined()
-    expect(data.errors.length).toBeGreaterThan(0)
-  })
-})
+    const res = await bulkHandler.onRequestDelete({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.deletedCount).toBe(0);
+    expect(data.errors).toBeDefined();
+    expect(data.errors.length).toBeGreaterThan(0);
+  });
+});
 
-describe('Admin bands API - Bulk POST add profiles (P1-B5)', () => {
-  it('POST bulk add correctly adds multiple profiles to a lineup', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'BulkAddEvent', slug: 'bulk-add-event' })
-    const p1 = rawDb.prepare('INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)').run('Roster One', 'rosterone')
-    const p2 = rawDb.prepare('INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)').run('Roster Two', 'rostertwo')
+describe("Admin bands API - Bulk POST add profiles (P1-B5)", () => {
+  it("POST bulk add correctly adds multiple profiles to a lineup", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "BulkAddEvent", slug: "bulk-add-event" });
+    const p1 = rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("Roster One", "rosterone");
+    const p2 = rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("Roster Two", "rostertwo");
 
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ band_profile_ids: [p1.lastInsertRowid, p2.lastInsertRowid], event_id: ev.id }),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(201)
-    const data = await res.json()
-    expect(data.added.length).toBe(2)
-    expect(data.skipped.length).toBe(0)
+    const res = await bulkHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.added.length).toBe(2);
+    expect(data.skipped.length).toBe(0);
 
-    const perfs = rawDb.prepare('SELECT id FROM performances WHERE event_id = ?').all(ev.id)
-    expect(perfs.length).toBe(2)
-  })
+    const perfs = rawDb.prepare("SELECT id FROM performances WHERE event_id = ?").all(ev.id);
+    expect(perfs.length).toBe(2);
+  });
 
-  it('POST bulk add skips a profile already in the event and reports it', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'SkipAddEvent', slug: 'skip-add-event' })
-    const band = insertBand(rawDb, { name: 'Already There', event_id: ev.id })
+  it("POST bulk add skips a profile already in the event and reports it", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "SkipAddEvent", slug: "skip-add-event" });
+    const band = insertBand(rawDb, { name: "Already There", event_id: ev.id });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ band_profile_ids: [band.band_profile_id], event_id: ev.id }),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(201)
-    const data = await res.json()
-    expect(data.added.length).toBe(0)
-    expect(data.skipped.length).toBe(1)
-  })
+    const res = await bulkHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.added.length).toBe(0);
+    expect(data.skipped.length).toBe(1);
+  });
 
-  it('POST bulk add handles duplicate profile IDs — adds once, skips the second', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'DupAddEvent', slug: 'dup-add-event' })
-    const profileInfo = rawDb.prepare('INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)').run('Dup Artist', 'dupartist')
-    const profileId = profileInfo.lastInsertRowid
+  it("POST bulk add handles duplicate profile IDs — adds once, skips the second", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "DupAddEvent", slug: "dup-add-event" });
+    const profileInfo = rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("Dup Artist", "dupartist");
+    const profileId = profileInfo.lastInsertRowid;
 
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ band_profile_ids: [profileId, profileId], event_id: ev.id }),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(201)
-    const data = await res.json()
-    expect(data.added.length).toBe(1)
-    expect(data.skipped.length).toBe(1)
+    const res = await bulkHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.added.length).toBe(1);
+    expect(data.skipped.length).toBe(1);
 
-    const perfs = rawDb.prepare('SELECT id FROM performances WHERE band_profile_id = ? AND event_id = ?').all(profileId, ev.id)
-    expect(perfs.length).toBe(1)
-  })
-})
+    const perfs = rawDb
+      .prepare("SELECT id FROM performances WHERE band_profile_id = ? AND event_id = ?")
+      .all(profileId, ev.id);
+    expect(perfs.length).toBe(1);
+  });
+});
 
-describe('Admin bands API - profile_abc integer validation in [id].js (P1-B7)', () => {
-  it('PUT /bands/profile_not_a_number returns 400 for non-integer profile ID', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+describe("Admin bands API - profile_abc integer validation in [id].js (P1-B7)", () => {
+  it("PUT /bands/profile_not_a_number returns 400 for non-integer profile ID", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const request = new Request('https://example.test/api/admin/bands/profile_not_a_number', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ name: 'Anything' }),
-    })
+    const request = new Request("https://example.test/api/admin/bands/profile_not_a_number", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ name: "Anything" }),
+    });
 
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toMatch(/bad request/i)
-  })
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/bad request/i);
+  });
 
-  it('DELETE /bands/profile_not_a_number returns 400 for non-integer profile ID', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+  it("DELETE /bands/profile_not_a_number returns 400 for non-integer profile ID", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const request = new Request('https://example.test/api/admin/bands/profile_not_a_number', {
-      method: 'DELETE',
+    const request = new Request("https://example.test/api/admin/bands/profile_not_a_number", {
+      method: "DELETE",
       headers: { ...headers },
-    })
+    });
 
-    const res = await bandIdHandler.onRequestDelete({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toMatch(/bad request/i)
-  })
-})
+    const res = await bandIdHandler.onRequestDelete({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/bad request/i);
+  });
+});
 
-describe('Admin bands API - Malformed JSON body (P2-B9)', () => {
-  it('bulk DELETE returns 400 for malformed JSON body', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+describe("Admin bands API - Malformed JSON body (P2-B9)", () => {
+  it("bulk DELETE returns 400 for malformed JSON body", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: 'not json{{{',
-    })
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: "not json{{{",
+    });
 
-    const res = await bulkHandler.onRequestDelete({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toMatch(/invalid/i)
-  })
+    const res = await bulkHandler.onRequestDelete({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid/i);
+  });
 
-  it('bulk-preview returns 400 for malformed JSON body', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+  it("bulk-preview returns 400 for malformed JSON body", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: 'not json{{{',
-    })
+    const request = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: "not json{{{",
+    });
 
-    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toMatch(/invalid/i)
-  })
-})
+    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid/i);
+  });
+});
 
-describe('Admin bands API - bulk-preview after-midnight conflict detection (T2/VL-1b)', () => {
-  it('move_venue detects overlap with an after-midnight band at the target venue', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'MidnightConflictEvent', slug: 'midnight-conflict' })
-    const sourceVenue = insertVenue(rawDb, { name: 'Source Venue' })
-    const targetVenue = insertVenue(rawDb, { name: 'Target Venue' })
+describe("Admin bands API - bulk-preview after-midnight conflict detection (T2/VL-1b)", () => {
+  it("move_venue detects overlap with an after-midnight band at the target venue", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "MidnightConflictEvent", slug: "midnight-conflict" });
+    const sourceVenue = insertVenue(rawDb, { name: "Source Venue" });
+    const targetVenue = insertVenue(rawDb, { name: "Target Venue" });
 
     // Existing band at target venue: 23:30–00:30 (crosses midnight)
     insertBand(rawDb, {
-      name: 'Midnight Resident',
+      name: "Midnight Resident",
       event_id: ev.id,
       venue_id: targetVenue.id,
-      start_time: '23:30',
-      end_time: '00:30',
-    })
+      start_time: "23:30",
+      end_time: "00:30",
+    });
 
     // Band we want to move to that venue: 23:50–01:00 — overlaps midnight resident
     const movingBand = insertBand(rawDb, {
-      name: 'Moving Band',
+      name: "Moving Band",
       event_id: ev.id,
       venue_id: sourceVenue.id,
-      start_time: '23:50',
-      end_time: '01:00',
-    })
+      start_time: "23:50",
+      end_time: "01:00",
+    });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ band_ids: [movingBand.id], action: 'move_venue', venue_id: targetVenue.id }),
-    })
+    const request = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ band_ids: [movingBand.id], action: "move_venue", venue_id: targetVenue.id }),
+    });
 
-    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
+    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
     // Must detect the overlap — HH:MM string comparison would miss this entirely
-    expect(data.conflicts.length).toBeGreaterThan(0)
-    expect(data.conflicts.some(c => c.message.includes('Midnight Resident'))).toBe(true)
-  })
+    expect(data.conflicts.length).toBeGreaterThan(0);
+    expect(data.conflicts.some((c) => c.message.includes("Midnight Resident"))).toBe(true);
+  });
 
-  it('change_time detects overlap with an after-midnight band at same venue', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ChangeTimeMidnight', slug: 'change-time-midnight' })
-    const venue = insertVenue(rawDb, { name: 'Midnight Venue 2' })
+  it("change_time detects overlap with an after-midnight band at same venue", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ChangeTimeMidnight", slug: "change-time-midnight" });
+    const venue = insertVenue(rawDb, { name: "Midnight Venue 2" });
 
     // Existing band: 23:00–00:00
     insertBand(rawDb, {
-      name: 'Late Night Band',
+      name: "Late Night Band",
       event_id: ev.id,
       venue_id: venue.id,
-      start_time: '23:00',
-      end_time: '00:00',
-    })
+      start_time: "23:00",
+      end_time: "00:00",
+    });
 
     // Band being moved: currently 21:00–22:00, being moved to 23:30 (new end: 00:30)
     const movingBand = insertBand(rawDb, {
-      name: 'Shifting Band',
+      name: "Shifting Band",
       event_id: ev.id,
       venue_id: venue.id,
-      start_time: '21:00',
-      end_time: '22:00',
-    })
+      start_time: "21:00",
+      end_time: "22:00",
+    });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ band_ids: [movingBand.id], action: 'change_time', start_time: '23:30' }),
-    })
+    const request = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ band_ids: [movingBand.id], action: "change_time", start_time: "23:30" }),
+    });
 
-    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.conflicts.length).toBeGreaterThan(0)
-    expect(data.conflicts.some(c => c.message.includes('Late Night Band'))).toBe(true)
-  })
-})
+    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.conflicts.length).toBeGreaterThan(0);
+    expect(data.conflicts.some((c) => c.message.includes("Late Night Band"))).toBe(true);
+  });
+});
 
-describe('Admin bands API - venue-optional PUT (Closes #407)', () => {
-  it('PUT with venueId: 0 on a venue-less performance returns 200 and keeps venue NULL', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'NullVenuePut0', slug: 'null-venue-put0' })
+describe("Admin bands API - venue-optional PUT (Closes #407)", () => {
+  it("PUT with venueId: 0 on a venue-less performance returns 200 and keeps venue NULL", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "NullVenuePut0", slug: "null-venue-put0" });
     // insertBand default: venue_id = null
-    const band = insertBand(rawDb, { name: 'No Venue Band 0', event_id: ev.id })
+    const band = insertBand(rawDb, { name: "No Venue Band 0", event_id: ev.id });
 
     const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({
         venueId: 0,
-        social_links: JSON.stringify({ website: 'https://example.com' }),
+        social_links: JSON.stringify({ website: "https://example.com" }),
       }),
-    })
+    });
 
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const row = rawDb.prepare('SELECT venue_id FROM performances WHERE id = ?').get(band.id)
-    expect(row.venue_id).toBeNull()
-  })
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const row = rawDb.prepare("SELECT venue_id FROM performances WHERE id = ?").get(band.id);
+    expect(row.venue_id).toBeNull();
+  });
 
   it('PUT with venueId: "" on a venue-less performance returns 200 and keeps venue NULL', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'NullVenuePutEmpty', slug: 'null-venue-put-empty' })
-    const band = insertBand(rawDb, { name: 'No Venue Band Empty', event_id: ev.id })
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "NullVenuePutEmpty", slug: "null-venue-put-empty" });
+    const band = insertBand(rawDb, { name: "No Venue Band Empty", event_id: ev.id });
 
     const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({
-        venueId: '',
-        social_links: JSON.stringify({ instagram: '@testband' }),
+        venueId: "",
+        social_links: JSON.stringify({ instagram: "@testband" }),
       }),
-    })
+    });
 
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const row = rawDb.prepare('SELECT venue_id FROM performances WHERE id = ?').get(band.id)
-    expect(row.venue_id).toBeNull()
-  })
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const row = rawDb.prepare("SELECT venue_id FROM performances WHERE id = ?").get(band.id);
+    expect(row.venue_id).toBeNull();
+  });
 
-  it('PUT without venueId on a venue-less performance returns 200 and keeps venue NULL', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'NullVenuePutOmit', slug: 'null-venue-put-omit' })
-    const band = insertBand(rawDb, { name: 'No Venue Band Omit', event_id: ev.id })
-
-    const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ social_links: JSON.stringify({ bandcamp: 'https://band.bandcamp.com' }) }),
-    })
-
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const row = rawDb.prepare('SELECT venue_id FROM performances WHERE id = ?').get(band.id)
-    expect(row.venue_id).toBeNull()
-  })
-
-  it('PUT with a positive invalid venueId still returns 404 (guard still fires)', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'InvalidVenuePut', slug: 'invalid-venue-put' })
-    const band = insertBand(rawDb, { name: 'Invalid Venue Band', event_id: ev.id })
+  it("PUT without venueId on a venue-less performance returns 200 and keeps venue NULL", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "NullVenuePutOmit", slug: "null-venue-put-omit" });
+    const band = insertBand(rawDb, { name: "No Venue Band Omit", event_id: ev.id });
 
     const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ social_links: JSON.stringify({ bandcamp: "https://band.bandcamp.com" }) }),
+    });
+
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const row = rawDb.prepare("SELECT venue_id FROM performances WHERE id = ?").get(band.id);
+    expect(row.venue_id).toBeNull();
+  });
+
+  it("PUT with a positive invalid venueId still returns 404 (guard still fires)", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "InvalidVenuePut", slug: "invalid-venue-put" });
+    const band = insertBand(rawDb, { name: "Invalid Venue Band", event_id: ev.id });
+
+    const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ venueId: 99999 }),
-    })
+    });
 
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(404)
-    const data = await res.json()
-    expect(data.message).toBe('Venue not found')
-  })
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.message).toBe("Venue not found");
+  });
 
-  it('PUT with venueId: null clears an existing venue assignment', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'ClearVenuePut', slug: 'clear-venue-put' })
-    const venue = insertVenue(rawDb, { name: 'Clear Test Venue' })
-    const band = insertBand(rawDb, { name: 'Clear Venue Band', event_id: ev.id, venue_id: venue.id })
+  it("PUT with venueId: null clears an existing venue assignment", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "ClearVenuePut", slug: "clear-venue-put" });
+    const venue = insertVenue(rawDb, { name: "Clear Test Venue" });
+    const band = insertBand(rawDb, { name: "Clear Venue Band", event_id: ev.id, venue_id: venue.id });
 
     const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ venueId: null }),
-    })
+    });
 
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const row = rawDb.prepare('SELECT venue_id FROM performances WHERE id = ?').get(band.id)
-    expect(row.venue_id).toBeNull()
-  })
-})
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const row = rawDb.prepare("SELECT venue_id FROM performances WHERE id = ?").get(band.id);
+    expect(row.venue_id).toBeNull();
+  });
+});
 
-describe('Admin bands API - PUT conflict self-exclusion (T3)', () => {
-  it('PUT update does not conflict with the band being updated (self-exclusion)', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'SelfExEvent', slug: 'self-ex-event' })
-    const venue = insertVenue(rawDb, { name: 'SelfEx Venue' })
-    const bandA = insertBand(rawDb, { name: 'Band A', event_id: ev.id, venue_id: venue.id, start_time: '22:00', end_time: '23:00' })
+describe("Admin bands API - PUT conflict self-exclusion (T3)", () => {
+  it("PUT update does not conflict with the band being updated (self-exclusion)", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "SelfExEvent", slug: "self-ex-event" });
+    const venue = insertVenue(rawDb, { name: "SelfEx Venue" });
+    const bandA = insertBand(rawDb, {
+      name: "Band A",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "22:00",
+      end_time: "23:00",
+    });
 
     // Update Band A to the exact same time — must not conflict with itself
     const request = new Request(`https://example.test/api/admin/bands/${bandA.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ startTime: '22:00', endTime: '23:00' }),
-    })
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-  })
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ startTime: "22:00", endTime: "23:00" }),
+    });
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+  });
 
-  it('PUT update conflicts with a different band at the same venue', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'CrossConflictEvent', slug: 'cross-conflict-event' })
-    const venue = insertVenue(rawDb, { name: 'CrossConflict Venue' })
-    insertBand(rawDb, { name: 'Band B', event_id: ev.id, venue_id: venue.id, start_time: '23:00', end_time: '00:00' })
-    const bandA = insertBand(rawDb, { name: 'Band A', event_id: ev.id, venue_id: venue.id, start_time: '22:00', end_time: '23:00' })
+  it("PUT update conflicts with a different band at the same venue", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "CrossConflictEvent", slug: "cross-conflict-event" });
+    const venue = insertVenue(rawDb, { name: "CrossConflict Venue" });
+    insertBand(rawDb, { name: "Band B", event_id: ev.id, venue_id: venue.id, start_time: "23:00", end_time: "00:00" });
+    const bandA = insertBand(rawDb, {
+      name: "Band A",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "22:00",
+      end_time: "23:00",
+    });
 
     // Move Band A to 22:30–23:30 — overlaps with Band B
     const request = new Request(`https://example.test/api/admin/bands/${bandA.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ startTime: '22:30', endTime: '23:30' }),
-    })
-    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(409)
-  })
-})
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ startTime: "22:30", endTime: "23:30" }),
+    });
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(409);
+  });
+});
 
-describe('Admin bands API - Bulk POST onRequestPost full flow (T6)', () => {
-  it('POST bulk add skips archived events and reports it as a conflict', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const archivedEvent = insertEvent(rawDb, { name: 'Archived Event', slug: 'archived-event', status: 'archived', is_published: 0 })
-    const venue = insertVenue(rawDb, { name: 'Venue A' })
-    const band = insertBand(rawDb, { name: 'Archived Band', event_id: archivedEvent.id, venue_id: venue.id })
+describe("Admin bands API - Bulk POST onRequestPost full flow (T6)", () => {
+  it("POST bulk add skips archived events and reports it as a conflict", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const archivedEvent = insertEvent(rawDb, {
+      name: "Archived Event",
+      slug: "archived-event",
+      status: "archived",
+      is_published: 0,
+    });
+    const venue = insertVenue(rawDb, { name: "Venue A" });
+    const band = insertBand(rawDb, { name: "Archived Band", event_id: archivedEvent.id, venue_id: venue.id });
 
-    const request = new Request('https://example.test/api/admin/bands/bulk-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
-      body: JSON.stringify({ band_ids: [band.id], action: 'move_venue', venue_id: venue.id }),
-    })
+    const request = new Request("https://example.test/api/admin/bands/bulk-preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ band_ids: [band.id], action: "move_venue", venue_id: venue.id }),
+    });
 
-    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect(res.status).toBe(200)
-    const data = await res.json()
+    const res = await bulkPreviewHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
     // archived band → changes list is empty, conflict reported
-    expect(data.changes).toHaveLength(0)
-    expect(data.conflicts.some(c => c.message.includes('archived event'))).toBe(true)
-  })
+    expect(data.changes).toHaveLength(0);
+    expect(data.conflicts.some((c) => c.message.includes("archived event"))).toBe(true);
+  });
 
-  it('POST bulk add to an event correctly deduplicates and skips already-in-event profiles', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'DedupeFullEvent', slug: 'dedupe-full-event' })
-    const p1 = rawDb.prepare('INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)').run('Unique Roster', 'uniqueroster')
+  it("POST bulk add to an event correctly deduplicates and skips already-in-event profiles", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "DedupeFullEvent", slug: "dedupe-full-event" });
+    const p1 = rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("Unique Roster", "uniqueroster");
     // p2 is already in the event
-    const p2info = rawDb.prepare('INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)').run('Already In', 'alreadyin')
-    rawDb.prepare('INSERT INTO performances (band_profile_id, event_id) VALUES (?, ?)').run(p2info.lastInsertRowid, ev.id)
+    const p2info = rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("Already In", "alreadyin");
+    rawDb
+      .prepare("INSERT INTO performances (band_profile_id, event_id) VALUES (?, ?)")
+      .run(p2info.lastInsertRowid, ev.id);
 
-    const request = new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/bands/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({ band_profile_ids: [p1.lastInsertRowid, p2info.lastInsertRowid], event_id: ev.id }),
-    })
+    });
 
-    const res = await bulkHandler.onRequestPost({ request, env, data: { user: { role: 'editor' } } })
-    expect([200, 201]).toContain(res.status)
-    const data = await res.json()
-    expect(data.added.length).toBe(1)
-    expect(data.skipped.length).toBe(1)
-  })
-})
+    const res = await bulkHandler.onRequestPost({ request, env, data: { user: { role: "editor" } } });
+    expect([200, 201]).toContain(res.status);
+    const data = await res.json();
+    expect(data.added.length).toBe(1);
+    expect(data.skipped.length).toBe(1);
+  });
+});

--- a/functions/api/admin/bands/__tests__/bulk.test.js
+++ b/functions/api/admin/bands/__tests__/bulk.test.js
@@ -1,48 +1,47 @@
 // Bulk band operations endpoint tests
 // DELETE /api/admin/bands/bulk
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from "vitest";
 
-vi.mock('../../_middleware.js', () => ({
+vi.mock("../../_middleware.js", () => ({
   checkPermission: async (context) => {
-    const role =
-      context?.data?.user?.role || context?.request?.headers?.get('x-test-role')
+    const role = context?.data?.user?.role || context?.request?.headers?.get("x-test-role");
     if (!role) {
       return {
         error: true,
-        response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        response: new Response(JSON.stringify({ error: "Unauthorized" }), {
           status: 401,
-          headers: { 'Content-Type': 'application/json' },
+          headers: { "Content-Type": "application/json" },
         }),
-      }
+      };
     }
-    return { error: false, user: { userId: 1, email: 'a@b.c', role }, userId: 1 }
+    return { error: false, user: { userId: 1, email: "a@b.c", role }, userId: 1 };
   },
   auditLog: vi.fn(async () => {}),
-}))
+}));
 
-import { onRequestDelete } from '../bulk.js'
-import { createTestEnv } from '../../../test-utils.js'
+import { onRequestDelete } from "../bulk.js";
+import { createTestEnv } from "../../../test-utils.js";
 
 function deleteRequest(env, bandIds) {
   return onRequestDelete({
-    request: new Request('https://example.test/api/admin/bands/bulk', {
-      method: 'DELETE',
-      headers: { 'x-test-role': 'editor', 'content-type': 'application/json' },
+    request: new Request("https://example.test/api/admin/bands/bulk", {
+      method: "DELETE",
+      headers: { "x-test-role": "editor", "content-type": "application/json" },
       body: JSON.stringify({ band_ids: bandIds }),
     }),
     env,
-    data: { user: { userId: 1, email: 'a@b.c', role: 'editor' } },
-  })
+    data: { user: { userId: 1, email: "a@b.c", role: "editor" } },
+  });
 }
 
-describe('DELETE /api/admin/bands/bulk', () => {
-  test('reports success:false when some ids could not be deleted', async () => {
-    const { env } = createTestEnv()
-    const res = await deleteRequest(env, ['profile_abc'])
-    expect(res.status).toBe(200)
-    const body = await res.json()
-    expect(body.success).toBe(false)
-    expect(body.errors).toBeTruthy()
-    expect(body.deletedCount).toBe(0)
-  })
-})
+describe("DELETE /api/admin/bands/bulk", () => {
+  test("reports success:false when some ids could not be deleted", async () => {
+    const { env } = createTestEnv();
+    const res = await deleteRequest(env, ["profile_abc"]);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.errors).toBeTruthy();
+    expect(body.deletedCount).toBe(0);
+  });
+});

--- a/functions/api/admin/bands/__tests__/import.test.js
+++ b/functions/api/admin/bands/__tests__/import.test.js
@@ -1,138 +1,120 @@
 // Bulk band import endpoint tests
 // POST /api/admin/bands/import
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from "vitest";
 
-vi.mock('../../_middleware.js', () => ({
+vi.mock("../../_middleware.js", () => ({
   checkPermission: async (context) => {
-    const role =
-      context?.data?.user?.role || context?.request?.headers?.get('x-test-role')
+    const role = context?.data?.user?.role || context?.request?.headers?.get("x-test-role");
     if (!role) {
       return {
         error: true,
-        response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        response: new Response(JSON.stringify({ error: "Unauthorized" }), {
           status: 401,
-          headers: { 'Content-Type': 'application/json' },
+          headers: { "Content-Type": "application/json" },
         }),
-      }
+      };
     }
-    return { error: false, user: { userId: 1, email: 'a@b.c', role }, userId: 1 }
+    return { error: false, user: { userId: 1, email: "a@b.c", role }, userId: 1 };
   },
   auditLog: vi.fn(async () => {}),
-}))
+}));
 
-import { onRequestPost } from '../import.js'
-import {
-  createTestEnv,
-  insertBand,
-  insertEvent,
-  insertVenue,
-} from '../../../test-utils.js'
+import { onRequestPost } from "../import.js";
+import { createTestEnv, insertBand, insertEvent, insertVenue } from "../../../test-utils.js";
 
 function importRequest(env, payload) {
   return onRequestPost({
-    request: new Request('https://example.test/api/admin/bands/import', {
-      method: 'POST',
-      headers: { 'x-test-role': 'editor', 'content-type': 'application/json' },
+    request: new Request("https://example.test/api/admin/bands/import", {
+      method: "POST",
+      headers: { "x-test-role": "editor", "content-type": "application/json" },
       body: JSON.stringify(payload),
     }),
     env,
-    data: { user: { userId: 1, email: 'a@b.c', role: 'editor' } },
-  })
+    data: { user: { userId: 1, email: "a@b.c", role: "editor" } },
+  });
 }
 
-describe('POST /api/admin/bands/import', () => {
-  test('imports new bands as performances for the event', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
-    insertVenue(rawDb, { name: 'The Hall' })
+describe("POST /api/admin/bands/import", () => {
+  test("imports new bands as performances for the event", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Fest", slug: "fest" });
+    insertVenue(rawDb, { name: "The Hall" });
 
     const res = await importRequest(env, {
       event_id: event.id,
       bands: [
         {
-          name: 'Alpha',
-          start_time: '20:00',
-          end_time: '21:00',
-          venue: 'The Hall',
-          genre: 'rock',
+          name: "Alpha",
+          start_time: "20:00",
+          end_time: "21:00",
+          venue: "The Hall",
+          genre: "rock",
         },
         {
-          name: 'Beta',
-          start_time: '21:00',
-          end_time: '22:00',
-          venue: 'The Hall',
-          genre: 'jazz',
+          name: "Beta",
+          start_time: "21:00",
+          end_time: "22:00",
+          venue: "The Hall",
+          genre: "jazz",
         },
       ],
-    })
+    });
 
-    expect(res.status).toBe(201)
-    const body = await res.json()
-    expect(body.success).toBe(true)
-    expect(body.imported).toBe(2)
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.imported).toBe(2);
 
-    const perfCount = rawDb
-      .prepare('SELECT COUNT(*) AS c FROM performances WHERE event_id = ?')
-      .get(event.id)
-    expect(perfCount.c).toBe(2)
+    const perfCount = rawDb.prepare("SELECT COUNT(*) AS c FROM performances WHERE event_id = ?").get(event.id);
+    expect(perfCount.c).toBe(2);
 
-    const alpha = rawDb
-      .prepare("SELECT * FROM band_profiles WHERE name_normalized = 'alpha'")
-      .get()
-    expect(alpha).toBeTruthy()
-    expect(alpha.genre).toBe('rock')
-  })
+    const alpha = rawDb.prepare("SELECT * FROM band_profiles WHERE name_normalized = 'alpha'").get();
+    expect(alpha).toBeTruthy();
+    expect(alpha.genre).toBe("rock");
+  });
 
-  test('rejects the whole import and writes nothing if any row is invalid (atomic)', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
-    insertVenue(rawDb, { name: 'The Hall' })
+  test("rejects the whole import and writes nothing if any row is invalid (atomic)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Fest", slug: "fest" });
+    insertVenue(rawDb, { name: "The Hall" });
 
     const res = await importRequest(env, {
       event_id: event.id,
       bands: [
-        { name: 'Good', start_time: '20:00', end_time: '21:00', venue: 'The Hall' },
-        { name: 'Bad', venue: 'No Such Venue' },
+        { name: "Good", start_time: "20:00", end_time: "21:00", venue: "The Hall" },
+        { name: "Bad", venue: "No Such Venue" },
       ],
-    })
+    });
 
-    expect(res.status).toBe(400)
-    const body = await res.json()
-    expect(body.success).toBe(false)
-    expect(body.errors.length).toBeGreaterThan(0)
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.errors.length).toBeGreaterThan(0);
 
-    const perfCount = rawDb
-      .prepare('SELECT COUNT(*) AS c FROM performances WHERE event_id = ?')
-      .get(event.id)
-    expect(perfCount.c).toBe(0)
+    const perfCount = rawDb.prepare("SELECT COUNT(*) AS c FROM performances WHERE event_id = ?").get(event.id);
+    expect(perfCount.c).toBe(0);
     const profileCount = rawDb
-      .prepare(
-        "SELECT COUNT(*) AS c FROM band_profiles WHERE name_normalized IN ('good','bad')"
-      )
-      .get()
-    expect(profileCount.c).toBe(0)
-  })
+      .prepare("SELECT COUNT(*) AS c FROM band_profiles WHERE name_normalized IN ('good','bad')")
+      .get();
+    expect(profileCount.c).toBe(0);
+  });
 
-  test('reuses an existing band profile instead of duplicating it', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
-    insertVenue(rawDb, { name: 'The Hall' })
-    insertBand(rawDb, { name: 'Alpha' })
+  test("reuses an existing band profile instead of duplicating it", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Fest", slug: "fest" });
+    insertVenue(rawDb, { name: "The Hall" });
+    insertBand(rawDb, { name: "Alpha" });
 
     const res = await importRequest(env, {
       event_id: event.id,
-      bands: [
-        { name: 'Alpha', start_time: '20:00', end_time: '21:00', venue: 'The Hall' },
-      ],
-    })
+      bands: [{ name: "Alpha", start_time: "20:00", end_time: "21:00", venue: "The Hall" }],
+    });
 
-    expect(res.status).toBe(201)
-    const body = await res.json()
-    expect(body.createdProfiles).toBe(0)
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.createdProfiles).toBe(0);
 
-    const profiles = rawDb
-      .prepare("SELECT COUNT(*) AS c FROM band_profiles WHERE name_normalized = 'alpha'")
-      .get()
-    expect(profiles.c).toBe(1)
-  })
-})
+    const profiles = rawDb.prepare("SELECT COUNT(*) AS c FROM band_profiles WHERE name_normalized = 'alpha'").get();
+    expect(profiles.c).toBe(1);
+  });
+});

--- a/functions/api/admin/bands/__tests__/resend-announcement.test.js
+++ b/functions/api/admin/bands/__tests__/resend-announcement.test.js
@@ -1,86 +1,72 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from "vitest";
 
-vi.mock('../../_middleware.js', () => ({
+vi.mock("../../_middleware.js", () => ({
   checkPermission: async (context) => {
-    const role =
-      context?.data?.user?.role || context?.request?.headers?.get('x-test-role')
+    const role = context?.data?.user?.role || context?.request?.headers?.get("x-test-role");
     if (!role) {
       return {
         error: true,
-        response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        response: new Response(JSON.stringify({ error: "Unauthorized" }), {
           status: 401,
-          headers: { 'Content-Type': 'application/json' },
+          headers: { "Content-Type": "application/json" },
         }),
-      }
+      };
     }
-    return { error: false, user: { userId: 1, email: 'admin@x.co', role }, userId: 1 }
+    return { error: false, user: { userId: 1, email: "admin@x.co", role }, userId: 1 };
   },
   auditLog: vi.fn(async () => {}),
-}))
+}));
 
-vi.mock('../../../../utils/email.js', () => ({
+vi.mock("../../../../utils/email.js", () => ({
   isEmailConfigured: () => true,
   sendEmail: vi.fn(() => Promise.resolve({ delivered: true })),
-}))
+}));
 
-import { onRequestPost } from '../[id]/resend-announcement.js'
-import {
-  createTestEnv,
-  insertEvent,
-  insertVenue,
-  insertBand,
-} from '../../../test-utils.js'
+import { onRequestPost } from "../[id]/resend-announcement.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils.js";
 
-describe('POST /api/admin/bands/[id]/resend-announcement', () => {
-  test('resends only to followers not yet notified for the performance', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
-    const venue = insertVenue(rawDb, { name: 'Hall' })
+describe("POST /api/admin/bands/[id]/resend-announcement", () => {
+  test("resends only to followers not yet notified for the performance", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Fest", slug: "fest" });
+    const venue = insertVenue(rawDb, { name: "Hall" });
     const perf = insertBand(rawDb, {
-      name: 'The Band',
+      name: "The Band",
       event_id: event.id,
       venue_id: venue.id,
-    })
-    const bandProfileId = perf.band_profile_id
+    });
+    const bandProfileId = perf.band_profile_id;
 
     const f1 = rawDb
-      .prepare(
-        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
-      )
-      .run('a@x.co', bandProfileId, 'tok-a').lastInsertRowid
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("a@x.co", bandProfileId, "tok-a").lastInsertRowid;
     const f2 = rawDb
-      .prepare(
-        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)'
-      )
-      .run('b@x.co', bandProfileId, 'tok-b').lastInsertRowid
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("b@x.co", bandProfileId, "tok-b").lastInsertRowid;
 
     // f1 was already notified for this performance.
     rawDb
-      .prepare(
-        'INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)'
-      )
-      .run(perf.id, f1)
+      .prepare("INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)")
+      .run(perf.id, f1);
 
     const res = await onRequestPost({
-      request: new Request(
-        `https://example.test/api/admin/bands/${perf.id}/resend-announcement`,
-        { method: 'POST', headers: { 'x-test-role': 'editor' } }
-      ),
+      request: new Request(`https://example.test/api/admin/bands/${perf.id}/resend-announcement`, {
+        method: "POST",
+        headers: { "x-test-role": "editor" },
+      }),
       params: { id: String(perf.id) },
       env,
-      data: { user: { userId: 1, email: 'admin@x.co', role: 'editor' } },
-    })
+      data: { user: { userId: 1, email: "admin@x.co", role: "editor" } },
+    });
 
-    expect(res.status).toBe(200)
-    const body = await res.json()
-    expect(body.sent).toBe(1)
-    expect(body.failed).toBe(0)
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+    expect(body.failed).toBe(0);
 
     const notified = rawDb
-      .prepare(
-        'SELECT band_follow_id FROM band_follow_notifications WHERE performance_id = ? ORDER BY band_follow_id'
-      )
-      .all(perf.id)
-    expect(notified.map((r) => r.band_follow_id)).toEqual([f1, f2])
-  })
-})
+      .prepare("SELECT band_follow_id FROM band_follow_notifications WHERE performance_id = ? ORDER BY band_follow_id")
+      .all(perf.id);
+    expect(notified.map((r) => r.band_follow_id)).toEqual([f1, f2]);
+  });
+});

--- a/functions/api/admin/bands/__tests__/stats.test.js
+++ b/functions/api/admin/bands/__tests__/stats.test.js
@@ -4,13 +4,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { normalizeBandName } from "../../../../utils/bandName.js";
 import { onRequestGet } from "../stats/[name].js";
-import {
-  createTestDB,
-  createDBEnv,
-  insertBand,
-  insertEvent,
-  insertVenue,
-} from "../../../test-utils.js";
+import { createTestDB, createDBEnv, insertBand, insertEvent, insertVenue } from "../../../test-utils.js";
 
 // Mock the middleware
 vi.mock("../../_middleware.js", () => ({
@@ -79,24 +73,14 @@ function insertBandWithProfile(db, data) {
   } = data;
 
   const nameNormalized = normalizeBandName(name);
-  const existingProfile = db
-    .prepare("SELECT id FROM band_profiles WHERE name_normalized = ?")
-    .get(nameNormalized);
+  const existingProfile = db.prepare("SELECT id FROM band_profiles WHERE name_normalized = ?").get(nameNormalized);
   const profileId = existingProfile
     ? existingProfile.id
     : db
         .prepare(
           "INSERT INTO band_profiles (name, name_normalized, genre, origin, description, photo_url, social_links) VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
-        .run(
-          name,
-          nameNormalized,
-          genre,
-          origin,
-          description,
-          photo_url,
-          social_links,
-        ).lastInsertRowid;
+        .run(name, nameNormalized, genre, origin, description, photo_url, social_links).lastInsertRowid;
 
   if (existingProfile) {
     const updates = [];
@@ -122,9 +106,7 @@ function insertBandWithProfile(db, data) {
       values.push(social_links);
     }
     if (updates.length > 0) {
-      db.prepare(
-        `UPDATE band_profiles SET ${updates.join(", ")} WHERE id = ?`,
-      ).run(...values, profileId);
+      db.prepare(`UPDATE band_profiles SET ${updates.join(", ")} WHERE id = ?`).run(...values, profileId);
     }
   }
 
@@ -134,9 +116,7 @@ function insertBandWithProfile(db, data) {
     )
     .run(event_id, venue_id, profileId, start_time, end_time, null);
 
-  return db
-    .prepare("SELECT * FROM performances WHERE id = ?")
-    .get(info.lastInsertRowid);
+  return db.prepare("SELECT * FROM performances WHERE id = ?").get(info.lastInsertRowid);
 }
 
 describe("GET /api/admin/bands/stats/:name", () => {
@@ -169,10 +149,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Test%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Test%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -181,9 +160,7 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should reject unauthenticated requests", async () => {
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Test%20Band",
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Test%20Band");
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -208,10 +185,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Test editor role
-      const editorRequest = new Request(
-        "https://example.test/api/admin/bands/stats/Test%20Band",
-        { headers: { "x-test-role": "editor" } },
-      );
+      const editorRequest = new Request("https://example.test/api/admin/bands/stats/Test%20Band", {
+        headers: { "x-test-role": "editor" },
+      });
       const editorResponse = await onRequestGet({
         request: editorRequest,
         env,
@@ -219,10 +195,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       expect(editorResponse.status).toBe(200);
 
       // Test admin role
-      const adminRequest = new Request(
-        "https://example.test/api/admin/bands/stats/Test%20Band",
-        { headers: { "x-test-role": "admin" } },
-      );
+      const adminRequest = new Request("https://example.test/api/admin/bands/stats/Test%20Band", {
+        headers: { "x-test-role": "admin" },
+      });
       const adminResponse = await onRequestGet({ request: adminRequest, env });
       expect(adminResponse.status).toBe(200);
     });
@@ -235,10 +210,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
   describe("Input Validation", () => {
     it("should return 400 for missing band name", async () => {
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -250,10 +224,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should return 400 for empty band name", async () => {
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/%20",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/%20", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -278,10 +251,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/The%20Rock%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/The%20Rock%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -312,10 +284,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Test%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Test%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -326,10 +297,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
 
     it("should return 404 for non-existent band", async () => {
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/NonExistent%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/NonExistent%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -354,10 +324,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act - Request with different case
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/test%20band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/test%20band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -414,10 +383,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Popular%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Popular%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -459,10 +427,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Touring%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Touring%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -500,10 +467,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Festival%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Festival%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -523,10 +489,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Rolodex%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Rolodex%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -551,10 +516,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Virtual%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Virtual%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -606,10 +570,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Evolving%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Evolving%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -643,10 +606,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Complete%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Complete%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -712,10 +674,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Time%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Time%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -734,10 +695,7 @@ describe("GET /api/admin/bands/stats/:name", () => {
         date: "2025-07-15",
       });
       // Update event city
-      db.prepare("UPDATE events SET city = ? WHERE id = ?").run(
-        "Central Park",
-        event.id,
-      );
+      db.prepare("UPDATE events SET city = ? WHERE id = ?").run("Central Park", event.id);
 
       const venue = insertVenue(db, { name: "Main Stage" });
       insertBandWithProfile(db, {
@@ -749,10 +707,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Event%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Event%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -785,10 +742,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Venue%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Venue%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -811,10 +767,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Orphan%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Orphan%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -838,10 +793,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       // But we can test it by querying a name that doesn't exist
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Never%20Performed",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Never%20Performed", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert
@@ -856,10 +810,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       const invalidEnv = { DB: null };
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Test%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Test%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env: invalidEnv });
 
       // Assert
@@ -876,10 +829,7 @@ describe("GET /api/admin/bands/stats/:name", () => {
         slug: "format-test",
         date: "2025-06-01",
       });
-      db.prepare("UPDATE events SET city = ? WHERE id = ?").run(
-        "Test Location",
-        event.id,
-      );
+      db.prepare("UPDATE events SET city = ? WHERE id = ?").run("Test Location", event.id);
 
       const venue = insertVenue(db, {
         name: "Format Venue",
@@ -899,10 +849,9 @@ describe("GET /api/admin/bands/stats/:name", () => {
       });
 
       // Act
-      const request = new Request(
-        "https://example.test/api/admin/bands/stats/Format%20Band",
-        { headers: { "x-test-role": "viewer" } },
-      );
+      const request = new Request("https://example.test/api/admin/bands/stats/Format%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
       const response = await onRequestGet({ request, env });
 
       // Assert

--- a/functions/api/admin/bands/bulk-preview.js
+++ b/functions/api/admin/bands/bulk-preview.js
@@ -69,9 +69,7 @@ export async function onRequestPost(context) {
     .all();
 
   const bandResults = bands.results || [];
-  const mutableBandResults = bandResults.filter(
-    (band) => band.event_status !== "archived",
-  );
+  const mutableBandResults = bandResults.filter((band) => band.event_status !== "archived");
 
   bandResults
     .filter((band) => band.event_status === "archived")
@@ -85,9 +83,7 @@ export async function onRequestPost(context) {
 
   if (action === "move_venue") {
     const { venue_id } = params;
-    const venue = await env.DB.prepare("SELECT name FROM venues WHERE id = ?")
-      .bind(venue_id)
-      .first();
+    const venue = await env.DB.prepare("SELECT name FROM venues WHERE id = ?").bind(venue_id).first();
 
     if (!venue) {
       return new Response(JSON.stringify({ error: "Target venue not found" }), {
@@ -129,10 +125,8 @@ export async function onRequestPost(context) {
       for (const other of existing) {
         if (!other.start_time || !other.end_time) continue;
         const otherIntervals = buildIntervals(other.start_time, other.end_time);
-        if (bandIntervals.some(a => otherIntervals.some(b => intervalsOverlap(a, b)))) {
-          const isExact =
-            other.start_time === band.start_time &&
-            other.end_time === band.end_time;
+        if (bandIntervals.some((a) => otherIntervals.some((b) => intervalsOverlap(a, b)))) {
+          const isExact = other.start_time === band.start_time && other.end_time === band.end_time;
           conflicts.push({
             band_id: band.id,
             type: isExact ? "conflict" : "overlap",
@@ -224,9 +218,8 @@ export async function onRequestPost(context) {
       for (const other of existing) {
         if (!other.start_time || !other.end_time) continue;
         const otherIntervals = buildIntervals(other.start_time, other.end_time);
-        if (bandIntervals.some(a => otherIntervals.some(b => intervalsOverlap(a, b)))) {
-          const isExact =
-            other.start_time === start_time && other.end_time === newEndTime;
+        if (bandIntervals.some((a) => otherIntervals.some((b) => intervalsOverlap(a, b)))) {
+          const isExact = other.start_time === start_time && other.end_time === newEndTime;
           conflicts.push({
             band_id: band.id,
             type: isExact ? "conflict" : "overlap",

--- a/functions/api/admin/bands/bulk.js
+++ b/functions/api/admin/bands/bulk.js
@@ -82,15 +82,10 @@ export async function onRequestDelete(context) {
       .filter((id) => !id.toString().startsWith("profile_"))
       .map(Number)
       .filter((n) => Number.isInteger(n) && n > 0);
-    const archivedPerformances = await getArchivedPerformancesByPerformanceIds(
-      DB,
-      performanceIds,
-    );
+    const archivedPerformances = await getArchivedPerformancesByPerformanceIds(DB, performanceIds);
 
     if (archivedPerformances.length > 0) {
-      const lockedNames = archivedPerformances
-        .map((performance) => performance.name)
-        .join(", ");
+      const lockedNames = archivedPerformances.map((performance) => performance.name).join(", ");
       return new Response(
         JSON.stringify({
           error: "Validation error",
@@ -163,13 +158,29 @@ export async function onRequestDelete(context) {
           }
 
           await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(profileId).run();
-          await auditLog(env, user.userId, "band_profile.deleted", "band_profile", profileId, { deletedBy: user.email, bulk: true }, ipAddress);
+          await auditLog(
+            env,
+            user.userId,
+            "band_profile.deleted",
+            "band_profile",
+            profileId,
+            { deletedBy: user.email, bulk: true },
+            ipAddress,
+          );
           deletedCount++;
         } else {
           const performance = performanceMap.get(Number(id));
           if (performance) {
             await DB.prepare("DELETE FROM performances WHERE id = ?").bind(id).run();
-            await auditLog(env, user.userId, "band.deleted", "band", id, { bandName: performance.name, bulk: true }, ipAddress);
+            await auditLog(
+              env,
+              user.userId,
+              "band.deleted",
+              "band",
+              id,
+              { bandName: performance.name, bulk: true },
+              ipAddress,
+            );
             deletedCount++;
           }
         }
@@ -248,10 +259,10 @@ export async function onRequestPost(context) {
     );
   }
   if (!event_id) {
-    return new Response(
-      JSON.stringify({ error: "Bad request", message: "event_id is required" }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ error: "Bad request", message: "event_id is required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   const resolvedVenueId = venue_id ? Number(venue_id) : null;
@@ -267,14 +278,12 @@ export async function onRequestPost(context) {
   }
 
   // Validate event exists and is not archived
-  const event = await DB.prepare("SELECT id, status FROM events WHERE id = ?")
-    .bind(event_id)
-    .first();
+  const event = await DB.prepare("SELECT id, status FROM events WHERE id = ?").bind(event_id).first();
   if (!event) {
-    return new Response(
-      JSON.stringify({ error: "Not found", message: "Event not found" }),
-      { status: 404, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ error: "Not found", message: "Event not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
   }
   if (event.status === "archived") {
     return new Response(
@@ -288,14 +297,12 @@ export async function onRequestPost(context) {
 
   // Validate venue exists only if provided
   if (resolvedVenueId) {
-    const venue = await DB.prepare("SELECT id FROM venues WHERE id = ?")
-      .bind(resolvedVenueId)
-      .first();
+    const venue = await DB.prepare("SELECT id FROM venues WHERE id = ?").bind(resolvedVenueId).first();
     if (!venue) {
-      return new Response(
-        JSON.stringify({ error: "Not found", message: "Venue not found" }),
-        { status: 404, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Not found", message: "Venue not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
     }
   }
 
@@ -305,9 +312,7 @@ export async function onRequestPost(context) {
 
   // Pre-fetch all band profiles in one query
   const profilePh = band_profile_ids.map(() => "?").join(",");
-  const profileRows = await DB.prepare(
-    `SELECT id, name FROM band_profiles WHERE id IN (${profilePh})`,
-  )
+  const profileRows = await DB.prepare(`SELECT id, name FROM band_profiles WHERE id IN (${profilePh})`)
     .bind(...band_profile_ids)
     .all();
   const profileMap = new Map((profileRows.results || []).map((p) => [p.id, p]));
@@ -428,14 +433,9 @@ export async function onRequestPatch(context) {
   }
   const validatedBandIds = idValidation.values;
 
-  const archivedPerformances = await getArchivedPerformancesByPerformanceIds(
-    env.DB,
-    validatedBandIds,
-  );
+  const archivedPerformances = await getArchivedPerformancesByPerformanceIds(env.DB, validatedBandIds);
   if (archivedPerformances.length > 0) {
-    const lockedNames = archivedPerformances
-      .map((performance) => performance.name)
-      .join(", ");
+    const lockedNames = archivedPerformances.map((performance) => performance.name).join(", ");
     return new Response(
       JSON.stringify({
         error: "Validation error",
@@ -453,9 +453,7 @@ export async function onRequestPatch(context) {
     return new Response(
       JSON.stringify({
         error: "Invalid action",
-        message: `Action must be one of: ${Array.from(allowedActions).join(
-          ", ",
-        )}`,
+        message: `Action must be one of: ${Array.from(allowedActions).join(", ")}`,
       }),
       {
         status: 400,
@@ -471,36 +469,29 @@ export async function onRequestPatch(context) {
     if (action === "move_venue") {
       const { venue_id } = params;
 
-      const venueExists = await env.DB.prepare("SELECT id FROM venues WHERE id = ?")
-        .bind(venue_id)
-        .first();
+      const venueExists = await env.DB.prepare("SELECT id FROM venues WHERE id = ?").bind(venue_id).first();
       if (!venueExists) {
-        return new Response(
-          JSON.stringify({ error: "Not found", message: "Venue not found" }),
-          { status: 404, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ error: "Not found", message: "Venue not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       // Build batch update statements (ATOMIC - all or nothing)
       const statements = validatedBandIds.map((id) =>
-        env.DB.prepare(
-          "UPDATE performances SET venue_id = ? WHERE id = ?",
-        ).bind(venue_id, id),
+        env.DB.prepare("UPDATE performances SET venue_id = ? WHERE id = ?").bind(venue_id, id),
       );
 
       result = await env.DB.batch(statements);
-      rowsAffected = result.reduce(
-        (total, res) => total + (res.meta?.changes ?? 0),
-        0,
-      );
+      rowsAffected = result.reduce((total, res) => total + (res.meta?.changes ?? 0), 0);
     } else if (action === "change_time") {
       const { start_time } = params;
 
       if (!isValidTime(start_time).valid) {
-        return new Response(
-          JSON.stringify({ error: "Bad request", message: "start_time must be in HH:MM format" }),
-          { status: 400, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ error: "Bad request", message: "start_time must be in HH:MM format" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       // Fetch current times so we can compute new end_time in JS.
@@ -515,24 +506,19 @@ export async function onRequestPatch(context) {
 
       const statements = currentPerfs.map((perf) => {
         const newEnd =
-          perf.start_time && perf.end_time
-            ? computeNewEndTime(perf.start_time, perf.end_time, start_time)
-            : null;
-        return env.DB.prepare(
-          "UPDATE performances SET start_time = ?, end_time = ? WHERE id = ?",
-        ).bind(start_time, newEnd, perf.id);
+          perf.start_time && perf.end_time ? computeNewEndTime(perf.start_time, perf.end_time, start_time) : null;
+        return env.DB.prepare("UPDATE performances SET start_time = ?, end_time = ? WHERE id = ?").bind(
+          start_time,
+          newEnd,
+          perf.id,
+        );
       });
 
       result = await env.DB.batch(statements);
-      rowsAffected = result.reduce(
-        (total, res) => total + (res.meta?.changes ?? 0),
-        0,
-      );
+      rowsAffected = result.reduce((total, res) => total + (res.meta?.changes ?? 0), 0);
     } else if (action === "delete") {
       const placeholders = validatedBandIds.map(() => "?").join(",");
-      result = await env.DB.prepare(
-        `DELETE FROM performances WHERE id IN (${placeholders})`,
-      )
+      result = await env.DB.prepare(`DELETE FROM performances WHERE id IN (${placeholders})`)
         .bind(...validatedBandIds)
         .run();
       rowsAffected = result.meta?.changes ?? 0;

--- a/functions/api/admin/bands/import.js
+++ b/functions/api/admin/bands/import.js
@@ -51,18 +51,14 @@ export async function onRequestPost(context) {
     return json({ error: `Maximum ${MAX_IMPORT_ROWS} bands per import` }, 400);
   }
 
-  const event = await DB.prepare("SELECT id FROM events WHERE id = ?")
-    .bind(eventId)
-    .first();
+  const event = await DB.prepare("SELECT id FROM events WHERE id = ?").bind(eventId).first();
   if (!event) {
     return json({ error: "Event not found" }, 404);
   }
 
   // Resolve venues by name (case-insensitive) up front.
   const venues = await DB.prepare("SELECT id, name FROM venues").all();
-  const venueByName = new Map(
-    (venues.results || []).map((v) => [v.name.toLowerCase(), v.id]),
-  );
+  const venueByName = new Map((venues.results || []).map((v) => [v.name.toLowerCase(), v.id]));
 
   // Validate every row before writing anything — import is all-or-nothing.
   const errors = [];
@@ -117,9 +113,7 @@ export async function onRequestPost(context) {
   const createdProfileIds = [];
   try {
     for (const p of prepared) {
-      let profile = await DB.prepare(
-        "SELECT id FROM band_profiles WHERE name_normalized = ?",
-      )
+      let profile = await DB.prepare("SELECT id FROM band_profiles WHERE name_normalized = ?")
         .bind(p.nameNormalized)
         .first();
 
@@ -152,10 +146,7 @@ export async function onRequestPost(context) {
       await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(id).run();
     }
     console.error("Bulk import failed, rolled back:", err);
-    return json(
-      { error: "Import failed", message: "No bands were imported" },
-      500,
-    );
+    return json({ error: "Import failed", message: "No bands were imported" }, 500);
   }
 
   await auditLog(

--- a/functions/api/admin/bands/photos.js
+++ b/functions/api/admin/bands/photos.js
@@ -25,12 +25,7 @@ async function detectMimeType(file) {
   const length = header.length;
 
   // JPEG: FF D8 FF
-  if (
-    length >= 3 &&
-    header[0] === 0xff &&
-    header[1] === 0xd8 &&
-    header[2] === 0xff
-  ) {
+  if (length >= 3 && header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff) {
     return "image/jpeg";
   }
   // PNG: 89 50 4E 47 0D 0A 1A 0A (full 8-byte signature)
@@ -103,9 +98,7 @@ export async function onRequestPost(context) {
     if (file.size > MAX_FILE_SIZE) {
       return new Response(
         JSON.stringify({
-          error: `File too large. Maximum size is ${
-            MAX_FILE_SIZE / 1024 / 1024
-          }MB`,
+          error: `File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`,
         }),
         { status: 400, headers: { "Content-Type": "application/json" } },
       );
@@ -124,9 +117,7 @@ export async function onRequestPost(context) {
 
     // Generate unique filename with timestamp
     const timestamp = Date.now();
-    const sanitizedName = file.name
-      .replace(/[^a-zA-Z0-9.-]/g, "_")
-      .toLowerCase();
+    const sanitizedName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_").toLowerCase();
     const filename = `band-photos/${timestamp}-${sanitizedName}`;
 
     // Upload to R2 bucket — use the server-verified type, not the client-supplied one.
@@ -145,8 +136,7 @@ export async function onRequestPost(context) {
     // Generate the public URL for the stored object. The base is configurable via
     // BAND_PHOTOS_PUBLIC_URL so dev/staging/prod can point at different R2 public
     // buckets / custom domains; falls back to the production custom domain.
-    const photoBaseUrl =
-      env.BAND_PHOTOS_PUBLIC_URL || "https://band-photos.settimes.ca";
+    const photoBaseUrl = env.BAND_PHOTOS_PUBLIC_URL || "https://band-photos.settimes.ca";
     const publicUrl = `${photoBaseUrl}/${filename}`;
 
     // If band_id provided, update the band profile record
@@ -157,17 +147,13 @@ export async function onRequestPost(context) {
       if (bandIdValue.startsWith("profile_")) {
         bandProfileId = Number(bandIdValue.replace("profile_", ""));
       } else if (!Number.isNaN(Number(bandIdValue))) {
-        const performance = await env.DB.prepare(
-          "SELECT band_profile_id FROM performances WHERE id = ?",
-        )
+        const performance = await env.DB.prepare("SELECT band_profile_id FROM performances WHERE id = ?")
           .bind(Number(bandIdValue))
           .first();
 
         bandProfileId = performance?.band_profile_id ?? null;
         if (!bandProfileId) {
-          const profile = await env.DB.prepare(
-            "SELECT id FROM band_profiles WHERE id = ?",
-          )
+          const profile = await env.DB.prepare("SELECT id FROM band_profiles WHERE id = ?")
             .bind(Number(bandIdValue))
             .first();
           bandProfileId = profile?.id ?? null;
@@ -175,9 +161,7 @@ export async function onRequestPost(context) {
       }
 
       if (bandProfileId) {
-        await env.DB.prepare(
-          "UPDATE band_profiles SET photo_url = ? WHERE id = ?",
-        )
+        await env.DB.prepare("UPDATE band_profiles SET photo_url = ? WHERE id = ?")
           .bind(publicUrl, bandProfileId)
           .run();
       }

--- a/functions/api/admin/bands/stats/[name].js
+++ b/functions/api/admin/bands/stats/[name].js
@@ -108,12 +108,8 @@ export async function onRequestGet(context) {
 
     // Calculate statistics
     const totalShows = history.filter((p) => p.event_id !== null).length;
-    const uniqueVenues = new Set(
-      history.filter((p) => p.venue_id !== null).map((p) => p.venue_id),
-    );
-    const uniqueEvents = new Set(
-      history.filter((p) => p.event_id !== null).map((p) => p.event_id),
-    );
+    const uniqueVenues = new Set(history.filter((p) => p.venue_id !== null).map((p) => p.venue_id));
+    const uniqueEvents = new Set(history.filter((p) => p.event_id !== null).map((p) => p.event_id));
 
     // Get band profile data from most recent entry
     const latestEntry = history[0];

--- a/functions/api/admin/events.js
+++ b/functions/api/admin/events.js
@@ -27,20 +27,10 @@ export async function onRequestGet(context) {
     // Parse query parameters
     const url = new URL(request.url);
     const showArchived = url.searchParams.get("archived") === "true";
-    const requestedLimit = Number.parseInt(
-      url.searchParams.get("limit") || "1000",
-      10,
-    );
-    const requestedOffset = Number.parseInt(
-      url.searchParams.get("offset") || "0",
-      10,
-    );
-    const limit = Number.isFinite(requestedLimit)
-      ? Math.min(Math.max(requestedLimit, 1), 1000)
-      : 1000;
-    const offset = Number.isFinite(requestedOffset)
-      ? Math.max(requestedOffset, 0)
-      : 0;
+    const requestedLimit = Number.parseInt(url.searchParams.get("limit") || "1000", 10);
+    const requestedOffset = Number.parseInt(url.searchParams.get("offset") || "0", 10);
+    const limit = Number.isFinite(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 1000) : 1000;
+    const offset = Number.isFinite(requestedOffset) ? Math.max(requestedOffset, 0) : 0;
 
     // Build query based on archived filter
     let query = `
@@ -173,9 +163,7 @@ export async function onRequestPost(context) {
     }
 
     if (end_date && end_date < date) {
-      return validationErrorResponse(
-        "End date must be on or after the event start date",
-      );
+      return validationErrorResponse("End date must be on or after the event start date");
     }
 
     // Check if slug already exists

--- a/functions/api/admin/events/[id].js
+++ b/functions/api/admin/events/[id].js
@@ -82,9 +82,7 @@ export async function onRequestPatch(context) {
     }
 
     // Get current event
-    const event = await DB.prepare(`SELECT * FROM events WHERE id = ?`)
-      .bind(eventId)
-      .first();
+    const event = await DB.prepare(`SELECT * FROM events WHERE id = ?`).bind(eventId).first();
 
     if (!event) {
       return new Response(
@@ -103,18 +101,8 @@ export async function onRequestPatch(context) {
     if (body.ticketLink && !body.ticket_url) {
       body.ticket_url = body.ticketLink;
     }
-    const {
-      name,
-      date,
-      end_date,
-      status,
-      description,
-      city,
-      ticket_url,
-      venue_info,
-      social_links,
-      theme_colors,
-    } = body;
+    const { name, date, end_date, status, description, city, ticket_url, venue_info, social_links, theme_colors } =
+      body;
 
     // Build update query dynamically based on provided fields
     const updates = [];
@@ -153,10 +141,10 @@ export async function onRequestPatch(context) {
     if (date !== undefined) {
       const dateResult = validateDate(date);
       if (!dateResult.valid) {
-        return new Response(
-          JSON.stringify({ error: "Validation error", message: dateResult.error }),
-          { status: 400, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ error: "Validation error", message: dateResult.error }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
       }
       updates.push("date = ?");
       params.push(date);
@@ -167,10 +155,10 @@ export async function onRequestPatch(context) {
       if (normalizedEndDate !== null) {
         const endDateResult = validateDate(normalizedEndDate);
         if (!endDateResult.valid) {
-          return new Response(
-            JSON.stringify({ error: "Validation error", message: endDateResult.error }),
-            { status: 400, headers: { "Content-Type": "application/json" } },
-          );
+          return new Response(JSON.stringify({ error: "Validation error", message: endDateResult.error }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          });
         }
         const effectiveStartDate = date ?? event.date;
         if (normalizedEndDate < effectiveStartDate) {
@@ -393,9 +381,7 @@ export async function onRequestPatch(context) {
     }
 
     // Execute update
-    const result = await DB.prepare(
-      `UPDATE events SET ${updates.join(", ")} WHERE id = ? RETURNING *`,
-    )
+    const result = await DB.prepare(`UPDATE events SET ${updates.join(", ")} WHERE id = ? RETURNING *`)
       .bind(...params)
       .first();
 
@@ -585,9 +571,7 @@ export async function onRequestDelete(context) {
     }
 
     // Check if event exists
-    const event = await DB.prepare("SELECT id, name FROM events WHERE id = ?")
-      .bind(eventIdNum)
-      .first();
+    const event = await DB.prepare("SELECT id, name FROM events WHERE id = ?").bind(eventIdNum).first();
 
     if (!event) {
       return new Response(JSON.stringify({ error: "Event not found" }), {
@@ -597,17 +581,13 @@ export async function onRequestDelete(context) {
     }
 
     // Check if event has any bands (for informational message)
-    const bandCount = await DB.prepare(
-      "SELECT COUNT(*) as count FROM performances WHERE event_id = ?",
-    )
+    const bandCount = await DB.prepare("SELECT COUNT(*) as count FROM performances WHERE event_id = ?")
       .bind(eventIdNum)
       .first();
 
     const body = await request.json().catch(() => ({}));
     const url = new URL(request.url);
-    const confirmCascade =
-      body?.confirmCascade === true ||
-      url.searchParams.get("confirmCascade") === "true";
+    const confirmCascade = body?.confirmCascade === true || url.searchParams.get("confirmCascade") === "true";
 
     if (bandCount.count > 0 && !confirmCascade) {
       return new Response(

--- a/functions/api/admin/events/[id]/archive.js
+++ b/functions/api/admin/events/[id]/archive.js
@@ -42,9 +42,7 @@ export async function onRequestPost(context) {
     }
 
     // Get current event
-    const event = await DB.prepare(`SELECT * FROM events WHERE id = ?`)
-      .bind(eventId)
-      .first();
+    const event = await DB.prepare(`SELECT * FROM events WHERE id = ?`).bind(eventId).first();
 
     if (!event) {
       return new Response(

--- a/functions/api/admin/events/[id]/duplicate.js
+++ b/functions/api/admin/events/[id]/duplicate.js
@@ -51,24 +51,17 @@ export async function onRequestPost(context) {
     }
 
     // Source event to copy from.
-    const originalEvent = await DB.prepare("SELECT * FROM events WHERE id = ?")
-      .bind(eventId)
-      .first();
+    const originalEvent = await DB.prepare("SELECT * FROM events WHERE id = ?").bind(eventId).first();
 
     if (!originalEvent) {
       return json({ error: "Not found", message: "Original event not found" }, 404);
     }
 
     // Slug is unique — reject before inserting.
-    const existingEvent = await DB.prepare("SELECT id FROM events WHERE slug = ?")
-      .bind(slug)
-      .first();
+    const existingEvent = await DB.prepare("SELECT id FROM events WHERE slug = ?").bind(slug).first();
 
     if (existingEvent) {
-      return json(
-        { error: "Conflict", message: "An event with this slug already exists" },
-        409,
-      );
+      return json({ error: "Conflict", message: "An event with this slug already exists" }, 409);
     }
 
     // Create the new event as an unpublished draft, carrying over the source's
@@ -116,9 +109,7 @@ export async function onRequestPost(context) {
       throw copyError;
     }
 
-    const bandCount = await DB.prepare(
-      "SELECT COUNT(*) as count FROM performances WHERE event_id = ?",
-    )
+    const bandCount = await DB.prepare("SELECT COUNT(*) as count FROM performances WHERE event_id = ?")
       .bind(newEvent.id)
       .first();
 

--- a/functions/api/admin/events/[id]/edit.js
+++ b/functions/api/admin/events/[id]/edit.js
@@ -3,91 +3,92 @@
 // Body: { name, date, slug }
 // Returns: { success: true, event: {...} } or error
 
-import { checkPermission, auditLog } from "../../_middleware.js"
-import { getClientIP } from "../../../../utils/request.js"
-import { validateId } from "../../../../utils/validation.js"
+import { checkPermission, auditLog } from "../../_middleware.js";
+import { getClientIP } from "../../../../utils/request.js";
+import { validateId } from "../../../../utils/validation.js";
 
 export async function onRequestPut(context) {
-  const { request, env, params } = context
-  const { DB } = env
-  const { valid, value: eventId, error: idError } = validateId(params.id)
+  const { request, env, params } = context;
+  const { DB } = env;
+  const { valid, value: eventId, error: idError } = validateId(params.id);
   if (!valid) {
-    return new Response(JSON.stringify({ error: idError }), { status: 400, headers: { "Content-Type": "application/json" } })
+    return new Response(JSON.stringify({ error: idError }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   }
-  const ipAddress = getClientIP(request)
+  const ipAddress = getClientIP(request);
 
   try {
-    const auth = await checkPermission(context, "editor")
+    const auth = await checkPermission(context, "editor");
     if (auth.error) {
-      return auth.response
+      return auth.response;
     }
 
-    const body = await request.json().catch(() => ({}))
-    const { name, date, slug, ticket_url } = body
+    const body = await request.json().catch(() => ({}));
+    const { name, date, slug, ticket_url } = body;
 
     // Validation
     if (!name || !date || !slug) {
       return new Response(
         JSON.stringify({
-          error: 'Validation error',
-          message: 'Name, date, and slug are required'
+          error: "Validation error",
+          message: "Name, date, and slug are required",
         }),
         {
           status: 400,
-          headers: { 'Content-Type': 'application/json' }
-        }
-      )
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     // Validate ticket_url URL if provided
     if (ticket_url && !ticket_url.match(/^https?:\/\//)) {
       return new Response(
         JSON.stringify({
-          error: 'Validation error',
-          message: 'Ticket link must be a valid URL starting with http:// or https://'
+          error: "Validation error",
+          message: "Ticket link must be a valid URL starting with http:// or https://",
         }),
         {
           status: 400,
-          headers: { 'Content-Type': 'application/json' }
-        }
-      )
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     // Check if event exists
-    const existingEvent = await DB.prepare(
-      'SELECT * FROM events WHERE id = ?'
-    ).bind(eventId).first()
+    const existingEvent = await DB.prepare("SELECT * FROM events WHERE id = ?").bind(eventId).first();
 
     if (!existingEvent) {
       return new Response(
         JSON.stringify({
-          error: 'Not found',
-          message: 'Event not found'
+          error: "Not found",
+          message: "Event not found",
         }),
         {
           status: 404,
-          headers: { 'Content-Type': 'application/json' }
-        }
-      )
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     // Check if slug is already taken by another event
     if (slug !== existingEvent.slug) {
-      const slugCheck = await DB.prepare(
-        'SELECT id FROM events WHERE slug = ? AND id != ?'
-      ).bind(slug, eventId).first()
+      const slugCheck = await DB.prepare("SELECT id FROM events WHERE slug = ? AND id != ?")
+        .bind(slug, eventId)
+        .first();
 
       if (slugCheck) {
         return new Response(
           JSON.stringify({
-            error: 'Conflict',
-            message: 'An event with this slug already exists'
+            error: "Conflict",
+            message: "An event with this slug already exists",
           }),
           {
             status: 409,
-            headers: { 'Content-Type': 'application/json' }
-          }
-        )
+            headers: { "Content-Type": "application/json" },
+          },
+        );
       }
     }
 
@@ -98,10 +99,10 @@ export async function onRequestPut(context) {
       SET name = ?, date = ?, slug = ?, ticket_url = ?
       WHERE id = ?
       RETURNING *
-    `
+    `,
     )
       .bind(name, date, slug, ticket_url || null, eventId)
-      .first()
+      .first();
 
     await auditLog(
       env,
@@ -115,31 +116,31 @@ export async function onRequestPut(context) {
         slug,
         ticket_url: ticket_url || null,
       },
-      ipAddress
-    )
+      ipAddress,
+    );
 
     return new Response(
       JSON.stringify({
         success: true,
         event: result,
-        message: 'Event updated successfully'
+        message: "Event updated successfully",
       }),
       {
         status: 200,
-        headers: { 'Content-Type': 'application/json' }
-      }
-    )
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   } catch (error) {
-    console.error('Event edit error:', error)
+    console.error("Event edit error:", error);
     return new Response(
       JSON.stringify({
-        error: 'Database error',
-        message: 'Failed to update event'
+        error: "Database error",
+        message: "Failed to update event",
       }),
       {
         status: 500,
-        headers: { 'Content-Type': 'application/json' }
-      }
-    )
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 }

--- a/functions/api/admin/events/[id]/metrics.js
+++ b/functions/api/admin/events/[id]/metrics.js
@@ -6,7 +6,10 @@ export async function onRequestGet(context) {
   const { DB } = env;
   const { valid, value: eventId, error: idError } = validateId(params.id);
   if (!valid) {
-    return new Response(JSON.stringify({ error: idError }), { status: 400, headers: { "Content-Type": "application/json" } });
+    return new Response(JSON.stringify({ error: idError }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   // RBAC: Require viewer role or higher (read-only metrics)

--- a/functions/api/admin/events/[id]/publish.js
+++ b/functions/api/admin/events/[id]/publish.js
@@ -42,9 +42,7 @@ export async function onRequestPost(context) {
     }
 
     // Get current event
-    const event = await DB.prepare(`SELECT * FROM events WHERE id = ?`)
-      .bind(eventId)
-      .first();
+    const event = await DB.prepare(`SELECT * FROM events WHERE id = ?`).bind(eventId).first();
 
     if (!event) {
       return new Response(
@@ -63,10 +61,10 @@ export async function onRequestPost(context) {
     const { publish } = body;
 
     if (typeof publish !== "boolean") {
-      return new Response(
-        JSON.stringify({ error: "Bad request", message: "publish must be a boolean" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Bad request", message: "publish must be a boolean" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     if (event.status === "archived") {
@@ -87,9 +85,7 @@ export async function onRequestPost(context) {
 
     // If publishing, check that event has at least 1 band
     if (publish) {
-      const bandCount = await DB.prepare(
-        `SELECT COUNT(*) as count FROM performances WHERE event_id = ?`,
-      )
+      const bandCount = await DB.prepare(`SELECT COUNT(*) as count FROM performances WHERE event_id = ?`)
         .bind(eventId)
         .first();
 
@@ -97,8 +93,7 @@ export async function onRequestPost(context) {
         return new Response(
           JSON.stringify({
             error: "Validation error",
-            message:
-              "Cannot publish event with no bands. Add at least one band first.",
+            message: "Cannot publish event with no bands. Add at least one band first.",
           }),
           {
             status: 400,
@@ -138,9 +133,7 @@ export async function onRequestPost(context) {
       JSON.stringify({
         success: true,
         event: result,
-        message: publish
-          ? "Event published successfully"
-          : "Event unpublished successfully",
+        message: publish ? "Event published successfully" : "Event unpublished successfully",
       }),
       {
         status: 200,

--- a/functions/api/admin/events/[id]/reveal-mode.js
+++ b/functions/api/admin/events/[id]/reveal-mode.js
@@ -12,7 +12,10 @@ export async function onRequestPost(context) {
   const { DB } = env;
   const { valid, value: eventId, error: idError } = validateId(params.id);
   if (!valid) {
-    return new Response(JSON.stringify({ error: idError }), { status: 400, headers: { "Content-Type": "application/json" } });
+    return new Response(JSON.stringify({ error: idError }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   }
   const ipAddress = getClientIP(request);
 
@@ -26,26 +29,24 @@ export async function onRequestPost(context) {
 
     const body = await request.json().catch(() => ({}));
     if (typeof body.reveal_mode !== "boolean") {
-      return new Response(
-        JSON.stringify({ error: "Bad request", message: "reveal_mode (boolean) is required" }),
-        { status: 400, headers: { "Content-Type": "application/json" } }
-      );
+      return new Response(JSON.stringify({ error: "Bad request", message: "reveal_mode (boolean) is required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
-    const event = await DB.prepare("SELECT id FROM events WHERE id = ?")
-      .bind(eventId)
-      .first();
+    const event = await DB.prepare("SELECT id FROM events WHERE id = ?").bind(eventId).first();
 
     if (!event) {
-      return new Response(
-        JSON.stringify({ error: "Not found", message: "Event not found" }),
-        { status: 404, headers: { "Content-Type": "application/json" } }
-      );
+      return new Response(JSON.stringify({ error: "Not found", message: "Event not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     const newValue = body.reveal_mode ? 1 : 0;
     await DB.prepare(
-      "UPDATE events SET reveal_mode = ?, updated_at = datetime('now'), updated_by_user_id = ? WHERE id = ?"
+      "UPDATE events SET reveal_mode = ?, updated_at = datetime('now'), updated_by_user_id = ? WHERE id = ?",
     )
       .bind(newValue, currentUser.userId, eventId)
       .run();
@@ -57,7 +58,7 @@ export async function onRequestPost(context) {
       "event",
       eventId,
       { event_id: eventId },
-      ipAddress
+      ipAddress,
     );
 
     return new Response(
@@ -65,13 +66,13 @@ export async function onRequestPost(context) {
         success: true,
         event: { id: Number(eventId), reveal_mode: newValue },
       }),
-      { status: 200, headers: { "Content-Type": "application/json" } }
+      { status: 200, headers: { "Content-Type": "application/json" } },
     );
   } catch (err) {
     console.error("[reveal-mode] Error:", err);
-    return new Response(
-      JSON.stringify({ error: "Internal server error" }),
-      { status: 500, headers: { "Content-Type": "application/json" } }
-    );
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/admin/events/__tests__/events.test.js
+++ b/functions/api/admin/events/__tests__/events.test.js
@@ -1,11 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createDBEnv,
-  createTestDB,
-  createTestEnv,
-  insertBand,
-  insertEvent,
-} from "../../../test-utils";
+import { createDBEnv, createTestDB, createTestEnv, insertBand, insertEvent } from "../../../test-utils";
 
 // We'll import the handler under test. It expects to be called as
 // onRequestPost({ request, env }) and uses env.DB. We also need to mock
@@ -28,10 +22,10 @@ vi.mock("../../_middleware.js", () => ({
     if (level === "admin" && role !== "admin") {
       return {
         error: true,
-        response: new Response(
-          JSON.stringify({ error: "Forbidden", message: "Admin required" }),
-          { status: 403, headers: { "Content-Type": "application/json" } },
-        ),
+        response: new Response(JSON.stringify({ error: "Forbidden", message: "Admin required" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
       };
     }
 
@@ -75,13 +69,9 @@ describe("Event API - smoke tests", () => {
   it.todo("POST /api/admin/events - should create event with valid data");
   it.todo("POST /api/admin/events - should validate required fields");
   it.todo("PATCH /api/admin/events/:id - should update event fields");
-  it.todo(
-    "POST /api/admin/events/:id/publish - should publish when bands >= 1",
-  );
+  it.todo("POST /api/admin/events/:id/publish - should publish when bands >= 1");
   it.todo("POST /api/admin/events/:id/archive - should archive only for admin");
-  it.todo(
-    "DELETE /api/admin/events/:id - should delete event and orphan bands",
-  );
+  it.todo("DELETE /api/admin/events/:id - should delete event and orphan bands");
 });
 
 describe("Event API - handler integration", () => {
@@ -122,17 +112,14 @@ describe("Event API - handler integration", () => {
     const ev = insertEvent(rawDb, { name: "Old Name", slug: "old-name" });
 
     const body = { name: "New Name" };
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}`,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify(body),
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify(body),
+    });
 
     const res = await eventIdHandler.onRequestPatch({ request, env });
     expect(res.status).toBe(200);
@@ -149,24 +136,19 @@ describe("Event API - handler integration", () => {
     insertBand(rawDb, { name: "Band A", event_id: ev.id });
 
     const body = { publish: true };
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}/publish`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify(body),
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/publish`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify(body),
+    });
 
     const res = await publishHandler.onRequestPost({ request, env });
     expect(res.status).toBe(200);
     const data = await res.json();
-    expect(
-      data.event.is_published === 1 || data.event.is_published === true,
-    ).toBeTruthy();
+    expect(data.event.is_published === 1 || data.event.is_published === true).toBeTruthy();
   });
 
   // Negative / validation cases
@@ -224,17 +206,14 @@ describe("Event API - handler integration", () => {
 
     const ev = insertEvent(rawDb, { name: "NoBands", slug: "nobands" });
     const body = { publish: true };
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}/publish`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify(body),
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/publish`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify(body),
+    });
 
     const res = await publishHandler.onRequestPost({ request, env });
     expect(res.status).toBe(400);
@@ -276,17 +255,14 @@ describe("Event API - handler integration", () => {
     });
 
     const body = { publish: false };
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}/publish`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify(body),
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/publish`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify(body),
+    });
 
     const res = await publishHandler.onRequestPost({ request, env });
     expect(res.status).toBe(400);
@@ -303,17 +279,14 @@ describe("Event API - handler integration", () => {
       slug: "no-slug-change",
     });
     const body = { slug: "new-slug" };
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}`,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify(body),
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify(body),
+    });
 
     const res = await eventIdHandler.onRequestPatch({ request, env });
     expect(res.status).toBe(400);
@@ -326,16 +299,13 @@ describe("Event API - handler integration", () => {
     const env = { DB: createDBEnv(rawDb) };
     const ev = insertEvent(rawDb, { name: "Protected", slug: "protected" });
 
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}/archive`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/archive`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+    });
 
     const res = await archiveHandler.onRequestPost({ request, env });
     expect(res.status).toBe(403);
@@ -349,16 +319,13 @@ describe("Event API - handler integration", () => {
       slug: "protected-delete",
     });
 
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}`,
-      {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+    });
 
     const res = await eventIdHandler.onRequestDelete({ request, env });
     expect(res.status).toBe(403);
@@ -371,13 +338,10 @@ describe("Event API - handler integration", () => {
     // Create event
     const ev = insertEvent(rawDb, { name: "To Archive", slug: "to-archive" });
 
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}/archive`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json", "x-test-role": "admin" },
-      },
-    );
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/archive`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "admin" },
+    });
 
     const res = await archiveHandler.onRequestPost({ request, env });
     expect(res.status).toBe(200);
@@ -399,17 +363,14 @@ describe("Event API - handler integration", () => {
       date: "2026-01-01",
       slug: "original-copy",
     };
-    const request = new Request(
-      `https://example.test/api/admin/events/${original.id}/duplicate`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify(body),
+    const request = new Request(`https://example.test/api/admin/events/${original.id}/duplicate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify(body),
+    });
 
     const res = await duplicateHandler.onRequestPost({
       request,
@@ -430,14 +391,11 @@ describe("Event API - handler integration", () => {
     const ev = insertEvent(rawDb, { name: "ToDelete", slug: "to-delete" });
     insertBand(rawDb, { name: "SoloBand", event_id: ev.id });
 
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}`,
-      {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json", "x-test-role": "admin" },
-        body: JSON.stringify({ confirmCascade: true }),
-      },
-    );
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json", "x-test-role": "admin" },
+      body: JSON.stringify({ confirmCascade: true }),
+    });
 
     const res = await eventIdHandler.onRequestDelete({ request, env });
     expect(res.status).toBe(200);
@@ -455,14 +413,11 @@ describe("Event API - handler integration", () => {
     });
     const b = insertBand(rawDb, { name: "OrphanBand", event_id: ev.id });
 
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}`,
-      {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json", "x-test-role": "admin" },
-        body: JSON.stringify({ confirmCascade: true }),
-      },
-    );
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json", "x-test-role": "admin" },
+      body: JSON.stringify({ confirmCascade: true }),
+    });
 
     const res = await eventIdHandler.onRequestDelete({ request, env });
     expect(res.status).toBe(200);
@@ -470,9 +425,7 @@ describe("Event API - handler integration", () => {
     expect(data.success).toBeTruthy();
 
     // Check performance was removed by cascade
-    const row = rawDb
-      .prepare("SELECT * FROM performances WHERE id = ?")
-      .get(b.id);
+    const row = rawDb.prepare("SELECT * FROM performances WHERE id = ?").get(b.id);
     expect(row).toBeUndefined();
   });
 
@@ -485,13 +438,10 @@ describe("Event API - handler integration", () => {
     });
     insertBand(rawDb, { name: "NeedsConfirm", event_id: ev.id });
 
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}`,
-      {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json", "x-test-role": "admin" },
-      },
-    );
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json", "x-test-role": "admin" },
+    });
 
     const res = await eventIdHandler.onRequestDelete({ request, env });
     expect(res.status).toBe(409);
@@ -509,17 +459,14 @@ describe("Event API - handler integration", () => {
     });
 
     const body = { date: "2026-03-03", status: "published" };
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}`,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify(body),
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify(body),
+    });
 
     const res = await eventIdHandler.onRequestPatch({ request, env });
     expect(res.status).toBe(200);
@@ -537,17 +484,14 @@ describe("Event API - handler integration", () => {
     });
 
     const body = { status: "archived" };
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}`,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify(body),
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify(body),
+    });
 
     const res = await eventIdHandler.onRequestPatch({ request, env });
     expect(res.status).toBe(400);
@@ -564,17 +508,14 @@ describe("Event API - handler integration", () => {
     });
     insertBand(rawDb, { name: "A Band", event_id: ev.id });
 
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}/publish`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify({ publish: "yes" }),
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/publish`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify({ publish: "yes" }),
+    });
 
     const res = await publishHandler.onRequestPost({ request, env });
     expect(res.status).toBe(400);
@@ -589,17 +530,14 @@ describe("Event API - handler integration", () => {
     });
     insertBand(rawDb, { name: "A Band 2", event_id: ev.id });
 
-    const request = new Request(
-      `https://example.test/api/admin/events/${ev.id}/publish`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify({ publish: 1 }),
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/publish`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify({ publish: 1 }),
+    });
 
     const res = await publishHandler.onRequestPost({ request, env });
     expect(res.status).toBe(400);
@@ -632,21 +570,18 @@ describe("Event duplication atomicity (P0-B2)", () => {
       return originalPrepare(sql);
     };
 
-    const request = new Request(
-      `https://example.test/api/admin/events/${original.id}/duplicate`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-role": "editor",
-        },
-        body: JSON.stringify({
-          name: "Copy",
-          date: "2027-01-01",
-          slug: "copy-event",
-        }),
+    const request = new Request(`https://example.test/api/admin/events/${original.id}/duplicate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
       },
-    );
+      body: JSON.stringify({
+        name: "Copy",
+        date: "2027-01-01",
+        slug: "copy-event",
+      }),
+    });
 
     const res = await duplicateHandler.onRequestPost({
       request,
@@ -656,9 +591,7 @@ describe("Event duplication atomicity (P0-B2)", () => {
     expect(res.status).toBe(500);
 
     // The new event must have been cleaned up — no orphan
-    const orphan = rawDb
-      .prepare("SELECT id FROM events WHERE slug = 'copy-event'")
-      .get();
+    const orphan = rawDb.prepare("SELECT id FROM events WHERE slug = 'copy-event'").get();
     expect(orphan).toBeUndefined();
   });
 });

--- a/functions/api/admin/events/__tests__/helpers.js
+++ b/functions/api/admin/events/__tests__/helpers.js
@@ -1,12 +1,12 @@
 // Test helpers for admin events API tests
-import { MockD1Database } from '../../../subscriptions/__tests__/mocks/d1.js'
+import { MockD1Database } from "../../../subscriptions/__tests__/mocks/d1.js";
 
 export class AdminMockD1Database extends MockD1Database {
   constructor() {
-    super()
+    super();
     // Add admin-specific tables
-    this.data.users = []
-    this.idCounter = 1
+    this.data.users = [];
+    this.idCounter = 1;
   }
 
   prepare(query) {
@@ -14,178 +14,184 @@ export class AdminMockD1Database extends MockD1Database {
       bind: (...params) => ({
         first: async () => this._executeSelectFirst(query, params),
         all: async () => this._executeSelect(query, params),
-        run: async () => this._executeWrite(query, params)
-      })
-    }
+        run: async () => this._executeWrite(query, params),
+      }),
+    };
   }
 
   _executeSelectFirst(query, params) {
-    const result = this._executeSelect(query, params)
-    return result.results && result.results.length > 0 ? result.results[0] : null
+    const result = this._executeSelect(query, params);
+    return result.results && result.results.length > 0 ? result.results[0] : null;
   }
 
   _executeSelect(query, params) {
-    const queryLower = query.toLowerCase()
+    const queryLower = query.toLowerCase();
 
     // SELECT event by ID
-    if (queryLower.includes('select * from events where id = ?')) {
-      const [id] = params
-      const event = this.data.events.find(e => e.id === id)
-      return { results: event ? [event] : [] }
+    if (queryLower.includes("select * from events where id = ?")) {
+      const [id] = params;
+      const event = this.data.events.find((e) => e.id === id);
+      return { results: event ? [event] : [] };
     }
 
     // SELECT event by slug (check duplicate)
-    if (queryLower.includes('select id from events where slug = ?')) {
-      const [slug] = params
-      const event = this.data.events.find(e => e.slug === slug)
-      return { results: event ? [{ id: event.id }] : [] }
+    if (queryLower.includes("select id from events where slug = ?")) {
+      const [slug] = params;
+      const event = this.data.events.find((e) => e.slug === slug);
+      return { results: event ? [{ id: event.id }] : [] };
     }
 
     // SELECT all events with archived filter
-    if (queryLower.includes('select') && queryLower.includes('from events')) {
-      let results = [...this.data.events]
+    if (queryLower.includes("select") && queryLower.includes("from events")) {
+      let results = [...this.data.events];
 
       // Filter archived events
-      if (!queryLower.includes('archived')) {
-        results = results.filter(e => e.status !== 'archived')
+      if (!queryLower.includes("archived")) {
+        results = results.filter((e) => e.status !== "archived");
       }
 
       // Order by date
-      if (queryLower.includes('order by date desc')) {
-        results.sort((a, b) => (b.date || '').localeCompare(a.date || ''))
+      if (queryLower.includes("order by date desc")) {
+        results.sort((a, b) => (b.date || "").localeCompare(a.date || ""));
       }
 
-      return { results }
+      return { results };
     }
 
     // SELECT band count for event
-    if (queryLower.includes('select count(*) as count from performances where event_id = ?')) {
-      const [eventId] = params
-      const count = this.data.performances.filter(p => p.event_id === eventId).length
-      return { results: [{ count }] }
+    if (queryLower.includes("select count(*) as count from performances where event_id = ?")) {
+      const [eventId] = params;
+      const count = this.data.performances.filter((p) => p.event_id === eventId).length;
+      return { results: [{ count }] };
     }
 
     // Fall back to parent class
-    return super._executeSelect(query, params)
+    return super._executeSelect(query, params);
   }
 
   _executeWrite(query, params) {
-    const queryLower = query.toLowerCase()
+    const queryLower = query.toLowerCase();
 
     // INSERT new event
-    if (queryLower.includes('insert into events')) {
-      const [name, slug, date, status, userId] = params
+    if (queryLower.includes("insert into events")) {
+      const [name, slug, date, status, userId] = params;
 
       const newEvent = {
         id: this.idCounter++,
         name,
         slug,
         date,
-        status: status || 'draft',
-        is_published: status === 'published' ? 1 : 0,
+        status: status || "draft",
+        is_published: status === "published" ? 1 : 0,
         archived_at: null,
         created_by_user_id: userId,
-        created_at: new Date().toISOString()
-      }
+        created_at: new Date().toISOString(),
+      };
 
-      this.data.events.push(newEvent)
-      return { success: true, meta: { changes: 1, last_row_id: newEvent.id } }
+      this.data.events.push(newEvent);
+      return { success: true, meta: { changes: 1, last_row_id: newEvent.id } };
     }
 
     // UPDATE event
-    if (queryLower.includes('update events set')) {
-      const eventId = params[params.length - 1]
-      const event = this.data.events.find(e => e.id === eventId)
+    if (queryLower.includes("update events set")) {
+      const eventId = params[params.length - 1];
+      const event = this.data.events.find((e) => e.id === eventId);
 
       if (!event) {
-        return { success: true, meta: { changes: 0 } }
+        return { success: true, meta: { changes: 0 } };
       }
 
       // Update status (publish/unpublish)
-      if (queryLower.includes('set status = ?')) {
-        const [status] = params
-        event.status = status
-        event.is_published = status === 'published' ? 1 : 0
-        return { success: true, meta: { changes: 1 } }
+      if (queryLower.includes("set status = ?")) {
+        const [status] = params;
+        event.status = status;
+        event.is_published = status === "published" ? 1 : 0;
+        return { success: true, meta: { changes: 1 } };
       }
 
       // Update for archive
-      if (queryLower.includes('set status = ?, archived_at = ?')) {
-        const [status, archivedAt] = params
-        event.status = status
-        event.archived_at = archivedAt
-        return { success: true, meta: { changes: 1 } }
+      if (queryLower.includes("set status = ?, archived_at = ?")) {
+        const [status, archivedAt] = params;
+        event.status = status;
+        event.archived_at = archivedAt;
+        return { success: true, meta: { changes: 1 } };
       }
 
       // General update
-      if (queryLower.includes('set name = ?, date = ?, slug = ?')) {
-        const [name, date, slug] = params
-        event.name = name
-        event.date = date
-        event.slug = slug
-        return { success: true, meta: { changes: 1 } }
+      if (queryLower.includes("set name = ?, date = ?, slug = ?")) {
+        const [name, date, slug] = params;
+        event.name = name;
+        event.date = date;
+        event.slug = slug;
+        return { success: true, meta: { changes: 1 } };
       }
 
-      return { success: true, meta: { changes: 1 } }
+      return { success: true, meta: { changes: 1 } };
     }
 
     // DELETE event
-    if (queryLower.includes('delete from events where id = ?')) {
-      const [id] = params
-      const index = this.data.events.findIndex(e => e.id === id)
+    if (queryLower.includes("delete from events where id = ?")) {
+      const [id] = params;
+      const index = this.data.events.findIndex((e) => e.id === id);
 
       if (index !== -1) {
-        this.data.events.splice(index, 1)
+        this.data.events.splice(index, 1);
 
-        this.data.performances = this.data.performances.filter(perf => perf.event_id !== id)
+        this.data.performances = this.data.performances.filter((perf) => perf.event_id !== id);
 
-        return { success: true, meta: { changes: 1 } }
+        return { success: true, meta: { changes: 1 } };
       }
 
-      return { success: true, meta: { changes: 0 } }
+      return { success: true, meta: { changes: 0 } };
     }
 
     // Fall back to parent class
-    return super._executeWrite(query, params)
+    return super._executeWrite(query, params);
   }
 }
 
-export function createMockUser({ id = 1, email = 'admin@test', role = 'admin' } = {}) {
-  return { id, email, role, displayName: 'Test User' }
+export function createMockUser({ id = 1, email = "admin@test", role = "admin" } = {}) {
+  return { id, email, role, displayName: "Test User" };
 }
 
-export function createMockEvent({ id = 1, name = 'Test Event', slug = 'test-event', date = '2025-12-15', status = 'draft' } = {}) {
+export function createMockEvent({
+  id = 1,
+  name = "Test Event",
+  slug = "test-event",
+  date = "2025-12-15",
+  status = "draft",
+} = {}) {
   return {
     id,
     name,
     slug,
     date,
     status,
-    is_published: status === 'published' ? 1 : 0,
-    archived_at: status === 'archived' ? new Date().toISOString() : null,
+    is_published: status === "published" ? 1 : 0,
+    archived_at: status === "archived" ? new Date().toISOString() : null,
     created_by_user_id: 1,
-    created_at: new Date().toISOString()
-  }
+    created_at: new Date().toISOString(),
+  };
 }
 
-export function createTestContext({ role = 'editor', db = null } = {}) {
-  const mockDB = db || new AdminMockD1Database()
-  const mockUser = createMockUser({ role })
+export function createTestContext({ role = "editor", db = null } = {}) {
+  const mockDB = db || new AdminMockD1Database();
+  const mockUser = createMockUser({ role });
 
   return {
     env: {
       DB: mockDB,
-      JWT_SECRET: 'test-secret',
-      ALLOW_HEADER_AUTH: 'true'
+      JWT_SECRET: "test-secret",
+      ALLOW_HEADER_AUTH: "true",
     },
     request: {
       user: mockUser,
       headers: new Headers({
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json'
-      })
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+      }),
     },
     mockDB,
-    mockUser
-  }
+    mockUser,
+  };
 }

--- a/functions/api/admin/events/__tests__/metrics.test.js
+++ b/functions/api/admin/events/__tests__/metrics.test.js
@@ -1,104 +1,106 @@
 // Admin event metrics endpoint tests
 // GET /api/admin/events/[id]/metrics
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from "vitest";
 
 // Mock RBAC middleware: authenticate via context.data.user.role or x-test-role header
-vi.mock('../../_middleware.js', () => ({
+vi.mock("../../_middleware.js", () => ({
   checkPermission: async (context) => {
-    const role =
-      context?.data?.user?.role || context?.request?.headers?.get('x-test-role')
+    const role = context?.data?.user?.role || context?.request?.headers?.get("x-test-role");
     if (!role) {
       return {
         error: true,
-        response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        response: new Response(JSON.stringify({ error: "Unauthorized" }), {
           status: 401,
-          headers: { 'Content-Type': 'application/json' },
+          headers: { "Content-Type": "application/json" },
         }),
-      }
+      };
     }
-    return { error: false, user: { userId: 1, role }, userId: 1 }
+    return { error: false, user: { userId: 1, role }, userId: 1 };
   },
   auditLog: async () => {},
-}))
+}));
 
-import { onRequestGet } from '../[id]/metrics.js'
-import { createTestEnv, insertEvent, insertShareLink, insertBand } from '../../../test-utils.js'
+import { onRequestGet } from "../[id]/metrics.js";
+import { createTestEnv, insertEvent, insertShareLink, insertBand } from "../../../test-utils.js";
 
-describe('GET /api/admin/events/[id]/metrics', () => {
+describe("GET /api/admin/events/[id]/metrics", () => {
   function call(env, eventId) {
     return onRequestGet({
-      request: new Request(
-        `https://example.test/api/admin/events/${eventId}/metrics`,
-        { headers: { 'x-test-role': 'viewer' } }
-      ),
+      request: new Request(`https://example.test/api/admin/events/${eventId}/metrics`, {
+        headers: { "x-test-role": "viewer" },
+      }),
       params: { id: String(eventId) },
       env,
-      data: { user: { userId: 1, role: 'viewer' } },
-    })
+      data: { user: { userId: 1, role: "viewer" } },
+    });
   }
 
-  test('includes share analytics: count, total views, and top routes by views', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'Fest', slug: 'fest' })
+  test("includes share analytics: count, total views, and top routes by views", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Fest", slug: "fest" });
     insertShareLink(rawDb, {
-      slug: 'routeaaa',
+      slug: "routeaaa",
       event_id: event.id,
-      event_slug: 'fest',
+      event_slug: "fest",
       performance_ids: [1],
-      band_names: ['A'],
-    })
+      band_names: ["A"],
+    });
     insertShareLink(rawDb, {
-      slug: 'routebbb',
+      slug: "routebbb",
       event_id: event.id,
-      event_slug: 'fest',
+      event_slug: "fest",
       performance_ids: [1, 2],
-      band_names: ['A', 'B'],
-    })
-    rawDb
-      .prepare('UPDATE share_links SET view_count = ? WHERE slug = ?')
-      .run(5, 'routeaaa')
-    rawDb
-      .prepare('UPDATE share_links SET view_count = ? WHERE slug = ?')
-      .run(2, 'routebbb')
+      band_names: ["A", "B"],
+    });
+    rawDb.prepare("UPDATE share_links SET view_count = ? WHERE slug = ?").run(5, "routeaaa");
+    rawDb.prepare("UPDATE share_links SET view_count = ? WHERE slug = ?").run(2, "routebbb");
 
-    const res = await call(env, event.id)
-    expect(res.status).toBe(200)
-    const body = await res.json()
-    expect(body.metrics.totalShares).toBe(2)
-    expect(body.metrics.totalShareViews).toBe(7)
-    expect(body.metrics.topSharedRoutes[0].slug).toBe('routeaaa')
-    expect(body.metrics.topSharedRoutes[0].view_count).toBe(5)
-  })
+    const res = await call(env, event.id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.metrics.totalShares).toBe(2);
+    expect(body.metrics.totalShareViews).toBe(7);
+    expect(body.metrics.topSharedRoutes[0].slug).toBe("routeaaa");
+    expect(body.metrics.topSharedRoutes[0].view_count).toBe(5);
+  });
 
-  test('popularBands is ordered by schedule_count desc and totalScheduleBuilds/uniqueVisitors reflect inserted rows', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'Band Fest', slug: 'band-fest' })
+  test("popularBands is ordered by schedule_count desc and totalScheduleBuilds/uniqueVisitors reflect inserted rows", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Band Fest", slug: "band-fest" });
 
-    const perfA = insertBand(rawDb, { name: 'Alpha Band', event_id: event.id })
-    const perfB = insertBand(rawDb, { name: 'Beta Band', event_id: event.id })
+    const perfA = insertBand(rawDb, { name: "Alpha Band", event_id: event.id });
+    const perfB = insertBand(rawDb, { name: "Beta Band", event_id: event.id });
 
     // Alpha Band: 3 schedule builds across 2 sessions
-    rawDb.prepare('INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)').run(event.id, perfA.id, 'session-1')
-    rawDb.prepare('INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)').run(event.id, perfA.id, 'session-2')
-    rawDb.prepare('INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)').run(event.id, perfA.id, 'session-2')
+    rawDb
+      .prepare("INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)")
+      .run(event.id, perfA.id, "session-1");
+    rawDb
+      .prepare("INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)")
+      .run(event.id, perfA.id, "session-2");
+    rawDb
+      .prepare("INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)")
+      .run(event.id, perfA.id, "session-2");
     // Beta Band: 1 schedule build in a new session
-    rawDb.prepare('INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)').run(event.id, perfB.id, 'session-3')
+    rawDb
+      .prepare("INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)")
+      .run(event.id, perfB.id, "session-3");
 
-    const res = await call(env, event.id)
-    expect(res.status).toBe(200)
-    const body = await res.json()
+    const res = await call(env, event.id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
 
     // popularBands should be a non-empty array ordered by schedule_count desc
-    expect(Array.isArray(body.metrics.popularBands)).toBe(true)
-    expect(body.metrics.popularBands.length).toBeGreaterThan(0)
-    expect(body.metrics.popularBands[0].band_name).toBe('Alpha Band')
-    expect(body.metrics.popularBands[0].schedule_count).toBe(3)
-    expect(body.metrics.popularBands[1].band_name).toBe('Beta Band')
-    expect(body.metrics.popularBands[1].schedule_count).toBe(1)
+    expect(Array.isArray(body.metrics.popularBands)).toBe(true);
+    expect(body.metrics.popularBands.length).toBeGreaterThan(0);
+    expect(body.metrics.popularBands[0].band_name).toBe("Alpha Band");
+    expect(body.metrics.popularBands[0].schedule_count).toBe(3);
+    expect(body.metrics.popularBands[1].band_name).toBe("Beta Band");
+    expect(body.metrics.popularBands[1].schedule_count).toBe(1);
 
     // totalScheduleBuilds: 4 rows inserted
-    expect(body.metrics.totalScheduleBuilds).toBe(4)
+    expect(body.metrics.totalScheduleBuilds).toBe(4);
     // uniqueVisitors: 3 distinct sessions
-    expect(body.metrics.uniqueVisitors).toBe(3)
-  })
-})
+    expect(body.metrics.uniqueVisitors).toBe(3);
+  });
+});

--- a/functions/api/admin/events/__tests__/reveal-mode.test.js
+++ b/functions/api/admin/events/__tests__/reveal-mode.test.js
@@ -1,102 +1,102 @@
-import { describe, it, expect } from 'vitest'
-import { createTestEnv, insertEvent } from '../../../test-utils'
-import { onRequestPost } from '../[id]/reveal-mode.js'
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertEvent } from "../../../test-utils";
+import { onRequestPost } from "../[id]/reveal-mode.js";
 
-describe('POST /api/admin/events/:id/reveal-mode', () => {
-  it('enables reveal mode on an event', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal' })
+describe("POST /api/admin/events/:id/reveal-mode", () => {
+  it("enables reveal mode on an event", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-reveal" });
 
     const res = await onRequestPost({
       request: new Request(`https://example.test/api/admin/events/${ev.id}/reveal-mode`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...headers },
         body: JSON.stringify({ reveal_mode: true }),
       }),
       env,
       params: { id: String(ev.id) },
-      data: { user: { role: 'editor', id: 2, userId: 2 } },
-    })
+      data: { user: { role: "editor", id: 2, userId: 2 } },
+    });
 
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.event.reveal_mode).toBe(1)
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.event.reveal_mode).toBe(1);
 
-    const row = rawDb.prepare('SELECT reveal_mode FROM events WHERE id=?').get(ev.id)
-    expect(row.reveal_mode).toBe(1)
-  })
+    const row = rawDb.prepare("SELECT reveal_mode FROM events WHERE id=?").get(ev.id);
+    expect(row.reveal_mode).toBe(1);
+  });
 
-  it('disables reveal mode on an event', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal-off' })
-    rawDb.prepare('UPDATE events SET reveal_mode=1 WHERE id=?').run(ev.id)
+  it("disables reveal mode on an event", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-reveal-off" });
+    rawDb.prepare("UPDATE events SET reveal_mode=1 WHERE id=?").run(ev.id);
 
     const res = await onRequestPost({
       request: new Request(`https://example.test/api/admin/events/${ev.id}/reveal-mode`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...headers },
         body: JSON.stringify({ reveal_mode: false }),
       }),
       env,
       params: { id: String(ev.id) },
-      data: { user: { role: 'editor', id: 2, userId: 2 } },
-    })
+      data: { user: { role: "editor", id: 2, userId: 2 } },
+    });
 
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.event.reveal_mode).toBe(0)
-  })
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.event.reveal_mode).toBe(0);
+  });
 
-  it('returns 400 when reveal_mode is missing from body', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal-bad' })
+  it("returns 400 when reveal_mode is missing from body", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-reveal-bad" });
 
     const res = await onRequestPost({
       request: new Request(`https://example.test/api/admin/events/${ev.id}/reveal-mode`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...headers },
         body: JSON.stringify({ other: true }),
       }),
       env,
       params: { id: String(ev.id) },
-      data: { user: { role: 'editor', id: 2, userId: 2 } },
-    })
+      data: { user: { role: "editor", id: 2, userId: 2 } },
+    });
 
-    expect(res.status).toBe(400)
-  })
+    expect(res.status).toBe(400);
+  });
 
-  it('returns 404 for a non-existent event', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' })
+  it("returns 404 for a non-existent event", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
     const res = await onRequestPost({
-      request: new Request('https://example.test/api/admin/events/99999/reveal-mode', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
+      request: new Request("https://example.test/api/admin/events/99999/reveal-mode", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...headers },
         body: JSON.stringify({ reveal_mode: true }),
       }),
       env,
-      params: { id: '99999' },
-      data: { user: { role: 'editor', id: 2, userId: 2 } },
-    })
+      params: { id: "99999" },
+      data: { user: { role: "editor", id: 2, userId: 2 } },
+    });
 
-    expect(res.status).toBe(404)
-  })
+    expect(res.status).toBe(404);
+  });
 
-  it('requires at least editor role', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'viewer' })
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-reveal-auth' })
+  it("requires at least editor role", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "viewer" });
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-reveal-auth" });
 
     const res = await onRequestPost({
       request: new Request(`https://example.test/api/admin/events/${ev.id}/reveal-mode`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...headers },
         body: JSON.stringify({ reveal_mode: true }),
       }),
       env,
       params: { id: String(ev.id) },
-      data: { user: { role: 'viewer', id: 3, userId: 3 } },
-    })
+      data: { user: { role: "viewer", id: 3, userId: 3 } },
+    });
 
-    expect(res.status).toBe(403)
-  })
-})
+    expect(res.status).toBe(403);
+  });
+});

--- a/functions/api/admin/events/__tests__/test-utils.js
+++ b/functions/api/admin/events/__tests__/test-utils.js
@@ -74,9 +74,7 @@ export function createTestDB() {
   `);
 
   // Insert fixture users
-  const insertUser = db.prepare(
-    "INSERT INTO users (email, role) VALUES (?, ?)",
-  );
+  const insertUser = db.prepare("INSERT INTO users (email, role) VALUES (?, ?)");
   insertUser.run("admin@test", "admin");
   insertUser.run("editor@test", "editor");
   insertUser.run("viewer@test", "viewer");
@@ -92,44 +90,23 @@ export const mockUsers = {
 
 export function insertEvent(
   db,
-  {
-    name = "Test Event",
-    slug = "test-event",
-    date = "2025-12-15",
-    status = "draft",
-    created_by = 1,
-  } = {},
+  { name = "Test Event", slug = "test-event", date = "2025-12-15", status = "draft", created_by = 1 } = {},
 ) {
-  const stmt = db.prepare(
-    "INSERT INTO events (name, slug, date, status, created_by_user_id) VALUES (?, ?, ?, ?, ?)",
-  );
+  const stmt = db.prepare("INSERT INTO events (name, slug, date, status, created_by_user_id) VALUES (?, ?, ?, ?, ?)");
   const info = stmt.run(name, slug, date, status, created_by);
-  return db
-    .prepare("SELECT * FROM events WHERE id = ?")
-    .get(info.lastInsertRowid);
+  return db.prepare("SELECT * FROM events WHERE id = ?").get(info.lastInsertRowid);
 }
 
 export function insertBand(
   db,
-  {
-    name = "Test Band",
-    event_id = null,
-    venue_id = null,
-    start_time = "20:00",
-    end_time = "21:00",
-  } = {},
+  { name = "Test Band", event_id = null, venue_id = null, start_time = "20:00", end_time = "21:00" } = {},
 ) {
   const nameNormalized = normalizeBandName(name);
-  const existingProfile = db
-    .prepare("SELECT id FROM band_profiles WHERE name_normalized = ?")
-    .get(nameNormalized);
+  const existingProfile = db.prepare("SELECT id FROM band_profiles WHERE name_normalized = ?").get(nameNormalized);
   const profileId = existingProfile
     ? existingProfile.id
-    : db
-        .prepare(
-          "INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)",
-        )
-        .run(name, nameNormalized).lastInsertRowid;
+    : db.prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)").run(name, nameNormalized)
+        .lastInsertRowid;
 
   const info = db
     .prepare(
@@ -137,22 +114,13 @@ export function insertBand(
     )
     .run(event_id, venue_id, profileId, start_time, end_time);
 
-  return db
-    .prepare("SELECT * FROM performances WHERE id = ?")
-    .get(info.lastInsertRowid);
+  return db.prepare("SELECT * FROM performances WHERE id = ?").get(info.lastInsertRowid);
 }
 
-export function insertVenue(
-  db,
-  { name = "Test Venue", city = "Portland", address = null } = {},
-) {
-  const stmt = db.prepare(
-    "INSERT INTO venues (name, city, address) VALUES (?, ?, ?)",
-  );
+export function insertVenue(db, { name = "Test Venue", city = "Portland", address = null } = {}) {
+  const stmt = db.prepare("INSERT INTO venues (name, city, address) VALUES (?, ?, ?)");
   const info = stmt.run(name, city, address);
-  return db
-    .prepare("SELECT * FROM venues WHERE id = ?")
-    .get(info.lastInsertRowid);
+  return db.prepare("SELECT * FROM venues WHERE id = ?").get(info.lastInsertRowid);
 }
 
 /**

--- a/functions/api/admin/events/__tests__/wizard.test.js
+++ b/functions/api/admin/events/__tests__/wizard.test.js
@@ -9,10 +9,10 @@ vi.mock("../../_middleware.js", () => ({
     if (role !== "admin") {
       return {
         error: true,
-        response: new Response(
-          JSON.stringify({ error: "Forbidden", message: "Admin required" }),
-          { status: 403, headers: { "Content-Type": "application/json" } },
-        ),
+        response: new Response(JSON.stringify({ error: "Forbidden", message: "Admin required" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
       };
     }
     return { error: false, user: { userId: 1, role: "admin" } };
@@ -40,9 +40,7 @@ function futureDate() {
 const basePayload = () => ({
   event: { name: "Test Fest", date: futureDate(), slug: "test-fest" },
   venues: [{ name: "The Venue", address: "123 Main St" }],
-  bands: [
-    { name: "Band One", venueIndex: 0, startTime: "20:00", endTime: "21:00" },
-  ],
+  bands: [{ name: "Band One", venueIndex: 0, startTime: "20:00", endTime: "21:00" }],
 });
 
 let rawDb;
@@ -130,9 +128,7 @@ describe("POST /api/admin/events/wizard - venue validation", () => {
     const data = await res.json();
 
     // The performance should reference the pre-existing venue, not a new one
-    const perf = rawDb
-      .prepare("SELECT * FROM performances WHERE event_id = ?")
-      .get(data.event.id);
+    const perf = rawDb.prepare("SELECT * FROM performances WHERE event_id = ?").get(data.event.id);
     expect(perf.venue_id).toBe(existingId);
   });
 });
@@ -228,15 +224,11 @@ describe("POST /api/admin/events/wizard - successful creation", () => {
     expect(data.success).toBe(true);
     expect(data.event.slug).toBe("test-fest");
 
-    const perf = rawDb
-      .prepare("SELECT * FROM performances WHERE event_id = ?")
-      .get(data.event.id);
+    const perf = rawDb.prepare("SELECT * FROM performances WHERE event_id = ?").get(data.event.id);
     expect(perf).toBeTruthy();
     expect(perf.start_time).toBe("20:00");
 
-    const profile = rawDb
-      .prepare("SELECT * FROM band_profiles WHERE id = ?")
-      .get(perf.band_profile_id);
+    const profile = rawDb.prepare("SELECT * FROM band_profiles WHERE id = ?").get(perf.band_profile_id);
     expect(profile.name).toBe("Band One");
   });
 
@@ -248,9 +240,7 @@ describe("POST /api/admin/events/wizard - successful creation", () => {
     });
     expect(res.status).toBe(201);
     const data = await res.json();
-    const perfs = rawDb
-      .prepare("SELECT * FROM performances WHERE event_id = ?")
-      .all(data.event.id);
+    const perfs = rawDb.prepare("SELECT * FROM performances WHERE event_id = ?").all(data.event.id);
     expect(perfs.length).toBe(0);
   });
 });
@@ -275,9 +265,7 @@ describe("POST /api/admin/events/wizard - error cleanup", () => {
     expect(res.status).toBe(500);
 
     // The compensating DELETE should have removed the orphan event row.
-    const orphan = rawDb
-      .prepare("SELECT id FROM events WHERE slug = ?")
-      .get("test-fest");
+    const orphan = rawDb.prepare("SELECT id FROM events WHERE slug = ?").get("test-fest");
     expect(orphan).toBeUndefined();
   });
 });

--- a/functions/api/admin/events/wizard.js
+++ b/functions/api/admin/events/wizard.js
@@ -18,10 +18,7 @@ import {
   FIELD_LIMITS,
 } from "../../../utils/validation.js";
 import { getClientIP } from "../../../utils/request.js";
-import {
-  buildIntervals,
-  intervalsOverlap,
-} from "../../../utils/timeConflicts.js";
+import { buildIntervals, intervalsOverlap } from "../../../utils/timeConflicts.js";
 import { normalizeBandName } from "../../../utils/bandName.js";
 
 // Detect scheduling conflicts within the submitted band list (all for a new event).
@@ -36,9 +33,7 @@ function findConflict(bands) {
       for (let j = i + 1; j < group.length; j++) {
         const aIntervals = buildIntervals(group[i].startTime, group[i].endTime);
         const bIntervals = buildIntervals(group[j].startTime, group[j].endTime);
-        const hasOverlap = aIntervals.some((a) =>
-          bIntervals.some((b) => intervalsOverlap(a, b)),
-        );
+        const hasOverlap = aIntervals.some((a) => bIntervals.some((b) => intervalsOverlap(a, b)));
         if (hasOverlap) {
           return `"${group[i].name}" and "${group[j].name}" have overlapping times at the same venue`;
         }
@@ -68,11 +63,7 @@ export async function onRequestPost(context) {
     });
   }
 
-  const {
-    event: eventInput = {},
-    venues: venuesInput = [],
-    bands: bandsInput = [],
-  } = body;
+  const { event: eventInput = {}, venues: venuesInput = [], bands: bandsInput = [] } = body;
 
   // --- Validate event ---
   const eventValidation = validateEntity(eventInput, VALIDATION_SCHEMAS.event);
@@ -92,82 +83,63 @@ export async function onRequestPost(context) {
   yesterday.setUTCDate(yesterday.getUTCDate() - 1);
   const cutoffStr = yesterday.toISOString().slice(0, 10);
   if (date < cutoffStr) {
-    return validationErrorResponse(
-      "Draft events created via the wizard cannot have a past date",
-    );
+    return validationErrorResponse("Draft events created via the wizard cannot have a past date");
   }
 
   // --- Validate venues ---
   if (!Array.isArray(venuesInput) || venuesInput.length > 50) {
-    return new Response(
-      JSON.stringify({ error: "venues must be an array of up to 50 items" }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ error: "venues must be an array of up to 50 items" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   }
   let sanitizedVenues;
   try {
     sanitizedVenues = venuesInput.map((v, i) => {
       const venueName = sanitizeString(String(v?.name || ""));
       if (!venueName || venueName.length > FIELD_LIMITS.venueName.max) {
-        throw new Error(
-          `Venue ${i + 1}: name is required (max ${FIELD_LIMITS.venueName.max} chars)`,
-        );
+        throw new Error(`Venue ${i + 1}: name is required (max ${FIELD_LIMITS.venueName.max} chars)`);
       }
       return {
         name: venueName,
-        address:
-          sanitizeString(String(v?.address || "")).slice(
-            0,
-            FIELD_LIMITS.venueAddress.max,
-          ) || null,
+        address: sanitizeString(String(v?.address || "")).slice(0, FIELD_LIMITS.venueAddress.max) || null,
       };
     });
   } catch (err) {
-    return new Response(
-      JSON.stringify({ error: "Invalid request", message: err.message }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ error: "Invalid request", message: err.message }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   // --- Validate bands ---
   if (!Array.isArray(bandsInput) || bandsInput.length > 200) {
-    return new Response(
-      JSON.stringify({ error: "bands must be an array of up to 200 items" }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ error: "bands must be an array of up to 200 items" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   }
   let sanitizedBands;
   try {
     sanitizedBands = bandsInput.map((b, i) => {
       const bandName = sanitizeString(String(b?.name || ""));
       if (!bandName || bandName.length > FIELD_LIMITS.bandName.max) {
-        throw new Error(
-          `Band ${i + 1}: name is required (max ${FIELD_LIMITS.bandName.max} chars)`,
-        );
+        throw new Error(`Band ${i + 1}: name is required (max ${FIELD_LIMITS.bandName.max} chars)`);
       }
       const venueIndex = Number(b?.venueIndex);
-      if (
-        !Number.isInteger(venueIndex) ||
-        venueIndex < 0 ||
-        venueIndex >= sanitizedVenues.length
-      ) {
-        throw new Error(
-          `Band ${i + 1}: venueIndex ${venueIndex} is out of range`,
-        );
+      if (!Number.isInteger(venueIndex) || venueIndex < 0 || venueIndex >= sanitizedVenues.length) {
+        throw new Error(`Band ${i + 1}: venueIndex ${venueIndex} is out of range`);
       }
       if (!b?.startTime || !b?.endTime) {
         throw new Error(`Band ${i + 1}: start and end time are required`);
       }
       const startCheck = isValidTime(b.startTime);
-      if (!startCheck.valid)
-        throw new Error(`Band ${i + 1}: ${startCheck.error}`);
+      if (!startCheck.valid) throw new Error(`Band ${i + 1}: ${startCheck.error}`);
       const endCheck = isValidTime(b.endTime);
       if (!endCheck.valid) throw new Error(`Band ${i + 1}: ${endCheck.error}`);
       if (b.startTime && b.endTime) {
         if (b.startTime === b.endTime) {
-          throw new Error(
-            `Band ${i + 1}: start and end time cannot be the same`,
-          );
+          throw new Error(`Band ${i + 1}: start and end time cannot be the same`);
         }
         const [sh, sm] = b.startTime.split(":").map(Number);
         const [eh, em] = b.endTime.split(":").map(Number);
@@ -179,11 +151,7 @@ export async function onRequestPost(context) {
       }
       let url = null;
       try {
-        url = sanitizeOptionalHttpUrl(
-          b?.url,
-          FIELD_LIMITS.bandUrl.max,
-          "Website URL",
-        );
+        url = sanitizeOptionalHttpUrl(b?.url, FIELD_LIMITS.bandUrl.max, "Website URL");
       } catch {
         throw new Error(`Band ${i + 1}: invalid URL`);
       }
@@ -196,32 +164,30 @@ export async function onRequestPost(context) {
       };
     });
   } catch (err) {
-    return new Response(
-      JSON.stringify({ error: "Invalid request", message: err.message }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ error: "Invalid request", message: err.message }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   // Detect time conflicts before touching the DB (new event = no pre-existing performances).
   const conflict = findConflict(sanitizedBands);
   if (conflict) {
-    return new Response(
-      JSON.stringify({ error: `Schedule conflict: ${conflict}` }),
-      { status: 409, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ error: `Schedule conflict: ${conflict}` }), {
+      status: 409,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   let event = null;
   try {
     // --- Check for duplicate slug ---
-    const existing = await DB.prepare("SELECT id FROM events WHERE slug = ?")
-      .bind(slug)
-      .first();
+    const existing = await DB.prepare("SELECT id FROM events WHERE slug = ?").bind(slug).first();
     if (existing) {
-      return new Response(
-        JSON.stringify({ error: "An event with this slug already exists" }),
-        { status: 409, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "An event with this slug already exists" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // --- Create event ---
@@ -236,14 +202,8 @@ export async function onRequestPost(context) {
     // --- Find or create venues (reuses existing venue if name already taken) ---
     const venueIds = [];
     for (const v of sanitizedVenues) {
-      await DB.prepare(
-        `INSERT OR IGNORE INTO venues (name, address) VALUES (?, ?)`,
-      )
-        .bind(v.name, v.address)
-        .run();
-      const venue = await DB.prepare(`SELECT id FROM venues WHERE name = ?`)
-        .bind(v.name)
-        .first();
+      await DB.prepare(`INSERT OR IGNORE INTO venues (name, address) VALUES (?, ?)`).bind(v.name, v.address).run();
+      const venue = await DB.prepare(`SELECT id FROM venues WHERE name = ?`).bind(v.name).first();
       venueIds.push(venue.id);
     }
 
@@ -253,15 +213,11 @@ export async function onRequestPost(context) {
       const profileIds = [];
       for (const band of sanitizedBands) {
         const normalized = normalizeBandName(band.name);
-        let profile = await DB.prepare(
-          "SELECT id FROM band_profiles WHERE name_normalized = ?",
-        )
+        let profile = await DB.prepare("SELECT id FROM band_profiles WHERE name_normalized = ?")
           .bind(normalized)
           .first();
         if (!profile) {
-          const socialLinksJson = band.url
-            ? JSON.stringify({ website: band.url })
-            : null;
+          const socialLinksJson = band.url ? JSON.stringify({ website: band.url }) : null;
           profile = await DB.prepare(
             `INSERT INTO band_profiles (name, name_normalized, is_active, social_links)
              VALUES (?, ?, 1, ?)
@@ -279,13 +235,7 @@ export async function onRequestPost(context) {
           DB.prepare(
             `INSERT INTO performances (event_id, venue_id, band_profile_id, start_time, end_time)
              VALUES (?, ?, ?, ?, ?)`,
-          ).bind(
-            event.id,
-            venueIds[band.venueIndex],
-            profileIds[i],
-            band.startTime,
-            band.endTime,
-          ),
+          ).bind(event.id, venueIds[band.venueIndex], profileIds[i], band.startTime, band.endTime),
         ),
       );
     }
@@ -316,9 +266,7 @@ export async function onRequestPost(context) {
     // so we don't leave an empty draft behind.
     if (event?.id) {
       try {
-        await DB.prepare("DELETE FROM events WHERE id = ?")
-          .bind(event.id)
-          .run();
+        await DB.prepare("DELETE FROM events WHERE id = ?").bind(event.id).run();
       } catch (e) {
         console.error("Wizard cleanup failed:", e);
       }

--- a/functions/api/admin/flush-announce-digest.js
+++ b/functions/api/admin/flush-announce-digest.js
@@ -28,10 +28,7 @@ export async function onRequestPost(context) {
   if (perm.error) return perm.response;
 
   if (!isEmailConfigured(env)) {
-    return json(
-      { error: "Email not configured", message: "Configure an email provider before flushing." },
-      400,
-    );
+    return json({ error: "Email not configured", message: "Configure an email provider before flushing." }, 400);
   }
 
   const { sent, failed, skipped } = await flushAnnounceDigest(env, DB);

--- a/functions/api/admin/invite-codes.js
+++ b/functions/api/admin/invite-codes.js
@@ -3,14 +3,9 @@
 // GET /api/admin/invite-codes - List invite codes (admin only)
 // DELETE /api/admin/invite-codes/[code] - Revoke invite code (admin only)
 
-import { checkPermission, auditLog } from './_middleware.js';
-import {
-  isValidEmail,
-  isValidRole,
-  validationErrorResponse,
-  FIELD_LIMITS,
-} from '../../utils/validation.js';
-import { getClientIP } from '../../utils/request.js';
+import { checkPermission, auditLog } from "./_middleware.js";
+import { isValidEmail, isValidRole, validationErrorResponse, FIELD_LIMITS } from "../../utils/validation.js";
+import { getClientIP } from "../../utils/request.js";
 
 // GET - List all invite codes
 export async function onRequestGet(context) {
@@ -18,7 +13,7 @@ export async function onRequestGet(context) {
   const { DB } = env;
 
   // RBAC: Require admin role
-  const permCheck = await checkPermission(context, 'admin');
+  const permCheck = await checkPermission(context, "admin");
   if (permCheck.error) {
     return permCheck.response;
   }
@@ -36,7 +31,7 @@ export async function onRequestGet(context) {
       LEFT JOIN users creator ON ic.created_by_user_id = creator.id
       LEFT JOIN users used_by ON ic.used_by_user_id = used_by.id
       ORDER BY ic.created_at DESC
-    `
+    `,
     ).all();
 
     return new Response(
@@ -45,21 +40,21 @@ export async function onRequestGet(context) {
       }),
       {
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   } catch (error) {
-    console.error('Error fetching invite codes:', error);
+    console.error("Error fetching invite codes:", error);
 
     return new Response(
       JSON.stringify({
-        error: 'Database error',
-        message: 'Failed to fetch invite codes',
+        error: "Database error",
+        message: "Failed to fetch invite codes",
       }),
       {
         status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   }
 }
@@ -70,7 +65,7 @@ export async function onRequestPost(context) {
   const { DB } = env;
 
   // RBAC: Require admin role
-  const permCheck = await checkPermission(context, 'admin');
+  const permCheck = await checkPermission(context, "admin");
   if (permCheck.error) {
     return permCheck.response;
   }
@@ -80,49 +75,39 @@ export async function onRequestPost(context) {
 
   try {
     const body = await request.json().catch(() => ({}));
-    const { email = null, role = 'editor', expiresInDays = 7 } = body;
+    const { email = null, role = "editor", expiresInDays = 7 } = body;
 
     // Validation using centralized utilities
     if (!isValidRole(role)) {
-      return validationErrorResponse('Role must be admin, editor, or viewer');
+      return validationErrorResponse("Role must be admin, editor, or viewer");
     }
 
-    if (
-      typeof expiresInDays !== 'number' ||
-      expiresInDays < 1 ||
-      expiresInDays > 365
-    ) {
-      return validationErrorResponse('Expiry must be between 1 and 365 days');
+    if (typeof expiresInDays !== "number" || expiresInDays < 1 || expiresInDays > 365) {
+      return validationErrorResponse("Expiry must be between 1 and 365 days");
     }
 
     if (email) {
       // Validate email format and length
       if (!isValidEmail(email)) {
-        return validationErrorResponse('Invalid email format');
+        return validationErrorResponse("Invalid email format");
       }
       if (email.length > FIELD_LIMITS.email.max) {
-        return validationErrorResponse(
-          `Email must be no more than ${FIELD_LIMITS.email.max} characters`
-        );
+        return validationErrorResponse(`Email must be no more than ${FIELD_LIMITS.email.max} characters`);
       }
 
       // Check if email already registered
-      const existingUser = await DB.prepare(
-        `SELECT id FROM users WHERE email = ?`
-      )
-        .bind(email)
-        .first();
+      const existingUser = await DB.prepare(`SELECT id FROM users WHERE email = ?`).bind(email).first();
 
       if (existingUser) {
         return new Response(
           JSON.stringify({
-            error: 'Email already registered',
-            message: 'A user with this email already exists',
+            error: "Email already registered",
+            message: "A user with this email already exists",
           }),
           {
             status: 409,
-            headers: { 'Content-Type': 'application/json' },
-          }
+            headers: { "Content-Type": "application/json" },
+          },
         );
       }
     }
@@ -131,9 +116,10 @@ export async function onRequestPost(context) {
     const inviteCode = crypto.randomUUID();
 
     // Calculate expiration
-    const expiresAt = new Date(
-      Date.now() + expiresInDays * 24 * 60 * 60 * 1000
-    ).toISOString().replace("T", " ").slice(0, 19);
+    const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .replace("T", " ")
+      .slice(0, 19);
 
     // Insert invite code
     const result = await DB.prepare(
@@ -141,7 +127,7 @@ export async function onRequestPost(context) {
       INSERT INTO invite_codes (code, email, role, created_by_user_id, expires_at)
       VALUES (?, ?, ?, ?, ?)
       RETURNING *
-    `
+    `,
     )
       .bind(inviteCode, email, role, user.userId, expiresAt)
       .first();
@@ -150,15 +136,15 @@ export async function onRequestPost(context) {
     await auditLog(
       env,
       user.userId,
-      'invite_code.created',
-      'invite_code',
+      "invite_code.created",
+      "invite_code",
       result.id,
       {
         role,
         expiresInDays,
-        inviteMode: email ? 'email_restricted' : 'open',
+        inviteMode: email ? "email_restricted" : "open",
       },
-      ipAddress
+      ipAddress,
     );
 
     return new Response(
@@ -168,21 +154,21 @@ export async function onRequestPost(context) {
       }),
       {
         status: 201,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   } catch (error) {
-    console.error('Error creating invite code:', error);
+    console.error("Error creating invite code:", error);
 
     return new Response(
       JSON.stringify({
-        error: 'Server error',
-        message: 'Failed to create invite code',
+        error: "Server error",
+        message: "Failed to create invite code",
       }),
       {
         status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   }
 }

--- a/functions/api/admin/invite-codes/[code].js
+++ b/functions/api/admin/invite-codes/[code].js
@@ -1,8 +1,8 @@
 // Admin invite code management
 // DELETE /api/admin/invite-codes/[code] - Revoke invite code
 
-import { checkPermission, auditLog } from '../_middleware.js';
-import { getClientIP } from '../../../utils/request.js';
+import { checkPermission, auditLog } from "../_middleware.js";
+import { getClientIP } from "../../../utils/request.js";
 
 // DELETE - Revoke invite code
 export async function onRequestDelete(context) {
@@ -11,7 +11,7 @@ export async function onRequestDelete(context) {
   const { code } = params;
 
   // RBAC: Require admin role
-  const permCheck = await checkPermission(context, 'admin');
+  const permCheck = await checkPermission(context, "admin");
   if (permCheck.error) {
     return permCheck.response;
   }
@@ -21,64 +21,60 @@ export async function onRequestDelete(context) {
 
   try {
     // Check if invite exists
-    const invite = await DB.prepare(`SELECT * FROM invite_codes WHERE code = ?`)
-      .bind(code)
-      .first();
+    const invite = await DB.prepare(`SELECT * FROM invite_codes WHERE code = ?`).bind(code).first();
 
     if (!invite) {
       return new Response(
         JSON.stringify({
-          error: 'Not found',
-          message: 'Invite code not found',
+          error: "Not found",
+          message: "Invite code not found",
         }),
         {
           status: 404,
-          headers: { 'Content-Type': 'application/json' },
-        }
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
 
     // Deactivate invite code
-    await DB.prepare(`UPDATE invite_codes SET is_active = 0 WHERE code = ?`)
-      .bind(code)
-      .run();
+    await DB.prepare(`UPDATE invite_codes SET is_active = 0 WHERE code = ?`).bind(code).run();
 
     // Audit log
     await auditLog(
       env,
       user.userId,
-      'invite_code.revoked',
-      'invite_code',
+      "invite_code.revoked",
+      "invite_code",
       invite.id,
       {
         wasUsed: invite.used_by_user_id !== null,
-        inviteMode: invite.email ? 'email_restricted' : 'open',
+        inviteMode: invite.email ? "email_restricted" : "open",
       },
-      ipAddress
+      ipAddress,
     );
 
     return new Response(
       JSON.stringify({
         success: true,
-        message: 'Invite code revoked',
+        message: "Invite code revoked",
       }),
       {
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   } catch (error) {
-    console.error('Error revoking invite code:', error);
+    console.error("Error revoking invite code:", error);
 
     return new Response(
       JSON.stringify({
-        error: 'Server error',
-        message: 'Failed to revoke invite code',
+        error: "Server error",
+        message: "Failed to revoke invite code",
       }),
       {
         status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   }
 }

--- a/functions/api/admin/invite-codes/__tests__/invite-codes.test.js
+++ b/functions/api/admin/invite-codes/__tests__/invite-codes.test.js
@@ -1,20 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { createTestEnv } from '../../../test-utils';
-import * as inviteCodesHandler from '../../invite-codes.js';
-import * as inviteCodeHandler from '../../invite-codes/[code].js';
+import { describe, it, expect } from "vitest";
+import { createTestEnv } from "../../../test-utils";
+import * as inviteCodesHandler from "../../invite-codes.js";
+import * as inviteCodeHandler from "../../invite-codes/[code].js";
 
-describe('Admin invite codes API', () => {
-  it('creates an invite code and lists it', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' });
+describe("Admin invite codes API", () => {
+  it("creates an invite code and lists it", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
 
-    const createReq = new Request(
-      'https://example.test/api/admin/invite-codes',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
-        body: JSON.stringify({ role: 'editor', expiresInDays: 3 }),
-      }
-    );
+    const createReq = new Request("https://example.test/api/admin/invite-codes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ role: "editor", expiresInDays: 3 }),
+    });
 
     const createRes = await inviteCodesHandler.onRequestPost({
       request: createReq,
@@ -22,9 +19,9 @@ describe('Admin invite codes API', () => {
     });
     expect(createRes.status).toBe(201);
     const created = await createRes.json();
-    expect(created.inviteCode).toHaveProperty('code');
+    expect(created.inviteCode).toHaveProperty("code");
 
-    const listReq = new Request('https://example.test/api/admin/invite-codes', {
+    const listReq = new Request("https://example.test/api/admin/invite-codes", {
       headers,
     });
     const listRes = await inviteCodesHandler.onRequestGet({
@@ -35,43 +32,32 @@ describe('Admin invite codes API', () => {
     const list = await listRes.json();
     expect(list.inviteCodes.length).toBeGreaterThan(0);
 
-    const found = list.inviteCodes.find(
-      (code) => code.code === created.inviteCode.code
-    );
+    const found = list.inviteCodes.find((code) => code.code === created.inviteCode.code);
     expect(found).toBeDefined();
 
-    const dbInvite = rawDb
-      .prepare('SELECT * FROM invite_codes WHERE code = ?')
-      .get(created.inviteCode.code);
+    const dbInvite = rawDb.prepare("SELECT * FROM invite_codes WHERE code = ?").get(created.inviteCode.code);
     expect(dbInvite).toBeTruthy();
 
-    const audit = rawDb
-      .prepare(
-        "SELECT * FROM audit_log WHERE action = 'invite_code.created' ORDER BY id DESC"
-      )
-      .get();
+    const audit = rawDb.prepare("SELECT * FROM audit_log WHERE action = 'invite_code.created' ORDER BY id DESC").get();
     expect(audit).toBeTruthy();
     const details = JSON.parse(audit.details);
     expect(details).toMatchObject({
-      role: 'editor',
+      role: "editor",
       expiresInDays: 3,
-      inviteMode: 'open',
+      inviteMode: "open",
     });
-    expect(details).not.toHaveProperty('code');
-    expect(details).not.toHaveProperty('email');
+    expect(details).not.toHaveProperty("code");
+    expect(details).not.toHaveProperty("email");
   });
 
-  it('rejects invalid role', async () => {
-    const { env, headers } = createTestEnv({ role: 'admin' });
+  it("rejects invalid role", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
 
-    const createReq = new Request(
-      'https://example.test/api/admin/invite-codes',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
-        body: JSON.stringify({ role: 'superuser' }),
-      }
-    );
+    const createReq = new Request("https://example.test/api/admin/invite-codes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ role: "superuser" }),
+    });
 
     const res = await inviteCodesHandler.onRequestPost({
       request: createReq,
@@ -80,22 +66,17 @@ describe('Admin invite codes API', () => {
     expect(res.status).toBe(400);
   });
 
-  it('rejects invite for existing user email', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' });
+  it("rejects invite for existing user email", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
 
-    const existingEmail = 'existing-user@example.com';
-    rawDb
-      .prepare('INSERT INTO users (email, role) VALUES (?, ?)')
-      .run(existingEmail, 'viewer');
+    const existingEmail = "existing-user@example.com";
+    rawDb.prepare("INSERT INTO users (email, role) VALUES (?, ?)").run(existingEmail, "viewer");
 
-    const createReq = new Request(
-      'https://example.test/api/admin/invite-codes',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
-        body: JSON.stringify({ email: existingEmail }),
-      }
-    );
+    const createReq = new Request("https://example.test/api/admin/invite-codes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ email: existingEmail }),
+    });
 
     const res = await inviteCodesHandler.onRequestPost({
       request: createReq,
@@ -104,20 +85,15 @@ describe('Admin invite codes API', () => {
     expect(res.status).toBe(409);
   });
 
-  it('revokes an invite code', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' });
+  it("revokes an invite code", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
 
-    const code = 'test-revoke-code';
+    const code = "test-revoke-code";
     rawDb
-      .prepare(
-        'INSERT INTO invite_codes (code, role, created_by_user_id, expires_at) VALUES (?, ?, ?, ?)'
-      )
-      .run(code, 'editor', 1, new Date(Date.now() + 86400000).toISOString());
+      .prepare("INSERT INTO invite_codes (code, role, created_by_user_id, expires_at) VALUES (?, ?, ?, ?)")
+      .run(code, "editor", 1, new Date(Date.now() + 86400000).toISOString());
 
-    const deleteReq = new Request(
-      `https://example.test/api/admin/invite-codes/${code}`,
-      { method: 'DELETE', headers }
-    );
+    const deleteReq = new Request(`https://example.test/api/admin/invite-codes/${code}`, { method: "DELETE", headers });
     const deleteRes = await inviteCodeHandler.onRequestDelete({
       request: deleteReq,
       env,
@@ -125,33 +101,27 @@ describe('Admin invite codes API', () => {
     });
     expect(deleteRes.status).toBe(200);
 
-    const updated = rawDb
-      .prepare('SELECT is_active FROM invite_codes WHERE code = ?')
-      .get(code);
+    const updated = rawDb.prepare("SELECT is_active FROM invite_codes WHERE code = ?").get(code);
     expect(updated.is_active).toBe(0);
 
-    const audit = rawDb
-      .prepare(
-        "SELECT * FROM audit_log WHERE action = 'invite_code.revoked' ORDER BY id DESC"
-      )
-      .get();
+    const audit = rawDb.prepare("SELECT * FROM audit_log WHERE action = 'invite_code.revoked' ORDER BY id DESC").get();
     expect(audit).toBeTruthy();
     const details = JSON.parse(audit.details);
-    expect(details).toMatchObject({ wasUsed: false, inviteMode: 'open' });
-    expect(details).not.toHaveProperty('code');
+    expect(details).toMatchObject({ wasUsed: false, inviteMode: "open" });
+    expect(details).not.toHaveProperty("code");
   });
 
-  it('returns 404 when invite code does not exist', async () => {
-    const { env, headers } = createTestEnv({ role: 'admin' });
+  it("returns 404 when invite code does not exist", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
 
-    const deleteReq = new Request(
-      'https://example.test/api/admin/invite-codes/does-not-exist',
-      { method: 'DELETE', headers }
-    );
+    const deleteReq = new Request("https://example.test/api/admin/invite-codes/does-not-exist", {
+      method: "DELETE",
+      headers,
+    });
     const deleteRes = await inviteCodeHandler.onRequestDelete({
       request: deleteReq,
       env,
-      params: { code: 'does-not-exist' },
+      params: { code: "does-not-exist" },
     });
     expect(deleteRes.status).toBe(404);
   });

--- a/functions/api/admin/maintenance/__tests__/cleanup-sessions.test.js
+++ b/functions/api/admin/maintenance/__tests__/cleanup-sessions.test.js
@@ -1,131 +1,123 @@
-import { describe, expect, test } from 'vitest';
-import { createTestEnv } from '../../../test-utils.js';
-import { onRequestPost } from '../cleanup-sessions.js';
+import { describe, expect, test } from "vitest";
+import { createTestEnv } from "../../../test-utils.js";
+import { onRequestPost } from "../cleanup-sessions.js";
 
-describe('POST /api/admin/maintenance/cleanup-sessions', () => {
-  test('admin can run retention cleanup across all tables', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' });
+describe("POST /api/admin/maintenance/cleanup-sessions", () => {
+  test("admin can run retention cleanup across all tables", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
     const expiredAt = Math.floor(Date.now() / 1000) - 60;
     const activeAt = Math.floor(Date.now() / 1000) + 60 * 60;
 
     // Expired session
     rawDb
-      .prepare(
-        'INSERT INTO lucia_sessions (id, user_id, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)'
-      )
-      .run('expired-token', 1, expiredAt, '127.0.0.1', 'test-agent');
+      .prepare("INSERT INTO lucia_sessions (id, user_id, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)")
+      .run("expired-token", 1, expiredAt, "127.0.0.1", "test-agent");
 
     // Active session — should survive
     rawDb
-      .prepare(
-        'INSERT INTO lucia_sessions (id, user_id, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)'
-      )
-      .run('active-token', 1, activeAt, '127.0.0.1', 'test-agent');
+      .prepare("INSERT INTO lucia_sessions (id, user_id, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)")
+      .run("active-token", 1, activeAt, "127.0.0.1", "test-agent");
 
     // Old auth_audit row (>90 days)
     rawDb
       .prepare(
-        "INSERT INTO auth_audit (timestamp, action, success, ip_address) VALUES (datetime('now', '-91 days'), 'login_attempt', 0, '1.2.3.4')"
+        "INSERT INTO auth_audit (timestamp, action, success, ip_address) VALUES (datetime('now', '-91 days'), 'login_attempt', 0, '1.2.3.4')",
       )
       .run();
 
     // Recent auth_audit row — should survive
     rawDb
       .prepare(
-        "INSERT INTO auth_audit (timestamp, action, success, ip_address) VALUES (datetime('now', '-1 day'), 'login_attempt', 1, '1.2.3.4')"
+        "INSERT INTO auth_audit (timestamp, action, success, ip_address) VALUES (datetime('now', '-1 day'), 'login_attempt', 1, '1.2.3.4')",
       )
       .run();
 
     // Old audit_log row (>1 year)
     rawDb
       .prepare(
-        "INSERT INTO audit_log (user_id, action, created_at) VALUES (1, 'event.updated', datetime('now', '-366 days'))"
+        "INSERT INTO audit_log (user_id, action, created_at) VALUES (1, 'event.updated', datetime('now', '-366 days'))",
       )
       .run();
 
     // Recent audit_log row — should survive
     rawDb
       .prepare(
-        "INSERT INTO audit_log (user_id, action, created_at) VALUES (1, 'event.updated', datetime('now', '-1 day'))"
+        "INSERT INTO audit_log (user_id, action, created_at) VALUES (1, 'event.updated', datetime('now', '-1 day'))",
       )
       .run();
 
     // Used MFA challenge — should be deleted
     rawDb
       .prepare(
-        "INSERT INTO mfa_challenges (token, user_id, ip_address, user_agent, expires_at, used, used_at) VALUES (?, ?, ?, ?, datetime('now', '+1 day'), 1, datetime('now', '-1 minute'))"
+        "INSERT INTO mfa_challenges (token, user_id, ip_address, user_agent, expires_at, used, used_at) VALUES (?, ?, ?, ?, datetime('now', '+1 day'), 1, datetime('now', '-1 minute'))",
       )
-      .run('used-mfa-token', 1, '1.2.3.4', 'test-agent');
+      .run("used-mfa-token", 1, "1.2.3.4", "test-agent");
 
     // Active MFA challenge — should survive
     rawDb
       .prepare(
-        "INSERT INTO mfa_challenges (token, user_id, ip_address, user_agent, expires_at, used) VALUES (?, ?, ?, ?, datetime('now', '+1 day'), 0)"
+        "INSERT INTO mfa_challenges (token, user_id, ip_address, user_agent, expires_at, used) VALUES (?, ?, ?, ?, datetime('now', '+1 day'), 0)",
       )
-      .run('active-mfa-token', 1, '1.2.3.4', 'test-agent');
+      .run("active-mfa-token", 1, "1.2.3.4", "test-agent");
 
     // Expired email OTP — should be deleted
     rawDb
       .prepare(
-        "INSERT INTO email_otp_codes (user_id, code, expires_at, used) VALUES (?, ?, datetime('now', '-1 minute'), 0)"
+        "INSERT INTO email_otp_codes (user_id, code, expires_at, used) VALUES (?, ?, datetime('now', '-1 minute'), 0)",
       )
-      .run(1, '123456');
+      .run(1, "123456");
 
     // Active email OTP — should survive
     rawDb
       .prepare(
-        "INSERT INTO email_otp_codes (user_id, code, expires_at, used) VALUES (?, ?, datetime('now', '+10 minutes'), 0)"
+        "INSERT INTO email_otp_codes (user_id, code, expires_at, used) VALUES (?, ?, datetime('now', '+10 minutes'), 0)",
       )
-      .run(1, '654321');
+      .run(1, "654321");
 
     // Used password reset token — should be deleted
     rawDb
       .prepare(
-        "INSERT INTO password_reset_tokens (user_id, token, created_by, expires_at, used, used_at, ip_address) VALUES (?, ?, ?, datetime('now', '+1 day'), 1, datetime('now', '-1 minute'), ?)"
+        "INSERT INTO password_reset_tokens (user_id, token, created_by, expires_at, used, used_at, ip_address) VALUES (?, ?, ?, datetime('now', '+1 day'), 1, datetime('now', '-1 minute'), ?)",
       )
-      .run(1, 'used-reset-token', 1, '1.2.3.4');
+      .run(1, "used-reset-token", 1, "1.2.3.4");
 
     // Active password reset token — should survive
     rawDb
       .prepare(
-        "INSERT INTO password_reset_tokens (user_id, token, created_by, expires_at, used, ip_address) VALUES (?, ?, ?, datetime('now', '+1 day'), 0, ?)"
+        "INSERT INTO password_reset_tokens (user_id, token, created_by, expires_at, used, ip_address) VALUES (?, ?, ?, datetime('now', '+1 day'), 0, ?)",
       )
-      .run(1, 'active-reset-token', 1, '1.2.3.4');
+      .run(1, "active-reset-token", 1, "1.2.3.4");
 
     // Expired trusted device — should be deleted
     rawDb
       .prepare(
-        "INSERT INTO trusted_devices (user_id, token, device_fingerprint, ip_address, user_agent, expires_at, last_used_at) VALUES (?, ?, 'fp-expired', '1.2.3.4', 'Mozilla/5.0', datetime('now', '-1 day'), datetime('now', '-2 days'))"
+        "INSERT INTO trusted_devices (user_id, token, device_fingerprint, ip_address, user_agent, expires_at, last_used_at) VALUES (?, ?, 'fp-expired', '1.2.3.4', 'Mozilla/5.0', datetime('now', '-1 day'), datetime('now', '-2 days'))",
       )
-      .run(1, 'expired-device-token');
+      .run(1, "expired-device-token");
 
     // Active trusted device — should survive
     rawDb
       .prepare(
-        "INSERT INTO trusted_devices (user_id, token, device_fingerprint, ip_address, user_agent, expires_at, last_used_at) VALUES (?, ?, 'fp-active', '1.2.3.4', 'Mozilla/5.0', datetime('now', '+30 days'), datetime('now'))"
+        "INSERT INTO trusted_devices (user_id, token, device_fingerprint, ip_address, user_agent, expires_at, last_used_at) VALUES (?, ?, 'fp-active', '1.2.3.4', 'Mozilla/5.0', datetime('now', '+30 days'), datetime('now'))",
       )
-      .run(1, 'active-device-token');
+      .run(1, "active-device-token");
 
     // Stale rate_limits row (updated >30 min ago)
     const staleUpdatedAt = Math.floor(Date.now() / 1000) - 2000;
     rawDb
-      .prepare(
-        'INSERT INTO rate_limits (key, count, window_start, updated_at) VALUES (?, 5, ?, ?)'
-      )
-      .run('1.2.3.4:/api/auth', staleUpdatedAt, staleUpdatedAt);
+      .prepare("INSERT INTO rate_limits (key, count, window_start, updated_at) VALUES (?, 5, ?, ?)")
+      .run("1.2.3.4:/api/auth", staleUpdatedAt, staleUpdatedAt);
 
     // Recent rate_limits row — should survive
     const recentUpdatedAt = Math.floor(Date.now() / 1000) - 60;
     rawDb
-      .prepare(
-        'INSERT INTO rate_limits (key, count, window_start, updated_at) VALUES (?, 1, ?, ?)'
-      )
-      .run('5.6.7.8:/api/auth', recentUpdatedAt, recentUpdatedAt);
+      .prepare("INSERT INTO rate_limits (key, count, window_start, updated_at) VALUES (?, 1, ?, ?)")
+      .run("5.6.7.8:/api/auth", recentUpdatedAt, recentUpdatedAt);
 
-    const request = new Request(
-      'https://example.test/api/admin/maintenance/cleanup-sessions',
-      { method: 'POST', headers }
-    );
+    const request = new Request("https://example.test/api/admin/maintenance/cleanup-sessions", {
+      method: "POST",
+      headers,
+    });
 
     const response = await onRequestPost({ request, env });
     expect(response.status).toBe(200);
@@ -142,73 +134,35 @@ describe('POST /api/admin/maintenance/cleanup-sessions', () => {
     expect(payload.rate_limits_deleted).toBe(1);
 
     // Active rows must survive
+    expect(rawDb.prepare("SELECT COUNT(*) as c FROM lucia_sessions WHERE id = ?").get("active-token").c).toBe(1);
+    expect(rawDb.prepare("SELECT COUNT(*) as c FROM lucia_sessions WHERE id = ?").get("expired-token").c).toBe(0);
+    expect(rawDb.prepare("SELECT COUNT(*) as c FROM mfa_challenges WHERE token = ?").get("active-mfa-token").c).toBe(1);
+    expect(rawDb.prepare("SELECT COUNT(*) as c FROM mfa_challenges WHERE token = ?").get("used-mfa-token").c).toBe(0);
+    expect(rawDb.prepare("SELECT COUNT(*) as c FROM email_otp_codes WHERE code = ?").get("654321").c).toBe(1);
+    expect(rawDb.prepare("SELECT COUNT(*) as c FROM email_otp_codes WHERE code = ?").get("123456").c).toBe(0);
     expect(
-      rawDb
-        .prepare('SELECT COUNT(*) as c FROM lucia_sessions WHERE id = ?')
-        .get('active-token').c
+      rawDb.prepare("SELECT COUNT(*) as c FROM password_reset_tokens WHERE token = ?").get("active-reset-token").c,
     ).toBe(1);
     expect(
-      rawDb
-        .prepare('SELECT COUNT(*) as c FROM lucia_sessions WHERE id = ?')
-        .get('expired-token').c
+      rawDb.prepare("SELECT COUNT(*) as c FROM password_reset_tokens WHERE token = ?").get("used-reset-token").c,
     ).toBe(0);
     expect(
-      rawDb
-        .prepare('SELECT COUNT(*) as c FROM mfa_challenges WHERE token = ?')
-        .get('active-mfa-token').c
+      rawDb.prepare("SELECT COUNT(*) as c FROM trusted_devices WHERE token = ?").get("active-device-token").c,
     ).toBe(1);
     expect(
-      rawDb
-        .prepare('SELECT COUNT(*) as c FROM mfa_challenges WHERE token = ?')
-        .get('used-mfa-token').c
-    ).toBe(0);
-    expect(
-      rawDb
-        .prepare('SELECT COUNT(*) as c FROM email_otp_codes WHERE code = ?')
-        .get('654321').c
-    ).toBe(1);
-    expect(
-      rawDb
-        .prepare('SELECT COUNT(*) as c FROM email_otp_codes WHERE code = ?')
-        .get('123456').c
-    ).toBe(0);
-    expect(
-      rawDb
-        .prepare(
-          'SELECT COUNT(*) as c FROM password_reset_tokens WHERE token = ?'
-        )
-        .get('active-reset-token').c
-    ).toBe(1);
-    expect(
-      rawDb
-        .prepare(
-          'SELECT COUNT(*) as c FROM password_reset_tokens WHERE token = ?'
-        )
-        .get('used-reset-token').c
-    ).toBe(0);
-    expect(
-      rawDb
-        .prepare('SELECT COUNT(*) as c FROM trusted_devices WHERE token = ?')
-        .get('active-device-token').c
-    ).toBe(1);
-    expect(
-      rawDb
-        .prepare('SELECT COUNT(*) as c FROM trusted_devices WHERE token = ?')
-        .get('expired-device-token').c
+      rawDb.prepare("SELECT COUNT(*) as c FROM trusted_devices WHERE token = ?").get("expired-device-token").c,
     ).toBe(0);
 
-    const auditEntry = rawDb
-      .prepare('SELECT COUNT(*) as c FROM audit_log WHERE action = ?')
-      .get('maintenance.cleanup');
+    const auditEntry = rawDb.prepare("SELECT COUNT(*) as c FROM audit_log WHERE action = ?").get("maintenance.cleanup");
     expect(auditEntry.c).toBe(1);
   });
 
-  test('non-admin requests are forbidden', async () => {
-    const { env, headers } = createTestEnv({ role: 'viewer' });
-    const request = new Request(
-      'https://example.test/api/admin/maintenance/cleanup-sessions',
-      { method: 'POST', headers }
-    );
+  test("non-admin requests are forbidden", async () => {
+    const { env, headers } = createTestEnv({ role: "viewer" });
+    const request = new Request("https://example.test/api/admin/maintenance/cleanup-sessions", {
+      method: "POST",
+      headers,
+    });
 
     const response = await onRequestPost({ request, env });
     expect(response.status).toBe(403);

--- a/functions/api/admin/maintenance/cleanup-sessions.js
+++ b/functions/api/admin/maintenance/cleanup-sessions.js
@@ -1,4 +1,3 @@
-
 import { checkPermission, auditLog } from "../_middleware.js";
 import { getClientIP } from "../../../utils/request.js";
 import { runRetentionCleanup } from "./retention.js";
@@ -14,15 +13,7 @@ export async function onRequestPost(context) {
   try {
     const results = await runRetentionCleanup(env);
 
-    await auditLog(
-      env,
-      auth.user.userId,
-      "maintenance.cleanup",
-      "system",
-      null,
-      results,
-      getClientIP(request),
-    );
+    await auditLog(env, auth.user.userId, "maintenance.cleanup", "system", null, results, getClientIP(request));
 
     return new Response(
       JSON.stringify({
@@ -33,16 +24,13 @@ export async function onRequestPost(context) {
       {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   } catch (error) {
     console.error("Cleanup error:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to run cleanup" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      }
-    );
+    return new Response(JSON.stringify({ error: "Failed to run cleanup" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/admin/maintenance/retention.js
+++ b/functions/api/admin/maintenance/retention.js
@@ -29,33 +29,15 @@ export async function runRetentionCleanup(env) {
     adminAudit,
     rateLimits,
   ] = await Promise.all([
-    DB.prepare('DELETE FROM lucia_sessions WHERE expires_at < ?')
-      .bind(nowUnix)
-      .run(),
-    DB.prepare(
-      "DELETE FROM mfa_challenges WHERE used = 1 OR expires_at < datetime('now')"
-    ).run(),
-    DB.prepare(
-      "DELETE FROM email_otp_codes WHERE expires_at < datetime('now')"
-    ).run(),
-    DB.prepare(
-      "DELETE FROM password_reset_tokens WHERE used = 1 OR datetime(expires_at) < datetime('now')"
-    ).run(),
-    DB.prepare(
-      "DELETE FROM trusted_devices WHERE expires_at <= datetime('now')"
-    ).run(),
-    DB.prepare(
-      "DELETE FROM auth_attempts WHERE created_at < datetime('now', '-30 days')"
-    ).run(),
-    DB.prepare(
-      "DELETE FROM auth_audit WHERE timestamp < datetime('now', '-90 days')"
-    ).run(),
-    DB.prepare(
-      "DELETE FROM audit_log WHERE created_at < datetime('now', '-1 year')"
-    ).run(),
-    DB.prepare(
-      'DELETE FROM rate_limits WHERE updated_at < unixepoch() - 1800'
-    ).run(),
+    DB.prepare("DELETE FROM lucia_sessions WHERE expires_at < ?").bind(nowUnix).run(),
+    DB.prepare("DELETE FROM mfa_challenges WHERE used = 1 OR expires_at < datetime('now')").run(),
+    DB.prepare("DELETE FROM email_otp_codes WHERE expires_at < datetime('now')").run(),
+    DB.prepare("DELETE FROM password_reset_tokens WHERE used = 1 OR datetime(expires_at) < datetime('now')").run(),
+    DB.prepare("DELETE FROM trusted_devices WHERE expires_at <= datetime('now')").run(),
+    DB.prepare("DELETE FROM auth_attempts WHERE created_at < datetime('now', '-30 days')").run(),
+    DB.prepare("DELETE FROM auth_audit WHERE timestamp < datetime('now', '-90 days')").run(),
+    DB.prepare("DELETE FROM audit_log WHERE created_at < datetime('now', '-1 year')").run(),
+    DB.prepare("DELETE FROM rate_limits WHERE updated_at < unixepoch() - 1800").run(),
   ]);
 
   return {

--- a/functions/api/admin/me.js
+++ b/functions/api/admin/me.js
@@ -3,7 +3,7 @@ export async function onRequestGet(context) {
 
   // Middleware has already verified the session and populated data.user
   // If we're here, the user is authenticated
-  
+
   const safeSession = data?.session
     ? {
         expires_at: data.session.expires_at || null,
@@ -14,11 +14,11 @@ export async function onRequestGet(context) {
     JSON.stringify({
       user: data.user,
       session: safeSession,
-      authenticated: true
+      authenticated: true,
     }),
     {
       status: 200,
       headers: { "Content-Type": "application/json" },
-    }
+    },
   );
 }

--- a/functions/api/admin/mfa/__tests__/mfa-settings.test.js
+++ b/functions/api/admin/mfa/__tests__/mfa-settings.test.js
@@ -90,9 +90,7 @@ describe("admin mfa settings", () => {
     const enablePayload = await enableRes.json();
     expect(enablePayload.backupCodes?.length).toBeGreaterThan(0);
 
-    const user = rawDb
-      .prepare("SELECT totp_enabled, backup_codes FROM users WHERE id = 1")
-      .get();
+    const user = rawDb.prepare("SELECT totp_enabled, backup_codes FROM users WHERE id = 1").get();
     expect(user.totp_enabled).toBe(1);
     expect(user.backup_codes).toBeTruthy();
   });
@@ -149,9 +147,7 @@ describe("admin mfa settings", () => {
       .get(1, AUTH_ATTEMPT_TYPES.mfaDisable);
     expect(disableAttempt.success).toBe(1);
 
-    const user = rawDb
-      .prepare("SELECT totp_enabled, totp_secret FROM users WHERE id = 1")
-      .get();
+    const user = rawDb.prepare("SELECT totp_enabled, totp_secret FROM users WHERE id = 1").get();
     expect(user.totp_enabled).toBe(0);
     expect(user.totp_secret).toBeNull();
   });

--- a/functions/api/admin/mfa/backup-codes.js
+++ b/functions/api/admin/mfa/backup-codes.js
@@ -31,15 +31,11 @@ export async function onRequestPost(context) {
       {
         status: 400,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
-  const user = await DB.prepare(
-    "SELECT email, totp_secret, totp_enabled FROM users WHERE id = ?"
-  )
-    .bind(userId)
-    .first();
+  const user = await DB.prepare("SELECT email, totp_secret, totp_enabled FROM users WHERE id = ?").bind(userId).first();
 
   if (!user) {
     return new Response(
@@ -50,7 +46,7 @@ export async function onRequestPost(context) {
       {
         status: 404,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -63,7 +59,7 @@ export async function onRequestPost(context) {
       {
         status: 400,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -82,7 +78,7 @@ export async function onRequestPost(context) {
       {
         status: 429,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -99,7 +95,7 @@ export async function onRequestPost(context) {
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -123,24 +119,18 @@ export async function onRequestPost(context) {
       {
         status: 401,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
   const backupCodes = generateBackupCodes();
-  const hashedCodes = await Promise.all(
-    backupCodes.map(codeValue => hashBackupCode(codeValue))
-  );
+  const hashedCodes = await Promise.all(backupCodes.map((codeValue) => hashBackupCode(codeValue)));
 
-  await DB.prepare(
-    "UPDATE users SET backup_codes = ?, totp_secret = ? WHERE id = ?"
-  )
+  await DB.prepare("UPDATE users SET backup_codes = ?, totp_secret = ? WHERE id = ?")
     .bind(
       JSON.stringify(hashedCodes),
-      totpSecretState?.shouldPersist
-        ? totpSecretState.encryptedSecret
-        : user.totp_secret,
-      userId
+      totpSecretState?.shouldPersist ? totpSecretState.encryptedSecret : user.totp_secret,
+      userId,
     )
     .run();
 
@@ -153,15 +143,7 @@ export async function onRequestPost(context) {
     userId,
   });
 
-  await auditLog(
-    env,
-    userId,
-    "mfa.backup_codes.regenerated",
-    "user",
-    userId,
-    { email: user.email },
-    ipAddress
-  );
+  await auditLog(env, userId, "mfa.backup_codes.regenerated", "user", userId, { email: user.email }, ipAddress);
 
   return new Response(
     JSON.stringify({
@@ -171,6 +153,6 @@ export async function onRequestPost(context) {
     {
       status: 200,
       headers: { "Content-Type": "application/json" },
-    }
+    },
   );
 }

--- a/functions/api/admin/mfa/disable.js
+++ b/functions/api/admin/mfa/disable.js
@@ -43,13 +43,11 @@ export async function onRequestPost(context) {
       {
         status: 400,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
-  const user = await DB.prepare(
-    "SELECT email, totp_secret, totp_enabled, backup_codes FROM users WHERE id = ?"
-  )
+  const user = await DB.prepare("SELECT email, totp_secret, totp_enabled, backup_codes FROM users WHERE id = ?")
     .bind(userId)
     .first();
 
@@ -62,7 +60,7 @@ export async function onRequestPost(context) {
       {
         status: 404,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -75,7 +73,7 @@ export async function onRequestPost(context) {
       {
         status: 400,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -94,7 +92,7 @@ export async function onRequestPost(context) {
       {
         status: 429,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -129,7 +127,7 @@ export async function onRequestPost(context) {
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -152,14 +150,14 @@ export async function onRequestPost(context) {
       {
         status: 401,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
   await DB.prepare(
     `UPDATE users
      SET totp_enabled = 0, totp_secret = NULL, backup_codes = NULL
-     WHERE id = ?`
+     WHERE id = ?`,
   )
     .bind(userId)
     .run();
@@ -175,15 +173,7 @@ export async function onRequestPost(context) {
     userId,
   });
 
-  await auditLog(
-    env,
-    userId,
-    "mfa.disabled",
-    "user",
-    userId,
-    { email: user.email },
-    ipAddress
-  );
+  await auditLog(env, userId, "mfa.disabled", "user", userId, { email: user.email }, ipAddress);
 
   return new Response(
     JSON.stringify({
@@ -192,6 +182,6 @@ export async function onRequestPost(context) {
     {
       status: 200,
       headers: { "Content-Type": "application/json" },
-    }
+    },
   );
 }

--- a/functions/api/admin/mfa/enable.js
+++ b/functions/api/admin/mfa/enable.js
@@ -32,15 +32,11 @@ export async function onRequestPost(context) {
       {
         status: 400,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
-  const user = await DB.prepare(
-    "SELECT email, totp_secret, totp_enabled FROM users WHERE id = ?"
-  )
-    .bind(userId)
-    .first();
+  const user = await DB.prepare("SELECT email, totp_secret, totp_enabled FROM users WHERE id = ?").bind(userId).first();
 
   if (!user) {
     return new Response(
@@ -51,7 +47,7 @@ export async function onRequestPost(context) {
       {
         status: 404,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -64,7 +60,7 @@ export async function onRequestPost(context) {
       {
         status: 409,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -77,7 +73,7 @@ export async function onRequestPost(context) {
       {
         status: 400,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -96,7 +92,7 @@ export async function onRequestPost(context) {
       {
         status: 429,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -113,7 +109,7 @@ export async function onRequestPost(context) {
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -137,26 +133,22 @@ export async function onRequestPost(context) {
       {
         status: 401,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
   const backupCodes = generateBackupCodes();
-  const hashedCodes = await Promise.all(
-    backupCodes.map(codeValue => hashBackupCode(codeValue))
-  );
+  const hashedCodes = await Promise.all(backupCodes.map((codeValue) => hashBackupCode(codeValue)));
 
   await DB.prepare(
     `UPDATE users
      SET totp_enabled = 1, backup_codes = ?, totp_secret = ?
-     WHERE id = ?`
+     WHERE id = ?`,
   )
     .bind(
       JSON.stringify(hashedCodes),
-      totpSecretState?.shouldPersist
-        ? totpSecretState.encryptedSecret
-        : user.totp_secret,
-      userId
+      totpSecretState?.shouldPersist ? totpSecretState.encryptedSecret : user.totp_secret,
+      userId,
     )
     .run();
 
@@ -171,15 +163,7 @@ export async function onRequestPost(context) {
     userId,
   });
 
-  await auditLog(
-    env,
-    userId,
-    "mfa.enabled",
-    "user",
-    userId,
-    { email: user.email },
-    ipAddress
-  );
+  await auditLog(env, userId, "mfa.enabled", "user", userId, { email: user.email }, ipAddress);
 
   return new Response(
     JSON.stringify({
@@ -189,6 +173,6 @@ export async function onRequestPost(context) {
     {
       status: 200,
       headers: { "Content-Type": "application/json" },
-    }
+    },
   );
 }

--- a/functions/api/admin/mfa/setup.js
+++ b/functions/api/admin/mfa/setup.js
@@ -18,11 +18,7 @@ export async function onRequestPost(context) {
 
   const userId = auth.user.userId;
 
-  const user = await DB.prepare(
-    "SELECT email, totp_enabled FROM users WHERE id = ?"
-  )
-    .bind(userId)
-    .first();
+  const user = await DB.prepare("SELECT email, totp_enabled FROM users WHERE id = ?").bind(userId).first();
 
   if (!user) {
     return new Response(
@@ -33,7 +29,7 @@ export async function onRequestPost(context) {
       {
         status: 404,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -46,7 +42,7 @@ export async function onRequestPost(context) {
       {
         status: 409,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -70,27 +66,19 @@ export async function onRequestPost(context) {
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
   await DB.prepare(
     `UPDATE users
      SET totp_secret = ?, totp_enabled = 0, backup_codes = NULL
-     WHERE id = ?`
+     WHERE id = ?`,
   )
     .bind(encryptedSecret, userId)
     .run();
 
-  await auditLog(
-    env,
-    userId,
-    "mfa.setup",
-    "user",
-    userId,
-    { email: user.email },
-    ipAddress
-  );
+  await auditLog(env, userId, "mfa.setup", "user", userId, { email: user.email }, ipAddress);
 
   return new Response(
     JSON.stringify({
@@ -100,6 +88,6 @@ export async function onRequestPost(context) {
     {
       status: 200,
       headers: { "Content-Type": "application/json" },
-    }
+    },
   );
 }

--- a/functions/api/admin/mfa/status.js
+++ b/functions/api/admin/mfa/status.js
@@ -19,7 +19,7 @@ export async function onRequestGet(context) {
     SELECT totp_enabled, totp_secret, backup_codes
     FROM users
     WHERE id = ?
-  `
+  `,
   )
     .bind(userId)
     .first();
@@ -33,7 +33,7 @@ export async function onRequestGet(context) {
       {
         status: 404,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -50,6 +50,6 @@ export async function onRequestGet(context) {
     {
       status: 200,
       headers: { "Content-Type": "application/json" },
-    }
+    },
   );
 }

--- a/functions/api/admin/sessions.js
+++ b/functions/api/admin/sessions.js
@@ -8,10 +8,10 @@
 // being able to forge or replay the underlying credential.
 async function sessionRevocationToken(sessionId) {
   const data = new TextEncoder().encode(sessionId);
-  const hash = await crypto.subtle.digest('SHA-256', data);
+  const hash = await crypto.subtle.digest("SHA-256", data);
   return Array.from(new Uint8Array(hash))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 export async function onRequestGet(context) {
@@ -32,7 +32,7 @@ export async function onRequestGet(context) {
       FROM lucia_sessions
       WHERE user_id = ?
       ORDER BY last_activity_at DESC
-    `
+    `,
     )
       .bind(user.userId)
       .all();
@@ -44,24 +44,22 @@ export async function onRequestGet(context) {
         user_agent: row.user_agent,
         created_at: row.created_at,
         last_activity_at: row.last_activity_at,
-        expires_at: row.expires_at
-          ? new Date(row.expires_at * 1000).toISOString()
-          : null,
+        expires_at: row.expires_at ? new Date(row.expires_at * 1000).toISOString() : null,
         current: currentSessionId ? row.id === currentSessionId : false,
-      }))
+      })),
     );
 
     return new Response(
       JSON.stringify({
         sessions,
       }),
-      { headers: { 'Content-Type': 'application/json' } }
+      { headers: { "Content-Type": "application/json" } },
     );
   } catch (error) {
-    console.error('Failed to load sessions:', error);
-    return new Response(JSON.stringify({ error: 'Failed to load sessions' }), {
+    console.error("Failed to load sessions:", error);
+    return new Response(JSON.stringify({ error: "Failed to load sessions" }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 }
@@ -75,50 +73,40 @@ export async function onRequestDelete(context) {
     const revocationToken = body.revocationToken;
 
     if (!revocationToken) {
-      return new Response(
-        JSON.stringify({ error: 'Revocation token is required' }),
-        {
-          status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
+      return new Response(JSON.stringify({ error: "Revocation token is required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Resolve the opaque token back to a real session id. Compute all hashes
     // in parallel first so no extra round-trips are needed per session.
-    const { results: userSessions } = await env.DB.prepare(
-      'SELECT id FROM lucia_sessions WHERE user_id = ?'
-    )
+    const { results: userSessions } = await env.DB.prepare("SELECT id FROM lucia_sessions WHERE user_id = ?")
       .bind(user.userId)
       .all();
 
     const tokenMap = new Map(
-      await Promise.all(
-        (userSessions || []).map(async (s) => [
-          await sessionRevocationToken(s.id),
-          s.id,
-        ])
-      )
+      await Promise.all((userSessions || []).map(async (s) => [await sessionRevocationToken(s.id), s.id])),
     );
     const targetSessionId = tokenMap.get(revocationToken) ?? null;
 
     if (!targetSessionId) {
-      return new Response(JSON.stringify({ error: 'Session not found' }), {
+      return new Response(JSON.stringify({ error: "Session not found" }), {
         status: 404,
-        headers: { 'Content-Type': 'application/json' },
+        headers: { "Content-Type": "application/json" },
       });
     }
 
     await lucia.invalidateSession(targetSessionId);
 
     return new Response(JSON.stringify({ success: true }), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   } catch (error) {
-    console.error('Failed to delete session:', error);
-    return new Response(JSON.stringify({ error: 'Failed to delete session' }), {
+    console.error("Failed to delete session:", error);
+    return new Response(JSON.stringify({ error: "Failed to delete session" }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 }

--- a/functions/api/admin/sessions/revoke-all.js
+++ b/functions/api/admin/sessions/revoke-all.js
@@ -14,14 +14,9 @@ export async function onRequestPost(context) {
   await env.DB.prepare(
     `UPDATE lucia_sessions
      SET ip_address = ?, user_agent = ?, remember_me = ?
-     WHERE id = ?`
+     WHERE id = ?`,
   )
-    .bind(
-      request.headers.get("CF-Connecting-IP"),
-      request.headers.get("User-Agent"),
-      0,
-      newSession.id
-    )
+    .bind(request.headers.get("CF-Connecting-IP"), request.headers.get("User-Agent"), 0, newSession.id)
     .run();
 
   const csrfToken = generateCSRFToken(request, env, newSession.id);
@@ -35,6 +30,6 @@ export async function onRequestPost(context) {
       success: true,
       message: "All other sessions revoked",
     }),
-    { headers }
+    { headers },
   );
 }

--- a/functions/api/admin/trusted-devices.js
+++ b/functions/api/admin/trusted-devices.js
@@ -19,21 +19,20 @@ export async function onRequestGet(context) {
       FROM trusted_devices
       WHERE user_id = ? AND expires_at > datetime('now')
       ORDER BY last_used_at DESC, created_at DESC
-    `
+    `,
     )
       .bind(user.userId)
       .all();
 
-    return new Response(
-      JSON.stringify({ devices: result.results || [] }),
-      { headers: { "Content-Type": "application/json" } }
-    );
+    return new Response(JSON.stringify({ devices: result.results || [] }), {
+      headers: { "Content-Type": "application/json" },
+    });
   } catch (error) {
     console.error("Failed to load trusted devices:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to load trusted devices" }),
-      { status: 500, headers: { "Content-Type": "application/json" } }
-    );
+    return new Response(JSON.stringify({ error: "Failed to load trusted devices" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }
 
@@ -61,9 +60,7 @@ export async function onRequestDelete(context) {
 
   try {
     // Verify the device belongs to the requesting user before deleting
-    const device = await env.DB.prepare(
-      "SELECT user_id FROM trusted_devices WHERE id = ?"
-    )
+    const device = await env.DB.prepare("SELECT user_id FROM trusted_devices WHERE id = ?")
       .bind(Number(deviceId))
       .first();
 
@@ -83,9 +80,9 @@ export async function onRequestDelete(context) {
     });
   } catch (error) {
     console.error("Failed to revoke trusted device:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to revoke device" }),
-      { status: 500, headers: { "Content-Type": "application/json" } }
-    );
+    return new Response(JSON.stringify({ error: "Failed to revoke device" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/admin/users.js
+++ b/functions/api/admin/users.js
@@ -2,16 +2,12 @@
 // GET /api/admin/users - List all users
 // POST /api/admin/users - Create new user
 
-import { checkPermission, auditLog } from './_middleware.js';
-import {
-  validateEntity,
-  VALIDATION_SCHEMAS,
-  validationErrorResponse,
-} from '../../utils/validation.js';
-import { getClientIP } from '../../utils/request.js';
-import { sendEmail, isEmailConfigured } from '../../utils/email.js';
-import { buildInviteEmail } from '../../utils/emailTemplates.js';
-import { getPublicBaseUrl } from '../../utils/publicUrl.js';
+import { checkPermission, auditLog } from "./_middleware.js";
+import { validateEntity, VALIDATION_SCHEMAS, validationErrorResponse } from "../../utils/validation.js";
+import { getClientIP } from "../../utils/request.js";
+import { sendEmail, isEmailConfigured } from "../../utils/email.js";
+import { buildInviteEmail } from "../../utils/emailTemplates.js";
+import { getPublicBaseUrl } from "../../utils/publicUrl.js";
 
 // GET - List all users (admin only)
 export async function onRequestGet(context) {
@@ -20,7 +16,7 @@ export async function onRequestGet(context) {
 
   try {
     // Check permission (admin only)
-    const permCheck = await checkPermission(context, 'admin');
+    const permCheck = await checkPermission(context, "admin");
     if (permCheck.error) {
       return permCheck.response;
     }
@@ -41,7 +37,7 @@ export async function onRequestGet(context) {
         updated_at
       FROM users
       ORDER BY created_at DESC
-    `
+    `,
     ).all();
 
     return new Response(
@@ -50,23 +46,20 @@ export async function onRequestGet(context) {
           ...u,
           firstName: u.first_name || null,
           lastName: u.last_name || null,
-          name:
-            u.name ||
-            [u.first_name, u.last_name].filter(Boolean).join(' ') ||
-            null,
+          name: u.name || [u.first_name, u.last_name].filter(Boolean).join(" ") || null,
           isActive: u.is_active === 1, // Convert to camelCase boolean
         })),
       }),
       {
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   } catch (error) {
-    console.error('Get users error:', error);
-    return new Response(JSON.stringify({ error: 'Failed to fetch users' }), {
+    console.error("Get users error:", error);
+    return new Response(JSON.stringify({ error: "Failed to fetch users" }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 }
@@ -79,7 +72,7 @@ export async function onRequestPost(context) {
 
   try {
     // Check permission (admin only)
-    const permCheck = await checkPermission(context, 'admin');
+    const permCheck = await checkPermission(context, "admin");
     if (permCheck.error) {
       return permCheck.response;
     }
@@ -97,13 +90,13 @@ export async function onRequestPost(context) {
     }
 
     const { email, role, firstName, lastName } = validation.sanitized;
-    const fullName = [firstName, lastName].filter(Boolean).join(' ').trim();
+    const fullName = [firstName, lastName].filter(Boolean).join(" ").trim();
 
     // Check if email already exists
     const existingUser = await DB.prepare(
       `
       SELECT id FROM users WHERE email = ?
-    `
+    `,
     )
       .bind(email)
       .first();
@@ -111,21 +104,22 @@ export async function onRequestPost(context) {
     if (existingUser) {
       return new Response(
         JSON.stringify({
-          error: 'Email exists',
-          message: 'A user with this email already exists',
+          error: "Email exists",
+          message: "A user with this email already exists",
         }),
         {
           status: 409,
-          headers: { 'Content-Type': 'application/json' },
-        }
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
 
     const inviteCode = crypto.randomUUID();
     const expiresInDays = 7;
-    const expiresAt = new Date(
-      Date.now() + expiresInDays * 24 * 60 * 60 * 1000
-    ).toISOString().replace("T", " ").slice(0, 19);
+    const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .replace("T", " ")
+      .slice(0, 19);
 
     // Create invite code
     const invite = await DB.prepare(
@@ -133,16 +127,16 @@ export async function onRequestPost(context) {
       INSERT INTO invite_codes (code, email, role, created_by_user_id, expires_at)
       VALUES (?, ?, ?, ?, ?)
       RETURNING *
-    `
+    `,
     )
       .bind(inviteCode, email, role, currentUser.userId, expiresAt)
       .first();
 
     const baseUrl = getPublicBaseUrl(env);
-    const inviteUrl = new URL('/admin/signup', baseUrl);
-    inviteUrl.searchParams.set('code', inviteCode);
+    const inviteUrl = new URL("/admin/signup", baseUrl);
+    inviteUrl.searchParams.set("code", inviteCode);
 
-    let emailResult = { delivered: false, reason: 'not_configured' };
+    let emailResult = { delivered: false, reason: "not_configured" };
     if (isEmailConfigured(env)) {
       const emailPayload = buildInviteEmail({
         inviteUrl: inviteUrl.toString(),
@@ -162,17 +156,17 @@ export async function onRequestPost(context) {
     await auditLog(
       env,
       currentUser.userId,
-      'user.invited',
-      'invite_code',
+      "user.invited",
+      "invite_code",
       invite?.id,
       {
         role,
         expiresAt,
         emailDelivered: emailResult.delivered,
-        inviteMode: email ? 'email_restricted' : 'open',
+        inviteMode: email ? "email_restricted" : "open",
         nameProvided: Boolean(fullName),
       },
-      ipAddress
+      ipAddress,
     );
 
     // Return invite details (only expose inviteUrl if email delivery failed)
@@ -186,13 +180,13 @@ export async function onRequestPost(context) {
     }
     return new Response(JSON.stringify(responseBody), {
       status: 201,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   } catch (error) {
-    console.error('Create user error:', error);
-    return new Response(JSON.stringify({ error: 'Failed to create user' }), {
+    console.error("Create user error:", error);
+    return new Response(JSON.stringify({ error: "Failed to create user" }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 }

--- a/functions/api/admin/users/[id].js
+++ b/functions/api/admin/users/[id].js
@@ -11,10 +11,10 @@ export async function onRequestPatch(context) {
   const { DB } = env;
   const userId = Number(params.id);
   if (!Number.isInteger(userId) || userId < 1) {
-    return new Response(
-      JSON.stringify({ error: "Invalid ID", code: "INVALID_ID" }),
-      { status: 400, headers: { "Content-Type": "application/json" } }
-    );
+    return new Response(JSON.stringify({ error: "Invalid ID", code: "INVALID_ID" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   }
   const ipAddress = getClientIP(request);
 
@@ -31,9 +31,7 @@ export async function onRequestPatch(context) {
     const body = await request.json().catch(() => ({}));
     const { role, name, firstName, lastName, isActive } = body;
     const allowedFields = new Set(["role", "name", "firstName", "lastName", "isActive"]);
-    const unknownFields = Object.keys(body || {}).filter(
-      key => !allowedFields.has(key),
-    );
+    const unknownFields = Object.keys(body || {}).filter((key) => !allowedFields.has(key));
     if (unknownFields.length) {
       return new Response(
         JSON.stringify({
@@ -102,8 +100,7 @@ export async function onRequestPatch(context) {
           return new Response(
             JSON.stringify({
               error: "Cannot modify last admin",
-              message:
-                "Cannot remove admin role from the last active admin user",
+              message: "Cannot remove admin role from the last active admin user",
             }),
             {
               status: 400,
@@ -118,10 +115,8 @@ export async function onRequestPatch(context) {
     }
 
     if (firstName !== undefined || lastName !== undefined) {
-      const nextFirstName =
-        firstName !== undefined ? String(firstName).trim() : user.first_name || "";
-      const nextLastName =
-        lastName !== undefined ? String(lastName).trim() : user.last_name || "";
+      const nextFirstName = firstName !== undefined ? String(firstName).trim() : user.first_name || "";
+      const nextLastName = lastName !== undefined ? String(lastName).trim() : user.last_name || "";
 
       if (!nextFirstName) {
         return new Response(
@@ -265,10 +260,7 @@ export async function onRequestPatch(context) {
     return new Response(
       JSON.stringify({
         ...updatedUser,
-        name:
-          updatedUser.name ||
-          [updatedUser.first_name, updatedUser.last_name].filter(Boolean).join(" ") ||
-          null,
+        name: updatedUser.name || [updatedUser.first_name, updatedUser.last_name].filter(Boolean).join(" ") || null,
         firstName: updatedUser.first_name || null,
         lastName: updatedUser.last_name || null,
         isActive: updatedUser.is_active === 1,
@@ -293,10 +285,10 @@ export async function onRequestDelete(context) {
   const { DB } = env;
   const userId = Number(params.id);
   if (!Number.isInteger(userId) || userId < 1) {
-    return new Response(
-      JSON.stringify({ error: "Invalid ID", code: "INVALID_ID" }),
-      { status: 400, headers: { "Content-Type": "application/json" } }
-    );
+    return new Response(JSON.stringify({ error: "Invalid ID", code: "INVALID_ID" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   }
   const ipAddress = getClientIP(request);
 
@@ -378,35 +370,21 @@ export async function onRequestDelete(context) {
 
     const cleanupStmts = [
       // Delink from Events
-      DB.prepare(
-        "UPDATE events SET created_by_user_id = NULL WHERE created_by_user_id = ?",
-      ).bind(userId),
-      DB.prepare(
-        "UPDATE events SET updated_by_user_id = NULL WHERE updated_by_user_id = ?",
-      ).bind(userId),
+      DB.prepare("UPDATE events SET created_by_user_id = NULL WHERE created_by_user_id = ?").bind(userId),
+      DB.prepare("UPDATE events SET updated_by_user_id = NULL WHERE updated_by_user_id = ?").bind(userId),
 
       // Delink from Venues
-      DB.prepare(
-        "UPDATE venues SET created_by_user_id = NULL WHERE created_by_user_id = ?",
-      ).bind(userId),
-      DB.prepare(
-        "UPDATE venues SET updated_by_user_id = NULL WHERE updated_by_user_id = ?",
-      ).bind(userId),
+      DB.prepare("UPDATE venues SET created_by_user_id = NULL WHERE created_by_user_id = ?").bind(userId),
+      DB.prepare("UPDATE venues SET updated_by_user_id = NULL WHERE updated_by_user_id = ?").bind(userId),
 
       // Delink from Bands
-      DB.prepare(
-        "UPDATE band_profiles SET created_by_user_id = NULL WHERE created_by_user_id = ?",
-      ).bind(userId),
+      DB.prepare("UPDATE band_profiles SET created_by_user_id = NULL WHERE created_by_user_id = ?").bind(userId),
       // band_profiles doesn't have updated_by_user_id in v2 schema generally, but let's check schema to be safe
       // Schema says: updated_at TEXT NOT NULL DEFAULT (datetime('now')) - No updated_by_user_id column logic in schema provided
 
       // Delink from Performances
-      DB.prepare(
-        "UPDATE performances SET created_by_user_id = NULL WHERE created_by_user_id = ?",
-      ).bind(userId),
-      DB.prepare(
-        "UPDATE performances SET updated_by_user_id = NULL WHERE updated_by_user_id = ?",
-      ).bind(userId),
+      DB.prepare("UPDATE performances SET created_by_user_id = NULL WHERE created_by_user_id = ?").bind(userId),
+      DB.prepare("UPDATE performances SET updated_by_user_id = NULL WHERE updated_by_user_id = ?").bind(userId),
 
       // Delete the user - this will trigger ON DELETE CASCADE for sessions/tokens
       DB.prepare("DELETE FROM users WHERE id = ?").bind(userId),

--- a/functions/api/admin/users/[id]/reset-password.js
+++ b/functions/api/admin/users/[id]/reset-password.js
@@ -3,21 +3,21 @@
 // Body: { reason?: string }
 // Returns: { success: true, resetUrl: string } or error
 
-import { checkPermission, auditLog } from '../../_middleware.js';
-import { generatePasswordResetToken } from '../../../../utils/tokens.js';
-import { sanitizeString, validateId } from '../../../../utils/validation.js';
-import { getClientIP } from '../../../../utils/request.js';
-import { sendEmail, isEmailConfigured } from '../../../../utils/email.js';
-import { buildResetPasswordEmail } from '../../../../utils/emailTemplates.js';
-import { revokeAllTrustedDevices } from '../../../../utils/trustedDevice.js';
-import { getPublicBaseUrl } from '../../../../utils/publicUrl.js';
+import { checkPermission, auditLog } from "../../_middleware.js";
+import { generatePasswordResetToken } from "../../../../utils/tokens.js";
+import { sanitizeString, validateId } from "../../../../utils/validation.js";
+import { getClientIP } from "../../../../utils/request.js";
+import { sendEmail, isEmailConfigured } from "../../../../utils/email.js";
+import { buildResetPasswordEmail } from "../../../../utils/emailTemplates.js";
+import { revokeAllTrustedDevices } from "../../../../utils/trustedDevice.js";
+import { getPublicBaseUrl } from "../../../../utils/publicUrl.js";
 
 export async function onRequestPost(context) {
   const { request, env, params } = context;
   const { DB } = env;
 
   // RBAC: Require admin role
-  const permCheck = await checkPermission(context, 'admin');
+  const permCheck = await checkPermission(context, "admin");
   if (permCheck.error) {
     return permCheck.response;
   }
@@ -28,16 +28,14 @@ export async function onRequestPost(context) {
   try {
     const idValidation = validateId(params.id);
     if (!idValidation.valid) {
-      return new Response(JSON.stringify({ error: 'Bad request', message: idValidation.error }), {
+      return new Response(JSON.stringify({ error: "Bad request", message: idValidation.error }), {
         status: 400,
-        headers: { 'Content-Type': 'application/json' },
+        headers: { "Content-Type": "application/json" },
       });
     }
     const userId = idValidation.value;
     const { reason } = await request.json().catch(() => ({}));
-    const sanitizedReason = reason
-      ? sanitizeString(reason).slice(0, 500)
-      : null;
+    const sanitizedReason = reason ? sanitizeString(reason).slice(0, 500) : null;
 
     // Get target user
     const targetUser = await DB.prepare(
@@ -45,26 +43,23 @@ export async function onRequestPost(context) {
       SELECT id, email, name, is_active
       FROM users
       WHERE id = ?
-    `
+    `,
     )
       .bind(userId)
       .first();
 
     if (!targetUser) {
-      return new Response(JSON.stringify({ error: 'User not found' }), {
+      return new Response(JSON.stringify({ error: "User not found" }), {
         status: 404,
-        headers: { 'Content-Type': 'application/json' },
+        headers: { "Content-Type": "application/json" },
       });
     }
 
     if (targetUser.is_active === 0) {
-      return new Response(
-        JSON.stringify({ error: 'Cannot reset password for inactive user' }),
-        {
-          status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
+      return new Response(JSON.stringify({ error: "Cannot reset password for inactive user" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Generate reset token and persist it
@@ -73,16 +68,9 @@ export async function onRequestPost(context) {
       `
       INSERT INTO password_reset_tokens (user_id, token, created_by, expires_at, ip_address, reason)
       VALUES (?, ?, ?, ?, ?, ?)
-    `
+    `,
     )
-      .bind(
-        userId,
-        resetToken.token,
-        user.userId,
-        resetToken.expiresAt,
-        ipAddress,
-        sanitizedReason
-      )
+      .bind(userId, resetToken.token, user.userId, resetToken.expiresAt, ipAddress, sanitizedReason)
       .run();
 
     // Revoke existing sessions to force re-authentication
@@ -90,7 +78,7 @@ export async function onRequestPost(context) {
       `
       DELETE FROM lucia_sessions
       WHERE user_id = ?
-    `
+    `,
     )
       .bind(userId)
       .run();
@@ -103,17 +91,16 @@ export async function onRequestPost(context) {
     const resetUrl = `${baseUrl}/reset-password#token=${resetToken.token}`;
 
     if (!isEmailConfigured(env)) {
-      console.error('[ResetPassword] Email not configured');
+      console.error("[ResetPassword] Email not configured");
       return new Response(
         JSON.stringify({
-          error: 'Email not configured',
-          message:
-            'Email delivery is not configured. Unable to send reset email.',
+          error: "Email not configured",
+          message: "Email delivery is not configured. Unable to send reset email.",
         }),
         {
           status: 500,
-          headers: { 'Content-Type': 'application/json' },
-        }
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
     const emailPayload = buildResetPasswordEmail({
@@ -129,18 +116,17 @@ export async function onRequestPost(context) {
     });
 
     if (!emailResult.delivered) {
-      console.error('[ResetPassword] Email delivery failed:', emailResult);
+      console.error("[ResetPassword] Email delivery failed:", emailResult);
       return new Response(
         JSON.stringify({
-          error: 'Email delivery failed',
-          message:
-            'Unable to send reset email. Please try again or check email settings.',
-          details: emailResult.reason || 'unknown',
+          error: "Email delivery failed",
+          message: "Unable to send reset email. Please try again or check email settings.",
+          details: emailResult.reason || "unknown",
         }),
         {
           status: 502,
-          headers: { 'Content-Type': 'application/json' },
-        }
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
 
@@ -148,31 +134,31 @@ export async function onRequestPost(context) {
     await auditLog(
       env,
       user.userId,
-      'user.password_reset',
-      'user',
+      "user.password_reset",
+      "user",
       userId,
       {
         reason: sanitizedReason,
         resetTokenGenerated: true,
       },
-      ipAddress
+      ipAddress,
     );
 
     return new Response(
       JSON.stringify({
         success: true,
-        message: 'Password reset email sent.',
+        message: "Password reset email sent.",
       }),
       {
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     );
   } catch (error) {
-    console.error('Admin password reset error:', error);
-    return new Response(JSON.stringify({ error: 'Failed to reset password' }), {
+    console.error("Admin password reset error:", error);
+    return new Response(JSON.stringify({ error: "Failed to reset password" }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 }

--- a/functions/api/admin/users/[id]/toggle-status.js
+++ b/functions/api/admin/users/[id]/toggle-status.js
@@ -20,13 +20,12 @@ export async function onRequestPost(context) {
   const ipAddress = getClientIP(request);
 
   try {
-
     const idResult = validateId(params.id);
     if (!idResult.valid) {
-      return new Response(
-        JSON.stringify({ error: "Bad request", message: idResult.error }),
-        { status: 400, headers: { "Content-Type": "application/json" } }
-      );
+      return new Response(JSON.stringify({ error: "Bad request", message: idResult.error }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
     const userId = idResult.value;
 
@@ -50,13 +49,10 @@ export async function onRequestPost(context) {
 
     // Prevent admin from deactivating themselves
     if (targetUser.id === user.userId) {
-      return new Response(
-        JSON.stringify({ error: "Cannot deactivate your own account" }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      return new Response(JSON.stringify({ error: "Cannot deactivate your own account" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Toggle user status
@@ -110,12 +106,9 @@ export async function onRequestPost(context) {
     );
   } catch (error) {
     console.error("Toggle user status error:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to update user status" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return new Response(JSON.stringify({ error: "Failed to update user status" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/admin/users/__tests__/reset-password.test.js
+++ b/functions/api/admin/users/__tests__/reset-password.test.js
@@ -1,15 +1,15 @@
-import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
-import { createTestEnv } from '../../../test-utils.js';
-import * as resetHandler from '../[id]/reset-password.js';
+import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
+import { createTestEnv } from "../../../test-utils.js";
+import * as resetHandler from "../[id]/reset-password.js";
 
-describe('Admin user password reset API', () => {
+describe("Admin user password reset API", () => {
   beforeEach(() => {
     vi.stubGlobal(
-      'fetch',
+      "fetch",
       vi.fn(async () => ({
         ok: true,
-        text: async () => '',
-      }))
+        text: async () => "",
+      })),
     );
   });
 
@@ -17,124 +17,98 @@ describe('Admin user password reset API', () => {
     vi.restoreAllMocks();
   });
 
-  test('admin generates reset token and logs action', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' });
-    env.EMAIL_PROVIDER = 'mailchannels';
-    env.EMAIL_FROM = 'no-reply@settimes.ca';
+  test("admin generates reset token and logs action", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    env.EMAIL_PROVIDER = "mailchannels";
+    env.EMAIL_FROM = "no-reply@settimes.ca";
     rawDb
-      .prepare(
-        'INSERT INTO users (email, role, name, password_hash) VALUES (?, ?, ?, ?)'
-      )
-      .run('resetme@test.com', 'viewer', 'Reset Me', 'oldhash');
-    const user = rawDb
-      .prepare('SELECT * FROM users WHERE email = ?')
-      .get('resetme@test.com');
-    const request = new Request(
-      `https://example.test/api/admin/users/${user.id}/reset-password`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
-        body: JSON.stringify({ reason: 'User forgot password' }),
-      }
-    );
+      .prepare("INSERT INTO users (email, role, name, password_hash) VALUES (?, ?, ?, ?)")
+      .run("resetme@test.com", "viewer", "Reset Me", "oldhash");
+    const user = rawDb.prepare("SELECT * FROM users WHERE email = ?").get("resetme@test.com");
+    const request = new Request(`https://example.test/api/admin/users/${user.id}/reset-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ reason: "User forgot password" }),
+    });
     const response = await resetHandler.onRequestPost({
       request,
       env,
       params: { id: String(user.id) },
-      data: { user: { userId: 1, role: 'admin', email: 'admin@test' } },
+      data: { user: { userId: 1, role: "admin", email: "admin@test" } },
     });
     expect(response.status).toBe(200);
     const payload = await response.json();
     expect(payload.success).toBe(true);
-    expect(payload.message).toContain('Password reset email sent');
+    expect(payload.message).toContain("Password reset email sent");
     const resetToken = rawDb
-      .prepare(
-        'SELECT * FROM password_reset_tokens WHERE user_id = ? ORDER BY created_at DESC'
-      )
+      .prepare("SELECT * FROM password_reset_tokens WHERE user_id = ? ORDER BY created_at DESC")
       .get(user.id);
     expect(resetToken).toBeTruthy();
     const audit = rawDb
-      .prepare(
-        "SELECT * FROM audit_log WHERE action = 'user.password_reset' AND resource_id = ?"
-      )
+      .prepare("SELECT * FROM audit_log WHERE action = 'user.password_reset' AND resource_id = ?")
       .get(user.id);
     expect(audit).toBeTruthy();
     const details = JSON.parse(audit.details);
     expect(details).toMatchObject({
-      reason: 'User forgot password',
+      reason: "User forgot password",
       resetTokenGenerated: true,
     });
-    expect(details).not.toHaveProperty('adminEmail');
-    expect(details).not.toHaveProperty('targetEmail');
+    expect(details).not.toHaveProperty("adminEmail");
+    expect(details).not.toHaveProperty("targetEmail");
   });
 
-  test('non-admin cannot reset password', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' });
+  test("non-admin cannot reset password", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
     rawDb
-      .prepare('INSERT INTO users (email, role, name) VALUES (?, ?, ?)')
-      .run('noreset@test.com', 'viewer', 'No Reset');
-    const user = rawDb
-      .prepare('SELECT * FROM users WHERE email = ?')
-      .get('noreset@test.com');
-    const request = new Request(
-      `https://example.test/api/admin/users/${user.id}/reset-password`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
-        body: JSON.stringify({ reason: 'Not authorized' }),
-      }
-    );
+      .prepare("INSERT INTO users (email, role, name) VALUES (?, ?, ?)")
+      .run("noreset@test.com", "viewer", "No Reset");
+    const user = rawDb.prepare("SELECT * FROM users WHERE email = ?").get("noreset@test.com");
+    const request = new Request(`https://example.test/api/admin/users/${user.id}/reset-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ reason: "Not authorized" }),
+    });
     const response = await resetHandler.onRequestPost({
       request,
       env,
       params: { id: String(user.id) },
-      data: { user: { userId: 2, role: 'editor', email: 'editor@test' } },
+      data: { user: { userId: 2, role: "editor", email: "editor@test" } },
     });
     expect(response.status).toBe(403);
   });
 
-  test('rejects non-integer user id with 400', async () => {
-    const { env, headers } = createTestEnv({ role: 'admin' });
-    const request = new Request(
-      `https://example.test/api/admin/users/1;DROP TABLE users/reset-password`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
-        body: JSON.stringify({}),
-      }
-    );
+  test("rejects non-integer user id with 400", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
+    const request = new Request(`https://example.test/api/admin/users/1;DROP TABLE users/reset-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({}),
+    });
     const response = await resetHandler.onRequestPost({
       request,
       env,
-      params: { id: '1;DROP TABLE users' },
-      data: { user: { userId: 1, role: 'admin', email: 'admin@test' } },
+      params: { id: "1;DROP TABLE users" },
+      data: { user: { userId: 1, role: "admin", email: "admin@test" } },
     });
     expect(response.status).toBe(400);
   });
 
-  test('rejects reset for inactive user', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' });
+  test("rejects reset for inactive user", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
     rawDb
-      .prepare(
-        'INSERT INTO users (email, role, name, is_active) VALUES (?, ?, ?, ?)'
-      )
-      .run('inactive@test.com', 'viewer', 'Inactive', 0);
-    const user = rawDb
-      .prepare('SELECT * FROM users WHERE email = ?')
-      .get('inactive@test.com');
-    const request = new Request(
-      `https://example.test/api/admin/users/${user.id}/reset-password`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...headers },
-        body: JSON.stringify({ reason: 'Account inactive' }),
-      }
-    );
+      .prepare("INSERT INTO users (email, role, name, is_active) VALUES (?, ?, ?, ?)")
+      .run("inactive@test.com", "viewer", "Inactive", 0);
+    const user = rawDb.prepare("SELECT * FROM users WHERE email = ?").get("inactive@test.com");
+    const request = new Request(`https://example.test/api/admin/users/${user.id}/reset-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ reason: "Account inactive" }),
+    });
     const response = await resetHandler.onRequestPost({
       request,
       env,
       params: { id: String(user.id) },
-      data: { user: { userId: 1, role: 'admin', email: 'admin@test' } },
+      data: { user: { userId: 1, role: "admin", email: "admin@test" } },
     });
     expect(response.status).toBe(400);
   });

--- a/functions/api/admin/users/__tests__/user-update-delete.test.js
+++ b/functions/api/admin/users/__tests__/user-update-delete.test.js
@@ -9,18 +9,13 @@ describe("Admin user item API", () => {
     rawDb
       .prepare("INSERT INTO users (email, role, name) VALUES (?, ?, ?)")
       .run("viewer2@test.com", "viewer", "View Two");
-    const toUpdate = rawDb
-      .prepare("SELECT * FROM users WHERE email = ?")
-      .get("viewer2@test.com");
+    const toUpdate = rawDb.prepare("SELECT * FROM users WHERE email = ?").get("viewer2@test.com");
 
-    const request = new Request(
-      `https://example.test/api/admin/users/${toUpdate.id}`,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json", ...headers },
-        body: JSON.stringify({ role: "editor", name: "Editor Two" }),
-      }
-    );
+    const request = new Request(`https://example.test/api/admin/users/${toUpdate.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ role: "editor", name: "Editor Two" }),
+    });
 
     const response = await userItemHandler.onRequestPatch({
       request,
@@ -28,41 +23,30 @@ describe("Admin user item API", () => {
       params: { id: String(toUpdate.id) },
     });
     expect(response.status).toBe(200);
-    const updated = rawDb
-      .prepare("SELECT * FROM users WHERE id = ?")
-      .get(toUpdate.id);
+    const updated = rawDb.prepare("SELECT * FROM users WHERE id = ?").get(toUpdate.id);
     expect(updated.role).toBe("editor");
     expect(updated.name).toBe("Editor Two");
     const audit = rawDb
-      .prepare(
-        "SELECT * FROM audit_log WHERE action = 'user.updated' AND resource_id = ?"
-      )
+      .prepare("SELECT * FROM audit_log WHERE action = 'user.updated' AND resource_id = ?")
       .get(toUpdate.id);
     expect(audit).toBeTruthy();
   });
 
   test("cannot demote last admin", async () => {
     const { env, rawDb, headers } = createTestEnv({ role: "admin" });
-    const soleAdmin = rawDb
-      .prepare("SELECT * FROM users WHERE role = 'admin'")
-      .get();
-    const request = new Request(
-      `https://example.test/api/admin/users/${soleAdmin.id}`,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json", ...headers },
-        body: JSON.stringify({ role: "viewer" }),
-      }
-    );
+    const soleAdmin = rawDb.prepare("SELECT * FROM users WHERE role = 'admin'").get();
+    const request = new Request(`https://example.test/api/admin/users/${soleAdmin.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ role: "viewer" }),
+    });
     const response = await userItemHandler.onRequestPatch({
       request,
       env,
       params: { id: String(soleAdmin.id) },
     });
     expect(response.status).toBe(400);
-    const stillAdmin = rawDb
-      .prepare("SELECT role FROM users WHERE id = ?")
-      .get(soleAdmin.id);
+    const stillAdmin = rawDb.prepare("SELECT role FROM users WHERE id = ?").get(soleAdmin.id);
     expect(stillAdmin.role).toBe("admin");
   });
 
@@ -71,17 +55,12 @@ describe("Admin user item API", () => {
     rawDb
       .prepare("INSERT INTO users (email, role, name) VALUES (?, ?, ?)")
       .run("tempuser@test.com", "viewer", "Temp User");
-    const temp = rawDb
-      .prepare("SELECT * FROM users WHERE email = ?")
-      .get("tempuser@test.com");
-    const request = new Request(
-      `https://example.test/api/admin/users/${temp.id}`,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json", ...headers },
-        body: JSON.stringify({ isActive: false }),
-      }
-    );
+    const temp = rawDb.prepare("SELECT * FROM users WHERE email = ?").get("tempuser@test.com");
+    const request = new Request(`https://example.test/api/admin/users/${temp.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ isActive: false }),
+    });
     const response = await userItemHandler.onRequestPatch({
       request,
       env,
@@ -89,33 +68,24 @@ describe("Admin user item API", () => {
     });
     expect(response.status).toBe(200);
     const updated = rawDb
-      .prepare(
-        "SELECT is_active, deactivated_at, deactivated_by FROM users WHERE id = ?"
-      )
+      .prepare("SELECT is_active, deactivated_at, deactivated_by FROM users WHERE id = ?")
       .get(temp.id);
     expect(updated.is_active).toBe(0);
     expect(updated.deactivated_at).toBeTruthy();
     expect(updated.deactivated_by).toBe(1); // admin user id
     const audit = rawDb
-      .prepare(
-        "SELECT * FROM audit_log WHERE action = 'user.updated' AND resource_id = ?"
-      )
+      .prepare("SELECT * FROM audit_log WHERE action = 'user.updated' AND resource_id = ?")
       .get(temp.id);
     expect(audit).toBeTruthy();
   });
 
   test("cannot delete self", async () => {
     const { env, rawDb, headers } = createTestEnv({ role: "admin" });
-    const admin = rawDb
-      .prepare("SELECT * FROM users WHERE role = 'admin'")
-      .get();
-    const request = new Request(
-      `https://example.test/api/admin/users/${admin.id}`,
-      {
-        method: "DELETE",
-        headers: { ...headers },
-      }
-    );
+    const admin = rawDb.prepare("SELECT * FROM users WHERE role = 'admin'").get();
+    const request = new Request(`https://example.test/api/admin/users/${admin.id}`, {
+      method: "DELETE",
+      headers: { ...headers },
+    });
     const response = await userItemHandler.onRequestDelete({
       request,
       env,
@@ -126,68 +96,59 @@ describe("Admin user item API", () => {
 
   test("admin permanently deletes a non-admin user and logs action", async () => {
     const { env, rawDb, headers } = createTestEnv({ role: "admin" });
-    rawDb
-      .prepare("INSERT INTO users (email, role, name) VALUES (?, ?, ?)")
-      .run("delme@test.com", "viewer", "Del Me");
-    const target = rawDb
-      .prepare("SELECT * FROM users WHERE email = ?")
-      .get("delme@test.com");
-    const request = new Request(
-      `https://example.test/api/admin/users/${target.id}`,
-      {
-        method: "DELETE",
-        headers: { ...headers },
-      }
-    );
+    rawDb.prepare("INSERT INTO users (email, role, name) VALUES (?, ?, ?)").run("delme@test.com", "viewer", "Del Me");
+    const target = rawDb.prepare("SELECT * FROM users WHERE email = ?").get("delme@test.com");
+    const request = new Request(`https://example.test/api/admin/users/${target.id}`, {
+      method: "DELETE",
+      headers: { ...headers },
+    });
     const response = await userItemHandler.onRequestDelete({
       request,
       env,
       params: { id: String(target.id) },
     });
     expect(response.status).toBe(200);
-    const updated = rawDb
-      .prepare("SELECT * FROM users WHERE id = ?")
-      .get(target.id);
+    const updated = rawDb.prepare("SELECT * FROM users WHERE id = ?").get(target.id);
     expect(updated).toBeUndefined();
     const audit = rawDb
-      .prepare(
-        "SELECT * FROM audit_log WHERE action = 'user.deleted' AND resource_id = ?"
-      )
+      .prepare("SELECT * FROM audit_log WHERE action = 'user.deleted' AND resource_id = ?")
       .get(target.id);
     expect(audit).toBeTruthy();
   });
 
   test("deleting user unlinks created content instead of cascading delete", async () => {
     const { env, rawDb, headers, user } = createTestEnv({ role: "admin" });
-    
+
     // Create a user to be deleted
-    rawDb.prepare("INSERT INTO users (email, role, name) VALUES (?, ?, ?)")
+    rawDb
+      .prepare("INSERT INTO users (email, role, name) VALUES (?, ?, ?)")
       .run("creator@test.com", "editor", "Content Creator");
     const creator = rawDb.prepare("SELECT * FROM users WHERE email = ?").get("creator@test.com");
-    
+
     // Create content linked to this user
-    rawDb.prepare("INSERT INTO events (name, slug, date, created_by_user_id) VALUES (?, ?, ?, ?)").run("Test Event", "test-event", "2026-01-01", creator.id);
+    rawDb
+      .prepare("INSERT INTO events (name, slug, date, created_by_user_id) VALUES (?, ?, ?, ?)")
+      .run("Test Event", "test-event", "2026-01-01", creator.id);
     rawDb.prepare("INSERT INTO venues (name, created_by_user_id) VALUES (?, ?)").run("Test Venue", creator.id);
-    rawDb.prepare("INSERT INTO band_profiles (name, name_normalized, created_by_user_id) VALUES (?, ?, ?)").run("Test Band", "test-band", creator.id);
+    rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized, created_by_user_id) VALUES (?, ?, ?)")
+      .run("Test Band", "test-band", creator.id);
 
     // Verify links exist
     const eventBefore = rawDb.prepare("SELECT * FROM events WHERE created_by_user_id = ?").get(creator.id);
     expect(eventBefore).toBeTruthy();
 
     // Delete the user
-    const request = new Request(
-      `https://example.test/api/admin/users/${creator.id}`,
-      {
-        method: "DELETE",
-        headers: { ...headers },
-      }
-    );
+    const request = new Request(`https://example.test/api/admin/users/${creator.id}`, {
+      method: "DELETE",
+      headers: { ...headers },
+    });
     const response = await userItemHandler.onRequestDelete({
       request,
       env,
       params: { id: String(creator.id) },
     });
-    
+
     expect(response.status).toBe(200);
 
     // Verify user is gone
@@ -202,7 +163,7 @@ describe("Admin user item API", () => {
     const venueAfter = rawDb.prepare("SELECT * FROM venues WHERE name = ?").get("Test Venue");
     expect(venueAfter).toBeTruthy();
     expect(venueAfter.created_by_user_id).toBeNull();
-    
+
     const bandAfter = rawDb.prepare("SELECT * FROM band_profiles WHERE name_normalized = ?").get("test-band");
     expect(bandAfter).toBeTruthy();
     expect(bandAfter.created_by_user_id).toBeNull();

--- a/functions/api/admin/users/__tests__/users.test.js
+++ b/functions/api/admin/users/__tests__/users.test.js
@@ -1,12 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { createTestEnv } from '../../../test-utils';
-import * as usersHandler from '../../users.js';
+import { describe, expect, it } from "vitest";
+import { createTestEnv } from "../../../test-utils";
+import * as usersHandler from "../../users.js";
 
-describe('Admin users API', () => {
-  it('allows admins to list users', async () => {
-    const { env, headers } = createTestEnv({ role: 'admin' });
+describe("Admin users API", () => {
+  it("allows admins to list users", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
 
-    const request = new Request('https://example.test/api/admin/users', {
+    const request = new Request("https://example.test/api/admin/users", {
       headers,
     });
 
@@ -15,16 +15,14 @@ describe('Admin users API', () => {
 
     const body = await response.json();
     expect(Array.isArray(body.users)).toBe(true);
-    expect(body.users.some((user) => user.email === 'admin@test')).toBe(true);
-    expect(body.users.every((user) => typeof user.isActive === 'boolean')).toBe(
-      true
-    );
+    expect(body.users.some((user) => user.email === "admin@test")).toBe(true);
+    expect(body.users.every((user) => typeof user.isActive === "boolean")).toBe(true);
   });
 
-  it('rejects non-admin list requests', async () => {
-    const { env, headers } = createTestEnv({ role: 'editor' });
+  it("rejects non-admin list requests", async () => {
+    const { env, headers } = createTestEnv({ role: "editor" });
 
-    const request = new Request('https://example.test/api/admin/users', {
+    const request = new Request("https://example.test/api/admin/users", {
       headers,
     });
 
@@ -32,91 +30,81 @@ describe('Admin users API', () => {
     expect(response.status).toBe(403);
   });
 
-  it('invites users and logs the action', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' });
+  it("invites users and logs the action", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
 
-    const request = new Request('https://example.test/api/admin/users', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({
-        email: 'new-user@test.com',
-        role: 'editor',
-        firstName: 'New',
-        lastName: 'User',
+        email: "new-user@test.com",
+        role: "editor",
+        firstName: "New",
+        lastName: "User",
       }),
     });
 
     const response = await usersHandler.onRequestPost({ request, env });
     expect(response.status).toBe(201);
 
-    const invite = rawDb
-      .prepare('SELECT * FROM invite_codes WHERE email = ?')
-      .get('new-user@test.com');
+    const invite = rawDb.prepare("SELECT * FROM invite_codes WHERE email = ?").get("new-user@test.com");
     expect(invite).toBeDefined();
-    expect(invite.role).toBe('editor');
+    expect(invite.role).toBe("editor");
 
-    const created = rawDb
-      .prepare('SELECT * FROM users WHERE email = ?')
-      .get('new-user@test.com');
+    const created = rawDb.prepare("SELECT * FROM users WHERE email = ?").get("new-user@test.com");
     expect(created).toBeUndefined();
 
-    const audit = rawDb
-      .prepare("SELECT * FROM audit_log WHERE action = 'user.invited'")
-      .get();
+    const audit = rawDb.prepare("SELECT * FROM audit_log WHERE action = 'user.invited'").get();
     expect(audit).toBeDefined();
     expect(audit.resource_id).toBe(invite.id);
     const details = JSON.parse(audit.details);
     expect(details).toMatchObject({
-      role: 'editor',
+      role: "editor",
       emailDelivered: false,
-      inviteMode: 'email_restricted',
+      inviteMode: "email_restricted",
       nameProvided: true,
     });
-    expect(details).not.toHaveProperty('email');
-    expect(details).not.toHaveProperty('firstName');
-    expect(details).not.toHaveProperty('lastName');
+    expect(details).not.toHaveProperty("email");
+    expect(details).not.toHaveProperty("firstName");
+    expect(details).not.toHaveProperty("lastName");
   });
 
-  it('prevents non-admins from creating users', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'editor' });
+  it("prevents non-admins from creating users", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
 
-    const request = new Request('https://example.test/api/admin/users', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify({
-        email: 'blocked@test.com',
-        role: 'viewer',
-        firstName: 'Blocked',
-        lastName: 'User',
+        email: "blocked@test.com",
+        role: "viewer",
+        firstName: "Blocked",
+        lastName: "User",
       }),
     });
 
     const response = await usersHandler.onRequestPost({ request, env });
     expect(response.status).toBe(403);
 
-    const exists = rawDb
-      .prepare('SELECT * FROM users WHERE email = ?')
-      .get('blocked@test.com');
+    const exists = rawDb.prepare("SELECT * FROM users WHERE email = ?").get("blocked@test.com");
     expect(exists).toBeUndefined();
   });
 
-  it('rejects duplicate user emails', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' });
+  it("rejects duplicate user emails", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
 
-    rawDb
-      .prepare('INSERT INTO users (email, role) VALUES (?, ?)')
-      .run('dup-user@test.com', 'viewer');
+    rawDb.prepare("INSERT INTO users (email, role) VALUES (?, ?)").run("dup-user@test.com", "viewer");
 
     const body = {
-      email: 'dup-user@test.com',
-      role: 'editor',
-      firstName: 'Dup',
-      lastName: 'User',
+      email: "dup-user@test.com",
+      role: "editor",
+      firstName: "Dup",
+      lastName: "User",
     };
 
-    const request = new Request('https://example.test/api/admin/users', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const request = new Request("https://example.test/api/admin/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
     });
 

--- a/functions/api/admin/venues.js
+++ b/functions/api/admin/venues.js
@@ -112,9 +112,7 @@ export async function onRequestPost(context) {
       contact_email,
     } = validation.sanitized;
 
-    const postal_code = rawPostalCode
-      ? normalizePostalCode(rawPostalCode)
-      : rawPostalCode;
+    const postal_code = rawPostalCode ? normalizePostalCode(rawPostalCode) : rawPostalCode;
 
     const formattedAddress =
       formatVenueAddress({
@@ -124,10 +122,11 @@ export async function onRequestPost(context) {
         region,
         postal_code,
         country,
-      }) || address || null;
+      }) ||
+      address ||
+      null;
 
-    const resolvedAddressLine1 =
-      address_line1 || (address ? address.trim() : null);
+    const resolvedAddressLine1 = address_line1 || (address ? address.trim() : null);
 
     // Check if venue already exists
     const existingVenue = await DB.prepare(

--- a/functions/api/admin/venues/[id].js
+++ b/functions/api/admin/venues/[id].js
@@ -60,18 +60,8 @@ export async function onRequestPut(context) {
     }
 
     const body = await request.json().catch(() => ({}));
-    const {
-      name,
-      address,
-      address_line1,
-      address_line2,
-      city,
-      region,
-      postal_code,
-      country,
-      phone,
-      contact_email,
-    } = body;
+    const { name, address, address_line1, address_line2, city, region, postal_code, country, phone, contact_email } =
+      body;
 
     const trimmedName = name ? sanitizeString(name) : "";
 
@@ -222,23 +212,12 @@ export async function onRequestPut(context) {
 
     // Update venue
     const nextAddressLine1 =
-      address_line1 !== undefined
-        ? address_line1 || null
-        : address
-          ? address.trim()
-          : venue.address_line1 || null;
-    const nextAddressLine2 =
-      address_line2 !== undefined
-        ? address_line2 || null
-        : venue.address_line2 || null;
+      address_line1 !== undefined ? address_line1 || null : address ? address.trim() : venue.address_line1 || null;
+    const nextAddressLine2 = address_line2 !== undefined ? address_line2 || null : venue.address_line2 || null;
     const nextCity = city !== undefined ? city || null : venue.city || null;
     const nextRegion = region !== undefined ? region || null : venue.region || null;
-    const nextPostal =
-      postal_code !== undefined
-        ? normalizePostalCode(postal_code)
-        : venue.postal_code || null;
-    const nextCountry =
-      country !== undefined ? country || null : venue.country || null;
+    const nextPostal = postal_code !== undefined ? normalizePostalCode(postal_code) : venue.postal_code || null;
+    const nextCountry = country !== undefined ? country || null : venue.country || null;
 
     const formattedAddress =
       formatVenueAddress({
@@ -440,7 +419,7 @@ export async function onRequestDelete(context) {
     return new Response(
       JSON.stringify({
         error: "Database error",
-        message: "Failed to delete venue"
+        message: "Failed to delete venue",
       }),
       {
         status: 500,

--- a/functions/api/admin/venues/__tests__/venues.test.js
+++ b/functions/api/admin/venues/__tests__/venues.test.js
@@ -1,172 +1,187 @@
-import { describe, it, expect } from 'vitest'
-import { createTestEnv, insertVenue, insertBand, insertEvent } from '../../../test-utils'
-import * as venueIdHandler from '../[id].js'
-import * as venuesHandler from '../../venues.js'
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertVenue, insertBand, insertEvent } from "../../../test-utils";
+import * as venueIdHandler from "../[id].js";
+import * as venuesHandler from "../../venues.js";
 
-describe('Admin venues API - CRUD operations', () => {
-  it('can create a venue and then list it', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' })
+describe("Admin venues API - CRUD operations", () => {
+  it("can create a venue and then list it", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
 
-    const body = { name: "The Roxy", address: "123 Main St" }
+    const body = { name: "The Roxy", address: "123 Main St" };
     const request = new Request("https://example.test/api/admin/venues", {
       method: "POST",
       headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await venuesHandler.onRequestPost({ request, env })
-    expect(res.status).toBe(201)
-    const data = await res.json()
-    expect(data.venue).toHaveProperty('id')
-    expect(data.venue.name).toBe('The Roxy')
+    const res = await venuesHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.venue).toHaveProperty("id");
+    expect(data.venue.name).toBe("The Roxy");
 
     // Now GET list
     const getReq = new Request("https://example.test/api/admin/venues", {
       headers: { ...headers },
-    })
-    const getRes = await venuesHandler.onRequestGet({ request: getReq, env })
-    expect(getRes.status).toBe(200)
-    const list = await getRes.json()
-    expect(list.venues.some((v) => v.name === "The Roxy")).toBeTruthy()
-  })
+    });
+    const getRes = await venuesHandler.onRequestGet({ request: getReq, env });
+    expect(getRes.status).toBe(200);
+    const list = await getRes.json();
+    expect(list.venues.some((v) => v.name === "The Roxy")).toBeTruthy();
+  });
 
-  it('GET /api/admin/venues returns venues with band_count', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' })
-    const venue = insertVenue(rawDb, { name: 'Count Venue' })
-    const event = insertEvent(rawDb, { name: 'Count Event', slug: 'count-event' })
-    insertBand(rawDb, { name: 'Band 1', event_id: event.id, venue_id: venue.id })
-    insertBand(rawDb, { name: 'Band 2', event_id: event.id, venue_id: venue.id })
+  it("GET /api/admin/venues returns venues with band_count", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const venue = insertVenue(rawDb, { name: "Count Venue" });
+    const event = insertEvent(rawDb, { name: "Count Event", slug: "count-event" });
+    insertBand(rawDb, { name: "Band 1", event_id: event.id, venue_id: venue.id });
+    insertBand(rawDb, { name: "Band 2", event_id: event.id, venue_id: venue.id });
 
-    const getReq = new Request('https://example.test/api/admin/venues', { headers })
-    const getRes = await venuesHandler.onRequestGet({ request: getReq, env })
-    expect(getRes.status).toBe(200)
-    const list = await getRes.json()
-    const countVenue = list.venues.find(v => v.name === 'Count Venue')
-    expect(countVenue).toBeDefined()
-    expect(countVenue.band_count).toBe(2)
-  })
+    const getReq = new Request("https://example.test/api/admin/venues", { headers });
+    const getRes = await venuesHandler.onRequestGet({ request: getReq, env });
+    expect(getRes.status).toBe(200);
+    const list = await getRes.json();
+    const countVenue = list.venues.find((v) => v.name === "Count Venue");
+    expect(countVenue).toBeDefined();
+    expect(countVenue.band_count).toBe(2);
+  });
 
-  it('PUT /api/admin/venues/{id} updates venue', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' })
-    const v = insertVenue(rawDb, { name: 'Old Name' })
+  it("PUT /api/admin/venues/{id} updates venue", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const v = insertVenue(rawDb, { name: "Old Name" });
 
     const putReq = new Request(`https://example.test/api/admin/venues/${v.id}`, {
-      method: 'PUT', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify({ name: 'New Name', address: '55 Road' })
-    })
-    const putRes = await venueIdHandler.onRequestPut({ request: putReq, env })
-    expect(putRes.status).toBe(200)
-    const data = await putRes.json()
-    expect(data.venue.name).toBe('New Name')
-    expect(data.venue.address).toBe('55 Road, Portland')
-  })
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ name: "New Name", address: "55 Road" }),
+    });
+    const putRes = await venueIdHandler.onRequestPut({ request: putReq, env });
+    expect(putRes.status).toBe(200);
+    const data = await putRes.json();
+    expect(data.venue.name).toBe("New Name");
+    expect(data.venue.address).toBe("55 Road, Portland");
+  });
 
-  it('DELETE /api/admin/venues/{id} removes venue without bands', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' })
-    const v = insertVenue(rawDb, { name: 'Empty Venue' })
+  it("DELETE /api/admin/venues/{id} removes venue without bands", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const v = insertVenue(rawDb, { name: "Empty Venue" });
 
     const deleteReq = new Request(`https://example.test/api/admin/venues/${v.id}`, {
-      method: 'DELETE', headers: { ...headers }
-    })
-    const deleteRes = await venueIdHandler.onRequestDelete({ request: deleteReq, env })
-    expect(deleteRes.status).toBe(200)
-    const data = await deleteRes.json()
-    expect(data.success).toBeTruthy()
-  })
-})
+      method: "DELETE",
+      headers: { ...headers },
+    });
+    const deleteRes = await venueIdHandler.onRequestDelete({ request: deleteReq, env });
+    expect(deleteRes.status).toBe(200);
+    const data = await deleteRes.json();
+    expect(data.success).toBeTruthy();
+  });
+});
 
-describe('Admin venues API - Validation', () => {
-  it('create validation fails when name is missing', async () => {
-    const { env, headers } = createTestEnv({ role: 'admin' })
+describe("Admin venues API - Validation", () => {
+  it("create validation fails when name is missing", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
 
-    const body = { address: '123 Main St' }
-    const request = new Request('https://example.test/api/admin/venues', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+    const body = { address: "123 Main St" };
+    const request = new Request("https://example.test/api/admin/venues", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
-    })
+    });
 
-    const res = await venuesHandler.onRequestPost({ request, env })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toBe('Validation error')
-  })
+    const res = await venuesHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Validation error");
+  });
 
-  it('creating duplicate venue returns 409', async () => {
-    const { env, headers } = createTestEnv({ role: 'admin' })
+  it("creating duplicate venue returns 409", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
 
-    const body = { name: 'Duplicate Venue' }
-    const req1 = new Request('https://example.test/api/admin/venues', {
-      method: 'POST', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify(body)
-    })
-    const r1 = await venuesHandler.onRequestPost({ request: req1, env })
-    expect(r1.status).toBe(201)
+    const body = { name: "Duplicate Venue" };
+    const req1 = new Request("https://example.test/api/admin/venues", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    });
+    const r1 = await venuesHandler.onRequestPost({ request: req1, env });
+    expect(r1.status).toBe(201);
 
-    const req2 = new Request('https://example.test/api/admin/venues', {
-      method: 'POST', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify(body)
-    })
-    const r2 = await venuesHandler.onRequestPost({ request: req2, env })
-    expect(r2.status).toBe(409)
-  })
+    const req2 = new Request("https://example.test/api/admin/venues", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    });
+    const r2 = await venuesHandler.onRequestPost({ request: req2, env });
+    expect(r2.status).toBe(409);
+  });
 
-  it('update validation fails when name is missing', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' })
-    const v = insertVenue(rawDb, { name: 'Test Venue' })
+  it("update validation fails when name is missing", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const v = insertVenue(rawDb, { name: "Test Venue" });
 
     const putReq = new Request(`https://example.test/api/admin/venues/${v.id}`, {
-      method: 'PUT', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify({ address: '123 Main St' })
-    })
-    const putRes = await venueIdHandler.onRequestPut({ request: putReq, env })
-    expect(putRes.status).toBe(400)
-    const data = await putRes.json()
-    expect(data.error).toBe('Validation error')
-  })
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ address: "123 Main St" }),
+    });
+    const putRes = await venueIdHandler.onRequestPut({ request: putReq, env });
+    expect(putRes.status).toBe(400);
+    const data = await putRes.json();
+    expect(data.error).toBe("Validation error");
+  });
 
-  it('update conflicts when renaming to existing venue name', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' })
-    const v1 = insertVenue(rawDb, { name: 'Venue 1' })
-    const v2 = insertVenue(rawDb, { name: 'Taken' })
+  it("update conflicts when renaming to existing venue name", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const v1 = insertVenue(rawDb, { name: "Venue 1" });
+    const v2 = insertVenue(rawDb, { name: "Taken" });
 
     const putReq = new Request(`https://example.test/api/admin/venues/${v1.id}`, {
-      method: 'PUT', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify({ name: 'Taken' })
-    })
-    const putRes = await venueIdHandler.onRequestPut({ request: putReq, env })
-    expect(putRes.status).toBe(409)
-  })
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ name: "Taken" }),
+    });
+    const putRes = await venueIdHandler.onRequestPut({ request: putReq, env });
+    expect(putRes.status).toBe(409);
+  });
 
-  it('update returns 404 for non-existent venue', async () => {
-    const { env, headers } = createTestEnv({ role: 'admin' })
+  it("update returns 404 for non-existent venue", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
 
-    const putReq = new Request('https://example.test/api/admin/venues/99999', {
-      method: 'PUT', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify({ name: 'New Name' })
-    })
-    const putRes = await venueIdHandler.onRequestPut({ request: putReq, env })
-    expect(putRes.status).toBe(404)
-  })
+    const putReq = new Request("https://example.test/api/admin/venues/99999", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ name: "New Name" }),
+    });
+    const putRes = await venueIdHandler.onRequestPut({ request: putReq, env });
+    expect(putRes.status).toBe(404);
+  });
 
-  it('delete returns 404 for non-existent venue', async () => {
-    const { env, headers } = createTestEnv({ role: 'admin' })
+  it("delete returns 404 for non-existent venue", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
 
-    const deleteReq = new Request('https://example.test/api/admin/venues/99999', {
-      method: 'DELETE', headers: { ...headers }
-    })
-    const deleteRes = await venueIdHandler.onRequestDelete({ request: deleteReq, env })
-    expect(deleteRes.status).toBe(404)
-  })
-})
+    const deleteReq = new Request("https://example.test/api/admin/venues/99999", {
+      method: "DELETE",
+      headers: { ...headers },
+    });
+    const deleteRes = await venueIdHandler.onRequestDelete({ request: deleteReq, env });
+    expect(deleteRes.status).toBe(404);
+  });
+});
 
-describe('Admin venues API - Conflicts', () => {
-  it('cannot delete venue with bands attached', async () => {
-    const { env, rawDb, headers } = createTestEnv({ role: 'admin' })
-    const venue = insertVenue(rawDb, { name: 'Used Venue' })
-    const event = insertEvent(rawDb, { name: 'Test Event', slug: 'test-event' })
-    insertBand(rawDb, { name: 'Attached Band', event_id: event.id, venue_id: venue.id })
+describe("Admin venues API - Conflicts", () => {
+  it("cannot delete venue with bands attached", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const venue = insertVenue(rawDb, { name: "Used Venue" });
+    const event = insertEvent(rawDb, { name: "Test Event", slug: "test-event" });
+    insertBand(rawDb, { name: "Attached Band", event_id: event.id, venue_id: venue.id });
 
     const deleteReq = new Request(`https://example.test/api/admin/venues/${venue.id}`, {
-      method: 'DELETE', headers: { ...headers }
-    })
-    const deleteRes = await venueIdHandler.onRequestDelete({ request: deleteReq, env })
-    expect(deleteRes.status).toBe(409)
-    const data = await deleteRes.json()
-    expect(data.message).toContain('Cannot delete venue')
-  })
-})
+      method: "DELETE",
+      headers: { ...headers },
+    });
+    const deleteRes = await venueIdHandler.onRequestDelete({ request: deleteReq, env });
+    expect(deleteRes.status).toBe(409);
+    const data = await deleteRes.json();
+    expect(data.message).toContain("Cannot delete venue");
+  });
+});

--- a/functions/api/artists.js
+++ b/functions/api/artists.js
@@ -28,13 +28,8 @@ export async function onRequestGet(context) {
   const q = (url.searchParams.get("q") || "").trim().slice(0, 100);
 
   const parsedLimit = Number.parseInt(url.searchParams.get("limit") || "", 10);
-  const parsedOffset = Number.parseInt(
-    url.searchParams.get("offset") || "",
-    10,
-  );
-  const limit = Number.isFinite(parsedLimit)
-    ? Math.min(Math.max(parsedLimit, 1), MAX_LIMIT)
-    : DEFAULT_LIMIT;
+  const parsedOffset = Number.parseInt(url.searchParams.get("offset") || "", 10);
+  const limit = Number.isFinite(parsedLimit) ? Math.min(Math.max(parsedLimit, 1), MAX_LIMIT) : DEFAULT_LIMIT;
   const offset = Number.isFinite(parsedOffset) ? Math.max(parsedOffset, 0) : 0;
 
   // Escape LIKE wildcards in user input so a literal % / _ isn't treated as one.

--- a/functions/api/auth/activate.js
+++ b/functions/api/auth/activate.js
@@ -19,7 +19,7 @@ export async function onRequestPost(context) {
       {
         status: 400,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 
@@ -30,7 +30,7 @@ export async function onRequestPost(context) {
              activation_token_expires_at, activated_at
       FROM users
       WHERE activation_token = ?
-    `
+    `,
     )
       .bind(token)
       .first();
@@ -39,20 +39,16 @@ export async function onRequestPost(context) {
       return new Response(
         JSON.stringify({
           error: "Invalid or expired token",
-          message:
-            "This activation link is invalid or has expired. Please request a new one.",
+          message: "This activation link is invalid or has expired. Please request a new one.",
         }),
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
-    if (
-      user.activation_token_expires_at &&
-      new Date(user.activation_token_expires_at) < new Date()
-    ) {
+    if (user.activation_token_expires_at && new Date(user.activation_token_expires_at) < new Date()) {
       return new Response(
         JSON.stringify({
           error: "Activation link expired",
@@ -61,7 +57,7 @@ export async function onRequestPost(context) {
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -74,7 +70,7 @@ export async function onRequestPost(context) {
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -88,7 +84,7 @@ export async function onRequestPost(context) {
       WHERE activation_token = ?
         AND is_active = 0
         AND (activation_token_expires_at IS NULL OR activation_token_expires_at >= datetime('now'))
-    `
+    `,
     )
       .bind(token)
       .run();
@@ -97,13 +93,12 @@ export async function onRequestPost(context) {
       return new Response(
         JSON.stringify({
           error: "Invalid or expired token",
-          message:
-            "This activation link is invalid, expired, or has already been used.",
+          message: "This activation link is invalid, expired, or has already been used.",
         }),
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -115,7 +110,7 @@ export async function onRequestPost(context) {
       {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   } catch (error) {
     console.error("Account activation error:", error);
@@ -127,7 +122,7 @@ export async function onRequestPost(context) {
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      }
+      },
     );
   }
 }

--- a/functions/api/auth/resend-activation.js
+++ b/functions/api/auth/resend-activation.js
@@ -44,8 +44,7 @@ export async function onRequestPost(context) {
   const genericResponse = new Response(
     JSON.stringify({
       success: true,
-      message:
-        "If an inactive account exists with this email, an activation link has been sent.",
+      message: "If an inactive account exists with this email, an activation link has been sent.",
     }),
     {
       status: 200,
@@ -72,11 +71,8 @@ export async function onRequestPost(context) {
       return genericResponse;
     }
 
-    const activationToken =
-      crypto.randomUUID() + crypto.randomUUID().replace(/-/g, "");
-    const activationExpires = new Date(
-      Date.now() + 24 * 60 * 60 * 1000,
-    ).toISOString();
+    const activationToken = crypto.randomUUID() + crypto.randomUUID().replace(/-/g, "");
+    const activationExpires = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
 
     try {
       await DB.prepare(
@@ -94,10 +90,7 @@ export async function onRequestPost(context) {
       // enumeration resistance), but a failed token write is infrastructural,
       // not a benign not-found/already-active branch — log it distinctly so it
       // is alertable rather than hidden behind the generic 200.
-      console.error(
-        "[ResendActivation] activation token write failed:",
-        writeErr,
-      );
+      console.error("[ResendActivation] activation token write failed:", writeErr);
       return genericResponse;
     }
 
@@ -106,10 +99,7 @@ export async function onRequestPost(context) {
     activationUrl.searchParams.set("token", activationToken);
 
     if (isEmailConfigured(env)) {
-      const fullName = [user.first_name, user.last_name]
-        .filter(Boolean)
-        .join(" ")
-        .trim();
+      const fullName = [user.first_name, user.last_name].filter(Boolean).join(" ").trim();
       const emailPayload = buildActivationEmail({
         activationUrl: activationUrl.toString(),
         recipientName: fullName || null,
@@ -121,14 +111,9 @@ export async function onRequestPost(context) {
         text: emailPayload.text,
         html: emailPayload.html,
       });
-      console.log(
-        "[ResendActivation] Activation email delivery attempted:",
-        emailResult.reason || "delivered",
-      );
+      console.log("[ResendActivation] Activation email delivery attempted:", emailResult.reason || "delivered");
     } else {
-      console.warn(
-        "[ResendActivation] Email not configured; activation email was not sent.",
-      );
+      console.warn("[ResendActivation] Email not configured; activation email was not sent.");
     }
 
     return genericResponse;

--- a/functions/api/auth/reset-password-complete.js
+++ b/functions/api/auth/reset-password-complete.js
@@ -49,9 +49,7 @@ export async function onRequestPost(context) {
       logDebug("missing_fields", { hasToken: Boolean(token) });
       await logFailure("MISSING_FIELDS", { hasToken: Boolean(token) });
       return new Response(
-        JSON.stringify(
-          withDebug({ error: "Token and new password are required", code: "MISSING_FIELDS" })
-        ),
+        JSON.stringify(withDebug({ error: "Token and new password are required", code: "MISSING_FIELDS" })),
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
@@ -101,9 +99,7 @@ export async function onRequestPost(context) {
       logDebug("token_invalid", {});
       await logFailure("TOKEN_INVALID");
       return new Response(
-        JSON.stringify(
-          withDebug({ error: "Invalid or expired reset token", code: "TOKEN_INVALID" })
-        ),
+        JSON.stringify(withDebug({ error: "Invalid or expired reset token", code: "TOKEN_INVALID" })),
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
@@ -112,41 +108,32 @@ export async function onRequestPost(context) {
     }
 
     // Check if token is expired
-    if (new Date(resetToken.expires_at.includes('T') ? resetToken.expires_at : resetToken.expires_at.replace(' ', 'T') + 'Z') < new Date()) {
+    if (
+      new Date(
+        resetToken.expires_at.includes("T") ? resetToken.expires_at : resetToken.expires_at.replace(" ", "T") + "Z",
+      ) < new Date()
+    ) {
       logDebug("token_expired", { expiresAt: resetToken.expires_at });
       await logFailure("TOKEN_EXPIRED", { expiresAt: resetToken.expires_at });
-      return new Response(
-        JSON.stringify(
-          withDebug({ error: "Reset token has expired", code: "TOKEN_EXPIRED" })
-        ),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      return new Response(JSON.stringify(withDebug({ error: "Reset token has expired", code: "TOKEN_EXPIRED" })), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Check if user is active
     if (resetToken.is_active === 0) {
       logDebug("user_inactive", { userId: resetToken.user_id });
       await logFailure("USER_INACTIVE", { userId: resetToken.user_id });
-      return new Response(
-        JSON.stringify(
-          withDebug({ error: "User account is inactive", code: "USER_INACTIVE" })
-        ),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      return new Response(JSON.stringify(withDebug({ error: "User account is inactive", code: "USER_INACTIVE" })), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Prevent password reuse
     if (resetToken.password_hash) {
-      const samePassword = await verifyPassword(
-        newPassword,
-        resetToken.password_hash,
-      );
+      const samePassword = await verifyPassword(newPassword, resetToken.password_hash);
       if (samePassword) {
         logDebug("password_reuse", { userId: resetToken.user_id });
         await logFailure("PASSWORD_REUSE", { userId: resetToken.user_id });
@@ -171,7 +158,7 @@ export async function onRequestPost(context) {
       UPDATE password_reset_tokens
       SET used = 1, used_at = datetime('now')
       WHERE id = ? AND used = 0
-    `
+    `,
     )
       .bind(resetToken.id)
       .run();
@@ -180,9 +167,7 @@ export async function onRequestPost(context) {
       logDebug("token_already_used", { tokenId: resetToken.id });
       await logFailure("TOKEN_ALREADY_USED", { tokenId: resetToken.id });
       return new Response(
-        JSON.stringify(
-          withDebug({ error: "Invalid or expired reset token", code: "TOKEN_INVALID" })
-        ),
+        JSON.stringify(withDebug({ error: "Invalid or expired reset token", code: "TOKEN_INVALID" })),
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
@@ -238,8 +223,7 @@ export async function onRequestPost(context) {
     return new Response(
       JSON.stringify({
         success: true,
-        message:
-          "Password has been reset successfully. Please log in with your new password.",
+        message: "Password has been reset successfully. Please log in with your new password.",
       }),
       {
         status: 200,

--- a/functions/api/auth/reset-password/validate.js
+++ b/functions/api/auth/reset-password/validate.js
@@ -43,24 +43,28 @@ export async function onRequestPost(context) {
       .first();
 
     if (!resetToken) {
-      return new Response(
-        JSON.stringify({ error: "Invalid or expired reset token", code: "TOKEN_INVALID" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Invalid or expired reset token", code: "TOKEN_INVALID" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
-    if (new Date(resetToken.expires_at.includes('T') ? resetToken.expires_at : resetToken.expires_at.replace(' ', 'T') + 'Z') < new Date()) {
-      return new Response(
-        JSON.stringify({ error: "Reset token has expired", code: "TOKEN_EXPIRED" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+    if (
+      new Date(
+        resetToken.expires_at.includes("T") ? resetToken.expires_at : resetToken.expires_at.replace(" ", "T") + "Z",
+      ) < new Date()
+    ) {
+      return new Response(JSON.stringify({ error: "Reset token has expired", code: "TOKEN_EXPIRED" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     if (resetToken.is_active === 0) {
-      return new Response(
-        JSON.stringify({ error: "User account is inactive", code: "USER_INACTIVE" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "User account is inactive", code: "USER_INACTIVE" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     return new Response(
@@ -76,9 +80,9 @@ export async function onRequestPost(context) {
     );
   } catch (error) {
     console.error("Reset token validation error:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to verify reset token", code: "TOKEN_VERIFY_FAILED" }),
-      { status: 500, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ error: "Failed to verify reset token", code: "TOKEN_VERIFY_FAILED" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/bands/[name].js
+++ b/functions/api/bands/[name].js
@@ -17,14 +17,9 @@ function formatOrigin(profile) {
 
 function formatVenueAddress(venue) {
   if (!venue) return null;
-  const line1 = [venue.address_line1, venue.address_line2]
-    .filter(Boolean)
-    .join(", ");
+  const line1 = [venue.address_line1, venue.address_line2].filter(Boolean).join(", ");
   const line2 = [venue.city, venue.region].filter(Boolean).join(", ");
-  const line3 = [venue.postal_code, venue.country]
-    .filter(Boolean)
-    .join(" ")
-    .trim();
+  const line3 = [venue.postal_code, venue.country].filter(Boolean).join(" ").trim();
   return [line1, line2, line3].filter(Boolean).join(", ");
 }
 
@@ -42,10 +37,10 @@ export async function onRequestGet(context) {
     const searchParam = decodeURIComponent(parts[parts.length - 1]);
 
     if (!searchParam) {
-      return new Response(
-        JSON.stringify({ error: "Band identifier is required" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Band identifier is required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Check if it's a numeric ID or a name
@@ -131,9 +126,7 @@ export async function onRequestGet(context) {
 
     let socialLinks = {};
     try {
-      socialLinks = bandProfile.social_links
-        ? JSON.parse(bandProfile.social_links)
-        : {};
+      socialLinks = bandProfile.social_links ? JSON.parse(bandProfile.social_links) : {};
     } catch (_error) {
       socialLinks = {};
     }
@@ -168,12 +161,7 @@ export async function onRequestGet(context) {
       },
     });
   } catch (error) {
-    console.error(
-      "Error fetching band profile:",
-      error,
-      error.message,
-      error.stack,
-    );
+    console.error("Error fetching band profile:", error, error.message, error.stack);
 
     return new Response(
       JSON.stringify({

--- a/functions/api/bands/[name]/confirm-follow.js
+++ b/functions/api/bands/[name]/confirm-follow.js
@@ -50,11 +50,7 @@ export async function onRequestGet(context) {
 
     // Verify and clear the one-time token in one statement. This is idempotent:
     // a second click finds no matching token (already NULL) and changes nothing.
-    await DB.prepare(
-      "UPDATE band_follows SET verified = 1, verification_token = NULL WHERE id = ?",
-    )
-      .bind(row.id)
-      .run();
+    await DB.prepare("UPDATE band_follows SET verified = 1, verification_token = NULL WHERE id = ?").bind(row.id).run();
 
     return htmlPage(
       `You're following ${escapeHtml(row.band_name)}`,

--- a/functions/api/bands/[name]/follow.js
+++ b/functions/api/bands/[name]/follow.js
@@ -15,8 +15,7 @@ export async function onRequestPost(context) {
 
   try {
     const body = await request.json().catch(() => ({}));
-    const email =
-      typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
     const turnstileToken = body.turnstileToken;
 
     if (!email || email.length > MAX_EMAIL_LENGTH || !isValidEmail(email)) {
@@ -28,26 +27,20 @@ export async function onRequestPost(context) {
 
     const turnstileValid = await verifyTurnstile(request, env, turnstileToken);
     if (!turnstileValid) {
-      return new Response(
-        JSON.stringify({ error: "Bot verification failed" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Bot verification failed" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Resolve band profile — params.name may be numeric ID or normalized name
     const nameOrId = params.name;
     let band;
     if (/^\d+$/.test(nameOrId)) {
-      band = await DB.prepare("SELECT id, name FROM band_profiles WHERE id = ?")
-        .bind(Number(nameOrId))
-        .first();
+      band = await DB.prepare("SELECT id, name FROM band_profiles WHERE id = ?").bind(Number(nameOrId)).first();
     } else {
       const normalized = normalizeBandName(nameOrId);
-      band = await DB.prepare(
-        "SELECT id, name FROM band_profiles WHERE name_normalized = ?",
-      )
-        .bind(normalized)
-        .first();
+      band = await DB.prepare("SELECT id, name FROM band_profiles WHERE name_normalized = ?").bind(normalized).first();
     }
 
     if (!band) {
@@ -92,17 +85,11 @@ export async function onRequestPost(context) {
         })
           .then((emailResult) => {
             if (!emailResult?.delivered) {
-              console.warn(
-                "[band-follow] Confirmation email not delivered:",
-                emailResult?.reason,
-              );
+              console.warn("[band-follow] Confirmation email not delivered:", emailResult?.reason);
             }
           })
           .catch((err) => {
-            console.error(
-              "[band-follow] Failed to send confirmation email:",
-              err,
-            );
+            console.error("[band-follow] Failed to send confirmation email:", err);
           }),
       );
     }

--- a/functions/api/bands/[name]/unfollow.js
+++ b/functions/api/bands/[name]/unfollow.js
@@ -31,9 +31,7 @@ export async function onRequestGet(context) {
       .bind(token)
       .first();
 
-    await DB.prepare("DELETE FROM band_follows WHERE unsubscribe_token = ?")
-      .bind(token)
-      .run();
+    await DB.prepare("DELETE FROM band_follows WHERE unsubscribe_token = ?").bind(token).run();
 
     const bandName = follow?.band_name ? escapeHtml(follow.band_name) : null;
     const heading = bandName ? `Unfollowed ${bandName}` : "Unfollowed";

--- a/functions/api/bands/__tests__/confirm-follow.test.js
+++ b/functions/api/bands/__tests__/confirm-follow.test.js
@@ -1,84 +1,98 @@
-import { describe, it, expect } from 'vitest'
-import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
-import * as followHandler from '../[name]/follow.js'
-import * as confirmHandler from '../[name]/confirm-follow.js'
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertBand, insertEvent } from "../../test-utils";
+import * as followHandler from "../[name]/follow.js";
+import * as confirmHandler from "../[name]/confirm-follow.js";
 
-const waitUntil = () => {}
+const waitUntil = () => {};
 
-describe('GET /api/bands/:name/confirm-follow', () => {
-  it('verifies a pending follow and clears the one-time token', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-confirm' })
-    const band = insertBand(rawDb, { name: 'Confirm Band', event_id: ev.id })
+describe("GET /api/bands/:name/confirm-follow", () => {
+  it("verifies a pending follow and clears the one-time token", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-confirm" });
+    const band = insertBand(rawDb, { name: "Confirm Band", event_id: ev.id });
 
     // Create the pending (verified=0) follow via the follow endpoint.
     const followReq = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'fan@example.com' }),
-    })
-    await followHandler.onRequestPost({ request: followReq, env, params: { name: String(band.band_profile_id) }, waitUntil })
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com" }),
+    });
+    await followHandler.onRequestPost({
+      request: followReq,
+      env,
+      params: { name: String(band.band_profile_id) },
+      waitUntil,
+    });
 
     const pending = rawDb
-      .prepare('SELECT verified, verification_token FROM band_follows WHERE email=? AND band_profile_id=?')
-      .get('fan@example.com', band.band_profile_id)
-    expect(pending.verified).toBe(0)
-    expect(pending.verification_token).toBeTruthy()
+      .prepare("SELECT verified, verification_token FROM band_follows WHERE email=? AND band_profile_id=?")
+      .get("fan@example.com", band.band_profile_id);
+    expect(pending.verified).toBe(0);
+    expect(pending.verification_token).toBeTruthy();
 
     // Confirm via the verification token.
     const confirmReq = new Request(
-      `https://example.test/api/bands/${band.band_profile_id}/confirm-follow?token=${pending.verification_token}`
-    )
-    const res = await confirmHandler.onRequestGet({ request: confirmReq, env, params: { name: String(band.band_profile_id) } })
-    expect(res.status).toBe(200)
+      `https://example.test/api/bands/${band.band_profile_id}/confirm-follow?token=${pending.verification_token}`,
+    );
+    const res = await confirmHandler.onRequestGet({
+      request: confirmReq,
+      env,
+      params: { name: String(band.band_profile_id) },
+    });
+    expect(res.status).toBe(200);
 
     const confirmed = rawDb
-      .prepare('SELECT verified, verification_token FROM band_follows WHERE email=? AND band_profile_id=?')
-      .get('fan@example.com', band.band_profile_id)
-    expect(confirmed.verified).toBe(1)
-    expect(confirmed.verification_token).toBeNull()
-  })
+      .prepare("SELECT verified, verification_token FROM band_follows WHERE email=? AND band_profile_id=?")
+      .get("fan@example.com", band.band_profile_id);
+    expect(confirmed.verified).toBe(1);
+    expect(confirmed.verification_token).toBeNull();
+  });
 
-  it('is idempotent — a second click on a used token changes nothing', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-confirm-twice' })
-    const band = insertBand(rawDb, { name: 'Twice Band', event_id: ev.id })
+  it("is idempotent — a second click on a used token changes nothing", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-confirm-twice" });
+    const band = insertBand(rawDb, { name: "Twice Band", event_id: ev.id });
 
     const followReq = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'fan@example.com' }),
-    })
-    await followHandler.onRequestPost({ request: followReq, env, params: { name: String(band.band_profile_id) }, waitUntil })
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com" }),
+    });
+    await followHandler.onRequestPost({
+      request: followReq,
+      env,
+      params: { name: String(band.band_profile_id) },
+      waitUntil,
+    });
 
     const { verification_token: token } = rawDb
-      .prepare('SELECT verification_token FROM band_follows WHERE email=? AND band_profile_id=?')
-      .get('fan@example.com', band.band_profile_id)
+      .prepare("SELECT verification_token FROM band_follows WHERE email=? AND band_profile_id=?")
+      .get("fan@example.com", band.band_profile_id);
 
-    const url = `https://example.test/api/bands/${band.band_profile_id}/confirm-follow?token=${token}`
-    const params = { name: String(band.band_profile_id) }
-    const first = await confirmHandler.onRequestGet({ request: new Request(url), env, params })
-    const second = await confirmHandler.onRequestGet({ request: new Request(url), env, params })
+    const url = `https://example.test/api/bands/${band.band_profile_id}/confirm-follow?token=${token}`;
+    const params = { name: String(band.band_profile_id) };
+    const first = await confirmHandler.onRequestGet({ request: new Request(url), env, params });
+    const second = await confirmHandler.onRequestGet({ request: new Request(url), env, params });
 
-    expect(first.status).toBe(200)
-    expect(second.status).toBe(200) // generic "link expired" page, still verified=1
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200); // generic "link expired" page, still verified=1
     const row = rawDb
-      .prepare('SELECT verified FROM band_follows WHERE email=? AND band_profile_id=?')
-      .get('fan@example.com', band.band_profile_id)
-    expect(row.verified).toBe(1)
-  })
+      .prepare("SELECT verified FROM band_follows WHERE email=? AND band_profile_id=?")
+      .get("fan@example.com", band.band_profile_id);
+    expect(row.verified).toBe(1);
+  });
 
-  it('returns 400 for a missing token', async () => {
-    const { env } = createTestEnv()
-    const req = new Request('https://example.test/api/bands/1/confirm-follow')
-    const res = await confirmHandler.onRequestGet({ request: req, env, params: { name: '1' } })
-    expect(res.status).toBe(400)
-  })
+  it("returns 400 for a missing token", async () => {
+    const { env } = createTestEnv();
+    const req = new Request("https://example.test/api/bands/1/confirm-follow");
+    const res = await confirmHandler.onRequestGet({ request: req, env, params: { name: "1" } });
+    expect(res.status).toBe(400);
+  });
 
-  it('shows a generic page for an unknown token (no enumeration)', async () => {
-    const { env } = createTestEnv()
-    const req = new Request('https://example.test/api/bands/1/confirm-follow?token=nonexistent-token')
-    const res = await confirmHandler.onRequestGet({ request: req, env, params: { name: '1' } })
-    expect(res.status).toBe(200)
-  })
-})
+  it("shows a generic page for an unknown token (no enumeration)", async () => {
+    const { env } = createTestEnv();
+    const req = new Request("https://example.test/api/bands/1/confirm-follow?token=nonexistent-token");
+    const res = await confirmHandler.onRequestGet({ request: req, env, params: { name: "1" } });
+    expect(res.status).toBe(200);
+  });
+});

--- a/functions/api/bands/__tests__/follow-batch.test.js
+++ b/functions/api/bands/__tests__/follow-batch.test.js
@@ -1,369 +1,346 @@
-import { describe, it, expect } from 'vitest'
-import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
-import * as followBatchHandler from '../follow-batch.js'
-import * as confirmBatchHandler from '../confirm-follow-batch.js'
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertBand, insertEvent } from "../../test-utils";
+import * as followBatchHandler from "../follow-batch.js";
+import * as confirmBatchHandler from "../confirm-follow-batch.js";
 
 // waitUntil in tests: run the promise synchronously so email side-effects
 // execute before assertions (mirrors follow.test.js pattern).
-const waitUntil = (p) => p
+const waitUntil = (p) => p;
 
-describe('POST /api/bands/follow-batch', () => {
-  it('inserts N verified=0 rows all sharing one batch_token', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-batch' })
-    const b1 = insertBand(rawDb, { name: 'Alpha', event_id: ev.id })
-    const b2 = insertBand(rawDb, { name: 'Beta', event_id: ev.id })
-    const b3 = insertBand(rawDb, { name: 'Gamma', event_id: ev.id })
+describe("POST /api/bands/follow-batch", () => {
+  it("inserts N verified=0 rows all sharing one batch_token", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-batch" });
+    const b1 = insertBand(rawDb, { name: "Alpha", event_id: ev.id });
+    const b2 = insertBand(rawDb, { name: "Beta", event_id: ev.id });
+    const b3 = insertBand(rawDb, { name: "Gamma", event_id: ev.id });
 
-    const req = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const req = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        email: 'fan@example.com',
+        email: "fan@example.com",
         performance_ids: [b1.id, b2.id, b3.id],
       }),
-    })
+    });
     const res = await followBatchHandler.onRequestPost({
       request: req,
       env,
       waitUntil,
-    })
+    });
 
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.success).toBe(true)
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
 
-    const rows = rawDb
-      .prepare('SELECT * FROM band_follows WHERE email = ? ORDER BY id')
-      .all('fan@example.com')
+    const rows = rawDb.prepare("SELECT * FROM band_follows WHERE email = ? ORDER BY id").all("fan@example.com");
 
     // Three rows — one per band
-    expect(rows).toHaveLength(3)
+    expect(rows).toHaveLength(3);
 
     // Security invariant: every row must be unverified
     for (const row of rows) {
-      expect(row.verified).toBe(0)
-      expect(row.verification_token).toBeTruthy()
-      expect(row.unsubscribe_token).toBeTruthy()
-      expect(row.consent_method).toBe('web_form')
+      expect(row.verified).toBe(0);
+      expect(row.verification_token).toBeTruthy();
+      expect(row.unsubscribe_token).toBeTruthy();
+      expect(row.consent_method).toBe("web_form");
     }
 
     // All three rows share the same batch_token
-    const tokens = new Set(rows.map((r) => r.batch_token))
-    expect(tokens.size).toBe(1)
-    expect([...tokens][0]).toBeTruthy()
-  })
+    const tokens = new Set(rows.map((r) => r.batch_token));
+    expect(tokens.size).toBe(1);
+    expect([...tokens][0]).toBeTruthy();
+  });
 
-  it('returns confirmUrl in dev (email unconfigured) instead of sending email', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-confirmurl' })
-    const b1 = insertBand(rawDb, { name: 'Dev Band A', event_id: ev.id })
-    const b2 = insertBand(rawDb, { name: 'Dev Band B', event_id: ev.id })
+  it("returns confirmUrl in dev (email unconfigured) instead of sending email", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-confirmurl" });
+    const b1 = insertBand(rawDb, { name: "Dev Band A", event_id: ev.id });
+    const b2 = insertBand(rawDb, { name: "Dev Band B", event_id: ev.id });
 
-    const req = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const req = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        email: 'dev@example.com',
+        email: "dev@example.com",
         performance_ids: [b1.id, b2.id],
       }),
-    })
+    });
     const res = await followBatchHandler.onRequestPost({
       request: req,
       env,
       waitUntil,
-    })
+    });
 
-    const data = await res.json()
-    expect(data.success).toBe(true)
+    const data = await res.json();
+    expect(data.success).toBe(true);
     // Dev env: email not configured → confirmUrl included
-    expect(data.confirmUrl).toMatch(/\/api\/bands\/confirm-follow-batch\?token=/)
-  })
+    expect(data.confirmUrl).toMatch(/\/api\/bands\/confirm-follow-batch\?token=/);
+  });
 
-  it('is idempotent — re-submitting the same email returns 200 with no duplicate rows', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-idempotent' })
-    const b1 = insertBand(rawDb, { name: 'Idem Band', event_id: ev.id })
+  it("is idempotent — re-submitting the same email returns 200 with no duplicate rows", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-idempotent" });
+    const b1 = insertBand(rawDb, { name: "Idem Band", event_id: ev.id });
 
     const makeReq = () =>
-      new Request('https://example.test/api/bands/follow-batch', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      new Request("https://example.test/api/bands/follow-batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          email: 'idem@example.com',
+          email: "idem@example.com",
           performance_ids: [b1.id],
         }),
-      })
+      });
 
-    const r1 = await followBatchHandler.onRequestPost({ request: makeReq(), env, waitUntil })
-    const r2 = await followBatchHandler.onRequestPost({ request: makeReq(), env, waitUntil })
+    const r1 = await followBatchHandler.onRequestPost({ request: makeReq(), env, waitUntil });
+    const r2 = await followBatchHandler.onRequestPost({ request: makeReq(), env, waitUntil });
 
-    expect(r1.status).toBe(200)
-    expect(r2.status).toBe(200)
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
 
-    const rows = rawDb
-      .prepare('SELECT * FROM band_follows WHERE email = ?')
-      .all('idem@example.com')
+    const rows = rawDb.prepare("SELECT * FROM band_follows WHERE email = ?").all("idem@example.com");
     // INSERT OR IGNORE: no duplicate rows
-    expect(rows).toHaveLength(1)
-  })
+    expect(rows).toHaveLength(1);
+  });
 
-  it('no-enumeration: existing follows return 200 without leaking state', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-noenum' })
-    const band = insertBand(rawDb, { name: 'Existing Band', event_id: ev.id })
+  it("no-enumeration: existing follows return 200 without leaking state", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-noenum" });
+    const band = insertBand(rawDb, { name: "Existing Band", event_id: ev.id });
 
     // Pre-seed a verified follow
     rawDb
-      .prepare(
-        'INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)',
-      )
-      .run('existing@example.com', band.band_profile_id, 'existing-unsub')
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("existing@example.com", band.band_profile_id, "existing-unsub");
 
-    const req = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const req = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        email: 'existing@example.com',
+        email: "existing@example.com",
         performance_ids: [band.id],
       }),
-    })
-    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
+    });
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil });
 
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.success).toBe(true)
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
     // No confirmUrl leaked — no new row was created
-    expect(data.confirmUrl).toBeUndefined()
+    expect(data.confirmUrl).toBeUndefined();
 
     // Original verified row untouched; no duplicate
-    const rows = rawDb
-      .prepare('SELECT * FROM band_follows WHERE email = ?')
-      .all('existing@example.com')
-    expect(rows).toHaveLength(1)
-    expect(rows[0].verified).toBe(1)
-  })
+    const rows = rawDb.prepare("SELECT * FROM band_follows WHERE email = ?").all("existing@example.com");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].verified).toBe(1);
+  });
 
-  it('returns 400 for an invalid email', async () => {
-    const { env } = createTestEnv()
+  it("returns 400 for an invalid email", async () => {
+    const { env } = createTestEnv();
 
-    const req = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'not-an-email', performance_ids: [1] }),
-    })
-    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
-    expect(res.status).toBe(400)
-    const data = await res.json()
-    expect(data.error).toMatch(/email/i)
-  })
+    const req = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email", performance_ids: [1] }),
+    });
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/email/i);
+  });
 
-  it('returns 400 when performance_ids is missing', async () => {
-    const { env } = createTestEnv()
+  it("returns 400 when performance_ids is missing", async () => {
+    const { env } = createTestEnv();
 
-    const req = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'fan@example.com' }),
-    })
-    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
-    expect(res.status).toBe(400)
-  })
+    const req = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com" }),
+    });
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil });
+    expect(res.status).toBe(400);
+  });
 
-  it('returns 400 when performance_ids is empty', async () => {
-    const { env } = createTestEnv()
+  it("returns 400 when performance_ids is empty", async () => {
+    const { env } = createTestEnv();
 
-    const req = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'fan@example.com', performance_ids: [] }),
-    })
-    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
-    expect(res.status).toBe(400)
-  })
+    const req = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com", performance_ids: [] }),
+    });
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil });
+    expect(res.status).toBe(400);
+  });
 
   it(`returns 400 when performance_ids exceeds MAX_BATCH_SIZE (30)`, async () => {
-    const { env } = createTestEnv()
-    const tooMany = Array.from({ length: 31 }, (_, i) => i + 1)
+    const { env } = createTestEnv();
+    const tooMany = Array.from({ length: 31 }, (_, i) => i + 1);
 
-    const req = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'fan@example.com', performance_ids: tooMany }),
-    })
-    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
-    expect(res.status).toBe(400)
-  })
+    const req = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com", performance_ids: tooMany }),
+    });
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil });
+    expect(res.status).toBe(400);
+  });
 
-  it('returns 400 when performance_ids contains non-integers', async () => {
-    const { env } = createTestEnv()
+  it("returns 400 when performance_ids contains non-integers", async () => {
+    const { env } = createTestEnv();
 
-    const req = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'fan@example.com', performance_ids: ['one', 2] }),
-    })
-    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
-    expect(res.status).toBe(400)
-  })
+    const req = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com", performance_ids: ["one", 2] }),
+    });
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil });
+    expect(res.status).toBe(400);
+  });
 
-  it('returns 200 silently when all performance_ids are unknown (no enumeration)', async () => {
-    const { env } = createTestEnv()
+  it("returns 200 silently when all performance_ids are unknown (no enumeration)", async () => {
+    const { env } = createTestEnv();
 
-    const req = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'fan@example.com', performance_ids: [99999, 99998] }),
-    })
-    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.success).toBe(true)
-  })
+    const req = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com", performance_ids: [99999, 99998] }),
+    });
+    const res = await followBatchHandler.onRequestPost({ request: req, env, waitUntil });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+  });
 
-  it('records consent_ip from CF-Connecting-IP', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-ip' })
-    const band = insertBand(rawDb, { name: 'IP Band Batch', event_id: ev.id })
+  it("records consent_ip from CF-Connecting-IP", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-ip" });
+    const band = insertBand(rawDb, { name: "IP Band Batch", event_id: ev.id });
 
-    const req = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
+    const req = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        'CF-Connecting-IP': '203.0.113.10',
+        "Content-Type": "application/json",
+        "CF-Connecting-IP": "203.0.113.10",
       },
-      body: JSON.stringify({ email: 'ip@example.com', performance_ids: [band.id] }),
-    })
-    await followBatchHandler.onRequestPost({ request: req, env, waitUntil })
+      body: JSON.stringify({ email: "ip@example.com", performance_ids: [band.id] }),
+    });
+    await followBatchHandler.onRequestPost({ request: req, env, waitUntil });
 
-    const row = rawDb
-      .prepare('SELECT consent_ip FROM band_follows WHERE email = ?')
-      .get('ip@example.com')
-    expect(row.consent_ip).toBe('203.0.113.10')
-  })
-})
+    const row = rawDb.prepare("SELECT consent_ip FROM band_follows WHERE email = ?").get("ip@example.com");
+    expect(row.consent_ip).toBe("203.0.113.10");
+  });
+});
 
-describe('GET /api/bands/confirm-follow-batch', () => {
-  it('verifies all pending follows in the batch and clears batch_token', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-confirm-batch' })
-    const b1 = insertBand(rawDb, { name: 'Confirm A', event_id: ev.id })
-    const b2 = insertBand(rawDb, { name: 'Confirm B', event_id: ev.id })
+describe("GET /api/bands/confirm-follow-batch", () => {
+  it("verifies all pending follows in the batch and clears batch_token", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-confirm-batch" });
+    const b1 = insertBand(rawDb, { name: "Confirm A", event_id: ev.id });
+    const b2 = insertBand(rawDb, { name: "Confirm B", event_id: ev.id });
 
     // Create the batch follows
-    const followReq = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const followReq = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        email: 'confirmbatch@example.com',
+        email: "confirmbatch@example.com",
         performance_ids: [b1.id, b2.id],
       }),
-    })
+    });
     const followRes = await followBatchHandler.onRequestPost({
       request: followReq,
       env,
       waitUntil,
-    })
-    const { confirmUrl } = await followRes.json()
-    expect(confirmUrl).toBeTruthy()
+    });
+    const { confirmUrl } = await followRes.json();
+    expect(confirmUrl).toBeTruthy();
 
-    const batchToken = new URL(confirmUrl).searchParams.get('token')
-    expect(batchToken).toBeTruthy()
+    const batchToken = new URL(confirmUrl).searchParams.get("token");
+    expect(batchToken).toBeTruthy();
 
     // Verify both rows are pending before confirm
-    const pending = rawDb
-      .prepare('SELECT verified FROM band_follows WHERE email = ?')
-      .all('confirmbatch@example.com')
-    expect(pending.every((r) => r.verified === 0)).toBe(true)
+    const pending = rawDb.prepare("SELECT verified FROM band_follows WHERE email = ?").all("confirmbatch@example.com");
+    expect(pending.every((r) => r.verified === 0)).toBe(true);
 
     // Confirm the batch
-    const confirmReq = new Request(
-      `https://example.test/api/bands/confirm-follow-batch?token=${batchToken}`,
-    )
+    const confirmReq = new Request(`https://example.test/api/bands/confirm-follow-batch?token=${batchToken}`);
     const confirmRes = await confirmBatchHandler.onRequestGet({
       request: confirmReq,
       env,
-    })
-    expect(confirmRes.status).toBe(200)
-    const html = await confirmRes.text()
-    expect(html).toMatch(/you're all set/i)
+    });
+    expect(confirmRes.status).toBe(200);
+    const html = await confirmRes.text();
+    expect(html).toMatch(/you're all set/i);
 
     // All rows now verified=1, batch_token cleared
     const confirmed = rawDb
-      .prepare('SELECT verified, batch_token FROM band_follows WHERE email = ?')
-      .all('confirmbatch@example.com')
-    expect(confirmed).toHaveLength(2)
+      .prepare("SELECT verified, batch_token FROM band_follows WHERE email = ?")
+      .all("confirmbatch@example.com");
+    expect(confirmed).toHaveLength(2);
     for (const row of confirmed) {
-      expect(row.verified).toBe(1)
-      expect(row.batch_token).toBeNull()
+      expect(row.verified).toBe(1);
+      expect(row.batch_token).toBeNull();
     }
-  })
+  });
 
-  it('is idempotent — a second click on a used token still returns 200', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol17', slug: 'vol17-idem-confirm' })
-    const band = insertBand(rawDb, { name: 'Idem Confirm', event_id: ev.id })
+  it("is idempotent — a second click on a used token still returns 200", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-idem-confirm" });
+    const band = insertBand(rawDb, { name: "Idem Confirm", event_id: ev.id });
 
-    const followReq = new Request('https://example.test/api/bands/follow-batch', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const followReq = new Request("https://example.test/api/bands/follow-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        email: 'idem2@example.com',
+        email: "idem2@example.com",
         performance_ids: [band.id],
       }),
-    })
+    });
     const followRes = await followBatchHandler.onRequestPost({
       request: followReq,
       env,
       waitUntil,
-    })
-    const { confirmUrl } = await followRes.json()
-    const batchToken = new URL(confirmUrl).searchParams.get('token')
+    });
+    const { confirmUrl } = await followRes.json();
+    const batchToken = new URL(confirmUrl).searchParams.get("token");
 
-    const makeConfirmReq = () =>
-      new Request(
-        `https://example.test/api/bands/confirm-follow-batch?token=${batchToken}`,
-      )
+    const makeConfirmReq = () => new Request(`https://example.test/api/bands/confirm-follow-batch?token=${batchToken}`);
 
-    const first = await confirmBatchHandler.onRequestGet({ request: makeConfirmReq(), env })
-    const second = await confirmBatchHandler.onRequestGet({ request: makeConfirmReq(), env })
+    const first = await confirmBatchHandler.onRequestGet({ request: makeConfirmReq(), env });
+    const second = await confirmBatchHandler.onRequestGet({ request: makeConfirmReq(), env });
 
-    expect(first.status).toBe(200)
-    expect(second.status).toBe(200)
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
 
     // Row still verified=1 after both clicks
-    const row = rawDb
-      .prepare('SELECT verified FROM band_follows WHERE email = ?')
-      .get('idem2@example.com')
-    expect(row.verified).toBe(1)
-  })
+    const row = rawDb.prepare("SELECT verified FROM band_follows WHERE email = ?").get("idem2@example.com");
+    expect(row.verified).toBe(1);
+  });
 
-  it('returns 400 for a missing token', async () => {
-    const { env } = createTestEnv()
-    const req = new Request('https://example.test/api/bands/confirm-follow-batch')
-    const res = await confirmBatchHandler.onRequestGet({ request: req, env })
-    expect(res.status).toBe(400)
-  })
+  it("returns 400 for a missing token", async () => {
+    const { env } = createTestEnv();
+    const req = new Request("https://example.test/api/bands/confirm-follow-batch");
+    const res = await confirmBatchHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(400);
+  });
 
-  it('returns 400 for an oversized token', async () => {
-    const { env } = createTestEnv()
-    const longToken = 'a'.repeat(257)
-    const req = new Request(
-      `https://example.test/api/bands/confirm-follow-batch?token=${longToken}`,
-    )
-    const res = await confirmBatchHandler.onRequestGet({ request: req, env })
-    expect(res.status).toBe(400)
-  })
+  it("returns 400 for an oversized token", async () => {
+    const { env } = createTestEnv();
+    const longToken = "a".repeat(257);
+    const req = new Request(`https://example.test/api/bands/confirm-follow-batch?token=${longToken}`);
+    const res = await confirmBatchHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(400);
+  });
 
-  it('returns 200 for an unknown token (no enumeration)', async () => {
-    const { env } = createTestEnv()
-    const req = new Request(
-      'https://example.test/api/bands/confirm-follow-batch?token=nonexistent-batch-token',
-    )
-    const res = await confirmBatchHandler.onRequestGet({ request: req, env })
+  it("returns 200 for an unknown token (no enumeration)", async () => {
+    const { env } = createTestEnv();
+    const req = new Request("https://example.test/api/bands/confirm-follow-batch?token=nonexistent-batch-token");
+    const res = await confirmBatchHandler.onRequestGet({ request: req, env });
     // Unknown token: changes=0, but we still show the success page (generic/no-enumeration)
-    expect(res.status).toBe(200)
-    const html = await res.text()
-    expect(html).toMatch(/you're all set/i)
-  })
-})
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toMatch(/you're all set/i);
+  });
+});

--- a/functions/api/bands/__tests__/follow.test.js
+++ b/functions/api/bands/__tests__/follow.test.js
@@ -1,103 +1,121 @@
-import { describe, it, expect } from 'vitest'
-import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
-import * as followHandler from '../[name]/follow.js'
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertBand, insertEvent } from "../../test-utils";
+import * as followHandler from "../[name]/follow.js";
 
-const waitUntil = () => {}
+const waitUntil = () => {};
 
-describe('POST /api/bands/:name/follow', () => {
-  it('creates a band follow for a valid email and band', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-follow' })
-    const band = insertBand(rawDb, { name: 'Follow Band', event_id: ev.id })
+describe("POST /api/bands/:name/follow", () => {
+  it("creates a band follow for a valid email and band", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-follow" });
+    const band = insertBand(rawDb, { name: "Follow Band", event_id: ev.id });
 
     const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'fan@example.com' }),
-    })
-    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) }, waitUntil })
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com" }),
+    });
+    const res = await followHandler.onRequestPost({
+      request: req,
+      env,
+      params: { name: String(band.band_profile_id) },
+      waitUntil,
+    });
 
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.success).toBe(true)
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
 
-    const row = rawDb.prepare('SELECT * FROM band_follows WHERE email=? AND band_profile_id=?')
-      .get('fan@example.com', band.band_profile_id)
-    expect(row).toBeTruthy()
+    const row = rawDb
+      .prepare("SELECT * FROM band_follows WHERE email=? AND band_profile_id=?")
+      .get("fan@example.com", band.band_profile_id);
+    expect(row).toBeTruthy();
     // Double opt-in: a new follow is created UNVERIFIED with a pending
     // verification token; it only becomes verified=1 after confirm-follow.
-    expect(row.verified).toBe(0)
-    expect(row.verification_token).toBeTruthy()
-    expect(row.unsubscribe_token).toBeTruthy()
+    expect(row.verified).toBe(0);
+    expect(row.verification_token).toBeTruthy();
+    expect(row.unsubscribe_token).toBeTruthy();
     // CASL/CAN-SPAM: consent fields are always recorded
-    expect(row.consent_method).toBe('web_form')
+    expect(row.consent_method).toBe("web_form");
     // CF-Connecting-IP is absent in test requests, so consent_ip is null
-    expect(row.consent_ip).toBeNull()
-  })
+    expect(row.consent_ip).toBeNull();
+  });
 
-  it('records CF-Connecting-IP as consent_ip when the header is present', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-consent-ip' })
-    const band = insertBand(rawDb, { name: 'IP Band', event_id: ev.id })
-
-    const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'CF-Connecting-IP': '203.0.113.42' },
-      body: JSON.stringify({ email: 'fan2@example.com' }),
-    })
-    await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) }, waitUntil })
-
-    const row = rawDb.prepare('SELECT consent_ip, consent_method FROM band_follows WHERE email=?')
-      .get('fan2@example.com')
-    expect(row.consent_ip).toBe('203.0.113.42')
-    expect(row.consent_method).toBe('web_form')
-  })
-
-  it('returns 400 for an invalid email', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-bad-email' })
-    const band = insertBand(rawDb, { name: 'Band', event_id: ev.id })
+  it("records CF-Connecting-IP as consent_ip when the header is present", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-consent-ip" });
+    const band = insertBand(rawDb, { name: "IP Band", event_id: ev.id });
 
     const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'not-an-email' }),
-    })
-    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) }, waitUntil })
-    expect(res.status).toBe(400)
-  })
+      method: "POST",
+      headers: { "Content-Type": "application/json", "CF-Connecting-IP": "203.0.113.42" },
+      body: JSON.stringify({ email: "fan2@example.com" }),
+    });
+    await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) }, waitUntil });
 
-  it('returns 200 silently if email already follows the band (no duplicate row)', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-dup' })
-    const band = insertBand(rawDb, { name: 'Dup Band', event_id: ev.id })
+    const row = rawDb
+      .prepare("SELECT consent_ip, consent_method FROM band_follows WHERE email=?")
+      .get("fan2@example.com");
+    expect(row.consent_ip).toBe("203.0.113.42");
+    expect(row.consent_method).toBe("web_form");
+  });
 
-    rawDb.prepare(
-      'INSERT INTO band_follows (email, band_profile_id, unsubscribe_token) VALUES (?, ?, ?)'
-    ).run('fan@example.com', band.band_profile_id, 'existing-token')
+  it("returns 400 for an invalid email", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-bad-email" });
+    const band = insertBand(rawDb, { name: "Band", event_id: ev.id });
 
     const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'fan@example.com' }),
-    })
-    const res = await followHandler.onRequestPost({ request: req, env, params: { name: String(band.band_profile_id) }, waitUntil })
-    expect(res.status).toBe(200)
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email" }),
+    });
+    const res = await followHandler.onRequestPost({
+      request: req,
+      env,
+      params: { name: String(band.band_profile_id) },
+      waitUntil,
+    });
+    expect(res.status).toBe(400);
+  });
 
-    const rows = rawDb.prepare('SELECT * FROM band_follows WHERE email=? AND band_profile_id=?')
-      .all('fan@example.com', band.band_profile_id)
-    expect(rows.length).toBe(1)
-  })
+  it("returns 200 silently if email already follows the band (no duplicate row)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-dup" });
+    const band = insertBand(rawDb, { name: "Dup Band", event_id: ev.id });
 
-  it('returns 404 if band does not exist', async () => {
-    const { env } = createTestEnv()
+    rawDb
+      .prepare("INSERT INTO band_follows (email, band_profile_id, unsubscribe_token) VALUES (?, ?, ?)")
+      .run("fan@example.com", band.band_profile_id, "existing-token");
 
-    const req = new Request('https://example.test/api/bands/99999/follow', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'fan@example.com' }),
-    })
-    const res = await followHandler.onRequestPost({ request: req, env, params: { name: '99999' }, waitUntil })
-    expect(res.status).toBe(404)
-  })
-})
+    const req = new Request(`https://example.test/api/bands/${band.band_profile_id}/follow`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com" }),
+    });
+    const res = await followHandler.onRequestPost({
+      request: req,
+      env,
+      params: { name: String(band.band_profile_id) },
+      waitUntil,
+    });
+    expect(res.status).toBe(200);
+
+    const rows = rawDb
+      .prepare("SELECT * FROM band_follows WHERE email=? AND band_profile_id=?")
+      .all("fan@example.com", band.band_profile_id);
+    expect(rows.length).toBe(1);
+  });
+
+  it("returns 404 if band does not exist", async () => {
+    const { env } = createTestEnv();
+
+    const req = new Request("https://example.test/api/bands/99999/follow", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com" }),
+    });
+    const res = await followHandler.onRequestPost({ request: req, env, params: { name: "99999" }, waitUntil });
+    expect(res.status).toBe(404);
+  });
+});

--- a/functions/api/bands/__tests__/profile.test.js
+++ b/functions/api/bands/__tests__/profile.test.js
@@ -1,11 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { onRequestGet } from "../[name].js";
-import {
-  createTestEnv,
-  insertEvent,
-  insertVenue,
-  insertBand,
-} from "../../test-utils.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
 
 describe("GET /api/bands/:name - reveal_mode gate", () => {
   test("hides unannounced performance when reveal_mode=1", async () => {
@@ -16,22 +11,16 @@ describe("GET /api/bands/:name - reveal_mode gate", () => {
       slug: "vol17-band-profile-1",
       date: "2026-08-02",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Prohibition Warehouse" });
     const perf = insertBand(rawDb, {
       name: "Embargoed Artist",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
 
-    const request = new Request(
-      "https://example.test/api/bands/Embargoed%20Artist",
-    );
+    const request = new Request("https://example.test/api/bands/Embargoed%20Artist");
     const response = await onRequestGet({ request, env, params: {} });
 
     // The only performance is embargoed — band appears to have no performances
@@ -47,22 +36,16 @@ describe("GET /api/bands/:name - reveal_mode gate", () => {
       slug: "vol17-band-profile-2",
       date: "2026-08-02",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Roost" });
     const perf = insertBand(rawDb, {
       name: "Revealed Artist",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=1 WHERE id=?").run(perf.id);
 
-    const request = new Request(
-      "https://example.test/api/bands/Revealed%20Artist",
-    );
+    const request = new Request("https://example.test/api/bands/Revealed%20Artist");
     const response = await onRequestGet({ request, env, params: {} });
 
     expect(response.status).toBe(200);
@@ -79,22 +62,16 @@ describe("GET /api/bands/:name - reveal_mode gate", () => {
       slug: "vol17-band-profile-3",
       date: "2026-08-02",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Revive Karaoke" });
     const perf = insertBand(rawDb, {
       name: "Normal Artist",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
 
-    const request = new Request(
-      "https://example.test/api/bands/Normal%20Artist",
-    );
+    const request = new Request("https://example.test/api/bands/Normal%20Artist");
     const response = await onRequestGet({ request, env, params: {} });
 
     // reveal_mode=0: unannounced performances still visible

--- a/functions/api/bands/__tests__/unfollow.test.js
+++ b/functions/api/bands/__tests__/unfollow.test.js
@@ -1,63 +1,63 @@
-import { describe, it, expect } from 'vitest'
-import { createTestEnv, insertBand, insertEvent } from '../../test-utils'
-import { onRequestGet } from '../[name]/unfollow.js'
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertBand, insertEvent } from "../../test-utils";
+import { onRequestGet } from "../[name]/unfollow.js";
 
-describe('GET /api/bands/:name/unfollow', () => {
-  it('deletes the follow row for a valid token and names the band in the response', async () => {
-    const { env, rawDb } = createTestEnv()
-    const ev = insertEvent(rawDb, { name: 'Vol6', slug: 'vol6-unfollow' })
-    const band = insertBand(rawDb, { name: 'Witchrot', event_id: ev.id })
-    rawDb.prepare(
-      'INSERT INTO band_follows (email, band_profile_id, unsubscribe_token) VALUES (?, ?, ?)'
-    ).run('fan@example.com', band.band_profile_id, 'valid-token-abc')
+describe("GET /api/bands/:name/unfollow", () => {
+  it("deletes the follow row for a valid token and names the band in the response", async () => {
+    const { env, rawDb } = createTestEnv();
+    const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-unfollow" });
+    const band = insertBand(rawDb, { name: "Witchrot", event_id: ev.id });
+    rawDb
+      .prepare("INSERT INTO band_follows (email, band_profile_id, unsubscribe_token) VALUES (?, ?, ?)")
+      .run("fan@example.com", band.band_profile_id, "valid-token-abc");
 
     const res = await onRequestGet({
-      request: new Request('https://example.test/api/bands/1/unfollow?token=valid-token-abc'),
+      request: new Request("https://example.test/api/bands/1/unfollow?token=valid-token-abc"),
       env,
-    })
+    });
 
-    expect(res.status).toBe(200)
-    const body = await res.text()
-    expect(body).toContain('Unfollowed')
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Unfollowed");
     // Should name the specific band the fan unsubscribed from, not "this band".
-    expect(body).toContain('Witchrot')
-    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    expect(body).toContain("Witchrot");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
 
-    const row = rawDb.prepare('SELECT * FROM band_follows WHERE unsubscribe_token=?').get('valid-token-abc')
-    expect(row).toBeUndefined()
-  })
+    const row = rawDb.prepare("SELECT * FROM band_follows WHERE unsubscribe_token=?").get("valid-token-abc");
+    expect(row).toBeUndefined();
+  });
 
-  it('returns 200 even when the token does not exist (avoids enumeration)', async () => {
-    const { env } = createTestEnv()
-
-    const res = await onRequestGet({
-      request: new Request('https://example.test/api/bands/1/unfollow?token=nonexistent-token'),
-      env,
-    })
-
-    expect(res.status).toBe(200)
-  })
-
-  it('returns 400 for a missing token', async () => {
-    const { env } = createTestEnv()
+  it("returns 200 even when the token does not exist (avoids enumeration)", async () => {
+    const { env } = createTestEnv();
 
     const res = await onRequestGet({
-      request: new Request('https://example.test/api/bands/1/unfollow'),
+      request: new Request("https://example.test/api/bands/1/unfollow?token=nonexistent-token"),
       env,
-    })
+    });
 
-    expect(res.status).toBe(400)
-  })
+    expect(res.status).toBe(200);
+  });
 
-  it('returns 400 for a token that exceeds 256 characters', async () => {
-    const { env } = createTestEnv()
-    const longToken = 'a'.repeat(257)
+  it("returns 400 for a missing token", async () => {
+    const { env } = createTestEnv();
+
+    const res = await onRequestGet({
+      request: new Request("https://example.test/api/bands/1/unfollow"),
+      env,
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a token that exceeds 256 characters", async () => {
+    const { env } = createTestEnv();
+    const longToken = "a".repeat(257);
 
     const res = await onRequestGet({
       request: new Request(`https://example.test/api/bands/1/unfollow?token=${longToken}`),
       env,
-    })
+    });
 
-    expect(res.status).toBe(400)
-  })
-})
+    expect(res.status).toBe(400);
+  });
+});

--- a/functions/api/bands/follow-batch.js
+++ b/functions/api/bands/follow-batch.js
@@ -36,8 +36,7 @@ export async function onRequestPost(context) {
 
   try {
     const body = await request.json().catch(() => ({}));
-    const email =
-      typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
     const turnstileToken = body.turnstileToken;
     const performanceIds = body.performance_ids;
 
@@ -64,10 +63,10 @@ export async function onRequestPost(context) {
 
     const turnstileValid = await verifyTurnstile(request, env, turnstileToken);
     if (!turnstileValid) {
-      return new Response(
-        JSON.stringify({ error: "Bot verification failed" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Bot verification failed" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Resolve performance_ids → distinct band_profile_ids + band names.
@@ -115,14 +114,7 @@ export async function onRequestPost(context) {
            (email, band_profile_id, verified, verification_token, unsubscribe_token,
             consent_ip, consent_method, batch_token)
          VALUES (?, ?, 0, ?, ?, ?, 'web_form', ?)`,
-      ).bind(
-        email,
-        band_profile_id,
-        verificationToken,
-        unsubscribeToken,
-        consentIp,
-        batchToken,
-      );
+      ).bind(email, band_profile_id, verificationToken, unsubscribeToken, consentIp, batchToken);
     });
 
     const results = await DB.batch(stmts);
@@ -130,12 +122,8 @@ export async function onRequestPost(context) {
     const isNewBatch = results.some((r) => r.meta.changes > 0);
 
     if (isNewBatch && isEmailConfigured(env)) {
-      const bandListText = bands.results
-        .map((b) => `• ${b.band_name}`)
-        .join("\n");
-      const bandListHtml = bands.results
-        .map((b) => `<li>${escapeHtml(b.band_name)}</li>`)
-        .join("");
+      const bandListText = bands.results.map((b) => `• ${b.band_name}`).join("\n");
+      const bandListHtml = bands.results.map((b) => `<li>${escapeHtml(b.band_name)}</li>`).join("");
 
       // ONE email for the whole batch — the core amplification mitigation.
       waitUntil(
@@ -160,17 +148,11 @@ export async function onRequestPost(context) {
         })
           .then((emailResult) => {
             if (!emailResult?.delivered) {
-              console.warn(
-                "[band-follow-batch] Confirmation email not delivered:",
-                emailResult?.reason,
-              );
+              console.warn("[band-follow-batch] Confirmation email not delivered:", emailResult?.reason);
             }
           })
           .catch((err) => {
-            console.error(
-              "[band-follow-batch] Failed to send confirmation email:",
-              err,
-            );
+            console.error("[band-follow-batch] Failed to send confirmation email:", err);
           }),
       );
     }

--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -18,14 +18,9 @@ function formatOrigin(profile) {
 
 function formatVenueAddress(venue) {
   if (!venue) return null;
-  const line1 = [venue.address_line1, venue.address_line2]
-    .filter(Boolean)
-    .join(", ");
+  const line1 = [venue.address_line1, venue.address_line2].filter(Boolean).join(", ");
   const line2 = [venue.city, venue.region].filter(Boolean).join(", ");
-  const line3 = [venue.postal_code, venue.country]
-    .filter(Boolean)
-    .join(" ")
-    .trim();
+  const line3 = [venue.postal_code, venue.country].filter(Boolean).join(" ").trim();
   return [line1, line2, line3].filter(Boolean).join(", ");
 }
 
@@ -43,10 +38,10 @@ export async function onRequestGet(context) {
     const searchParam = decodeURIComponent(parts[parts.length - 1]);
 
     if (!searchParam) {
-      return new Response(
-        JSON.stringify({ error: "Band identifier is required" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Band identifier is required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Check if it's a numeric ID or a name
@@ -131,12 +126,8 @@ export async function onRequestGet(context) {
 
     // Separate upcoming and past performances
     // Archived events always go to past regardless of date
-    const upcomingPerformances = allPerformances.filter(
-      (p) => p.event_date >= today && p.event_status !== "archived",
-    );
-    const pastPerformances = allPerformances.filter(
-      (p) => p.event_date < today || p.event_status === "archived",
-    );
+    const upcomingPerformances = allPerformances.filter((p) => p.event_date >= today && p.event_status !== "archived");
+    const pastPerformances = allPerformances.filter((p) => p.event_date < today || p.event_status === "archived");
 
     // Get unique venues
     const venueMap = new Map();
@@ -152,16 +143,11 @@ export async function onRequestGet(context) {
     // Find signature venue (most played)
     const signatureVenue =
       uniqueVenues.length > 0
-        ? uniqueVenues.reduce(
-            (max, venue) => (venue.count > max.count ? venue : max),
-            uniqueVenues[0],
-          )
+        ? uniqueVenues.reduce((max, venue) => (venue.count > max.count ? venue : max), uniqueVenues[0])
         : null;
 
     // Get unique events
-    const uniqueEvents = new Set(
-      allPerformances.map((p) => p.event_id).filter(Boolean),
-    );
+    const uniqueEvents = new Set(allPerformances.map((p) => p.event_id).filter(Boolean));
 
     // Calculate average set time in minutes
     const setTimes = allPerformances
@@ -171,16 +157,12 @@ export async function onRequestGet(context) {
         const [endH, endM] = p.end_time.split(":").map(Number);
         const startMinutes = startH * 60 + startM;
         const endMinutes = endH * 60 + endM;
-        return endMinutes >= startMinutes
-          ? endMinutes - startMinutes
-          : endMinutes + 24 * 60 - startMinutes;
+        return endMinutes >= startMinutes ? endMinutes - startMinutes : endMinutes + 24 * 60 - startMinutes;
       })
       .filter((t) => t > 0);
 
     const averageSetMinutes =
-      setTimes.length > 0
-        ? Math.round(setTimes.reduce((sum, t) => sum + t, 0) / setTimes.length)
-        : null;
+      setTimes.length > 0 ? Math.round(setTimes.reduce((sum, t) => sum + t, 0) / setTimes.length) : null;
 
     // Get debut and latest dates
     const sortedDates = allPerformances
@@ -189,14 +171,11 @@ export async function onRequestGet(context) {
       .sort();
 
     const debutDate = sortedDates.length > 0 ? sortedDates[0] : null;
-    const latestDate =
-      sortedDates.length > 0 ? sortedDates[sortedDates.length - 1] : null;
+    const latestDate = sortedDates.length > 0 ? sortedDates[sortedDates.length - 1] : null;
 
     let socialLinks = {};
     try {
-      socialLinks = bandProfile.social_links
-        ? JSON.parse(bandProfile.social_links)
-        : {};
+      socialLinks = bandProfile.social_links ? JSON.parse(bandProfile.social_links) : {};
     } catch (_error) {
       socialLinks = {};
     }
@@ -271,12 +250,7 @@ export async function onRequestGet(context) {
       },
     });
   } catch (error) {
-    console.error(
-      "Error fetching band stats:",
-      error,
-      error.message,
-      error.stack,
-    );
+    console.error("Error fetching band stats:", error, error.message, error.stack);
 
     return new Response(
       JSON.stringify({

--- a/functions/api/bands/stats/__tests__/stats.test.js
+++ b/functions/api/bands/stats/__tests__/stats.test.js
@@ -1,11 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { onRequestGet } from "../[name].js";
-import {
-  createTestEnv,
-  insertEvent,
-  insertVenue,
-  insertBand,
-} from "../../../test-utils.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils.js";
 
 describe("GET /api/bands/stats/:name — reveal_mode gate", () => {
   // Use a far-future date so performances land in the "upcoming" bucket
@@ -23,21 +18,15 @@ describe("GET /api/bands/stats/:name — reveal_mode gate", () => {
       date: futureDate,
       status: "published",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Stats Hidden Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
 
-    const request = new Request(
-      "https://example.test/api/bands/stats/Stats%20Hidden%20Band",
-    );
+    const request = new Request("https://example.test/api/bands/stats/Stats%20Hidden%20Band");
     const response = await onRequestGet({ request, env });
 
     expect(response.status).toBe(200);
@@ -58,21 +47,15 @@ describe("GET /api/bands/stats/:name — reveal_mode gate", () => {
       date: futureDate,
       status: "published",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Stats Revealed Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=1 WHERE id=?").run(perf.id);
 
-    const request = new Request(
-      "https://example.test/api/bands/stats/Stats%20Revealed%20Band",
-    );
+    const request = new Request("https://example.test/api/bands/stats/Stats%20Revealed%20Band");
     const response = await onRequestGet({ request, env });
 
     expect(response.status).toBe(200);
@@ -93,21 +76,15 @@ describe("GET /api/bands/stats/:name — reveal_mode gate", () => {
       date: futureDate,
       status: "published",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Stats Normal Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
 
-    const request = new Request(
-      "https://example.test/api/bands/stats/Stats%20Normal%20Band",
-    );
+    const request = new Request("https://example.test/api/bands/stats/Stats%20Normal%20Band");
     const response = await onRequestGet({ request, env });
 
     expect(response.status).toBe(200);

--- a/functions/api/events/[id]/details.js
+++ b/functions/api/events/[id]/details.js
@@ -16,14 +16,9 @@ export async function onRequestGet(context) {
 
   const formatVenueAddress = (venue) => {
     if (!venue) return null;
-    const line1 = [venue.address_line1, venue.address_line2]
-      .filter(Boolean)
-      .join(", ");
+    const line1 = [venue.address_line1, venue.address_line2].filter(Boolean).join(", ");
     const line2 = [venue.city, venue.region].filter(Boolean).join(", ");
-    const line3 = [venue.postal_code, venue.country]
-      .filter(Boolean)
-      .join(" ")
-      .trim();
+    const line3 = [venue.postal_code, venue.country].filter(Boolean).join(" ").trim();
     return [line1, line2, line3].filter(Boolean).join(", ");
   };
 
@@ -48,10 +43,10 @@ export async function onRequestGet(context) {
       .first();
 
     if (!event) {
-      return new Response(
-        JSON.stringify({ error: "Event not found or not published" }),
-        { status: 404, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Event not found or not published" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     const bandsResult = await DB.prepare(
@@ -129,9 +124,9 @@ export async function onRequestGet(context) {
     );
   } catch (error) {
     console.error("Error fetching event details:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to fetch event details" }),
-      { status: 500, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ error: "Failed to fetch event details" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -25,22 +25,18 @@ export async function onRequestGet(context) {
 
   try {
     const event = isNumeric
-      ? await DB.prepare(
-          `SELECT id, name, slug, date FROM events WHERE id = ? AND status = 'archived' LIMIT 1`
-        )
+      ? await DB.prepare(`SELECT id, name, slug, date FROM events WHERE id = ? AND status = 'archived' LIMIT 1`)
           .bind(numericId)
           .first()
-      : await DB.prepare(
-          `SELECT id, name, slug, date FROM events WHERE slug = ? AND status = 'archived' LIMIT 1`
-        )
+      : await DB.prepare(`SELECT id, name, slug, date FROM events WHERE slug = ? AND status = 'archived' LIMIT 1`)
           .bind(rawId)
           .first();
 
     if (!event) {
-      return new Response(
-        JSON.stringify({ error: "Event not found or not archived" }),
-        { status: 404, headers: { "Content-Type": "application/json" } }
-      );
+      return new Response(JSON.stringify({ error: "Event not found or not archived" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     const bandsResult = await DB.prepare(
@@ -67,7 +63,7 @@ export async function onRequestGet(context) {
       LEFT JOIN venues v ON p.venue_id = v.id
       WHERE p.event_id = ?
       ORDER BY p.start_time NULLS LAST, bp.name
-      `
+      `,
     )
       .bind(event.id, event.id)
       .all();
@@ -111,21 +107,18 @@ export async function onRequestGet(context) {
       returning_acts: returningActs,
     };
 
-    return new Response(
-      JSON.stringify({ event, stats, bands }),
-      {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-          "Cache-Control": "public, max-age=3600",
-        },
-      }
-    );
+    return new Response(JSON.stringify({ event, stats, bands }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
   } catch (error) {
     console.error("Error fetching event recap:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to fetch event recap" }),
-      { status: 500, headers: { "Content-Type": "application/json" } }
-    );
+    return new Response(JSON.stringify({ error: "Failed to fetch event recap" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/events/__tests__/details.test.js
+++ b/functions/api/events/__tests__/details.test.js
@@ -1,11 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { onRequestGet } from "../[id]/details.js";
-import {
-  createTestEnv,
-  insertEvent,
-  insertVenue,
-  insertBand,
-} from "../../test-utils.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
 
 describe("GET /api/events/:id/details", () => {
   test("returns event details for a published event", async () => {
@@ -16,9 +11,7 @@ describe("GET /api/events/:id/details", () => {
       slug: "test-event",
       date: "2026-01-01",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published = 1 WHERE id = ?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Test Venue", city: "Portland" });
     insertBand(rawDb, {
@@ -29,9 +22,7 @@ describe("GET /api/events/:id/details", () => {
       end_time: "20:00",
     });
 
-    const request = new Request(
-      `https://example.test/api/events/${event.id}/details`,
-    );
+    const request = new Request(`https://example.test/api/events/${event.id}/details`);
     const response = await onRequestGet({
       request,
       env,
@@ -78,9 +69,7 @@ describe("GET /api/events/:id/details", () => {
       slug: "draft-event",
     });
 
-    const request = new Request(
-      `https://example.test/api/events/${event.id}/details`,
-    );
+    const request = new Request(`https://example.test/api/events/${event.id}/details`);
     const response = await onRequestGet({
       request,
       env,
@@ -100,30 +89,22 @@ describe("GET /api/events/:id/details - reveal_mode gate", () => {
       slug: "reveal-details-1",
       date: "2026-08-02",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     const announced = insertBand(rawDb, {
       name: "Visible Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
-      .run(announced.id);
+    rawDb.prepare("UPDATE performances SET is_announced=1 WHERE id=?").run(announced.id);
     const hidden = insertBand(rawDb, {
       name: "Hidden Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(hidden.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(hidden.id);
 
-    const request = new Request(
-      `https://example.test/api/events/${event.id}/details`,
-    );
+    const request = new Request(`https://example.test/api/events/${event.id}/details`);
     const response = await onRequestGet({
       request,
       env,
@@ -144,22 +125,16 @@ describe("GET /api/events/:id/details - reveal_mode gate", () => {
       slug: "reveal-details-2",
       date: "2026-08-02",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Princess Cafe" });
     const announced = insertBand(rawDb, {
       name: "Announced Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
-      .run(announced.id);
+    rawDb.prepare("UPDATE performances SET is_announced=1 WHERE id=?").run(announced.id);
 
-    const request = new Request(
-      `https://example.test/api/events/${event.id}/details`,
-    );
+    const request = new Request(`https://example.test/api/events/${event.id}/details`);
     const response = await onRequestGet({
       request,
       env,
@@ -180,22 +155,16 @@ describe("GET /api/events/:id/details - reveal_mode gate", () => {
       slug: "reveal-details-0",
       date: "2026-08-02",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Room 47" });
     const unannounced = insertBand(rawDb, {
       name: "Unannounced But Visible",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(unannounced.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(unannounced.id);
 
-    const request = new Request(
-      `https://example.test/api/events/${event.id}/details`,
-    );
+    const request = new Request(`https://example.test/api/events/${event.id}/details`);
     const response = await onRequestGet({
       request,
       env,

--- a/functions/api/events/__tests__/public.test.js
+++ b/functions/api/events/__tests__/public.test.js
@@ -1,36 +1,31 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { onRequestGet } from '../public.js';
-import { MockD1Database } from '../../subscriptions/__tests__/mocks/d1.js';
-import {
-  createMockEvent,
-  createMockVenue,
-  createMockBand,
-  seedMockData,
-} from './helpers.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { onRequestGet } from "../public.js";
+import { MockD1Database } from "../../subscriptions/__tests__/mocks/d1.js";
+import { createMockEvent, createMockVenue, createMockBand, seedMockData } from "./helpers.js";
 
-describe('GET /api/events/public', () => {
+describe("GET /api/events/public", () => {
   let mockDB;
   let mockEnv;
 
   beforeEach(() => {
     mockDB = new MockD1Database();
-    mockEnv = { DB: mockDB, PUBLIC_DATA_PUBLISH_ENABLED: 'true' };
+    mockEnv = { DB: mockDB, PUBLIC_DATA_PUBLISH_ENABLED: "true" };
 
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('should return all events with venue and band details', async () => {
+  it("should return all events with venue and band details", async () => {
     const event = createMockEvent();
     const venue = createMockVenue();
     const band = createMockBand();
 
     seedMockData(mockDB, [event], [venue], [band]);
 
-    const request = new Request('http://localhost/api/events/public');
+    const request = new Request("http://localhost/api/events/public");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
@@ -41,19 +36,19 @@ describe('GET /api/events/public', () => {
     expect(data.events).toHaveLength(1);
     expect(data.events[0]).toMatchObject({
       id: 1,
-      name: 'Summer Music Festival 2024',
-      city: 'portland',
+      name: "Summer Music Festival 2024",
+      city: "portland",
     });
     expect(data.events[0].band_count).toBeGreaterThan(0);
     expect(data.events[0].venue_count).toBeGreaterThan(0);
   });
 
-  it('should filter by city parameter', async () => {
-    const event1 = createMockEvent({ id: 1, city: 'portland' });
+  it("should filter by city parameter", async () => {
+    const event1 = createMockEvent({ id: 1, city: "portland" });
     const event2 = createMockEvent({
       id: 2,
-      city: 'seattle',
-      name: 'Seattle Showcase',
+      city: "seattle",
+      name: "Seattle Showcase",
     });
     const venue = createMockVenue();
     const band1 = createMockBand({ id: 1 });
@@ -61,9 +56,7 @@ describe('GET /api/events/public', () => {
 
     seedMockData(mockDB, [event1, event2], [venue], [band1, band2]);
 
-    const request = new Request(
-      'http://localhost/api/events/public?city=portland'
-    );
+    const request = new Request("http://localhost/api/events/public?city=portland");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
@@ -71,77 +64,66 @@ describe('GET /api/events/public', () => {
 
     expect(response.status).toBe(200);
     expect(data.events).toHaveLength(1);
-    expect(data.events[0].city).toBe('portland');
-    expect(data.filters.city).toBe('portland');
+    expect(data.events[0].city).toBe("portland");
+    expect(data.filters.city).toBe("portland");
   });
 
-  it('should filter by genre parameter', async () => {
+  it("should filter by genre parameter", async () => {
     const event = createMockEvent();
     const venue = createMockVenue();
     const punkBand = createMockBand({
       id: 1,
-      genre: 'punk',
-      name: 'Punk Band',
+      genre: "punk",
+      name: "Punk Band",
     });
     const indieBand = createMockBand({
       id: 2,
-      genre: 'indie',
-      name: 'Indie Band',
+      genre: "indie",
+      name: "Indie Band",
     });
 
     seedMockData(mockDB, [event], [venue], [punkBand, indieBand]);
 
-    const request = new Request(
-      'http://localhost/api/events/public?genre=punk'
-    );
+    const request = new Request("http://localhost/api/events/public?genre=punk");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.filters.genre).toBe('punk');
+    expect(data.filters.genre).toBe("punk");
     // Should still return the event but filtered by genre
     expect(data.events).toBeInstanceOf(Array);
   });
 
-  it('should combine city and genre filters', async () => {
-    const portlandEvent = createMockEvent({ id: 1, city: 'portland' });
+  it("should combine city and genre filters", async () => {
+    const portlandEvent = createMockEvent({ id: 1, city: "portland" });
     const seattleEvent = createMockEvent({
       id: 2,
-      city: 'seattle',
-      name: 'Seattle Showcase',
+      city: "seattle",
+      name: "Seattle Showcase",
     });
     const venue = createMockVenue();
-    const punkBand = createMockBand({ id: 1, event_id: 1, genre: 'punk' });
-    const indieBand = createMockBand({ id: 2, event_id: 2, genre: 'indie' });
+    const punkBand = createMockBand({ id: 1, event_id: 1, genre: "punk" });
+    const indieBand = createMockBand({ id: 2, event_id: 2, genre: "indie" });
 
-    seedMockData(
-      mockDB,
-      [portlandEvent, seattleEvent],
-      [venue],
-      [punkBand, indieBand]
-    );
+    seedMockData(mockDB, [portlandEvent, seattleEvent], [venue], [punkBand, indieBand]);
 
-    const request = new Request(
-      'http://localhost/api/events/public?city=portland&genre=punk'
-    );
+    const request = new Request("http://localhost/api/events/public?city=portland&genre=punk");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.filters.city).toBe('portland');
-    expect(data.filters.genre).toBe('punk');
+    expect(data.filters.city).toBe("portland");
+    expect(data.filters.genre).toBe("punk");
   });
 
-  it('should return empty array when no events match filters', async () => {
+  it("should return empty array when no events match filters", async () => {
     seedMockData(mockDB, [], [], []);
 
-    const request = new Request(
-      'http://localhost/api/events/public?city=nonexistent'
-    );
+    const request = new Request("http://localhost/api/events/public?city=nonexistent");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
@@ -152,16 +134,14 @@ describe('GET /api/events/public', () => {
     expect(data.count).toBe(0);
   });
 
-  it('should return empty array for invalid city', async () => {
-    const event = createMockEvent({ city: 'portland' });
+  it("should return empty array for invalid city", async () => {
+    const event = createMockEvent({ city: "portland" });
     const venue = createMockVenue();
     const band = createMockBand();
 
     seedMockData(mockDB, [event], [venue], [band]);
 
-    const request = new Request(
-      'http://localhost/api/events/public?city=invalidcity'
-    );
+    const request = new Request("http://localhost/api/events/public?city=invalidcity");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
@@ -171,32 +151,32 @@ describe('GET /api/events/public', () => {
     expect(data.events).toHaveLength(0);
   });
 
-  it('should verify response includes all required fields', async () => {
+  it("should verify response includes all required fields", async () => {
     const event = createMockEvent();
     const venue = createMockVenue();
     const band = createMockBand();
 
     seedMockData(mockDB, [event], [venue], [band]);
 
-    const request = new Request('http://localhost/api/events/public');
+    const request = new Request("http://localhost/api/events/public");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data).toHaveProperty('events');
-    expect(data).toHaveProperty('filters');
-    expect(data).toHaveProperty('count');
-    expect(data).toHaveProperty('generated_at');
+    expect(data).toHaveProperty("events");
+    expect(data).toHaveProperty("filters");
+    expect(data).toHaveProperty("count");
+    expect(data).toHaveProperty("generated_at");
 
-    expect(data.filters).toHaveProperty('city');
-    expect(data.filters).toHaveProperty('genre');
-    expect(data.filters).toHaveProperty('upcoming');
-    expect(data.filters).toHaveProperty('limit');
+    expect(data.filters).toHaveProperty("city");
+    expect(data.filters).toHaveProperty("genre");
+    expect(data.filters).toHaveProperty("upcoming");
+    expect(data.filters).toHaveProperty("limit");
   });
 
-  it('should sort events chronologically by date', async () => {
+  it("should sort events chronologically by date", async () => {
     const today = new Date();
     const tomorrow = new Date(today);
     tomorrow.setDate(tomorrow.getDate() + 1);
@@ -205,18 +185,18 @@ describe('GET /api/events/public', () => {
 
     const event1 = createMockEvent({
       id: 1,
-      date: dayAfter.toISOString().split('T')[0],
-      name: 'Event 3',
+      date: dayAfter.toISOString().split("T")[0],
+      name: "Event 3",
     });
     const event2 = createMockEvent({
       id: 2,
-      date: tomorrow.toISOString().split('T')[0],
-      name: 'Event 1',
+      date: tomorrow.toISOString().split("T")[0],
+      name: "Event 1",
     });
     const event3 = createMockEvent({
       id: 3,
-      date: tomorrow.toISOString().split('T')[0],
-      name: 'Event 2',
+      date: tomorrow.toISOString().split("T")[0],
+      name: "Event 2",
     });
 
     const venue = createMockVenue();
@@ -224,14 +204,9 @@ describe('GET /api/events/public', () => {
     const band2 = createMockBand({ id: 2, event_id: 2 });
     const band3 = createMockBand({ id: 3, event_id: 3 });
 
-    seedMockData(
-      mockDB,
-      [event1, event2, event3],
-      [venue],
-      [band1, band2, band3]
-    );
+    seedMockData(mockDB, [event1, event2, event3], [venue], [band1, band2, band3]);
 
-    const request = new Request('http://localhost/api/events/public');
+    const request = new Request("http://localhost/api/events/public");
     const context = { request, env: mockEnv };
 
     const response = await onRequestGet(context);

--- a/functions/api/events/__tests__/recap.test.js
+++ b/functions/api/events/__tests__/recap.test.js
@@ -1,26 +1,19 @@
-import { describe, expect, it, test } from 'vitest';
-import { onRequestGet } from '../[id]/recap.js';
-import {
-  createTestEnv,
-  insertEvent,
-  insertVenue,
-  insertBand,
-} from '../../test-utils.js';
+import { describe, expect, it, test } from "vitest";
+import { onRequestGet } from "../[id]/recap.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
 
-describe('GET /api/events/:id/recap', () => {
-  test('returns 404 for a non-archived event', async () => {
+describe("GET /api/events/:id/recap", () => {
+  test("returns 404 for a non-archived event", async () => {
     const { env, rawDb } = createTestEnv();
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const event = insertEvent(rawDb, {
-      name: 'Draft Event',
-      slug: 'draft-event',
-      date: '2024-08-03',
-      status: 'draft',
+      name: "Draft Event",
+      slug: "draft-event",
+      date: "2024-08-03",
+      status: "draft",
     });
 
-    const request = new Request(
-      `https://example.test/api/events/${event.slug}/recap`
-    );
+    const request = new Request(`https://example.test/api/events/${event.slug}/recap`);
     const response = await onRequestGet({
       request,
       env,
@@ -30,28 +23,26 @@ describe('GET /api/events/:id/recap', () => {
     expect(response.status).toBe(404);
   });
 
-  test('returns 200 with stats and bands for an archived event looked up by slug', async () => {
+  test("returns 200 with stats and bands for an archived event looked up by slug", async () => {
     const { env, rawDb } = createTestEnv();
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const event = insertEvent(rawDb, {
-      name: 'LWBC Vol5',
-      slug: 'lwbc-vol5',
-      date: '2024-08-03',
-      status: 'archived',
+      name: "LWBC Vol5",
+      slug: "lwbc-vol5",
+      date: "2024-08-03",
+      status: "archived",
     });
 
-    const venue = insertVenue(rawDb, { name: 'Main Stage', city: 'Portland' });
+    const venue = insertVenue(rawDb, { name: "Main Stage", city: "Portland" });
     insertBand(rawDb, {
-      name: 'Band Alpha',
+      name: "Band Alpha",
       event_id: event.id,
       venue_id: venue.id,
-      start_time: '19:00',
-      end_time: '20:00',
+      start_time: "19:00",
+      end_time: "20:00",
     });
 
-    const request = new Request(
-      `https://example.test/api/events/${event.slug}/recap`
-    );
+    const request = new Request(`https://example.test/api/events/${event.slug}/recap`);
     const response = await onRequestGet({
       request,
       env,
@@ -59,14 +50,14 @@ describe('GET /api/events/:id/recap', () => {
     });
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=3600");
 
     const payload = await response.json();
     expect(payload.event).toMatchObject({
       id: event.id,
-      name: 'LWBC Vol5',
-      slug: 'lwbc-vol5',
-      date: '2024-08-03',
+      name: "LWBC Vol5",
+      slug: "lwbc-vol5",
+      date: "2024-08-03",
     });
     expect(payload.stats).toMatchObject({
       total_sets: 1,
@@ -74,37 +65,35 @@ describe('GET /api/events/:id/recap', () => {
     });
     expect(payload.bands).toHaveLength(1);
     expect(payload.bands[0]).toMatchObject({
-      name: 'Band Alpha',
+      name: "Band Alpha",
       performance_id: expect.any(Number),
       venue_id: venue.id,
-      venue_name: 'Main Stage',
-      start_time: '19:00',
-      end_time: '20:00',
+      venue_name: "Main Stage",
+      start_time: "19:00",
+      end_time: "20:00",
     });
   });
 
-  test('returns 200 when looked up by numeric ID', async () => {
+  test("returns 200 when looked up by numeric ID", async () => {
     const { env, rawDb } = createTestEnv();
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const event = insertEvent(rawDb, {
-      name: 'LWBC Vol6',
-      slug: 'lwbc-vol6',
-      date: '2024-09-15',
-      status: 'archived',
+      name: "LWBC Vol6",
+      slug: "lwbc-vol6",
+      date: "2024-09-15",
+      status: "archived",
     });
 
-    const venue = insertVenue(rawDb, { name: 'Side Stage', city: 'Portland' });
+    const venue = insertVenue(rawDb, { name: "Side Stage", city: "Portland" });
     insertBand(rawDb, {
-      name: 'Band Beta',
+      name: "Band Beta",
       event_id: event.id,
       venue_id: venue.id,
-      start_time: '20:00',
-      end_time: '21:00',
+      start_time: "20:00",
+      end_time: "21:00",
     });
 
-    const request = new Request(
-      `https://example.test/api/events/${event.id}/recap`
-    );
+    const request = new Request(`https://example.test/api/events/${event.id}/recap`);
     const response = await onRequestGet({
       request,
       env,
@@ -117,58 +106,56 @@ describe('GET /api/events/:id/recap', () => {
     expect(payload.bands).toHaveLength(1);
   });
 
-  test('correctly classifies first-timers vs returning acts', async () => {
+  test("correctly classifies first-timers vs returning acts", async () => {
     const { env, rawDb } = createTestEnv();
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true';
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
 
     // Prior event
     const priorEvent = insertEvent(rawDb, {
-      name: 'LWBC Vol4',
-      slug: 'lwbc-vol4',
-      date: '2023-08-01',
-      status: 'archived',
+      name: "LWBC Vol4",
+      slug: "lwbc-vol4",
+      date: "2023-08-01",
+      status: "archived",
     });
 
     // Current event (archived)
     const currentEvent = insertEvent(rawDb, {
-      name: 'LWBC Vol5',
-      slug: 'lwbc-vol5-ft',
-      date: '2024-08-03',
-      status: 'archived',
+      name: "LWBC Vol5",
+      slug: "lwbc-vol5-ft",
+      date: "2024-08-03",
+      status: "archived",
     });
 
-    const venue = insertVenue(rawDb, { name: 'Main Stage', city: 'Portland' });
+    const venue = insertVenue(rawDb, { name: "Main Stage", city: "Portland" });
 
     // Returning act: appears in prior event
     const returningAct = insertBand(rawDb, {
-      name: 'Returning Band',
+      name: "Returning Band",
       event_id: priorEvent.id,
       venue_id: venue.id,
-      start_time: '18:00',
-      end_time: '19:00',
+      start_time: "18:00",
+      end_time: "19:00",
     });
 
     // Add the same band (by name, so same band_profile_id) to the current event
     insertBand(rawDb, {
-      name: 'Returning Band',
+      name: "Returning Band",
       event_id: currentEvent.id,
       venue_id: venue.id,
-      start_time: '19:00',
-      end_time: '20:00',
+      start_time: "19:00",
+      end_time: "20:00",
     });
 
     // First-timer: only appears in the current event
     insertBand(rawDb, {
-      name: 'New Band',
+      name: "New Band",
       event_id: currentEvent.id,
       venue_id: venue.id,
-      start_time: '20:00',
-      end_time: '21:00',
+      start_time: "20:00",
+      end_time: "21:00",
     });
 
-    const request = new Request(
-      `https://example.test/api/events/${currentEvent.slug}/recap`
-    );
+    const request = new Request(`https://example.test/api/events/${currentEvent.slug}/recap`);
     const response = await onRequestGet({
       request,
       env,
@@ -182,60 +169,60 @@ describe('GET /api/events/:id/recap', () => {
     expect(payload.stats.first_timers).toBe(1);
     expect(payload.stats.returning_acts).toBe(1);
 
-    const returningBand = payload.bands.find((b) => b.name === 'Returning Band');
-    const newBand = payload.bands.find((b) => b.name === 'New Band');
+    const returningBand = payload.bands.find((b) => b.name === "Returning Band");
+    const newBand = payload.bands.find((b) => b.name === "New Band");
     expect(returningBand.is_returning).toBe(true);
     expect(newBand.is_returning).toBe(false);
   });
 
-  it('counts only assigned venues (null venue does not increment venue_count)', async () => {
-    const { env, rawDb } = createTestEnv()
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
-    const event = insertEvent(rawDb, { name: 'Mixed Venues', slug: 'mixed-venues' })
-    rawDb.prepare("UPDATE events SET status='archived', is_published=1 WHERE id=?").run(event.id)
-    const venue = insertVenue(rawDb, { name: 'Stage A' })
-    insertBand(rawDb, { name: 'Band With Venue', event_id: event.id, venue_id: venue.id })
-    insertBand(rawDb, { name: 'Band Without Venue', event_id: event.id }) // no venue
+  it("counts only assigned venues (null venue does not increment venue_count)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, { name: "Mixed Venues", slug: "mixed-venues" });
+    rawDb.prepare("UPDATE events SET status='archived', is_published=1 WHERE id=?").run(event.id);
+    const venue = insertVenue(rawDb, { name: "Stage A" });
+    insertBand(rawDb, { name: "Band With Venue", event_id: event.id, venue_id: venue.id });
+    insertBand(rawDb, { name: "Band Without Venue", event_id: event.id }); // no venue
 
     const res = await onRequestGet({
       request: new Request(`https://example.test/api/events/${event.id}/recap`),
       env,
       params: { id: String(event.id) },
-    })
-    expect(res.status).toBe(200)
-    const data = await res.json()
-    expect(data.stats.venue_count).toBe(1) // only the one with a venue
-    expect(data.stats.total_sets).toBe(2) // both bands appear
-  })
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.stats.venue_count).toBe(1); // only the one with a venue
+    expect(data.stats.total_sets).toBe(2); // both bands appear
+  });
 
-  it('returns 500 on DB error', async () => {
-    const { env } = createTestEnv()
-    env.PUBLIC_DATA_PUBLISH_ENABLED = 'true'
+  it("returns 500 on DB error", async () => {
+    const { env } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     env.DB = {
-      prepare: () => { throw new Error('simulated DB failure') },
-    }
+      prepare: () => {
+        throw new Error("simulated DB failure");
+      },
+    };
 
     const res = await onRequestGet({
-      request: new Request('https://example.test/api/events/any-slug/recap'),
+      request: new Request("https://example.test/api/events/any-slug/recap"),
       env,
-      params: { id: 'any-slug' },
-    })
-    expect(res.status).toBe(500)
-  })
+      params: { id: "any-slug" },
+    });
+    expect(res.status).toBe(500);
+  });
 
-  test('returns 503 when PUBLIC_DATA_PUBLISH_ENABLED is not set', async () => {
+  test("returns 503 when PUBLIC_DATA_PUBLISH_ENABLED is not set", async () => {
     const { env, rawDb } = createTestEnv();
     // Do NOT set PUBLIC_DATA_PUBLISH_ENABLED
     const event = insertEvent(rawDb, {
-      name: 'LWBC Vol5',
-      slug: 'lwbc-vol5-gate',
-      date: '2024-08-03',
-      status: 'archived',
+      name: "LWBC Vol5",
+      slug: "lwbc-vol5-gate",
+      date: "2024-08-03",
+      status: "archived",
     });
 
-    const request = new Request(
-      `https://example.test/api/events/${event.slug}/recap`
-    );
+    const request = new Request(`https://example.test/api/events/${event.slug}/recap`);
     const response = await onRequestGet({
       request,
       env,

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -7,12 +7,7 @@
 
 import { describe, it, test, expect, beforeEach, vi } from "vitest";
 import { onRequestGet as timelineHandler } from "../timeline.js";
-import {
-  createTestEnv,
-  insertEvent,
-  insertVenue,
-  insertBand,
-} from "../../test-utils.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
 
 // Returns the mock result set for a query string, keyed off the distinctive
 // WHERE clause for each period (now / upcoming / past).
@@ -101,8 +96,7 @@ const createMockDB = () => {
 
   return {
     prepare: mockPrepare,
-    batch: async (statements) =>
-      statements.map((statement) => resultForQuery(statement.query)),
+    batch: async (statements) => statements.map((statement) => resultForQuery(statement.query)),
   };
 };
 
@@ -175,9 +169,7 @@ describe("Timeline API - Optimized JOIN Queries", () => {
 
   describe("Query Parameters", () => {
     it('should support disabling "now" events', async () => {
-      mockContext.request = new Request(
-        "https://example.com/api/events/timeline?now=false",
-      );
+      mockContext.request = new Request("https://example.com/api/events/timeline?now=false");
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
@@ -185,9 +177,7 @@ describe("Timeline API - Optimized JOIN Queries", () => {
     });
 
     it('should support disabling "upcoming" events', async () => {
-      mockContext.request = new Request(
-        "https://example.com/api/events/timeline?upcoming=false",
-      );
+      mockContext.request = new Request("https://example.com/api/events/timeline?upcoming=false");
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
@@ -195,9 +185,7 @@ describe("Timeline API - Optimized JOIN Queries", () => {
     });
 
     it('should support disabling "past" events', async () => {
-      mockContext.request = new Request(
-        "https://example.com/api/events/timeline?past=false",
-      );
+      mockContext.request = new Request("https://example.com/api/events/timeline?past=false");
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
@@ -205,9 +193,7 @@ describe("Timeline API - Optimized JOIN Queries", () => {
     });
 
     it("should respect pastLimit parameter", async () => {
-      mockContext.request = new Request(
-        "https://example.com/api/events/timeline?pastLimit=5",
-      );
+      mockContext.request = new Request("https://example.com/api/events/timeline?pastLimit=5");
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
@@ -388,9 +374,7 @@ describe("Timeline API - Optimized JOIN Queries", () => {
         ],
       };
 
-      mockContext.request = new Request(
-        "https://example.test/api/events/timeline",
-      );
+      mockContext.request = new Request("https://example.test/api/events/timeline");
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
@@ -444,9 +428,7 @@ describe("Timeline API - Optimized JOIN Queries", () => {
         ],
       };
 
-      mockContext.request = new Request(
-        "https://example.test/api/events/timeline",
-      );
+      mockContext.request = new Request("https://example.test/api/events/timeline");
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
@@ -500,9 +482,7 @@ describe("Timeline API - Optimized JOIN Queries", () => {
         ],
       };
 
-      mockContext.request = new Request(
-        "https://example.test/api/events/timeline",
-      );
+      mockContext.request = new Request("https://example.test/api/events/timeline");
       const response = await onRequestGet(mockContext);
       const data = await response.json();
 
@@ -620,9 +600,7 @@ describe("Timeline real-DB — reveal_mode JOIN gate (SQL exercise)", () => {
       date: today,
       status: "published",
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     const perf = insertBand(rawDb, {
@@ -630,9 +608,7 @@ describe("Timeline real-DB — reveal_mode JOIN gate (SQL exercise)", () => {
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -663,9 +639,7 @@ describe("Timeline real-DB — upcoming has no fixed day-window cap (SQL exercis
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
 
     // 45 days out — comfortably past the old 30-day horizon.
-    const farFuture = new Date(Date.now() + 45 * 24 * 60 * 60 * 1000)
-      .toISOString()
-      .split("T")[0];
+    const farFuture = new Date(Date.now() + 45 * 24 * 60 * 60 * 1000).toISOString().split("T")[0];
 
     const event = insertEvent(rawDb, {
       name: "Flagship Crawl",

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -26,14 +26,9 @@ export async function onRequestGet(context) {
 
   const formatVenueAddress = (venue) => {
     if (!venue) return null;
-    const line1 = [venue.address_line1, venue.address_line2]
-      .filter(Boolean)
-      .join(", ");
+    const line1 = [venue.address_line1, venue.address_line2].filter(Boolean).join(", ");
     const line2 = [venue.city, venue.region].filter(Boolean).join(", ");
-    const line3 = [venue.postal_code, venue.country]
-      .filter(Boolean)
-      .join(" ")
-      .trim();
+    const line3 = [venue.postal_code, venue.country].filter(Boolean).join(" ").trim();
     return [line1, line2, line3].filter(Boolean).join(", ");
   };
 
@@ -43,13 +38,8 @@ export async function onRequestGet(context) {
     const includeUpcoming = url.searchParams.get("upcoming") !== "false"; // default true
     const includePast = url.searchParams.get("past") !== "false"; // default true
     const includeBands = url.searchParams.get("includeBands") !== "false"; // default true
-    const parsedPastLimit = parseInt(
-      url.searchParams.get("pastLimit") || "10",
-      10,
-    );
-    const pastLimit = Number.isFinite(parsedPastLimit)
-      ? Math.min(Math.max(parsedPastLimit, 1), 100)
-      : 10;
+    const parsedPastLimit = parseInt(url.searchParams.get("pastLimit") || "10", 10);
+    const pastLimit = Number.isFinite(parsedPastLimit) ? Math.min(Math.max(parsedPastLimit, 1), 100) : 10;
 
     const response = {
       now: [],
@@ -89,8 +79,7 @@ export async function onRequestGet(context) {
             if (!url && row.social_links) {
               try {
                 const links = JSON.parse(row.social_links);
-                url =
-                  links.website || links.bandcamp || links.instagram || null;
+                url = links.website || links.bandcamp || links.instagram || null;
               } catch (_) {}
             }
 
@@ -298,9 +287,7 @@ export async function onRequestGet(context) {
         response.now = groupEventData(batchResults[slots.now].results || []);
       }
       if (slots.upcoming !== undefined) {
-        response.upcoming = groupEventData(
-          batchResults[slots.upcoming].results || [],
-        );
+        response.upcoming = groupEventData(batchResults[slots.upcoming].results || []);
       }
       if (slots.past !== undefined) {
         response.past = groupEventData(batchResults[slots.past].results || []);

--- a/functions/api/feeds/__tests__/ical.test.js
+++ b/functions/api/feeds/__tests__/ical.test.js
@@ -1,20 +1,10 @@
 import { describe, it, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { onRequestGet } from "../ical.js";
-import {
-  createTestEnv,
-  insertEvent,
-  insertVenue,
-  insertBand,
-} from "../../test-utils.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
 import { MockD1Database } from "../../subscriptions/__tests__/mocks/d1.js";
 
 // Reuse helpers from events tests
-import {
-  createMockEvent,
-  createMockVenue,
-  createMockBand,
-  seedMockData,
-} from "../../events/__tests__/helpers.js";
+import { createMockEvent, createMockVenue, createMockBand, seedMockData } from "../../events/__tests__/helpers.js";
 
 describe("GET /api/feeds/ical", () => {
   let mockDB;
@@ -73,9 +63,7 @@ describe("GET /api/feeds/ical", () => {
     const response = await onRequestGet(context);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toBe(
-      "text/calendar; charset=utf-8",
-    );
+    expect(response.headers.get("Content-Type")).toBe("text/calendar; charset=utf-8");
   });
 
   it("should include iCal headers VERSION, PRODID, CALSCALE", async () => {
@@ -222,12 +210,8 @@ describe("GET /api/feeds/ical", () => {
     expect(icalData).toContain("SUMMARY:Band Two");
 
     // UIDs should be unique (using performance IDs)
-    expect(icalData).toContain(
-      `UID:performance-1-${dateStr}@concertschedule.app`,
-    );
-    expect(icalData).toContain(
-      `UID:performance-2-${dateStr}@concertschedule.app`,
-    );
+    expect(icalData).toContain(`UID:performance-1-${dateStr}@concertschedule.app`);
+    expect(icalData).toContain(`UID:performance-2-${dateStr}@concertschedule.app`);
 
     // Count VEVENT blocks - should be 2
     const vevents = icalData.split("BEGIN:VEVENT").length - 1;
@@ -252,18 +236,14 @@ describe("GET /api/feeds/ical — reveal_mode gate (real-DB)", () => {
       slug: "ical-reveal-hidden",
       date: futureDate,
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     const perf = insertBand(rawDb, {
       name: "Hidden iCal Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
 
     const request = new Request("https://example.test/api/feeds/ical");
     const response = await onRequestGet({ request, env });
@@ -283,18 +263,14 @@ describe("GET /api/feeds/ical — reveal_mode gate (real-DB)", () => {
       slug: "ical-reveal-shown",
       date: futureDate,
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Princess Cafe" });
     const perf = insertBand(rawDb, {
       name: "Revealed iCal Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=1 WHERE id=?").run(perf.id);
 
     const request = new Request("https://example.test/api/feeds/ical");
     const response = await onRequestGet({ request, env });
@@ -314,18 +290,14 @@ describe("GET /api/feeds/ical — reveal_mode gate (real-DB)", () => {
       slug: "ical-reveal-mode0",
       date: futureDate,
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Room 47" });
     const perf = insertBand(rawDb, {
       name: "Normal iCal Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
 
     const request = new Request("https://example.test/api/feeds/ical");
     const response = await onRequestGet({ request, env });

--- a/functions/api/feeds/ical.js
+++ b/functions/api/feeds/ical.js
@@ -115,16 +115,10 @@ function generateICal(bands, city, genre) {
     const uid = `performance-${band.performance_id}-${eventDate}@concertschedule.app`;
 
     // Location
-    const location = band.venue_name
-      ? `${band.venue_name}${band.address ? ", " + band.address : ""}`
-      : "TBD";
+    const location = band.venue_name ? `${band.venue_name}${band.address ? ", " + band.address : ""}` : "TBD";
 
     // Description
-    const description = [
-      band.band_name,
-      band.venue_name ? `Venue: ${band.venue_name}` : "",
-      band.description || "",
-    ]
+    const description = [band.band_name, band.venue_name ? `Venue: ${band.venue_name}` : "", band.description || ""]
       .filter(Boolean)
       .join("\\n");
 

--- a/functions/api/internal/__tests__/run-scheduled.test.js
+++ b/functions/api/internal/__tests__/run-scheduled.test.js
@@ -46,28 +46,19 @@ describe("POST /api/internal/run-scheduled", () => {
   });
 
   it("returns 401 when Bearer token is wrong", async () => {
-    const ctx = makeContext(
-      makeRequest({ Authorization: "Bearer wrong-secret" }),
-      { CRON_SECRET: SECRET },
-    );
+    const ctx = makeContext(makeRequest({ Authorization: "Bearer wrong-secret" }), { CRON_SECRET: SECRET });
     const res = await onRequestPost(ctx);
     expect(res.status).toBe(401);
   });
 
   it("returns 401 when X-Cron-Secret header has wrong token", async () => {
-    const ctx = makeContext(
-      makeRequest({ "X-Cron-Secret": "not-the-secret" }),
-      { CRON_SECRET: SECRET },
-    );
+    const ctx = makeContext(makeRequest({ "X-Cron-Secret": "not-the-secret" }), { CRON_SECRET: SECRET });
     const res = await onRequestPost(ctx);
     expect(res.status).toBe(401);
   });
 
   it("returns 200 and invokes scheduled handler when Bearer token is correct", async () => {
-    const ctx = makeContext(
-      makeRequest({ Authorization: `Bearer ${SECRET}` }),
-      { CRON_SECRET: SECRET },
-    );
+    const ctx = makeContext(makeRequest({ Authorization: `Bearer ${SECRET}` }), { CRON_SECRET: SECRET });
     const res = await onRequestPost(ctx);
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/functions/api/internal/run-scheduled.js
+++ b/functions/api/internal/run-scheduled.js
@@ -37,18 +37,14 @@ export async function onRequestPost(context) {
 
   // Fail closed: CRON_SECRET must be configured in the Cloudflare Pages project.
   if (!env.CRON_SECRET) {
-    console.error(
-      "[run-scheduled] CRON_SECRET is not configured — refusing request.",
-    );
+    console.error("[run-scheduled] CRON_SECRET is not configured — refusing request.");
     return Response.json({ error: "Service unavailable" }, { status: 503 });
   }
 
   // Accept token from Authorization: Bearer <token> or X-Cron-Secret: <token>.
   const authHeader = request.headers.get("Authorization") ?? "";
   const cronHeader = request.headers.get("X-Cron-Secret") ?? "";
-  const presented = authHeader.startsWith("Bearer ")
-    ? authHeader.slice(7)
-    : cronHeader || null;
+  const presented = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : cronHeader || null;
 
   if (!presented || !secretsMatch(presented, env.CRON_SECRET)) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });

--- a/functions/api/metrics.js
+++ b/functions/api/metrics.js
@@ -43,11 +43,7 @@ function parseInteger(value) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
-async function executeInChunks(
-  db,
-  statements,
-  chunkSize = MAX_BATCH_STATEMENTS,
-) {
+async function executeInChunks(db, statements, chunkSize = MAX_BATCH_STATEMENTS) {
   for (let i = 0; i < statements.length; i += chunkSize) {
     await db.batch(statements.slice(i, i + chunkSize));
   }
@@ -64,10 +60,7 @@ export async function onRequestPost(context) {
       return new Response("OK", { status: 200 });
     }
 
-    const validEvents = rawEvents
-      .map(sanitizeEvent)
-      .filter(Boolean)
-      .slice(0, 50);
+    const validEvents = rawEvents.map(sanitizeEvent).filter(Boolean).slice(0, 50);
 
     if (validEvents.length === 0) {
       return new Response("OK", { status: 200 });
@@ -106,10 +99,7 @@ export async function onRequestPost(context) {
         if (event.event === "social_link_click") {
           const bandId = parseInteger(event.props?.band_profile_id);
           if (bandId) {
-            socialClickCounts.set(
-              bandId,
-              (socialClickCounts.get(bandId) || 0) + 1,
-            );
+            socialClickCounts.set(bandId, (socialClickCounts.get(bandId) || 0) + 1);
           }
         }
 
@@ -120,10 +110,7 @@ export async function onRequestPost(context) {
       }
 
       // Merge view and click counts per band into a single upsert each
-      const allBandIds = new Set([
-        ...bandViewCounts.keys(),
-        ...socialClickCounts.keys(),
-      ]);
+      const allBandIds = new Set([...bandViewCounts.keys(), ...socialClickCounts.keys()]);
 
       const stmts = [];
       for (const bandId of allBandIds) {
@@ -166,10 +153,10 @@ export async function onRequestPost(context) {
         try {
           await executeInChunks(env.DB, pvStmts);
         } catch (err) {
-          logger.warn(
-            "page_views_daily upsert failed (table may be missing or write error)",
-            { error: err, statementCount: pvStmts.length },
-          );
+          logger.warn("page_views_daily upsert failed (table may be missing or write error)", {
+            error: err,
+            statementCount: pvStmts.length,
+          });
         }
       }
     }

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -15,12 +15,8 @@ export async function onRequestGet(context) {
 
   try {
     const { DB } = env;
-    const configuredTtl = Number.parseInt(
-      env.SCHEDULE_CACHE_TTL_SECONDS || "60",
-      10,
-    );
-    const cacheTtl =
-      Number.isFinite(configuredTtl) && configuredTtl >= 0 ? configuredTtl : 60;
+    const configuredTtl = Number.parseInt(env.SCHEDULE_CACHE_TTL_SECONDS || "60", 10);
+    const cacheTtl = Number.isFinite(configuredTtl) && configuredTtl >= 0 ? configuredTtl : 60;
 
     let event;
 
@@ -116,13 +112,7 @@ export async function onRequestGet(context) {
         if (band.social_links) {
           const links = JSON.parse(band.social_links);
           // Prioritize website, then bandcamp, then instagram, etc.
-          primaryUrl =
-            links.website ||
-            links.bandcamp ||
-            links.instagram ||
-            links.facebook ||
-            links.spotify ||
-            null;
+          primaryUrl = links.website || links.bandcamp || links.instagram || links.facebook || links.spotify || null;
         }
       } catch (_) {
         // Ignore JSON parse errors

--- a/functions/api/schedule/__tests__/build.test.js
+++ b/functions/api/schedule/__tests__/build.test.js
@@ -29,9 +29,7 @@ describe("POST /api/schedule/build", () => {
     const response = await onRequestPost({ request, env });
     expect(response.status).toBe(200);
 
-    const row = rawDb
-      .prepare("SELECT * FROM schedule_builds WHERE event_id = ?")
-      .get(event.id);
+    const row = rawDb.prepare("SELECT * FROM schedule_builds WHERE event_id = ?").get(event.id);
     expect(row).toMatchObject({
       event_id: event.id,
       performance_id: performance.id,

--- a/functions/api/schedule/__tests__/share-create.test.js
+++ b/functions/api/schedule/__tests__/share-create.test.js
@@ -1,143 +1,143 @@
-import { describe, expect, test } from 'vitest'
-import { onRequestPost } from '../share.js'
-import { createTestEnv, insertEvent, insertBand, insertVenue } from '../../test-utils.js'
+import { describe, expect, test } from "vitest";
+import { onRequestPost } from "../share.js";
+import { createTestEnv, insertEvent, insertBand, insertVenue } from "../../test-utils.js";
 
-describe('POST /api/schedule/share', () => {
+describe("POST /api/schedule/share", () => {
   function makeRequest(body) {
-    return new Request('https://example.test/api/schedule/share', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    return new Request("https://example.test/api/schedule/share", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
-    })
+    });
   }
 
-  test('creates a share link and returns a slug', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { slug: 'my-event' })
-    rawDb.prepare('UPDATE events SET is_published = 1 WHERE id = ?').run(event.id)
-    const venue = insertVenue(rawDb)
-    const perf = insertBand(rawDb, { event_id: event.id, venue_id: venue.id })
+  test("creates a share link and returns a slug", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { slug: "my-event" });
+    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    const venue = insertVenue(rawDb);
+    const perf = insertBand(rawDb, { event_id: event.id, venue_id: venue.id });
 
     const res = await onRequestPost({
       request: makeRequest({
         event_id: event.id,
-        event_slug: 'my-event',
+        event_slug: "my-event",
         performance_ids: [perf.id],
         band_names: [perf.name],
       }),
       env,
-    })
+    });
 
-    expect(res.status).toBe(200)
-    const body = await res.json()
-    expect(body.slug).toMatch(/^[a-zA-Z0-9]{8}$/)
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slug).toMatch(/^[a-zA-Z0-9]{8}$/);
 
-    const row = rawDb.prepare('SELECT * FROM share_links WHERE slug = ?').get(body.slug)
-    expect(row).not.toBeNull()
-    expect(JSON.parse(row.performance_ids)).toEqual([perf.id])
-    expect(JSON.parse(row.band_names)).toEqual([perf.name])
-    expect(row.event_slug).toBe('my-event')
-  })
+    const row = rawDb.prepare("SELECT * FROM share_links WHERE slug = ?").get(body.slug);
+    expect(row).not.toBeNull();
+    expect(JSON.parse(row.performance_ids)).toEqual([perf.id]);
+    expect(JSON.parse(row.band_names)).toEqual([perf.name]);
+    expect(row.event_slug).toBe("my-event");
+  });
 
-  test('rejects missing event_id', async () => {
-    const { env } = createTestEnv()
+  test("rejects missing event_id", async () => {
+    const { env } = createTestEnv();
     const res = await onRequestPost({
-      request: makeRequest({ event_slug: 'e', performance_ids: [1], band_names: ['B'] }),
+      request: makeRequest({ event_slug: "e", performance_ids: [1], band_names: ["B"] }),
       env,
-    })
-    expect(res.status).toBe(400)
-  })
+    });
+    expect(res.status).toBe(400);
+  });
 
-  test('rejects invalid event_slug characters', async () => {
-    const { env } = createTestEnv()
+  test("rejects invalid event_slug characters", async () => {
+    const { env } = createTestEnv();
     const res = await onRequestPost({
       request: makeRequest({
         event_id: 1,
-        event_slug: '<script>',
+        event_slug: "<script>",
         performance_ids: [1],
-        band_names: ['B'],
+        band_names: ["B"],
       }),
       env,
-    })
-    expect(res.status).toBe(400)
-  })
+    });
+    expect(res.status).toBe(400);
+  });
 
-  test('rejects empty performance_ids', async () => {
-    const { env } = createTestEnv()
+  test("rejects empty performance_ids", async () => {
+    const { env } = createTestEnv();
     const res = await onRequestPost({
       request: makeRequest({
         event_id: 1,
-        event_slug: 'e',
+        event_slug: "e",
         performance_ids: [],
         band_names: [],
       }),
       env,
-    })
-    expect(res.status).toBe(400)
-  })
+    });
+    expect(res.status).toBe(400);
+  });
 
-  test('rejects performance_ids exceeding 50', async () => {
-    const { env } = createTestEnv()
+  test("rejects performance_ids exceeding 50", async () => {
+    const { env } = createTestEnv();
     const res = await onRequestPost({
       request: makeRequest({
         event_id: 1,
-        event_slug: 'e',
+        event_slug: "e",
         performance_ids: Array.from({ length: 51 }, (_, i) => i + 1),
         band_names: Array.from({ length: 51 }, (_, i) => `Band ${i}`),
       }),
       env,
-    })
-    expect(res.status).toBe(400)
-  })
+    });
+    expect(res.status).toBe(400);
+  });
 
-  test('rejects mismatched band_names length', async () => {
-    const { env } = createTestEnv()
+  test("rejects mismatched band_names length", async () => {
+    const { env } = createTestEnv();
     const res = await onRequestPost({
       request: makeRequest({
         event_id: 1,
-        event_slug: 'e',
+        event_slug: "e",
         performance_ids: [1, 2],
-        band_names: ['Only One'],
+        band_names: ["Only One"],
       }),
       env,
-    })
-    expect(res.status).toBe(400)
-  })
+    });
+    expect(res.status).toBe(400);
+  });
 
-  test('rejects band name exceeding 100 chars', async () => {
-    const { env } = createTestEnv()
+  test("rejects band name exceeding 100 chars", async () => {
+    const { env } = createTestEnv();
     const res = await onRequestPost({
       request: makeRequest({
         event_id: 1,
-        event_slug: 'e',
+        event_slug: "e",
         performance_ids: [1],
-        band_names: ['x'.repeat(101)],
+        band_names: ["x".repeat(101)],
       }),
       env,
-    })
-    expect(res.status).toBe(400)
-  })
+    });
+    expect(res.status).toBe(400);
+  });
 
-  test('returns 404 for unknown event_id', async () => {
-    const { env } = createTestEnv()
+  test("returns 404 for unknown event_id", async () => {
+    const { env } = createTestEnv();
     const res = await onRequestPost({
       request: makeRequest({
         event_id: 9999,
-        event_slug: 'ghost',
+        event_slug: "ghost",
         performance_ids: [1],
-        band_names: ['B'],
+        band_names: ["B"],
       }),
       env,
-    })
-    expect(res.status).toBe(404)
-  })
+    });
+    expect(res.status).toBe(404);
+  });
 
-  test('rejects null event_id', async () => {
-    const { env } = createTestEnv()
+  test("rejects null event_id", async () => {
+    const { env } = createTestEnv();
     const res = await onRequestPost({
-      request: makeRequest({ event_id: null, event_slug: 'e', performance_ids: [1], band_names: ['B'] }),
+      request: makeRequest({ event_id: null, event_slug: "e", performance_ids: [1], band_names: ["B"] }),
       env,
-    })
-    expect(res.status).toBe(400)
-  })
-})
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/functions/api/schedule/__tests__/share-get.test.js
+++ b/functions/api/schedule/__tests__/share-get.test.js
@@ -1,133 +1,127 @@
-import { describe, expect, test } from 'vitest'
-import { onRequestGet } from '../share/[slug].js'
-import { createTestEnv, insertEvent, insertShareLink } from '../../test-utils.js'
+import { describe, expect, test } from "vitest";
+import { onRequestGet } from "../share/[slug].js";
+import { createTestEnv, insertEvent, insertShareLink } from "../../test-utils.js";
 
-describe('GET /api/schedule/share/[slug]', () => {
+describe("GET /api/schedule/share/[slug]", () => {
   function makeRequest(slug) {
-    return new Request(`https://example.test/api/schedule/share/${slug}`)
+    return new Request(`https://example.test/api/schedule/share/${slug}`);
   }
 
-  test('returns share link data for a valid slug', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'My Fest', slug: 'my-fest' })
-    rawDb.prepare('UPDATE events SET is_published = 1 WHERE id = ?').run(event.id)
+  test("returns share link data for a valid slug", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
+    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
-      slug: 'abc12345',
+      slug: "abc12345",
       event_id: event.id,
-      event_slug: 'my-fest',
+      event_slug: "my-fest",
       performance_ids: [10, 20],
-      band_names: ['Band A', 'Band B'],
-    })
+      band_names: ["Band A", "Band B"],
+    });
 
     const res = await onRequestGet({
-      request: makeRequest('abc12345'),
-      params: { slug: 'abc12345' },
+      request: makeRequest("abc12345"),
+      params: { slug: "abc12345" },
       env,
-    })
+    });
 
-    expect(res.status).toBe(200)
-    const body = await res.json()
-    expect(body.slug).toBe('abc12345')
-    expect(body.event_slug).toBe('my-fest')
-    expect(body.event_name).toBe('My Fest')
-    expect(body.performance_ids).toEqual([10, 20])
-    expect(body.band_names).toEqual(['Band A', 'Band B'])
-  })
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slug).toBe("abc12345");
+    expect(body.event_slug).toBe("my-fest");
+    expect(body.event_name).toBe("My Fest");
+    expect(body.performance_ids).toEqual([10, 20]);
+    expect(body.band_names).toEqual(["Band A", "Band B"]);
+  });
 
-  test('returns 404 for unknown slug', async () => {
-    const { env } = createTestEnv()
+  test("returns 404 for unknown slug", async () => {
+    const { env } = createTestEnv();
     const res = await onRequestGet({
-      request: makeRequest('notfound'),
-      params: { slug: 'notfound' },
+      request: makeRequest("notfound"),
+      params: { slug: "notfound" },
       env,
-    })
-    expect(res.status).toBe(404)
-  })
+    });
+    expect(res.status).toBe(404);
+  });
 
-  test('returns 404 for expired slug', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb)
+  test("returns 404 for expired slug", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb);
     insertShareLink(rawDb, {
-      slug: 'expired1',
+      slug: "expired1",
       event_id: event.id,
       performance_ids: [1],
-      band_names: ['B'],
-      expires_at: '2000-01-01 00:00:00',
-    })
+      band_names: ["B"],
+      expires_at: "2000-01-01 00:00:00",
+    });
 
     const res = await onRequestGet({
-      request: makeRequest('expired1'),
-      params: { slug: 'expired1' },
+      request: makeRequest("expired1"),
+      params: { slug: "expired1" },
       env,
-    })
-    expect(res.status).toBe(404)
-  })
+    });
+    expect(res.status).toBe(404);
+  });
 
-  test('returns 400 for invalid slug format', async () => {
-    const { env } = createTestEnv()
+  test("returns 400 for invalid slug format", async () => {
+    const { env } = createTestEnv();
     const res = await onRequestGet({
-      request: makeRequest('../etc/passwd'),
-      params: { slug: '../etc/passwd' },
+      request: makeRequest("../etc/passwd"),
+      params: { slug: "../etc/passwd" },
       env,
-    })
-    expect(res.status).toBe(400)
-  })
+    });
+    expect(res.status).toBe(400);
+  });
 
-  test('increments view_count each time the share link is fetched', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'My Fest', slug: 'my-fest' })
-    rawDb.prepare('UPDATE events SET is_published = 1 WHERE id = ?').run(event.id)
+  test("increments view_count each time the share link is fetched", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
+    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
-      slug: 'view1234',
+      slug: "view1234",
       event_id: event.id,
-      event_slug: 'my-fest',
+      event_slug: "my-fest",
       performance_ids: [10],
-      band_names: ['Band A'],
-    })
+      band_names: ["Band A"],
+    });
 
     const call = () =>
       onRequestGet({
-        request: makeRequest('view1234'),
-        params: { slug: 'view1234' },
+        request: makeRequest("view1234"),
+        params: { slug: "view1234" },
         env,
-      })
+      });
 
-    await call()
-    await call()
+    await call();
+    await call();
 
-    const row = rawDb
-      .prepare('SELECT view_count FROM share_links WHERE slug = ?')
-      .get('view1234')
-    expect(row.view_count).toBe(2)
-  })
+    const row = rawDb.prepare("SELECT view_count FROM share_links WHERE slug = ?").get("view1234");
+    expect(row.view_count).toBe(2);
+  });
 
-  test('does not increment view_count for an import refetch (?import=1)', async () => {
-    const { env, rawDb } = createTestEnv()
-    const event = insertEvent(rawDb, { name: 'My Fest', slug: 'my-fest' })
-    rawDb.prepare('UPDATE events SET is_published = 1 WHERE id = ?').run(event.id)
+  test("does not increment view_count for an import refetch (?import=1)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
+    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
-      slug: 'import12',
+      slug: "import12",
       event_id: event.id,
-      event_slug: 'my-fest',
+      event_slug: "my-fest",
       performance_ids: [10],
-      band_names: ['Band A'],
-    })
+      band_names: ["Band A"],
+    });
 
     const importFetch = () =>
       onRequestGet({
-        request: new Request(
-          'https://example.test/api/schedule/share/import12?import=1'
-        ),
-        params: { slug: 'import12' },
+        request: new Request("https://example.test/api/schedule/share/import12?import=1"),
+        params: { slug: "import12" },
         env,
-      })
+      });
 
-    await importFetch()
-    await importFetch()
+    await importFetch();
+    await importFetch();
 
-    const row = rawDb
-      .prepare('SELECT view_count FROM share_links WHERE slug = ?')
-      .get('import12')
-    expect(row.view_count).toBe(0)
-  })
-})
+    const row = rawDb.prepare("SELECT view_count FROM share_links WHERE slug = ?").get("import12");
+    expect(row.view_count).toBe(0);
+  });
+});

--- a/functions/api/schedule/build.js
+++ b/functions/api/schedule/build.js
@@ -27,39 +27,33 @@ export async function onRequestPost(context) {
           : [];
 
     if (!Number.isFinite(eventId)) {
-      return new Response(
-        JSON.stringify({ error: "Invalid event_id" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Invalid event_id" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
-    if (
-      !userSession ||
-      userSession.length > MAX_USER_SESSION_LENGTH ||
-      !isSafeSessionId(userSession)
-    ) {
-      return new Response(
-        JSON.stringify({ error: "Invalid user_session" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+    if (!userSession || userSession.length > MAX_USER_SESSION_LENGTH || !isSafeSessionId(userSession)) {
+      return new Response(JSON.stringify({ error: "Invalid user_session" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     if (performanceIdsInput.length > MAX_PERFORMANCE_IDS) {
-      return new Response(
-        JSON.stringify({ error: "Too many performance_ids provided" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "Too many performance_ids provided" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
-    const performanceIds = performanceIdsInput
-      .map((id) => Number(id))
-      .filter((id) => Number.isFinite(id));
+    const performanceIds = performanceIdsInput.map((id) => Number(id)).filter((id) => Number.isFinite(id));
 
     if (performanceIds.length === 0) {
-      return new Response(
-        JSON.stringify({ error: "No performance_ids provided" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ error: "No performance_ids provided" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     const statements = performanceIds.map((performanceId) =>
@@ -96,9 +90,9 @@ export async function onRequestPost(context) {
     });
   } catch (error) {
     console.error("Schedule build tracking error:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to record schedule build" }),
-      { status: 500, headers: { "Content-Type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ error: "Failed to record schedule build" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/functions/api/schedule/share.js
+++ b/functions/api/schedule/share.js
@@ -2,36 +2,36 @@
 // POST /api/schedule/share
 // Body: { event_id, event_slug, performance_ids[], band_names[] }
 
-const MAX_PERFORMANCE_IDS = 50
-const MAX_BAND_NAME_LENGTH = 100
-const SLUG_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+const MAX_PERFORMANCE_IDS = 50;
+const MAX_BAND_NAME_LENGTH = 100;
+const SLUG_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
 function generateSlug(length = 8) {
-  const bytes = crypto.getRandomValues(new Uint8Array(length))
-  return Array.from(bytes, b => SLUG_CHARS[b % SLUG_CHARS.length]).join('')
+  const bytes = crypto.getRandomValues(new Uint8Array(length));
+  return Array.from(bytes, (b) => SLUG_CHARS[b % SLUG_CHARS.length]).join("");
 }
 
 function json(body, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 export async function onRequestPost(context) {
   try {
-    const { request, env } = context
-    const { DB } = env
+    const { request, env } = context;
+    const { DB } = env;
 
-    const body = await request.json().catch(() => ({}))
-    const { event_id, event_slug, performance_ids, band_names } = body
+    const body = await request.json().catch(() => ({}));
+    const { event_id, event_slug, performance_ids, band_names } = body;
 
-    if (typeof event_id !== 'number' || !Number.isFinite(event_id)) {
-      return json({ error: 'Invalid event_id' }, 400)
+    if (typeof event_id !== "number" || !Number.isFinite(event_id)) {
+      return json({ error: "Invalid event_id" }, 400);
     }
 
-    if (typeof event_slug !== 'string' || !/^[a-z0-9-]+$/.test(event_slug)) {
-      return json({ error: 'Invalid event_slug' }, 400)
+    if (typeof event_slug !== "string" || !/^[a-z0-9-]+$/.test(event_slug)) {
+      return json({ error: "Invalid event_slug" }, 400);
     }
 
     if (
@@ -39,56 +39,51 @@ export async function onRequestPost(context) {
       performance_ids.length === 0 ||
       performance_ids.length > MAX_PERFORMANCE_IDS
     ) {
-      return json(
-        { error: `performance_ids must be a non-empty array of up to ${MAX_PERFORMANCE_IDS} integers` },
-        400
-      )
+      return json({ error: `performance_ids must be a non-empty array of up to ${MAX_PERFORMANCE_IDS} integers` }, 400);
     }
 
     if (!Array.isArray(band_names) || band_names.length !== performance_ids.length) {
-      return json({ error: 'band_names must be an array matching performance_ids length' }, 400)
+      return json({ error: "band_names must be an array matching performance_ids length" }, 400);
     }
 
-    const ids = performance_ids.map(Number)
-    if (ids.some(id => !Number.isFinite(id) || id <= 0)) {
-      return json({ error: 'All performance_ids must be positive integers' }, 400)
+    const ids = performance_ids.map(Number);
+    if (ids.some((id) => !Number.isFinite(id) || id <= 0)) {
+      return json({ error: "All performance_ids must be positive integers" }, 400);
     }
 
-    const names = band_names.map(String)
-    if (names.some(n => n.length > MAX_BAND_NAME_LENGTH)) {
-      return json({ error: `Band names must not exceed ${MAX_BAND_NAME_LENGTH} characters` }, 400)
+    const names = band_names.map(String);
+    if (names.some((n) => n.length > MAX_BAND_NAME_LENGTH)) {
+      return json({ error: `Band names must not exceed ${MAX_BAND_NAME_LENGTH} characters` }, 400);
     }
 
-    const event = await DB.prepare(
-      `SELECT id FROM events WHERE id = ? AND (is_published = 1 OR status = 'archived')`
-    )
+    const event = await DB.prepare(`SELECT id FROM events WHERE id = ? AND (is_published = 1 OR status = 'archived')`)
       .bind(Number(event_id))
-      .first()
+      .first();
     if (!event) {
-      return json({ error: 'Event not found' }, 404)
+      return json({ error: "Event not found" }, 404);
     }
 
     const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
       .toISOString()
-      .replace('T', ' ')
-      .replace(/\.\d+Z$/, '')
+      .replace("T", " ")
+      .replace(/\.\d+Z$/, "");
 
     for (let attempt = 0; attempt < 2; attempt++) {
-      const slug = generateSlug()
+      const slug = generateSlug();
       try {
         await DB.prepare(
           `INSERT INTO share_links (slug, event_id, event_slug, performance_ids, band_names, expires_at)
-           VALUES (?, ?, ?, ?, ?, ?)`
+           VALUES (?, ?, ?, ?, ?, ?)`,
         )
           .bind(slug, Number(event_id), event_slug, JSON.stringify(ids), JSON.stringify(names), expiresAt)
-          .run()
-        return json({ slug })
+          .run();
+        return json({ slug });
       } catch (err) {
-        if (attempt === 1 || !String(err).includes('UNIQUE')) throw err
+        if (attempt === 1 || !String(err).includes("UNIQUE")) throw err;
       }
     }
   } catch (error) {
-    console.error('Schedule share error:', error)
-    return json({ error: 'Failed to create share link' }, 500)
+    console.error("Schedule share error:", error);
+    return json({ error: "Failed to create share link" }, 500);
   }
 }

--- a/functions/api/schedule/share/[slug].js
+++ b/functions/api/schedule/share/[slug].js
@@ -4,17 +4,17 @@
 function json(body, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 export async function onRequestGet(context) {
-  const { params, env, request } = context
-  const { DB } = env
-  const { slug } = params
+  const { params, env, request } = context;
+  const { DB } = env;
+  const { slug } = params;
 
   if (!slug || !/^[a-zA-Z0-9]{1,16}$/.test(slug)) {
-    return json({ error: 'Invalid slug' }, 400)
+    return json({ error: "Invalid slug" }, 400);
   }
 
   try {
@@ -24,13 +24,13 @@ export async function onRequestGet(context) {
       `SELECT sl.slug, sl.event_slug, sl.performance_ids, sl.band_names, e.name AS event_name
        FROM share_links sl
        JOIN events e ON e.id = sl.event_id AND (e.is_published = 1 OR e.status = 'archived')
-       WHERE sl.slug = ? AND sl.expires_at > datetime('now')`
+       WHERE sl.slug = ? AND sl.expires_at > datetime('now')`,
     )
       .bind(slug)
-      .first()
+      .first();
 
     if (!row) {
-      return json({ error: 'Share link not found or expired' }, 404)
+      return json({ error: "Share link not found or expired" }, 404);
     }
 
     // Best-effort view counter — a counter failure must never break share
@@ -38,27 +38,22 @@ export async function onRequestGet(context) {
     // The import refetch (App.jsx adds ?import=1) re-fetches the same snapshot to
     // apply it after the preview already counted, so it must NOT count again —
     // only genuine preview views (SharePreviewPage, no flag) increment.
-    const isImportRefetch =
-      new URL(request.url).searchParams.get('import') === '1'
+    const isImportRefetch = new URL(request.url).searchParams.get("import") === "1";
     if (!isImportRefetch) {
       try {
-        await DB.prepare(
-          'UPDATE share_links SET view_count = view_count + 1 WHERE slug = ?'
-        )
-          .bind(slug)
-          .run()
+        await DB.prepare("UPDATE share_links SET view_count = view_count + 1 WHERE slug = ?").bind(slug).run();
       } catch (err) {
-        console.error('Share link view-count increment failed:', slug, err)
+        console.error("Share link view-count increment failed:", slug, err);
       }
     }
 
-    let performance_ids, band_names
+    let performance_ids, band_names;
     try {
-      performance_ids = JSON.parse(row.performance_ids)
-      band_names = JSON.parse(row.band_names)
+      performance_ids = JSON.parse(row.performance_ids);
+      band_names = JSON.parse(row.band_names);
     } catch (_err) {
-      console.error('Share link data is corrupted:', row.slug)
-      return json({ error: 'Share link data is corrupted' }, 500)
+      console.error("Share link data is corrupted:", row.slug);
+      return json({ error: "Share link data is corrupted" }, 500);
     }
 
     return json({
@@ -67,9 +62,9 @@ export async function onRequestGet(context) {
       event_name: row.event_name,
       performance_ids,
       band_names,
-    })
+    });
   } catch (err) {
-    console.error('Share link fetch error:', err)
-    return json({ error: 'Failed to fetch share link' }, 500)
+    console.error("Share link fetch error:", err);
+    return json({ error: "Failed to fetch share link" }, 500);
   }
 }

--- a/functions/api/subscriptions/__tests__/helpers.js
+++ b/functions/api/subscriptions/__tests__/helpers.js
@@ -2,47 +2,42 @@
 export function createMockRequest(method, path, body = null) {
   const options = {
     method,
-    headers: { 'Content-Type': 'application/json' }
-  }
-  
+    headers: { "Content-Type": "application/json" },
+  };
+
   if (body) {
-    options.body = JSON.stringify(body)
+    options.body = JSON.stringify(body);
   }
-  
-  return new Request(`http://localhost${path}`, options)
+
+  return new Request(`http://localhost${path}`, options);
 }
 
 export function createMockContext(mockDB) {
   return {
     env: {
       DB: mockDB,
-      PUBLIC_URL: 'https://example.com',
+      PUBLIC_URL: "https://example.com",
       // Required so isDevRequest() returns true and Turnstile/CSRF skip in
       // unit tests.  Without an explicit ENVIRONMENT the security default is
       // now "production" (secure/closed), not localhost-sniffing. (#425)
-      ENVIRONMENT: 'test',
-    }
-  }
+      ENVIRONMENT: "test",
+    },
+  };
 }
 
 // Valid subscription payload
 export const VALID_SUBSCRIPTION = {
-  email: 'test@example.com',
-  city: 'portland',
-  genre: 'punk',
-  frequency: 'weekly'
-}
+  email: "test@example.com",
+  city: "portland",
+  genre: "punk",
+  frequency: "weekly",
+};
 
 // Invalid payloads
 export const INVALID_PAYLOADS = {
-  missingEmail: { city: 'portland', genre: 'punk', frequency: 'weekly' },
-  invalidEmail: { email: 'not-an-email', city: 'portland', genre: 'punk', frequency: 'weekly' },
-  missingCity: { email: 'test@example.com', genre: 'punk', frequency: 'weekly' },
-  missingGenre: { email: 'test@example.com', city: 'portland', frequency: 'weekly' },
-  missingFrequency: { email: 'test@example.com', city: 'portland', genre: 'punk' }
-}
-
-
-
-
-
+  missingEmail: { city: "portland", genre: "punk", frequency: "weekly" },
+  invalidEmail: { email: "not-an-email", city: "portland", genre: "punk", frequency: "weekly" },
+  missingCity: { email: "test@example.com", genre: "punk", frequency: "weekly" },
+  missingGenre: { email: "test@example.com", city: "portland", frequency: "weekly" },
+  missingFrequency: { email: "test@example.com", city: "portland", genre: "punk" },
+};

--- a/functions/api/subscriptions/__tests__/mocks/d1.js
+++ b/functions/api/subscriptions/__tests__/mocks/d1.js
@@ -8,114 +8,117 @@ export class MockD1Database {
       events: [],
       venues: [],
       band_profiles: [],
-      performances: []
-    }
-    this.idCounter = 1
+      performances: [],
+    };
+    this.idCounter = 1;
   }
 
   prepare(query) {
     return {
       bind: (...params) => ({
         all: async () => this._executeSelect(query, params),
-        run: async () => this._executeWrite(query, params)
-      })
-    }
+        run: async () => this._executeWrite(query, params),
+      }),
+    };
   }
 
   _executeSelect(query, params) {
-    const queryLower = query.toLowerCase()
-    
+    const queryLower = query.toLowerCase();
+
     // SELECT from email_subscriptions with WHERE clauses
-    if (queryLower.includes('select') && queryLower.includes('from email_subscriptions')) {
-      let results = [...this.data.email_subscriptions]
-      
+    if (queryLower.includes("select") && queryLower.includes("from email_subscriptions")) {
+      let results = [...this.data.email_subscriptions];
+
       // Filter by WHERE clause
       // WHERE email = ? AND city = ? AND genre = ?
-      if (queryLower.includes('where email = ?')) {
-        const [email, city, genre] = params
-        results = results.filter(sub => 
-          sub.email === email && sub.city === city && sub.genre === genre
-        )
+      if (queryLower.includes("where email = ?")) {
+        const [email, city, genre] = params;
+        results = results.filter((sub) => sub.email === email && sub.city === city && sub.genre === genre);
       }
-      
+
       // WHERE verification_token = ?
-      if (queryLower.includes('where verification_token = ?')) {
-        const [token] = params
-        results = results.filter(sub => sub.verification_token === token)
+      if (queryLower.includes("where verification_token = ?")) {
+        const [token] = params;
+        results = results.filter((sub) => sub.verification_token === token);
       }
-      
+
       // WHERE unsubscribe_token = ?
-      if (queryLower.includes('where unsubscribe_token = ?')) {
-        const [token] = params
-        results = results.filter(sub => sub.unsubscribe_token === token)
+      if (queryLower.includes("where unsubscribe_token = ?")) {
+        const [token] = params;
+        results = results.filter((sub) => sub.unsubscribe_token === token);
       }
-      
+
       // Map results based on SELECT columns
-      if (queryLower.includes('select id, verified, verification_token')) {
-        results = results.map(sub => ({
+      if (queryLower.includes("select id, verified, verification_token")) {
+        results = results.map((sub) => ({
           id: sub.id,
           verified: sub.verified,
-          verification_token: sub.verification_token
-        }))
-      } else if (queryLower.includes('select id, verified')) {
-        results = results.map(sub => ({
+          verification_token: sub.verification_token,
+        }));
+      } else if (queryLower.includes("select id, verified")) {
+        results = results.map((sub) => ({
           id: sub.id,
-          verified: sub.verified
-        }))
-      } else if (queryLower.includes('select id, email, city, genre, verified')) {
-        results = results.map(sub => ({
+          verified: sub.verified,
+        }));
+      } else if (queryLower.includes("select id, email, city, genre, verified")) {
+        results = results.map((sub) => ({
           id: sub.id,
           email: sub.email,
           city: sub.city,
           genre: sub.genre,
-          verified: sub.verified
-        }))
-      } else if (queryLower.includes('select id, email, city, genre')) {
-        results = results.map(sub => ({
+          verified: sub.verified,
+        }));
+      } else if (queryLower.includes("select id, email, city, genre")) {
+        results = results.map((sub) => ({
           id: sub.id,
           email: sub.email,
           city: sub.city,
-          genre: sub.genre
-        }))
-      } else if (queryLower.includes('select id, verification_token')) {
-        results = results.map(sub => ({
+          genre: sub.genre,
+        }));
+      } else if (queryLower.includes("select id, verification_token")) {
+        results = results.map((sub) => ({
           id: sub.id,
-          verification_token: sub.verification_token
-        }))
+          verification_token: sub.verification_token,
+        }));
       }
-      
-      return { results }
+
+      return { results };
     }
-    
+
     // SELECT from subscription_verifications
-    if (queryLower.includes('select') && queryLower.includes('from subscription_verifications')) {
-      return { results: this.data.subscription_verifications }
+    if (queryLower.includes("select") && queryLower.includes("from subscription_verifications")) {
+      return { results: this.data.subscription_verifications };
     }
-    
+
     // SELECT from subscription_unsubscribes
-    if (queryLower.includes('select') && queryLower.includes('from subscription_unsubscribes')) {
-      return { results: this.data.subscription_unsubscribes }
+    if (queryLower.includes("select") && queryLower.includes("from subscription_unsubscribes")) {
+      return { results: this.data.subscription_unsubscribes };
     }
-    
+
     // SELECT from events (check if it's for bands/iCal feed by looking for band_name)
-    if (queryLower.includes('select') && queryLower.includes('from events')) {
+    if (queryLower.includes("select") && queryLower.includes("from events")) {
       // If query asks for band_name, it's for iCal feed
-      if (queryLower.includes('bp.name as band_name') || queryLower.includes('p.start_time') || queryLower.includes('b.name as band_name') || queryLower.includes('b.start_time')) {
-        return this._handleBandsQuery(queryLower, params)
+      if (
+        queryLower.includes("bp.name as band_name") ||
+        queryLower.includes("p.start_time") ||
+        queryLower.includes("b.name as band_name") ||
+        queryLower.includes("b.start_time")
+      ) {
+        return this._handleBandsQuery(queryLower, params);
       }
       // Otherwise it's for public API
-      return this._handleEventsQuery(queryLower, params)
+      return this._handleEventsQuery(queryLower, params);
     }
-    
-    return { results: [] }
+
+    return { results: [] };
   }
 
   _executeWrite(query, params) {
-    const queryLower = query.toLowerCase()
-    
+    const queryLower = query.toLowerCase();
+
     // INSERT INTO email_subscriptions
-    if (queryLower.includes('insert into email_subscriptions')) {
-      const [email, city, genre, frequency, verificationToken, unsubscribeToken, consentIp] = params
+    if (queryLower.includes("insert into email_subscriptions")) {
+      const [email, city, genre, frequency, verificationToken, unsubscribeToken, consentIp] = params;
 
       const newSub = {
         id: this.idCounter++,
@@ -129,96 +132,96 @@ export class MockD1Database {
         created_at: new Date().toISOString(),
         last_email_sent: null,
         consent_ip: consentIp ?? null,
-        consent_method: 'web_form',
-      }
+        consent_method: "web_form",
+      };
 
-      this.data.email_subscriptions.push(newSub)
-      return { success: true, meta: { changes: 1 } }
+      this.data.email_subscriptions.push(newSub);
+      return { success: true, meta: { changes: 1 } };
     }
-    
+
     // UPDATE email_subscriptions SET verified = 1
-    if (queryLower.includes('update email_subscriptions')) {
+    if (queryLower.includes("update email_subscriptions")) {
       // New atomic path: UPDATE ... WHERE verification_token = ? AND verified = 0
-      if (queryLower.includes('where verification_token = ?')) {
-        const [token] = params
+      if (queryLower.includes("where verification_token = ?")) {
+        const [token] = params;
         const subscription = this.data.email_subscriptions.find(
-          sub => sub.verification_token === token && !sub.verified
-        )
+          (sub) => sub.verification_token === token && !sub.verified,
+        );
 
         if (subscription) {
-          subscription.verified = true
-          return { success: true, meta: { changes: 1 } }
+          subscription.verified = true;
+          return { success: true, meta: { changes: 1 } };
         }
 
-        return { success: true, meta: { changes: 0 } }
+        return { success: true, meta: { changes: 0 } };
       }
 
       // Legacy path: UPDATE ... WHERE id = ?
-      const [id] = params
-      const subscription = this.data.email_subscriptions.find(sub => sub.id === id)
+      const [id] = params;
+      const subscription = this.data.email_subscriptions.find((sub) => sub.id === id);
 
       if (subscription) {
-        subscription.verified = true
-        return { success: true, meta: { changes: 1 } }
+        subscription.verified = true;
+        return { success: true, meta: { changes: 1 } };
       }
 
-      return { success: true, meta: { changes: 0 } }
+      return { success: true, meta: { changes: 0 } };
     }
-    
+
     // DELETE FROM email_subscriptions
-    if (queryLower.includes('delete from email_subscriptions')) {
-      const [id] = params
-      const index = this.data.email_subscriptions.findIndex(sub => sub.id === id)
-      
+    if (queryLower.includes("delete from email_subscriptions")) {
+      const [id] = params;
+      const index = this.data.email_subscriptions.findIndex((sub) => sub.id === id);
+
       if (index !== -1) {
-        this.data.email_subscriptions.splice(index, 1)
-        return { success: true, meta: { changes: 1 } }
+        this.data.email_subscriptions.splice(index, 1);
+        return { success: true, meta: { changes: 1 } };
       }
-      
-      return { success: true, meta: { changes: 0 } }
+
+      return { success: true, meta: { changes: 0 } };
     }
-    
+
     // INSERT INTO subscription_verifications
-    if (queryLower.includes('insert into subscription_verifications')) {
-      const [subscriptionId] = params
-      
+    if (queryLower.includes("insert into subscription_verifications")) {
+      const [subscriptionId] = params;
+
       const verification = {
         id: this.data.subscription_verifications.length + 1,
         subscription_id: subscriptionId,
         verified_at: new Date().toISOString(),
-        ip_address: null
-      }
-      
-      this.data.subscription_verifications.push(verification)
-      return { success: true, meta: { changes: 1 } }
+        ip_address: null,
+      };
+
+      this.data.subscription_verifications.push(verification);
+      return { success: true, meta: { changes: 1 } };
     }
-    
+
     // INSERT INTO subscription_unsubscribes
-    if (queryLower.includes('insert into subscription_unsubscribes')) {
-      const [subscriptionId] = params
-      
+    if (queryLower.includes("insert into subscription_unsubscribes")) {
+      const [subscriptionId] = params;
+
       const unsub = {
         id: this.data.subscription_unsubscribes.length + 1,
         subscription_id: subscriptionId,
         unsubscribed_at: new Date().toISOString(),
-        reason: null
-      }
-      
-      this.data.subscription_unsubscribes.push(unsub)
-      return { success: true, meta: { changes: 1 } }
+        reason: null,
+      };
+
+      this.data.subscription_unsubscribes.push(unsub);
+      return { success: true, meta: { changes: 1 } };
     }
-    
-    return { success: true }
+
+    return { success: true };
   }
 
   _handleEventsQuery(queryLower, params) {
     // This is a complex query with JOINs - return aggregated data
-    let results = []
-    
-    results = this.data.events.map(event => {
-      const eventPerformances = this.data.performances.filter(p => p.event_id === event.id)
-      const uniqueBandIds = new Set(eventPerformances.map(p => p.band_profile_id))
-      const uniqueVenueIds = new Set(eventPerformances.map(p => p.venue_id).filter(Boolean))
+    let results = [];
+
+    results = this.data.events.map((event) => {
+      const eventPerformances = this.data.performances.filter((p) => p.event_id === event.id);
+      const uniqueBandIds = new Set(eventPerformances.map((p) => p.band_profile_id));
+      const uniqueVenueIds = new Set(eventPerformances.map((p) => p.venue_id).filter(Boolean));
 
       return {
         id: event.id,
@@ -231,50 +234,50 @@ export class MockD1Database {
         band_count: uniqueBandIds.size,
         venue_count: uniqueVenueIds.size,
         is_published: event.is_published,
-        published: event.published
-      }
-    })
-    
+        published: event.published,
+      };
+    });
+
     // Apply WHERE filters
-    if (queryLower.includes('published = 1') || queryLower.includes('is_published = 1')) {
-      results = results.filter(e => e.is_published !== 0 && e.published !== false)
-    }
-    
-    let paramIndex = 0
-    if (queryLower.includes("where city = ?") || queryLower.includes('lower(e.city) = lower(?)')) {
-      const city = params[paramIndex++]
-      results = results.filter(e => e.city?.toLowerCase() === city.toLowerCase())
+    if (queryLower.includes("published = 1") || queryLower.includes("is_published = 1")) {
+      results = results.filter((e) => e.is_published !== 0 && e.published !== false);
     }
 
-    if (queryLower.includes('lower(bp.genre) = lower(?)') || queryLower.includes('lower(b.genre) = lower(?)')) {
-      const genre = params[paramIndex++]
-      results = results.filter(event => {
-        const performances = this.data.performances.filter(p => p.event_id === event.id)
-        return performances.some(perf => {
-          const band = this.data.band_profiles.find(bp => bp.id === perf.band_profile_id)
-          return band?.genre?.toLowerCase() === genre.toLowerCase()
-        })
-      })
+    let paramIndex = 0;
+    if (queryLower.includes("where city = ?") || queryLower.includes("lower(e.city) = lower(?)")) {
+      const city = params[paramIndex++];
+      results = results.filter((e) => e.city?.toLowerCase() === city.toLowerCase());
+    }
+
+    if (queryLower.includes("lower(bp.genre) = lower(?)") || queryLower.includes("lower(b.genre) = lower(?)")) {
+      const genre = params[paramIndex++];
+      results = results.filter((event) => {
+        const performances = this.data.performances.filter((p) => p.event_id === event.id);
+        return performances.some((perf) => {
+          const band = this.data.band_profiles.find((bp) => bp.id === perf.band_profile_id);
+          return band?.genre?.toLowerCase() === genre.toLowerCase();
+        });
+      });
     }
 
     if (queryLower.includes("where date >= date('now')") || queryLower.includes("e.date >= date('now'")) {
-      const today = new Date().toISOString().split('T')[0]
-      results = results.filter(e => e.date >= today)
-    }
-    
-    // Sort
-    if (queryLower.includes('order by e.date asc')) {
-      results.sort((a, b) => (a.date || '').localeCompare(b.date || ''))
+      const today = new Date().toISOString().split("T")[0];
+      results = results.filter((e) => e.date >= today);
     }
 
-    if (queryLower.includes('limit ?')) {
-      const limit = params[params.length - 1]
+    // Sort
+    if (queryLower.includes("order by e.date asc")) {
+      results.sort((a, b) => (a.date || "").localeCompare(b.date || ""));
+    }
+
+    if (queryLower.includes("limit ?")) {
+      const limit = params[params.length - 1];
       if (Number.isFinite(limit)) {
-        results = results.slice(0, limit)
+        results = results.slice(0, limit);
       }
     }
-    
-    return { results }
+
+    return { results };
   }
 
   _handleBandsQuery(queryLower, params) {
@@ -282,45 +285,48 @@ export class MockD1Database {
     // Params order: [cityFilter, genreFilter] if both filters present
     //                [cityFilter] if only city filter
     //                [] if no filters
-    
-    let results = []
-    let cityFilter = null
-    let genreFilter = null
-    
+
+    let results = [];
+    let cityFilter = null;
+    let genreFilter = null;
+
     // Simple param extraction - check query structure
-    if (queryLower.includes('lower(e.city) = lower(?)') && (queryLower.includes('lower(b.genre) = lower(?)') || queryLower.includes('lower(bp.genre) = lower(?)'))) {
+    if (
+      queryLower.includes("lower(e.city) = lower(?)") &&
+      (queryLower.includes("lower(b.genre) = lower(?)") || queryLower.includes("lower(bp.genre) = lower(?)"))
+    ) {
       // Both filters present
-      cityFilter = params[0]
-      genreFilter = params[1]
-    } else if (queryLower.includes('lower(e.city) = lower(?)')) {
+      cityFilter = params[0];
+      genreFilter = params[1];
+    } else if (queryLower.includes("lower(e.city) = lower(?)")) {
       // Only city filter
-      cityFilter = params[0]
-    } else if (queryLower.includes('lower(b.genre) = lower(?)') || queryLower.includes('lower(bp.genre) = lower(?)')) {
+      cityFilter = params[0];
+    } else if (queryLower.includes("lower(b.genre) = lower(?)") || queryLower.includes("lower(bp.genre) = lower(?)")) {
       // Only genre filter
-      genreFilter = params[0]
+      genreFilter = params[0];
     }
-    
+
     for (const perf of this.data.performances) {
-      const event = this.data.events.find(e => e.id === perf.event_id)
-      const band = this.data.band_profiles.find(bp => bp.id === perf.band_profile_id)
-      const venue = this.data.venues.find(v => v.id === perf.venue_id)
-      
-      if (!event || !band) continue
-      
+      const event = this.data.events.find((e) => e.id === perf.event_id);
+      const band = this.data.band_profiles.find((bp) => bp.id === perf.band_profile_id);
+      const venue = this.data.venues.find((v) => v.id === perf.venue_id);
+
+      if (!event || !band) continue;
+
       // Check future events only
-      const today = new Date().toISOString().split('T')[0]
-      if (event.date < today) continue
-      
+      const today = new Date().toISOString().split("T")[0];
+      if (event.date < today) continue;
+
       // Apply city filter
       if (cityFilter && event.city?.toLowerCase() !== cityFilter.toLowerCase()) {
-        continue
+        continue;
       }
-      
+
       // Apply genre filter
       if (genreFilter && band.genre?.toLowerCase() !== genreFilter.toLowerCase()) {
-        continue
+        continue;
       }
-      
+
       results.push({
         id: event.id,
         name: event.name,
@@ -344,20 +350,23 @@ export class MockD1Database {
         event_date: event.date,
         band_id: band.id,
         venue_id: venue?.id,
-        venue_address: venue?.address
-      })
+        venue_address: venue?.address,
+      });
     }
-    
+
     // Sort
-    if (queryLower.includes('order by e.date asc, b.start_time asc') || queryLower.includes('order by e.date asc, p.start_time asc')) {
+    if (
+      queryLower.includes("order by e.date asc, b.start_time asc") ||
+      queryLower.includes("order by e.date asc, p.start_time asc")
+    ) {
       results.sort((a, b) => {
-        const dateCompare = (a.date || '').localeCompare(b.date || '')
-        if (dateCompare !== 0) return dateCompare
-        return (a.start_time || '').localeCompare(b.start_time || '')
-      })
+        const dateCompare = (a.date || "").localeCompare(b.date || "");
+        if (dateCompare !== 0) return dateCompare;
+        return (a.start_time || "").localeCompare(b.start_time || "");
+      });
     }
-    
-    return { results }
+
+    return { results };
   }
 
   reset() {
@@ -368,8 +377,8 @@ export class MockD1Database {
       events: [],
       venues: [],
       band_profiles: [],
-      performances: []
-    }
-    this.idCounter = 1
+      performances: [],
+    };
+    this.idCounter = 1;
   }
 }

--- a/functions/api/subscriptions/__tests__/subscribe.test.js
+++ b/functions/api/subscriptions/__tests__/subscribe.test.js
@@ -1,14 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { onRequestPost } from '../subscribe.js';
-import { MockD1Database } from './mocks/d1.js';
-import {
-  createMockRequest,
-  createMockContext,
-  VALID_SUBSCRIPTION,
-  INVALID_PAYLOADS,
-} from './helpers.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { onRequestPost } from "../subscribe.js";
+import { MockD1Database } from "./mocks/d1.js";
+import { createMockRequest, createMockContext, VALID_SUBSCRIPTION, INVALID_PAYLOADS } from "./helpers.js";
 
-describe('POST /api/subscriptions/subscribe', () => {
+describe("POST /api/subscriptions/subscribe", () => {
   let mockDB;
   let mockContext;
 
@@ -18,142 +13,116 @@ describe('POST /api/subscriptions/subscribe', () => {
     mockContext = createMockContext(mockDB);
 
     // Mock console.log and info to suppress logs
-    vi.spyOn(console, 'log').mockImplementation(() => {});
-    vi.spyOn(console, 'info').mockImplementation(() => {});
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('should create new subscription successfully', async () => {
-    const request = createMockRequest(
-      'POST',
-      '/api/subscriptions/subscribe',
-      VALID_SUBSCRIPTION
-    );
+  it("should create new subscription successfully", async () => {
+    const request = createMockRequest("POST", "/api/subscriptions/subscribe", VALID_SUBSCRIPTION);
     mockContext.request = request;
 
     const response = await onRequestPost(mockContext);
 
     expect(response.status).toBe(201);
     const data = await response.json();
-    expect(data.message).toContain('Subscription created');
+    expect(data.message).toContain("Subscription created");
     // When email is not configured the response includes a verificationUrl
     // so developers/local environments can complete verification without email
-    expect(data.verificationUrl).toMatch(
-      /^https:\/\/example\.com\/verify\?token=/
-    );
+    expect(data.verificationUrl).toMatch(/^https:\/\/example\.com\/verify\?token=/);
 
     expect(mockDB.data.email_subscriptions).toHaveLength(1);
     expect(mockDB.data.email_subscriptions[0]).toMatchObject({
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
       verified: false,
-      consent_method: 'web_form',
+      consent_method: "web_form",
     });
     // CF-Connecting-IP is not present in test requests, so consent_ip is null
     expect(mockDB.data.email_subscriptions[0].consent_ip).toBeNull();
   });
 
-  it('should reject request with missing email', async () => {
-    const request = createMockRequest(
-      'POST',
-      '/api/subscriptions/subscribe',
-      INVALID_PAYLOADS.missingEmail
-    );
+  it("should reject request with missing email", async () => {
+    const request = createMockRequest("POST", "/api/subscriptions/subscribe", INVALID_PAYLOADS.missingEmail);
     mockContext.request = request;
 
     const response = await onRequestPost(mockContext);
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe('Invalid email address');
+    expect(data.error).toBe("Invalid email address");
     expect(mockDB.data.email_subscriptions).toHaveLength(0);
   });
 
-  it('should reject request with invalid email format', async () => {
-    const request = createMockRequest(
-      'POST',
-      '/api/subscriptions/subscribe',
-      INVALID_PAYLOADS.invalidEmail
-    );
+  it("should reject request with invalid email format", async () => {
+    const request = createMockRequest("POST", "/api/subscriptions/subscribe", INVALID_PAYLOADS.invalidEmail);
     mockContext.request = request;
 
     const response = await onRequestPost(mockContext);
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe('Invalid email address');
+    expect(data.error).toBe("Invalid email address");
   });
 
-  it('should reject request with missing city', async () => {
-    const request = createMockRequest(
-      'POST',
-      '/api/subscriptions/subscribe',
-      INVALID_PAYLOADS.missingCity
-    );
+  it("should reject request with missing city", async () => {
+    const request = createMockRequest("POST", "/api/subscriptions/subscribe", INVALID_PAYLOADS.missingCity);
     mockContext.request = request;
 
     const response = await onRequestPost(mockContext);
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe('Missing required fields');
+    expect(data.error).toBe("Missing required fields");
   });
 
-  it('should reject duplicate verified subscription', async () => {
+  it("should reject duplicate verified subscription", async () => {
     // Pre-populate with verified subscription
     mockDB.data.email_subscriptions.push({
       id: 1,
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
       verified: true,
-      verification_token: 'existing-token-12345',
-      unsubscribe_token: 'existing-unsub-token-67890',
+      verification_token: "existing-token-12345",
+      unsubscribe_token: "existing-unsub-token-67890",
       created_at: new Date().toISOString(),
     });
 
-    const request = createMockRequest(
-      'POST',
-      '/api/subscriptions/subscribe',
-      VALID_SUBSCRIPTION
-    );
+    const request = createMockRequest("POST", "/api/subscriptions/subscribe", VALID_SUBSCRIPTION);
     mockContext.request = request;
 
     const response = await onRequestPost(mockContext);
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toContain('already subscribed');
+    expect(data.error).toContain("already subscribed");
     expect(mockDB.data.email_subscriptions).toHaveLength(1);
   });
 
-  it('should resend verification email for unverified subscription', async () => {
+  it("should resend verification email for unverified subscription", async () => {
     // Pre-populate with unverified subscription
     mockDB.data.email_subscriptions.push({
       id: 1,
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
       verified: false,
-      verification_token: 'existing-token-12345',
-      unsubscribe_token: 'existing-unsub-token-67890',
+      verification_token: "existing-token-12345",
+      unsubscribe_token: "existing-unsub-token-67890",
       created_at: new Date().toISOString(),
     });
 
-    const request = createMockRequest(
-      'POST',
-      '/api/subscriptions/subscribe',
-      VALID_SUBSCRIPTION
-    );
+    const request = createMockRequest("POST", "/api/subscriptions/subscribe", VALID_SUBSCRIPTION);
     mockContext.request = request;
 
     const response = await onRequestPost(mockContext);
@@ -162,19 +131,13 @@ describe('POST /api/subscriptions/subscribe', () => {
     const data = await response.json();
     // When email is not configured, the response is explicit about it and
     // includes the verificationUrl instead of falsely claiming email was sent
-    expect(data.message).toContain('not configured');
-    expect(data.verificationUrl).toMatch(
-      /^https:\/\/example\.com\/verify\?token=existing-token-12345$/
-    );
+    expect(data.message).toContain("not configured");
+    expect(data.verificationUrl).toMatch(/^https:\/\/example\.com\/verify\?token=existing-token-12345$/);
     expect(mockDB.data.email_subscriptions).toHaveLength(1);
   });
 
-  it('should generate unique verification and unsubscribe tokens', async () => {
-    const request = createMockRequest(
-      'POST',
-      '/api/subscriptions/subscribe',
-      VALID_SUBSCRIPTION
-    );
+  it("should generate unique verification and unsubscribe tokens", async () => {
+    const request = createMockRequest("POST", "/api/subscriptions/subscribe", VALID_SUBSCRIPTION);
     mockContext.request = request;
 
     await onRequestPost(mockContext);
@@ -182,56 +145,50 @@ describe('POST /api/subscriptions/subscribe', () => {
     const subscription = mockDB.data.email_subscriptions[0];
     expect(subscription.verification_token).toMatch(/^[0-9a-f]{64}$/);
     expect(subscription.unsubscribe_token).toMatch(/^[0-9a-f]{64}$/);
-    expect(subscription.verification_token).not.toBe(
-      subscription.unsubscribe_token
-    );
+    expect(subscription.verification_token).not.toBe(subscription.unsubscribe_token);
   });
 
-  it('should handle database errors gracefully', async () => {
+  it("should handle database errors gracefully", async () => {
     // Mock database to throw error
     mockDB.prepare = () => ({
       bind: () => ({
         run: async () => {
-          throw new Error('Database connection failed');
+          throw new Error("Database connection failed");
         },
         all: async () => {
-          throw new Error('Database connection failed');
+          throw new Error("Database connection failed");
         },
       }),
     });
 
-    const request = createMockRequest(
-      'POST',
-      '/api/subscriptions/subscribe',
-      VALID_SUBSCRIPTION
-    );
+    const request = createMockRequest("POST", "/api/subscriptions/subscribe", VALID_SUBSCRIPTION);
     mockContext.request = request;
 
     const response = await onRequestPost(mockContext);
 
     expect(response.status).toBe(500);
     const data = await response.json();
-    expect(data.error).toBe('Subscription failed');
+    expect(data.error).toBe("Subscription failed");
   });
 
-  it('should allow same email for different city/genre combinations', async () => {
+  it("should allow same email for different city/genre combinations", async () => {
     // First subscription
-    const request1 = createMockRequest('POST', '/api/subscriptions/subscribe', {
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+    const request1 = createMockRequest("POST", "/api/subscriptions/subscribe", {
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
     });
     mockContext.request = request1;
 
     const response1 = await onRequestPost(mockContext);
 
     // Second subscription (different city)
-    const request2 = createMockRequest('POST', '/api/subscriptions/subscribe', {
-      email: 'test@example.com',
-      city: 'seattle',
-      genre: 'punk',
-      frequency: 'weekly',
+    const request2 = createMockRequest("POST", "/api/subscriptions/subscribe", {
+      email: "test@example.com",
+      city: "seattle",
+      genre: "punk",
+      frequency: "weekly",
     });
     mockContext.request = request2;
 
@@ -240,24 +197,20 @@ describe('POST /api/subscriptions/subscribe', () => {
     expect(response1.status).toBe(201);
     expect(response2.status).toBe(201);
     expect(mockDB.data.email_subscriptions).toHaveLength(2);
-    expect(mockDB.data.email_subscriptions[0].city).toBe('portland');
-    expect(mockDB.data.email_subscriptions[1].city).toBe('seattle');
+    expect(mockDB.data.email_subscriptions[0].city).toBe("portland");
+    expect(mockDB.data.email_subscriptions[1].city).toBe("seattle");
   });
 
-  it('should accept all valid frequency values', async () => {
-    const frequencies = ['daily', 'weekly', 'monthly'];
+  it("should accept all valid frequency values", async () => {
+    const frequencies = ["daily", "weekly", "monthly"];
 
     for (const frequency of frequencies) {
-      const request = createMockRequest(
-        'POST',
-        '/api/subscriptions/subscribe',
-        {
-          email: `test-${frequency}@example.com`,
-          city: 'portland',
-          genre: 'punk',
-          frequency,
-        }
-      );
+      const request = createMockRequest("POST", "/api/subscriptions/subscribe", {
+        email: `test-${frequency}@example.com`,
+        city: "portland",
+        genre: "punk",
+        frequency,
+      });
       mockContext.request = request;
 
       const response = await onRequestPost(mockContext);
@@ -265,24 +218,18 @@ describe('POST /api/subscriptions/subscribe', () => {
     }
 
     expect(mockDB.data.email_subscriptions).toHaveLength(3);
-    expect(mockDB.data.email_subscriptions[0].frequency).toBe('daily');
-    expect(mockDB.data.email_subscriptions[1].frequency).toBe('weekly');
-    expect(mockDB.data.email_subscriptions[2].frequency).toBe('monthly');
+    expect(mockDB.data.email_subscriptions[0].frequency).toBe("daily");
+    expect(mockDB.data.email_subscriptions[1].frequency).toBe("weekly");
+    expect(mockDB.data.email_subscriptions[2].frequency).toBe("monthly");
   });
 
-  it('does not log verification links or subscriber emails when email is not configured', async () => {
-    const request = createMockRequest(
-      'POST',
-      '/api/subscriptions/subscribe',
-      VALID_SUBSCRIPTION
-    );
+  it("does not log verification links or subscriber emails when email is not configured", async () => {
+    const request = createMockRequest("POST", "/api/subscriptions/subscribe", VALID_SUBSCRIPTION);
     mockContext.request = request;
 
     await onRequestPost(mockContext);
 
     expect(console.info).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledWith(
-      '[Subscribe] Email not configured; verification email was not sent.'
-    );
+    expect(console.warn).toHaveBeenCalledWith("[Subscribe] Email not configured; verification email was not sent.");
   });
 });

--- a/functions/api/subscriptions/__tests__/unsubscribe.test.js
+++ b/functions/api/subscriptions/__tests__/unsubscribe.test.js
@@ -1,120 +1,120 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { onRequestGet } from '../unsubscribe.js'
-import { MockD1Database } from './mocks/d1.js'
-import { createMockContext } from './helpers.js'
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { onRequestGet } from "../unsubscribe.js";
+import { MockD1Database } from "./mocks/d1.js";
+import { createMockContext } from "./helpers.js";
 
-describe('GET /api/subscriptions/unsubscribe', () => {
-  let mockDB
-  let mockContext
+describe("GET /api/subscriptions/unsubscribe", () => {
+  let mockDB;
+  let mockContext;
 
   beforeEach(() => {
-    mockDB = new MockD1Database()
-    mockContext = createMockContext(mockDB)
-    
-    vi.spyOn(console, 'error').mockImplementation(() => {})
-  })
+    mockDB = new MockD1Database();
+    mockContext = createMockContext(mockDB);
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('should unsubscribe with valid token', async () => {
+  it("should unsubscribe with valid token", async () => {
     // Pre-populate with subscription
     mockDB.data.email_subscriptions.push({
       id: 1,
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
       verified: true,
-      verification_token: 'verify-token-12345',
-      unsubscribe_token: 'valid-token-67890',
-      created_at: new Date().toISOString()
-    })
+      verification_token: "verify-token-12345",
+      unsubscribe_token: "valid-token-67890",
+      created_at: new Date().toISOString(),
+    });
 
-    const request = new Request('http://localhost/api/subscriptions/unsubscribe?token=valid-token-67890')
-    mockContext.request = request
+    const request = new Request("http://localhost/api/subscriptions/unsubscribe?token=valid-token-67890");
+    mockContext.request = request;
 
-    const response = await onRequestGet(mockContext)
+    const response = await onRequestGet(mockContext);
 
-    expect(response.status).toBe(200)
-    expect(mockDB.data.email_subscriptions).toHaveLength(0)
-    expect(mockDB.data.subscription_unsubscribes).toHaveLength(1)
-    expect(mockDB.data.subscription_unsubscribes[0].subscription_id).toBe(1)
-  })
+    expect(response.status).toBe(200);
+    expect(mockDB.data.email_subscriptions).toHaveLength(0);
+    expect(mockDB.data.subscription_unsubscribes).toHaveLength(1);
+    expect(mockDB.data.subscription_unsubscribes[0].subscription_id).toBe(1);
+  });
 
-  it('should reject request without token', async () => {
-    const request = new Request('http://localhost/api/subscriptions/unsubscribe')
-    mockContext.request = request
+  it("should reject request without token", async () => {
+    const request = new Request("http://localhost/api/subscriptions/unsubscribe");
+    mockContext.request = request;
 
-    const response = await onRequestGet(mockContext)
+    const response = await onRequestGet(mockContext);
 
-    expect(response.status).toBe(400)
-    const text = await response.text()
-    expect(text).toContain('Missing unsubscribe token')
-  })
+    expect(response.status).toBe(400);
+    const text = await response.text();
+    expect(text).toContain("Missing unsubscribe token");
+  });
 
-  it('should reject invalid token', async () => {
-    const request = new Request('http://localhost/api/subscriptions/unsubscribe?token=invalid-token')
-    mockContext.request = request
+  it("should reject invalid token", async () => {
+    const request = new Request("http://localhost/api/subscriptions/unsubscribe?token=invalid-token");
+    mockContext.request = request;
 
-    const response = await onRequestGet(mockContext)
+    const response = await onRequestGet(mockContext);
 
-    expect(response.status).toBe(404)
-    const text = await response.text()
-    expect(text).toContain('Invalid unsubscribe token')
-  })
+    expect(response.status).toBe(404);
+    const text = await response.text();
+    expect(text).toContain("Invalid unsubscribe token");
+  });
 
-  it('should log unsubscribe to subscription_unsubscribes table', async () => {
+  it("should log unsubscribe to subscription_unsubscribes table", async () => {
     mockDB.data.email_subscriptions.push({
       id: 1,
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
       verified: true,
-      verification_token: 'verify-token-12345',
-      unsubscribe_token: 'valid-token-67890',
-      created_at: new Date().toISOString()
-    })
+      verification_token: "verify-token-12345",
+      unsubscribe_token: "valid-token-67890",
+      created_at: new Date().toISOString(),
+    });
 
-    const request = new Request('http://localhost/api/subscriptions/unsubscribe?token=valid-token-67890')
-    mockContext.request = request
+    const request = new Request("http://localhost/api/subscriptions/unsubscribe?token=valid-token-67890");
+    mockContext.request = request;
 
-    await onRequestGet(mockContext)
+    await onRequestGet(mockContext);
 
-    expect(mockDB.data.subscription_unsubscribes).toHaveLength(1)
+    expect(mockDB.data.subscription_unsubscribes).toHaveLength(1);
     expect(mockDB.data.subscription_unsubscribes[0]).toMatchObject({
       subscription_id: 1,
-      unsubscribed_at: expect.any(String)
-    })
-  })
+      unsubscribed_at: expect.any(String),
+    });
+  });
 
-  it('should return HTML success page', async () => {
+  it("should return HTML success page", async () => {
     mockDB.data.email_subscriptions.push({
       id: 1,
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
       verified: true,
-      verification_token: 'verify-token-12345',
-      unsubscribe_token: 'valid-token-67890',
-      created_at: new Date().toISOString()
-    })
+      verification_token: "verify-token-12345",
+      unsubscribe_token: "valid-token-67890",
+      created_at: new Date().toISOString(),
+    });
 
-    const request = new Request('http://localhost/api/subscriptions/unsubscribe?token=valid-token-67890')
-    mockContext.request = request
+    const request = new Request("http://localhost/api/subscriptions/unsubscribe?token=valid-token-67890");
+    mockContext.request = request;
 
-    const response = await onRequestGet(mockContext)
+    const response = await onRequestGet(mockContext);
 
-    expect(response.status).toBe(200)
-    expect(response.headers.get('Content-Type')).toBe('text/html')
-    
-    const html = await response.text()
-    expect(html).toContain('Unsubscribed')
-    expect(html).toContain('portland')
-    expect(html).toContain('punk')
-    expect(html).toContain('example.com/subscribe')
-  })
-})
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/html");
+
+    const html = await response.text();
+    expect(html).toContain("Unsubscribed");
+    expect(html).toContain("portland");
+    expect(html).toContain("punk");
+    expect(html).toContain("example.com/subscribe");
+  });
+});

--- a/functions/api/subscriptions/__tests__/verify.test.js
+++ b/functions/api/subscriptions/__tests__/verify.test.js
@@ -1,140 +1,140 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { onRequestGet } from '../verify.js'
-import { MockD1Database } from './mocks/d1.js'
-import { createMockContext } from './helpers.js'
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { onRequestGet } from "../verify.js";
+import { MockD1Database } from "./mocks/d1.js";
+import { createMockContext } from "./helpers.js";
 
-describe('GET /api/subscriptions/verify', () => {
-  let mockDB
-  let mockContext
+describe("GET /api/subscriptions/verify", () => {
+  let mockDB;
+  let mockContext;
 
   beforeEach(() => {
-    mockDB = new MockD1Database()
-    mockContext = createMockContext(mockDB)
-    
-    vi.spyOn(console, 'error').mockImplementation(() => {})
-  })
+    mockDB = new MockD1Database();
+    mockContext = createMockContext(mockDB);
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('should verify subscription with valid token', async () => {
+  it("should verify subscription with valid token", async () => {
     // Pre-populate with unverified subscription
     mockDB.data.email_subscriptions.push({
       id: 1,
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
       verified: false,
-      verification_token: 'valid-token-12345',
-      unsubscribe_token: 'unsub-token-67890',
-      created_at: new Date().toISOString()
-    })
+      verification_token: "valid-token-12345",
+      unsubscribe_token: "unsub-token-67890",
+      created_at: new Date().toISOString(),
+    });
 
-    const request = new Request('http://localhost/api/subscriptions/verify?token=valid-token-12345')
-    mockContext.request = request
+    const request = new Request("http://localhost/api/subscriptions/verify?token=valid-token-12345");
+    mockContext.request = request;
 
-    const response = await onRequestGet(mockContext)
+    const response = await onRequestGet(mockContext);
 
-    expect(response.status).toBe(302)
-    const subscription = mockDB.data.email_subscriptions.find(sub => sub.id === 1)
-    expect(subscription.verified).toBe(true)
-    expect(mockDB.data.subscription_verifications).toHaveLength(1)
-    expect(mockDB.data.subscription_verifications[0].subscription_id).toBe(1)
-  })
+    expect(response.status).toBe(302);
+    const subscription = mockDB.data.email_subscriptions.find((sub) => sub.id === 1);
+    expect(subscription.verified).toBe(true);
+    expect(mockDB.data.subscription_verifications).toHaveLength(1);
+    expect(mockDB.data.subscription_verifications[0].subscription_id).toBe(1);
+  });
 
-  it('should reject request without token', async () => {
-    const request = new Request('http://localhost/api/subscriptions/verify')
-    mockContext.request = request
+  it("should reject request without token", async () => {
+    const request = new Request("http://localhost/api/subscriptions/verify");
+    mockContext.request = request;
 
-    const response = await onRequestGet(mockContext)
+    const response = await onRequestGet(mockContext);
 
-    expect(response.status).toBe(400)
-    const text = await response.text()
-    expect(text).toContain('Missing verification token')
-  })
+    expect(response.status).toBe(400);
+    const text = await response.text();
+    expect(text).toContain("Missing verification token");
+  });
 
-  it('should reject invalid token', async () => {
-    const request = new Request('http://localhost/api/subscriptions/verify?token=invalid-token')
-    mockContext.request = request
+  it("should reject invalid token", async () => {
+    const request = new Request("http://localhost/api/subscriptions/verify?token=invalid-token");
+    mockContext.request = request;
 
-    const response = await onRequestGet(mockContext)
+    const response = await onRequestGet(mockContext);
 
-    expect(response.status).toBe(404)
-    const text = await response.text()
-    expect(text).toContain('Invalid verification token')
-  })
+    expect(response.status).toBe(404);
+    const text = await response.text();
+    expect(text).toContain("Invalid verification token");
+  });
 
-  it('should handle already verified subscription gracefully', async () => {
+  it("should handle already verified subscription gracefully", async () => {
     // Pre-populate with verified subscription
     mockDB.data.email_subscriptions.push({
       id: 1,
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
       verified: true,
-      verification_token: 'valid-token-12345',
-      unsubscribe_token: 'unsub-token-67890',
-      created_at: new Date().toISOString()
-    })
+      verification_token: "valid-token-12345",
+      unsubscribe_token: "unsub-token-67890",
+      created_at: new Date().toISOString(),
+    });
 
-    const request = new Request('http://localhost/api/subscriptions/verify?token=valid-token-12345')
-    mockContext.request = request
+    const request = new Request("http://localhost/api/subscriptions/verify?token=valid-token-12345");
+    mockContext.request = request;
 
-    const response = await onRequestGet(mockContext)
+    const response = await onRequestGet(mockContext);
 
-    expect(response.status).toBe(200)
-    const text = await response.text()
-    expect(text).toContain('Email already verified')
-  })
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toContain("Email already verified");
+  });
 
-  it('should log verification to subscription_verifications table', async () => {
+  it("should log verification to subscription_verifications table", async () => {
     mockDB.data.email_subscriptions.push({
       id: 1,
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
       verified: false,
-      verification_token: 'valid-token-12345',
-      unsubscribe_token: 'unsub-token-67890',
-      created_at: new Date().toISOString()
-    })
+      verification_token: "valid-token-12345",
+      unsubscribe_token: "unsub-token-67890",
+      created_at: new Date().toISOString(),
+    });
 
-    const request = new Request('http://localhost/api/subscriptions/verify?token=valid-token-12345')
-    mockContext.request = request
+    const request = new Request("http://localhost/api/subscriptions/verify?token=valid-token-12345");
+    mockContext.request = request;
 
-    await onRequestGet(mockContext)
+    await onRequestGet(mockContext);
 
-    expect(mockDB.data.subscription_verifications).toHaveLength(1)
+    expect(mockDB.data.subscription_verifications).toHaveLength(1);
     expect(mockDB.data.subscription_verifications[0]).toMatchObject({
       subscription_id: 1,
-      verified_at: expect.any(String)
-    })
-  })
+      verified_at: expect.any(String),
+    });
+  });
 
-  it('should redirect to success page after verification', async () => {
+  it("should redirect to success page after verification", async () => {
     mockDB.data.email_subscriptions.push({
       id: 1,
-      email: 'test@example.com',
-      city: 'portland',
-      genre: 'punk',
-      frequency: 'weekly',
+      email: "test@example.com",
+      city: "portland",
+      genre: "punk",
+      frequency: "weekly",
       verified: false,
-      verification_token: 'valid-token-12345',
-      unsubscribe_token: 'unsub-token-67890',
-      created_at: new Date().toISOString()
-    })
+      verification_token: "valid-token-12345",
+      unsubscribe_token: "unsub-token-67890",
+      created_at: new Date().toISOString(),
+    });
 
-    const request = new Request('http://localhost/api/subscriptions/verify?token=valid-token-12345')
-    mockContext.request = request
+    const request = new Request("http://localhost/api/subscriptions/verify?token=valid-token-12345");
+    mockContext.request = request;
 
-    const response = await onRequestGet(mockContext)
+    const response = await onRequestGet(mockContext);
 
-    expect(response.status).toBe(302)
-    const location = response.headers.get('location')
-    expect(location).toBe('https://example.com/subscribe?verified=true')
-  })
-})
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location");
+    expect(location).toBe("https://example.com/subscribe?verified=true");
+  });
+});

--- a/functions/api/subscriptions/subscribe.js
+++ b/functions/api/subscriptions/subscribe.js
@@ -35,10 +35,7 @@ export async function onRequestPost(context) {
     const email = typeof body.email === "string" ? body.email.trim() : "";
     const city = typeof body.city === "string" ? body.city.trim() : "";
     const genre = typeof body.genre === "string" ? body.genre.trim() : "";
-    const frequency =
-      typeof body.frequency === "string"
-        ? body.frequency.trim().toLowerCase()
-        : "";
+    const frequency = typeof body.frequency === "string" ? body.frequency.trim().toLowerCase() : "";
     const turnstileToken = body.turnstileToken;
 
     // Validation
@@ -50,48 +47,32 @@ export async function onRequestPost(context) {
     }
 
     if (!city || !genre || !frequency) {
-      return new Response(
-        JSON.stringify({ error: "Missing required fields" }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      return new Response(JSON.stringify({ error: "Missing required fields" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
-    if (
-      city.length > MAX_CITY_LENGTH ||
-      genre.length > MAX_GENRE_LENGTH ||
-      frequency.length > MAX_FREQUENCY_LENGTH
-    ) {
-      return new Response(
-        JSON.stringify({ error: "One or more fields exceed maximum length" }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+    if (city.length > MAX_CITY_LENGTH || genre.length > MAX_GENRE_LENGTH || frequency.length > MAX_FREQUENCY_LENGTH) {
+      return new Response(JSON.stringify({ error: "One or more fields exceed maximum length" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     if (!FREQUENCY_OPTIONS.has(frequency)) {
-      return new Response(
-        JSON.stringify({ error: "Invalid frequency value" }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      return new Response(JSON.stringify({ error: "Invalid frequency value" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     const turnstileValid = await verifyTurnstile(request, env, turnstileToken);
     if (!turnstileValid) {
-      return new Response(
-        JSON.stringify({ error: "Bot verification failed" }),
-        {
-          status: 403,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      return new Response(JSON.stringify({ error: "Bot verification failed" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     // Generate tokens
@@ -121,19 +102,12 @@ export async function onRequestPost(context) {
         );
       } else {
         // Re-send verification email
-        const emailResult = await sendVerificationEmail(
-          env,
-          email,
-          city,
-          genre,
-          existing[0].verification_token,
-        );
+        const emailResult = await sendVerificationEmail(env, email, city, genre, existing[0].verification_token);
 
         if (!emailResult.delivered && emailResult.reason === "not_configured") {
           return subscriptionResponse(
             {
-              message:
-                "Email delivery is not configured. Use the link below to verify your subscription.",
+              message: "Email delivery is not configured. Use the link below to verify your subscription.",
             },
             200,
             emailResult,
@@ -161,34 +135,20 @@ export async function onRequestPost(context) {
         VALUES (?, ?, ?, ?, ?, ?, ?, 'web_form')
       `,
       )
-        .bind(
-          email,
-          city,
-          genre,
-          frequency,
-          verificationToken,
-          unsubscribeToken,
-          consentIp,
-        )
+        .bind(email, city, genre, frequency, verificationToken, unsubscribeToken, consentIp)
         .run();
     } catch (insertError) {
       if (insertError?.message?.includes("UNIQUE constraint failed")) {
-        return new Response(
-          JSON.stringify({ error: "You are already subscribed to this feed" }),
-          { status: 400, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ error: "You are already subscribed to this feed" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
       }
       throw insertError;
     }
 
     // Send verification email
-    const emailResult = await sendVerificationEmail(
-      env,
-      email,
-      city,
-      genre,
-      verificationToken,
-    );
+    const emailResult = await sendVerificationEmail(env, email, city, genre, verificationToken);
 
     if (!emailResult.delivered && emailResult.reason === "not_configured") {
       return subscriptionResponse(
@@ -241,9 +201,7 @@ async function sendVerificationEmail(env, email, city, genre, token) {
     });
     return { ...emailResult, verifyUrl };
   } else {
-    console.warn(
-      "[Subscribe] Email not configured; verification email was not sent.",
-    );
+    console.warn("[Subscribe] Email not configured; verification email was not sent.");
     return { delivered: false, reason: "not_configured", verifyUrl };
   }
 }

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -355,9 +355,7 @@ export function createTestDB() {
     );
   `);
 
-  const insertUser = db.prepare(
-    "INSERT INTO users (email, role, activated_at) VALUES (?, ?, datetime('now'))",
-  );
+  const insertUser = db.prepare("INSERT INTO users (email, role, activated_at) VALUES (?, ?, datetime('now'))");
   insertUser.run("admin@test", "admin");
   insertUser.run("editor@test", "editor");
   insertUser.run("viewer@test", "viewer");
@@ -373,21 +371,11 @@ export const mockUsers = {
 
 export function insertEvent(
   db,
-  {
-    name = "Test Event",
-    slug = "test-event",
-    date = "2025-12-15",
-    status = "draft",
-    created_by = 1,
-  } = {},
+  { name = "Test Event", slug = "test-event", date = "2025-12-15", status = "draft", created_by = 1 } = {},
 ) {
-  const stmt = db.prepare(
-    "INSERT INTO events (name, slug, date, status, created_by_user_id) VALUES (?, ?, ?, ?, ?)",
-  );
+  const stmt = db.prepare("INSERT INTO events (name, slug, date, status, created_by_user_id) VALUES (?, ?, ?, ?, ?)");
   const info = stmt.run(name, slug, date, status, created_by);
-  return db
-    .prepare("SELECT * FROM events WHERE id = ?")
-    .get(info.lastInsertRowid);
+  return db.prepare("SELECT * FROM events WHERE id = ?").get(info.lastInsertRowid);
 }
 
 export function insertBand(
@@ -409,11 +397,8 @@ export function insertBand(
   // Insert into band_profiles + performances (v2 schema)
   const nameNormalized = normalizeBandName(name);
   let profileId;
-  const resolvedSocialLinks =
-    social_links ?? (url ? JSON.stringify({ website: url }) : null);
-  const existingProfile = db
-    .prepare("SELECT * FROM band_profiles WHERE name_normalized = ?")
-    .get(nameNormalized);
+  const resolvedSocialLinks = social_links ?? (url ? JSON.stringify({ website: url }) : null);
+  const existingProfile = db.prepare("SELECT * FROM band_profiles WHERE name_normalized = ?").get(nameNormalized);
   if (existingProfile) {
     profileId = existingProfile.id;
     const updates = [];
@@ -439,24 +424,14 @@ export function insertBand(
       values.push(resolvedSocialLinks);
     }
     if (updates.length > 0) {
-      db.prepare(
-        `UPDATE band_profiles SET ${updates.join(", ")} WHERE id = ?`,
-      ).run(...values, profileId);
+      db.prepare(`UPDATE band_profiles SET ${updates.join(", ")} WHERE id = ?`).run(...values, profileId);
     }
   } else {
     const profileInfo = db
       .prepare(
         "INSERT INTO band_profiles (name, name_normalized, genre, origin, description, photo_url, social_links) VALUES (?, ?, ?, ?, ?, ?, ?)",
       )
-      .run(
-        name,
-        nameNormalized,
-        genre,
-        origin,
-        description,
-        photo_url,
-        resolvedSocialLinks,
-      );
+      .run(name, nameNormalized, genre, origin, description, photo_url, resolvedSocialLinks);
     profileId = profileInfo.lastInsertRowid;
   }
 
@@ -519,9 +494,7 @@ export function insertVenue(
     contact_email,
     address,
   );
-  return db
-    .prepare("SELECT * FROM venues WHERE id = ?")
-    .get(info.lastInsertRowid);
+  return db.prepare("SELECT * FROM venues WHERE id = ?").get(info.lastInsertRowid);
 }
 
 export function createDBEnv(db) {
@@ -617,9 +590,7 @@ export function createTestEnv({ role = "editor" } = {}) {
   const expiresAt = Math.floor(Date.now() / 1000) + 24 * 60 * 60;
 
   rawDb
-    .prepare(
-      "INSERT INTO lucia_sessions (id, user_id, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)",
-    )
+    .prepare("INSERT INTO lucia_sessions (id, user_id, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)")
     .run(sessionId, userId, expiresAt, "127.0.0.1", "test-agent");
 
   return {
@@ -669,7 +640,5 @@ export function insertShareLink(
     JSON.stringify(band_names),
     expiresAt,
   );
-  return db
-    .prepare("SELECT * FROM share_links WHERE id = ?")
-    .get(info.lastInsertRowid);
+  return db.prepare("SELECT * FROM share_links WHERE id = ?").get(info.lastInsertRowid);
 }

--- a/functions/api/venues.js
+++ b/functions/api/venues.js
@@ -27,13 +27,8 @@ export async function onRequestGet(context) {
   const q = (url.searchParams.get("q") || "").trim().slice(0, 100);
 
   const parsedLimit = Number.parseInt(url.searchParams.get("limit") || "", 10);
-  const parsedOffset = Number.parseInt(
-    url.searchParams.get("offset") || "",
-    10,
-  );
-  const limit = Number.isFinite(parsedLimit)
-    ? Math.min(Math.max(parsedLimit, 1), MAX_LIMIT)
-    : DEFAULT_LIMIT;
+  const parsedOffset = Number.parseInt(url.searchParams.get("offset") || "", 10);
+  const limit = Number.isFinite(parsedLimit) ? Math.min(Math.max(parsedLimit, 1), MAX_LIMIT) : DEFAULT_LIMIT;
   const offset = Number.isFinite(parsedOffset) ? Math.max(parsedOffset, 0) : 0;
 
   const like = `%${q.replace(/[%_\\]/g, (m) => `\\${m}`)}%`;

--- a/functions/api/venues/[id].js
+++ b/functions/api/venues/[id].js
@@ -21,12 +21,7 @@ function formatLocation(v) {
 
 function formatAddress(v) {
   const cityRegion = [v.city, v.region].filter(Boolean).join(", ");
-  const parts = [
-    v.address_line1,
-    v.address_line2,
-    cityRegion,
-    v.postal_code,
-  ].filter(Boolean);
+  const parts = [v.address_line1, v.address_line2, cityRegion, v.postal_code].filter(Boolean);
   return parts.length ? parts.join(", ") : v.address || null;
 }
 
@@ -45,9 +40,7 @@ export async function onRequestGet(context) {
   }
 
   try {
-    const venue = await DB.prepare("SELECT * FROM venues WHERE id = ?")
-      .bind(id)
-      .first();
+    const venue = await DB.prepare("SELECT * FROM venues WHERE id = ?").bind(id).first();
     if (!venue) {
       return json({ error: "Venue not found" }, 404);
     }
@@ -114,9 +107,6 @@ export async function onRequestGet(context) {
     );
   } catch (error) {
     console.error("Error fetching venue:", error);
-    return json(
-      { error: "Database error", message: "Failed to fetch venue" },
-      500,
-    );
+    return json({ error: "Database error", message: "Failed to fetch venue" }, 500);
   }
 }

--- a/functions/api/venues/__tests__/venue-detail.test.js
+++ b/functions/api/venues/__tests__/venue-detail.test.js
@@ -1,11 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { onRequestGet } from "../[id].js";
-import {
-  createTestEnv,
-  insertEvent,
-  insertVenue,
-  insertBand,
-} from "../../test-utils.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
 
 describe("GET /api/venues/:id — reveal_mode gate", () => {
   // Use a far-future date so performances land in the "upcoming" bucket.
@@ -21,17 +16,13 @@ describe("GET /api/venues/:id — reveal_mode gate", () => {
       slug: "venue-reveal-hidden",
       date: futureDate,
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Hidden Venue Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
 
     const response = await onRequestGet({
       env,
@@ -54,17 +45,13 @@ describe("GET /api/venues/:id — reveal_mode gate", () => {
       slug: "venue-reveal-shown",
       date: futureDate,
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Revealed Venue Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=1 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=1 WHERE id=?").run(perf.id);
 
     const response = await onRequestGet({
       env,
@@ -87,17 +74,13 @@ describe("GET /api/venues/:id — reveal_mode gate", () => {
       slug: "venue-reveal-mode0",
       date: futureDate,
     });
-    rawDb
-      .prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?")
-      .run(event.id);
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Normal Venue Band",
       event_id: event.id,
       venue_id: venue.id,
     });
-    rawDb
-      .prepare("UPDATE performances SET is_announced=0 WHERE id=?")
-      .run(perf.id);
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
 
     const response = await onRequestGet({
       env,

--- a/functions/band/[id].js
+++ b/functions/band/[id].js
@@ -32,8 +32,7 @@ export async function onRequest(context) {
   const plainDesc = toPlainText(band.description, 200);
   const tagline = [band.genre, band.origin].filter(Boolean).join(" · ");
   const description =
-    plainDesc ||
-    `${band.name}${tagline ? ` — ${tagline}` : ""} on SetTimes, Waterloo Region's live music platform.`;
+    plainDesc || `${band.name}${tagline ? ` — ${tagline}` : ""} on SetTimes, Waterloo Region's live music platform.`;
 
   const metaTags = [
     `<meta name="description" content="${escapeAttr(description)}" />`,
@@ -70,20 +69,19 @@ export async function onRequest(context) {
 
   // Prefer the structured origin_city/origin_region columns; fall back to the
   // legacy free-text origin string (used as-is in foundingLocation.name).
-  const foundingLocation =
-    band.origin_city
-      ? {
-          "@type": "Place",
-          address: {
-            "@type": "PostalAddress",
-            addressLocality: band.origin_city,
-            ...(band.origin_region ? { addressRegion: band.origin_region } : {}),
-            addressCountry: "CA",
-          },
-        }
-      : band.origin
-        ? { "@type": "Place", name: band.origin }
-        : null;
+  const foundingLocation = band.origin_city
+    ? {
+        "@type": "Place",
+        address: {
+          "@type": "PostalAddress",
+          addressLocality: band.origin_city,
+          ...(band.origin_region ? { addressRegion: band.origin_region } : {}),
+          addressCountry: "CA",
+        },
+      }
+    : band.origin
+      ? { "@type": "Place", name: band.origin }
+      : null;
 
   const musicGroup = {
     "@context": "https://schema.org",

--- a/functions/event/[slug].js
+++ b/functions/event/[slug].js
@@ -2,13 +2,7 @@
 // JSON-LD for crawlers. See functions/utils/ssrMeta.js for rationale + fallback.
 
 import { isPublicDataEnabled } from "../utils/publicGate.js";
-import {
-  escapeAttr,
-  toPlainText,
-  serveWithInjectedMeta,
-  WATERLOO_ADDRESS,
-  CANONICAL_HOST,
-} from "../utils/ssrMeta.js";
+import { escapeAttr, toPlainText, serveWithInjectedMeta, WATERLOO_ADDRESS, CANONICAL_HOST } from "../utils/ssrMeta.js";
 
 export async function onRequest(context) {
   const { params, env, request } = context;
@@ -69,8 +63,7 @@ export async function onRequest(context) {
   const where = event.city || "Waterloo Region";
   const plainDesc = toPlainText(event.description, 200);
   const description =
-    plainDesc ||
-    `${event.name} — live music in ${where} on SetTimes.${event.date ? ` ${event.date}.` : ""}`;
+    plainDesc || `${event.name} — live music in ${where} on SetTimes.${event.date ? ` ${event.date}.` : ""}`;
 
   const metaTags = [
     `<meta name="description" content="${escapeAttr(description)}" />`,
@@ -93,9 +86,7 @@ export async function onRequest(context) {
           name: v.name,
           address: {
             "@type": "PostalAddress",
-            ...(v.address_line1 || v.address
-              ? { streetAddress: v.address_line1 || v.address }
-              : {}),
+            ...(v.address_line1 || v.address ? { streetAddress: v.address_line1 || v.address } : {}),
             addressLocality: v.city || "Waterloo",
             addressRegion: v.region || "ON",
             ...(v.postal_code ? { postalCode: v.postal_code } : {}),

--- a/functions/s/[slug].js
+++ b/functions/s/[slug].js
@@ -7,11 +7,7 @@
 const CANONICAL_HOST = "https://settimes.ca";
 
 function escapeAttr(str) {
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  return String(str).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 export async function onRequest(context) {

--- a/functions/scheduled/__tests__/aggregate-stats.test.js
+++ b/functions/scheduled/__tests__/aggregate-stats.test.js
@@ -1,91 +1,108 @@
-import { describe, it, expect } from 'vitest'
-import { createTestEnv } from '../../api/test-utils.js'
-import { scheduled } from '../aggregate-stats.js'
+import { describe, it, expect } from "vitest";
+import { createTestEnv } from "../../api/test-utils.js";
+import { scheduled } from "../aggregate-stats.js";
 
 async function runScheduled(env) {
-  await scheduled({}, env, {})
+  await scheduled({}, env, {});
 }
 
 function daysAgo(n) {
-  const d = new Date()
-  d.setDate(d.getDate() - n)
-  return d.toISOString().slice(0, 10)
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
 }
 
-describe('aggregate-stats scheduled job (P1-P3)', () => {
-  it('sets total_views to sum of page_views for the profile', async () => {
-    const { env, rawDb } = createTestEnv()
-    const { lastInsertRowid: profileId } = rawDb.prepare(
-      'INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)'
-    ).run('Stat Band', 'statband')
+describe("aggregate-stats scheduled job (P1-P3)", () => {
+  it("sets total_views to sum of page_views for the profile", async () => {
+    const { env, rawDb } = createTestEnv();
+    const { lastInsertRowid: profileId } = rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("Stat Band", "statband");
 
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)')
-      .run(profileId, '2026-05-01', 100, 5)
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)')
-      .run(profileId, '2026-05-02', 200, 10)
+    rawDb
+      .prepare("INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)")
+      .run(profileId, "2026-05-01", 100, 5);
+    rawDb
+      .prepare("INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)")
+      .run(profileId, "2026-05-02", 200, 10);
 
-    await runScheduled(env)
+    await runScheduled(env);
 
-    const profile = rawDb.prepare('SELECT total_views, total_social_clicks FROM band_profiles WHERE id = ?').get(profileId)
-    expect(profile.total_views).toBe(300)
-    expect(profile.total_social_clicks).toBe(15)
-  })
+    const profile = rawDb
+      .prepare("SELECT total_views, total_social_clicks FROM band_profiles WHERE id = ?")
+      .get(profileId);
+    expect(profile.total_views).toBe(300);
+    expect(profile.total_social_clicks).toBe(15);
+  });
 
-  it('resets total_views to 0 for profiles with no stats', async () => {
-    const { env, rawDb } = createTestEnv()
+  it("resets total_views to 0 for profiles with no stats", async () => {
+    const { env, rawDb } = createTestEnv();
     // Insert a profile and manually set non-zero totals (simulating a prior run)
-    rawDb.prepare(
-      'INSERT INTO band_profiles (name, name_normalized, total_views, total_social_clicks, popularity_score) VALUES (?, ?, ?, ?, ?)'
-    ).run('Stale Band', 'staleband', 999, 888, 77.0)
-    const profileId = rawDb.prepare('SELECT id FROM band_profiles WHERE name_normalized = ?').get('staleband').id
+    rawDb
+      .prepare(
+        "INSERT INTO band_profiles (name, name_normalized, total_views, total_social_clicks, popularity_score) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run("Stale Band", "staleband", 999, 888, 77.0);
+    const profileId = rawDb.prepare("SELECT id FROM band_profiles WHERE name_normalized = ?").get("staleband").id;
 
     // No artist_daily_stats rows for this profile — aggregation should reset to 0
-    await runScheduled(env)
+    await runScheduled(env);
 
-    const profile = rawDb.prepare('SELECT total_views, total_social_clicks, popularity_score FROM band_profiles WHERE id = ?').get(profileId)
-    expect(profile.total_views).toBe(0)
-    expect(profile.total_social_clicks).toBe(0)
-    expect(profile.popularity_score).toBe(0)
-  })
+    const profile = rawDb
+      .prepare("SELECT total_views, total_social_clicks, popularity_score FROM band_profiles WHERE id = ?")
+      .get(profileId);
+    expect(profile.total_views).toBe(0);
+    expect(profile.total_social_clicks).toBe(0);
+    expect(profile.popularity_score).toBe(0);
+  });
 
-  it('popularity_score only counts data from the last 30 days', async () => {
-    const { env, rawDb } = createTestEnv()
-    const { lastInsertRowid: profileId } = rawDb.prepare(
-      'INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)'
-    ).run('Trending Band', 'trendingband')
+  it("popularity_score only counts data from the last 30 days", async () => {
+    const { env, rawDb } = createTestEnv();
+    const { lastInsertRowid: profileId } = rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("Trending Band", "trendingband");
 
     // Recent row — should count toward popularity
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)')
-      .run(profileId, daysAgo(5), 10, 4)
+    rawDb
+      .prepare("INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)")
+      .run(profileId, daysAgo(5), 10, 4);
     // Old row — should NOT count toward popularity (> 30 days ago)
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)')
-      .run(profileId, daysAgo(60), 1000, 500)
+    rawDb
+      .prepare("INSERT INTO artist_daily_stats (band_profile_id, date, page_views, social_clicks) VALUES (?, ?, ?, ?)")
+      .run(profileId, daysAgo(60), 1000, 500);
 
-    await runScheduled(env)
+    await runScheduled(env);
 
-    const profile = rawDb.prepare('SELECT total_views, popularity_score FROM band_profiles WHERE id = ?').get(profileId)
+    const profile = rawDb
+      .prepare("SELECT total_views, popularity_score FROM band_profiles WHERE id = ?")
+      .get(profileId);
     // total_views sums ALL history
-    expect(profile.total_views).toBe(1010)
+    expect(profile.total_views).toBe(1010);
     // popularity_score only counts recent: 10*1 + 4*3 = 22
-    expect(profile.popularity_score).toBeCloseTo(22, 1)
-  })
+    expect(profile.popularity_score).toBeCloseTo(22, 1);
+  });
 
-  it('deletes artist_daily_stats older than 90 days', async () => {
-    const { env, rawDb } = createTestEnv()
-    const { lastInsertRowid: profileId } = rawDb.prepare(
-      'INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)'
-    ).run('Retention Band', 'retentionband')
+  it("deletes artist_daily_stats older than 90 days", async () => {
+    const { env, rawDb } = createTestEnv();
+    const { lastInsertRowid: profileId } = rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized) VALUES (?, ?)")
+      .run("Retention Band", "retentionband");
 
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views) VALUES (?, ?, ?)')
-      .run(profileId, daysAgo(91), 50)
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views) VALUES (?, ?, ?)')
-      .run(profileId, daysAgo(45), 30)
-    rawDb.prepare('INSERT INTO artist_daily_stats (band_profile_id, date, page_views) VALUES (?, ?, ?)')
-      .run(profileId, daysAgo(0), 10)
+    rawDb
+      .prepare("INSERT INTO artist_daily_stats (band_profile_id, date, page_views) VALUES (?, ?, ?)")
+      .run(profileId, daysAgo(91), 50);
+    rawDb
+      .prepare("INSERT INTO artist_daily_stats (band_profile_id, date, page_views) VALUES (?, ?, ?)")
+      .run(profileId, daysAgo(45), 30);
+    rawDb
+      .prepare("INSERT INTO artist_daily_stats (band_profile_id, date, page_views) VALUES (?, ?, ?)")
+      .run(profileId, daysAgo(0), 10);
 
-    await runScheduled(env)
+    await runScheduled(env);
 
-    const remaining = rawDb.prepare('SELECT COUNT(*) as count FROM artist_daily_stats WHERE band_profile_id = ?').get(profileId)
-    expect(remaining.count).toBe(2) // only -45 days and today survive
-  })
-})
+    const remaining = rawDb
+      .prepare("SELECT COUNT(*) as count FROM artist_daily_stats WHERE band_profile_id = ?")
+      .get(profileId);
+    expect(remaining.count).toBe(2); // only -45 days and today survive
+  });
+});

--- a/functions/scheduled/__tests__/scheduled.test.js
+++ b/functions/scheduled/__tests__/scheduled.test.js
@@ -3,9 +3,7 @@ import { createTestEnv } from "../../api/test-utils.js";
 
 // Mock announce digest so we can assert it was called without real email I/O.
 vi.mock("../../utils/announceDigest.js", () => ({
-  flushAnnounceDigest: vi.fn(() =>
-    Promise.resolve({ sent: 0, failed: 0, skipped: 0 }),
-  ),
+  flushAnnounceDigest: vi.fn(() => Promise.resolve({ sent: 0, failed: 0, skipped: 0 })),
 }));
 
 import { flushAnnounceDigest } from "../../utils/announceDigest.js";

--- a/functions/scheduled/aggregate-stats.js
+++ b/functions/scheduled/aggregate-stats.js
@@ -12,9 +12,7 @@ export async function scheduled(_event, env, _ctx) {
     // Two-pass approach: reset all to 0, then fill from a single GROUP BY aggregation.
     // This replaces three correlated subqueries (O(B×S)) with one scan of artist_daily_stats.
     await DB.batch([
-      DB.prepare(
-        `UPDATE band_profiles SET total_views = 0, total_social_clicks = 0, popularity_score = 0`,
-      ),
+      DB.prepare(`UPDATE band_profiles SET total_views = 0, total_social_clicks = 0, popularity_score = 0`),
       DB.prepare(
         `UPDATE band_profiles
          SET

--- a/functions/scheduled/expire-share-links.js
+++ b/functions/scheduled/expire-share-links.js
@@ -1,10 +1,10 @@
 export async function expireShareLinks(_event, env, _ctx) {
-  const { DB } = env
-  if (!DB) return
+  const { DB } = env;
+  if (!DB) return;
 
   try {
-    await DB.prepare(`DELETE FROM share_links WHERE expires_at < datetime('now')`).run()
+    await DB.prepare(`DELETE FROM share_links WHERE expires_at < datetime('now')`).run();
   } catch (err) {
-    console.error('[scheduled] Failed to clean up expired share links', err)
+    console.error("[scheduled] Failed to clean up expired share links", err);
   }
 }

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -13,26 +13,23 @@ export async function onRequestGet(context) {
   }
 
   try {
-    const [{ results: events }, { results: bands }, { results: venues }] =
-      await Promise.all([
-        env.DB.prepare(
-          `SELECT slug, date FROM events WHERE is_published = 1 ORDER BY date DESC`,
-        ).all(),
-        env.DB.prepare(
-          `SELECT DISTINCT bp.id
+    const [{ results: events }, { results: bands }, { results: venues }] = await Promise.all([
+      env.DB.prepare(`SELECT slug, date FROM events WHERE is_published = 1 ORDER BY date DESC`).all(),
+      env.DB.prepare(
+        `SELECT DISTINCT bp.id
          FROM band_profiles bp
          INNER JOIN performances p ON p.band_profile_id = bp.id
          INNER JOIN events e ON e.id = p.event_id
          WHERE e.is_published = 1`,
-        ).all(),
-        env.DB.prepare(
-          `SELECT DISTINCT v.id
+      ).all(),
+      env.DB.prepare(
+        `SELECT DISTINCT v.id
          FROM venues v
          INNER JOIN performances p ON p.venue_id = v.id
          INNER JOIN events e ON e.id = p.event_id
          WHERE e.is_published = 1`,
-        ).all(),
-      ]);
+      ).all(),
+    ]);
 
     const rows = [
       `  <url>

--- a/functions/utils/__tests__/auth.test.js
+++ b/functions/utils/__tests__/auth.test.js
@@ -1,70 +1,70 @@
 // functions/utils/__tests__/auth.test.js
-import { describe, test, expect, beforeEach } from 'vitest';
-import { createTestDB, createDBEnv, mockUsers } from '../../api/test-utils.js';
-import { initializeLucia, isDevRequest } from '../auth.js';
+import { describe, test, expect, beforeEach } from "vitest";
+import { createTestDB, createDBEnv, mockUsers } from "../../api/test-utils.js";
+import { initializeLucia, isDevRequest } from "../auth.js";
 
 function makeEnv(rawDb, opts = {}) {
   return {
     DB: createDBEnv(rawDb),
-    ENVIRONMENT: opts.env ?? 'test',
+    ENVIRONMENT: opts.env ?? "test",
   };
 }
 
 function makeRequest(opts = {}) {
-  return new Request('https://example.test/api/admin/me', {
+  return new Request("https://example.test/api/admin/me", {
     headers: opts.headers ?? {},
   });
 }
 
-describe('isDevRequest', () => {
-  const localhostRequest = new Request('http://localhost:8788/api/x', {
-    headers: { Host: 'localhost:8788' },
+describe("isDevRequest", () => {
+  const localhostRequest = new Request("http://localhost:8788/api/x", {
+    headers: { Host: "localhost:8788" },
   });
-  const prodRequest = new Request('https://settimes.ca/api/x', {
-    headers: { Host: 'settimes.ca' },
+  const prodRequest = new Request("https://settimes.ca/api/x", {
+    headers: { Host: "settimes.ca" },
   });
 
   test('returns false when ENVIRONMENT is "production"', () => {
-    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'production' })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: "production" })).toBe(false);
   });
 
   test('returns true when ENVIRONMENT is "development"', () => {
-    expect(isDevRequest(localhostRequest, { ENVIRONMENT: 'development' })).toBe(true);
+    expect(isDevRequest(localhostRequest, { ENVIRONMENT: "development" })).toBe(true);
   });
 
   test('returns true when ENVIRONMENT is "test"', () => {
-    expect(isDevRequest(localhostRequest, { ENVIRONMENT: 'test' })).toBe(true);
+    expect(isDevRequest(localhostRequest, { ENVIRONMENT: "test" })).toBe(true);
   });
 
   test('returns false for a deployed non-allowlisted ENVIRONMENT like "staging" (secure by default)', () => {
-    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'staging' })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: "staging" })).toBe(false);
   });
 
   test('fails CLOSED (secure) for a typo / case / whitespace variant of "production"', () => {
     // A misconfigured prod ENVIRONMENT value must never downgrade to insecure dev mode.
-    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'Production' })).toBe(false);
-    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'PRODUCTION' })).toBe(false);
-    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'prod' })).toBe(false);
-    expect(isDevRequest(prodRequest, { ENVIRONMENT: 'production\n' })).toBe(false);
-    expect(isDevRequest(prodRequest, { ENVIRONMENT: '  production  ' })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: "Production" })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: "PRODUCTION" })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: "prod" })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: "production\n" })).toBe(false);
+    expect(isDevRequest(prodRequest, { ENVIRONMENT: "  production  " })).toBe(false);
   });
 
-  test('returns false when ENVIRONMENT is unset ({}), even for a localhost Host/url (#425 security)', () => {
+  test("returns false when ENVIRONMENT is unset ({}), even for a localhost Host/url (#425 security)", () => {
     // The Host header is client-controlled — trusting it when env is unset would let
     // an attacker coerce a misconfigured deploy into dev (insecure) cookie behavior.
     expect(isDevRequest(localhostRequest, {})).toBe(false);
   });
 
-  test('returns false when env is null, even for a localhost request', () => {
+  test("returns false when env is null, even for a localhost request", () => {
     expect(isDevRequest(localhostRequest, null)).toBe(false);
   });
 
-  test('returns false when called without env argument (isDevRequest(request))', () => {
+  test("returns false when called without env argument (isDevRequest(request))", () => {
     expect(isDevRequest(localhostRequest)).toBe(false);
   });
 });
 
-describe('initializeLucia / session manager', () => {
+describe("initializeLucia / session manager", () => {
   let rawDb;
 
   beforeEach(() => {
@@ -73,54 +73,52 @@ describe('initializeLucia / session manager', () => {
 
   // ── readSessionCookie ─────────────────────────────────────────────────────
 
-  describe('readSessionCookie', () => {
-    test('returns session ID from session_token cookie in dev/test', () => {
-      const env = makeEnv(rawDb, { env: 'test' });
+  describe("readSessionCookie", () => {
+    test("returns session ID from session_token cookie in dev/test", () => {
+      const env = makeEnv(rawDb, { env: "test" });
       const manager = initializeLucia(env.DB, makeRequest(), env);
-      const id = manager.readSessionCookie('session_token=abc123; other=x');
-      expect(id).toBe('abc123');
+      const id = manager.readSessionCookie("session_token=abc123; other=x");
+      expect(id).toBe("abc123");
     });
 
-    test('returns null when session cookie is absent', () => {
-      const env = makeEnv(rawDb, { env: 'test' });
+    test("returns null when session cookie is absent", () => {
+      const env = makeEnv(rawDb, { env: "test" });
       const manager = initializeLucia(env.DB, makeRequest(), env);
-      expect(manager.readSessionCookie('other=x')).toBeNull();
+      expect(manager.readSessionCookie("other=x")).toBeNull();
     });
 
-    test('returns session ID from __Host-session_token in production', () => {
-      const env = makeEnv(rawDb, { env: 'production' });
-      const req = makeRequest({ headers: { Host: 'settimes.ca' } });
+    test("returns session ID from __Host-session_token in production", () => {
+      const env = makeEnv(rawDb, { env: "production" });
+      const req = makeRequest({ headers: { Host: "settimes.ca" } });
       const manager = initializeLucia(env.DB, req, env);
-      const id = manager.readSessionCookie('__Host-session_token=prodid; other=x');
-      expect(id).toBe('prodid');
+      const id = manager.readSessionCookie("__Host-session_token=prodid; other=x");
+      expect(id).toBe("prodid");
     });
   });
 
   // ── createSession ─────────────────────────────────────────────────────────
 
-  describe('createSession', () => {
-    test('returns a session object with fresh:true and a string id', async () => {
+  describe("createSession", () => {
+    test("returns a session object with fresh:true and a string id", async () => {
       const env = makeEnv(rawDb);
       const manager = initializeLucia(env.DB, makeRequest(), env);
       const session = await manager.createSession(mockUsers.admin.id, {});
 
-      expect(typeof session.id).toBe('string');
+      expect(typeof session.id).toBe("string");
       expect(session.id.length).toBeGreaterThan(8);
       expect(session.userId).toBe(mockUsers.admin.id);
       expect(session.fresh).toBe(true);
       expect(session.expiresAt).toBeInstanceOf(Date);
     });
 
-    test('stores the session in lucia_sessions with expires_at ~30 days out', async () => {
+    test("stores the session in lucia_sessions with expires_at ~30 days out", async () => {
       const env = makeEnv(rawDb);
       const manager = initializeLucia(env.DB, makeRequest(), env);
       const before = Math.floor(Date.now() / 1000);
       const session = await manager.createSession(mockUsers.admin.id, {});
       const after = Math.floor(Date.now() / 1000);
 
-      const row = rawDb
-        .prepare('SELECT * FROM lucia_sessions WHERE id = ?')
-        .get(session.id);
+      const row = rawDb.prepare("SELECT * FROM lucia_sessions WHERE id = ?").get(session.id);
 
       expect(row).not.toBeNull();
       expect(row.user_id).toBe(mockUsers.admin.id);
@@ -133,19 +131,19 @@ describe('initializeLucia / session manager', () => {
 
   // ── validateSession ───────────────────────────────────────────────────────
 
-  describe('validateSession', () => {
+  describe("validateSession", () => {
     async function seedSession(rawDb, userId = 1, offsetSeconds = 20 * 86400) {
       const id = crypto.randomUUID();
       const expiresAt = Math.floor(Date.now() / 1000) + offsetSeconds;
       rawDb
         .prepare(
-          "INSERT INTO lucia_sessions (id, user_id, expires_at, created_at, last_activity_at) VALUES (?, ?, ?, datetime('now'), datetime('now'))"
+          "INSERT INTO lucia_sessions (id, user_id, expires_at, created_at, last_activity_at) VALUES (?, ?, ?, datetime('now'), datetime('now'))",
         )
         .run(id, userId, expiresAt);
       return id;
     }
 
-    test('returns session and user for a valid session', async () => {
+    test("returns session and user for a valid session", async () => {
       const env = makeEnv(rawDb);
       const manager = initializeLucia(env.DB, makeRequest(), env);
       const sessionId = await seedSession(rawDb, mockUsers.admin.id);
@@ -158,19 +156,19 @@ describe('initializeLucia / session manager', () => {
       expect(session.fresh).toBe(false);
       expect(session.expiresAt).toBeInstanceOf(Date);
       expect(user).not.toBeNull();
-      expect(user.email).toBe('admin@test');
-      expect(user.role).toBe('admin');
+      expect(user.email).toBe("admin@test");
+      expect(user.role).toBe("admin");
     });
 
-    test('returns nulls for a non-existent session', async () => {
+    test("returns nulls for a non-existent session", async () => {
       const env = makeEnv(rawDb);
       const manager = initializeLucia(env.DB, makeRequest(), env);
-      const { session, user } = await manager.validateSession('no-such-id');
+      const { session, user } = await manager.validateSession("no-such-id");
       expect(session).toBeNull();
       expect(user).toBeNull();
     });
 
-    test('returns nulls and deletes an expired session', async () => {
+    test("returns nulls and deletes an expired session", async () => {
       const env = makeEnv(rawDb);
       const manager = initializeLucia(env.DB, makeRequest(), env);
       // expires_at in the past
@@ -180,32 +178,30 @@ describe('initializeLucia / session manager', () => {
       expect(session).toBeNull();
       expect(user).toBeNull();
 
-      const row = rawDb.prepare('SELECT id FROM lucia_sessions WHERE id = ?').get(id);
+      const row = rawDb.prepare("SELECT id FROM lucia_sessions WHERE id = ?").get(id);
       expect(row).toBeUndefined();
     });
   });
 
   // ── invalidateSession ─────────────────────────────────────────────────────
 
-  describe('invalidateSession', () => {
-    test('removes the session row', async () => {
+  describe("invalidateSession", () => {
+    test("removes the session row", async () => {
       const env = makeEnv(rawDb);
       const manager = initializeLucia(env.DB, makeRequest(), env);
       const session = await manager.createSession(mockUsers.admin.id, {});
 
       await manager.invalidateSession(session.id);
 
-      const row = rawDb
-        .prepare('SELECT id FROM lucia_sessions WHERE id = ?')
-        .get(session.id);
+      const row = rawDb.prepare("SELECT id FROM lucia_sessions WHERE id = ?").get(session.id);
       expect(row).toBeUndefined();
     });
   });
 
   // ── invalidateUserSessions ────────────────────────────────────────────────
 
-  describe('invalidateUserSessions', () => {
-    test('removes all sessions for a user', async () => {
+  describe("invalidateUserSessions", () => {
+    test("removes all sessions for a user", async () => {
       const env = makeEnv(rawDb);
       const manager = initializeLucia(env.DB, makeRequest(), env);
       await manager.createSession(mockUsers.admin.id, {});
@@ -214,70 +210,66 @@ describe('initializeLucia / session manager', () => {
 
       await manager.invalidateUserSessions(mockUsers.admin.id);
 
-      const user1Rows = rawDb
-        .prepare('SELECT id FROM lucia_sessions WHERE user_id = ?')
-        .all(mockUsers.admin.id);
+      const user1Rows = rawDb.prepare("SELECT id FROM lucia_sessions WHERE user_id = ?").all(mockUsers.admin.id);
       expect(user1Rows).toHaveLength(0);
 
-      const user2Rows = rawDb
-        .prepare('SELECT id FROM lucia_sessions WHERE user_id = ?')
-        .all(mockUsers.editor.id);
+      const user2Rows = rawDb.prepare("SELECT id FROM lucia_sessions WHERE user_id = ?").all(mockUsers.editor.id);
       expect(user2Rows).toHaveLength(1);
     });
   });
 
   // ── cookie serialization ──────────────────────────────────────────────────
 
-  describe('createSessionCookie', () => {
-    test('dev: serializes with session_token name, no Secure flag, SameSite=Lax', () => {
-      const env = makeEnv(rawDb, { env: 'test' });
+  describe("createSessionCookie", () => {
+    test("dev: serializes with session_token name, no Secure flag, SameSite=Lax", () => {
+      const env = makeEnv(rawDb, { env: "test" });
       const manager = initializeLucia(env.DB, makeRequest(), env);
-      const cookie = manager.createSessionCookie('test-session-id').serialize();
+      const cookie = manager.createSessionCookie("test-session-id").serialize();
 
-      expect(cookie).toContain('session_token=test-session-id');
-      expect(cookie).toContain('HttpOnly');
-      expect(cookie).toContain('Path=/');
-      expect(cookie).toContain('Max-Age=2592000');
-      expect(cookie).toContain('SameSite=Lax');
-      expect(cookie.toLowerCase()).not.toContain('secure');
-      expect(cookie).not.toContain('__Host-');
+      expect(cookie).toContain("session_token=test-session-id");
+      expect(cookie).toContain("HttpOnly");
+      expect(cookie).toContain("Path=/");
+      expect(cookie).toContain("Max-Age=2592000");
+      expect(cookie).toContain("SameSite=Lax");
+      expect(cookie.toLowerCase()).not.toContain("secure");
+      expect(cookie).not.toContain("__Host-");
     });
 
-    test('prod: serializes with __Host-session_token, Secure, SameSite=Strict', () => {
-      const env = makeEnv(rawDb, { env: 'production' });
-      const req = makeRequest({ headers: { Host: 'settimes.ca' } });
+    test("prod: serializes with __Host-session_token, Secure, SameSite=Strict", () => {
+      const env = makeEnv(rawDb, { env: "production" });
+      const req = makeRequest({ headers: { Host: "settimes.ca" } });
       const manager = initializeLucia(env.DB, req, env);
-      const cookie = manager.createSessionCookie('prod-session-id').serialize();
+      const cookie = manager.createSessionCookie("prod-session-id").serialize();
 
-      expect(cookie).toContain('__Host-session_token=prod-session-id');
-      expect(cookie).toContain('HttpOnly');
-      expect(cookie).toContain('Path=/');
-      expect(cookie).toContain('Max-Age=2592000');
-      expect(cookie).toContain('SameSite=Strict');
-      expect(cookie).toContain('Secure');
+      expect(cookie).toContain("__Host-session_token=prod-session-id");
+      expect(cookie).toContain("HttpOnly");
+      expect(cookie).toContain("Path=/");
+      expect(cookie).toContain("Max-Age=2592000");
+      expect(cookie).toContain("SameSite=Strict");
+      expect(cookie).toContain("Secure");
     });
   });
 
-  describe('createBlankSessionCookie', () => {
-    test('dev: serializes with Max-Age=0 to clear the cookie', () => {
-      const env = makeEnv(rawDb, { env: 'test' });
+  describe("createBlankSessionCookie", () => {
+    test("dev: serializes with Max-Age=0 to clear the cookie", () => {
+      const env = makeEnv(rawDb, { env: "test" });
       const manager = initializeLucia(env.DB, makeRequest(), env);
       const cookie = manager.createBlankSessionCookie().serialize();
 
-      expect(cookie).toContain('session_token=');
-      expect(cookie).toContain('Max-Age=0');
-      expect(cookie).toContain('HttpOnly');
+      expect(cookie).toContain("session_token=");
+      expect(cookie).toContain("Max-Age=0");
+      expect(cookie).toContain("HttpOnly");
     });
 
-    test('prod: serializes with __Host-session_token and Max-Age=0', () => {
-      const env = makeEnv(rawDb, { env: 'production' });
-      const req = makeRequest({ headers: { Host: 'settimes.ca' } });
+    test("prod: serializes with __Host-session_token and Max-Age=0", () => {
+      const env = makeEnv(rawDb, { env: "production" });
+      const req = makeRequest({ headers: { Host: "settimes.ca" } });
       const manager = initializeLucia(env.DB, req, env);
       const cookie = manager.createBlankSessionCookie().serialize();
 
-      expect(cookie).toContain('__Host-session_token=');
-      expect(cookie).toContain('Max-Age=0');
-      expect(cookie).toContain('Secure');
+      expect(cookie).toContain("__Host-session_token=");
+      expect(cookie).toContain("Max-Age=0");
+      expect(cookie).toContain("Secure");
     });
   });
 });

--- a/functions/utils/__tests__/authAttempts.test.js
+++ b/functions/utils/__tests__/authAttempts.test.js
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { createDBEnv, createTestDB } from "../../api/test-utils.js";
-import {
-  AUTH_ATTEMPT_TYPES,
-  checkAuthRateLimit,
-  writeAuthAttempt,
-} from "../authAttempts.js";
+import { AUTH_ATTEMPT_TYPES, checkAuthRateLimit, writeAuthAttempt } from "../authAttempts.js";
 
 describe("authAttempts", () => {
   let rawDb;
@@ -24,9 +20,7 @@ describe("authAttempts", () => {
       userAgent: "test-agent",
     });
 
-    const row = rawDb
-      .prepare("SELECT * FROM auth_attempts WHERE attempt_type = ?")
-      .get(AUTH_ATTEMPT_TYPES.mfa);
+    const row = rawDb.prepare("SELECT * FROM auth_attempts WHERE attempt_type = ?").get(AUTH_ATTEMPT_TYPES.mfa);
 
     expect(row.email).toBeNull();
     expect(row.user_id).toBeNull();
@@ -130,7 +124,7 @@ describe("authAttempts", () => {
         email: null,
         ipAddress: "1.2.3.4",
         scope: "email",
-      })
+      }),
     ).rejects.toThrow('checkAuthRateLimit: email is required for scope "email"');
   });
 

--- a/functions/utils/__tests__/bandFollowNotify.test.js
+++ b/functions/utils/__tests__/bandFollowNotify.test.js
@@ -7,12 +7,7 @@ vi.mock("../email.js", () => ({
 import { sendEmail } from "../email.js";
 import { notifyBandFollowers } from "../bandFollowNotify.js";
 import * as loggerModule from "../logger.js";
-import {
-  createTestEnv,
-  insertEvent,
-  insertVenue,
-  insertBand,
-} from "../../api/test-utils.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../api/test-utils.js";
 
 describe("notifyBandFollowers", () => {
   afterEach(() => {
@@ -30,20 +25,14 @@ describe("notifyBandFollowers", () => {
     const bandProfileId = perf.band_profile_id;
 
     const f1 = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("a@example.com", bandProfileId, "tok-a").lastInsertRowid;
     const f2 = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("b@example.com", bandProfileId, "tok-b").lastInsertRowid;
 
     // First delivers, second fails.
-    sendEmail.mockImplementation((_env, { to }) =>
-      Promise.resolve({ delivered: to === "a@example.com" }),
-    );
+    sendEmail.mockImplementation((_env, { to }) => Promise.resolve({ delivered: to === "a@example.com" }));
 
     const result = await notifyBandFollowers(env, env.DB, {
       performanceId: perf.id,
@@ -59,9 +48,7 @@ describe("notifyBandFollowers", () => {
     expect(result).toEqual({ sent: 1, failed: 1 });
 
     const notified = rawDb
-      .prepare(
-        "SELECT band_follow_id FROM band_follow_notifications WHERE performance_id = ? ORDER BY band_follow_id",
-      )
+      .prepare("SELECT band_follow_id FROM band_follow_notifications WHERE performance_id = ? ORDER BY band_follow_id")
       .all(perf.id);
     expect(notified.map((r) => r.band_follow_id)).toEqual([f1]);
   });
@@ -78,16 +65,12 @@ describe("notifyBandFollowers", () => {
     const bandProfileId = perf.band_profile_id;
 
     const fId = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fan@example.com", bandProfileId, "tok").lastInsertRowid;
 
     // Pre-claim the follower as if another concurrent request already did
     rawDb
-      .prepare(
-        "INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)",
-      )
+      .prepare("INSERT INTO band_follow_notifications (performance_id, band_follow_id) VALUES (?, ?)")
       .run(perf.id, fId);
 
     sendEmail.mockReset();
@@ -98,9 +81,7 @@ describe("notifyBandFollowers", () => {
       bandProfileId,
       bandName: "Band",
       eventName: "Test",
-      followers: [
-        { id: fId, email: "fan@example.com", unsubscribe_token: "tok" },
-      ],
+      followers: [{ id: fId, email: "fan@example.com", unsubscribe_token: "tok" }],
     });
 
     expect(result).toEqual({ sent: 0, failed: 1 });
@@ -120,9 +101,7 @@ describe("notifyBandFollowers", () => {
     const bandProfileId = perf.band_profile_id;
 
     const fId = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fan@example.com", bandProfileId, "tok").lastInsertRowid;
 
     sendEmail.mockReset();
@@ -135,9 +114,7 @@ describe("notifyBandFollowers", () => {
       bandProfileId,
       bandName: "Band",
       eventName: "Test",
-      followers: [
-        { id: fId, email: "fan@example.com", unsubscribe_token: "tok" },
-      ],
+      followers: [{ id: fId, email: "fan@example.com", unsubscribe_token: "tok" }],
     });
 
     expect(result.failed).toBeGreaterThan(0);
@@ -162,9 +139,7 @@ describe("notifyBandFollowers", () => {
     const bandProfileId = perf.band_profile_id;
 
     const fId = rawDb
-      .prepare(
-        "INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)",
-      )
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
       .run("fan@example.com", bandProfileId, "tok").lastInsertRowid;
 
     sendEmail.mockReset();
@@ -175,18 +150,14 @@ describe("notifyBandFollowers", () => {
       bandProfileId,
       bandName: "Band",
       eventName: "Test",
-      followers: [
-        { id: fId, email: "fan@example.com", unsubscribe_token: "tok" },
-      ],
+      followers: [{ id: fId, email: "fan@example.com", unsubscribe_token: "tok" }],
     });
 
     expect(result).toEqual({ sent: 0, failed: 1 });
 
     // The claim row should have been deleted — resend will pick up this follower
     const rows = rawDb
-      .prepare(
-        "SELECT id FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?",
-      )
+      .prepare("SELECT id FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?")
       .all(perf.id, fId);
     expect(rows).toHaveLength(0);
   });

--- a/functions/utils/__tests__/csrf.test.js
+++ b/functions/utils/__tests__/csrf.test.js
@@ -10,42 +10,33 @@ function makeRequest(url, method, headers = {}) {
 
 describe("CSRF middleware — rejection paths (T5)", () => {
   it("blocks auth route mutation with no Origin header", () => {
-    const req = makeRequest(
-      "https://settimes.ca/api/admin/auth/login",
-      "POST",
-      { "Content-Type": "application/json" }
-    );
+    const req = makeRequest("https://settimes.ca/api/admin/auth/login", "POST", { "Content-Type": "application/json" });
     const result = validateCSRFMiddleware(req, devEnv);
     expect(result).not.toBeNull();
     expect(result.status).toBe(403);
   });
 
   it("blocks auth route mutation with mismatched Origin header", () => {
-    const req = makeRequest(
-      "https://settimes.ca/api/admin/auth/login",
-      "POST",
-      { Origin: "https://evil.example.com", "Content-Type": "application/json" }
-    );
+    const req = makeRequest("https://settimes.ca/api/admin/auth/login", "POST", {
+      Origin: "https://evil.example.com",
+      "Content-Type": "application/json",
+    });
     const result = validateCSRFMiddleware(req, devEnv);
     expect(result).not.toBeNull();
     expect(result.status).toBe(403);
   });
 
   it("allows auth route mutation with matching Origin header", () => {
-    const req = makeRequest(
-      "https://settimes.ca/api/admin/auth/login",
-      "POST",
-      { Origin: "https://settimes.ca", "Content-Type": "application/json" }
-    );
+    const req = makeRequest("https://settimes.ca/api/admin/auth/login", "POST", {
+      Origin: "https://settimes.ca",
+      "Content-Type": "application/json",
+    });
     const result = validateCSRFMiddleware(req, devEnv);
     expect(result).toBeNull();
   });
 
   it("allows GET requests through without CSRF check", () => {
-    const req = makeRequest(
-      "https://settimes.ca/api/admin/auth/login",
-      "GET"
-    );
+    const req = makeRequest("https://settimes.ca/api/admin/auth/login", "GET");
     const result = validateCSRFMiddleware(req, devEnv);
     expect(result).toBeNull();
   });

--- a/functions/utils/__tests__/logger.test.js
+++ b/functions/utils/__tests__/logger.test.js
@@ -1,20 +1,15 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  createLogger,
-  createRequestLogger,
-  logger,
-  logError,
-} from '../logger.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createLogger, createRequestLogger, logger, logError } from "../logger.js";
 
-describe('Structured Logger', () => {
+describe("Structured Logger", () => {
   let consoleSpy;
 
   beforeEach(() => {
     consoleSpy = {
-      debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
-      info: vi.spyOn(console, 'info').mockImplementation(() => {}),
-      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
-      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+      debug: vi.spyOn(console, "debug").mockImplementation(() => {}),
+      info: vi.spyOn(console, "info").mockImplementation(() => {}),
+      warn: vi.spyOn(console, "warn").mockImplementation(() => {}),
+      error: vi.spyOn(console, "error").mockImplementation(() => {}),
     };
   });
 
@@ -22,8 +17,8 @@ describe('Structured Logger', () => {
     vi.restoreAllMocks();
   });
 
-  describe('createLogger', () => {
-    it('should create a logger with all log methods', () => {
+  describe("createLogger", () => {
+    it("should create a logger with all log methods", () => {
       const log = createLogger();
 
       expect(log.debug).toBeInstanceOf(Function);
@@ -34,53 +29,53 @@ describe('Structured Logger', () => {
       expect(log.getRequestId).toBeInstanceOf(Function);
     });
 
-    it('should log messages with structured format', () => {
+    it("should log messages with structured format", () => {
       const log = createLogger();
-      log.info('Test message');
+      log.info("Test message");
 
       expect(consoleSpy.info).toHaveBeenCalled();
       const logOutput = consoleSpy.info.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
 
-      expect(parsed.level).toBe('info');
-      expect(parsed.message).toBe('Test message');
+      expect(parsed.level).toBe("info");
+      expect(parsed.message).toBe("Test message");
       expect(parsed.timestamp).toBeDefined();
       expect(parsed.requestId).toBeDefined();
     });
 
-    it('should include metadata in log output', () => {
+    it("should include metadata in log output", () => {
       const log = createLogger();
-      log.error('Error occurred', { userId: 123, action: 'login' });
+      log.error("Error occurred", { userId: 123, action: "login" });
 
       const logOutput = consoleSpy.error.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
 
       expect(parsed.userId).toBe(123);
-      expect(parsed.action).toBe('login');
+      expect(parsed.action).toBe("login");
     });
 
-    it('should redact email and IP-like metadata keys', () => {
+    it("should redact email and IP-like metadata keys", () => {
       const log = createLogger();
-      log.info('Privacy-safe log', {
-        email: 'admin@test.com',
-        ipAddress: '1.2.3.4',
-        userAgent: 'Mozilla/5.0',
+      log.info("Privacy-safe log", {
+        email: "admin@test.com",
+        ipAddress: "1.2.3.4",
+        userAgent: "Mozilla/5.0",
       });
 
       const logOutput = consoleSpy.info.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
 
-      expect(parsed.email).toBe('[REDACTED]');
-      expect(parsed.ipAddress).toBe('[REDACTED]');
-      expect(parsed.userAgent).toBe('[REDACTED]');
+      expect(parsed.email).toBe("[REDACTED]");
+      expect(parsed.ipAddress).toBe("[REDACTED]");
+      expect(parsed.userAgent).toBe("[REDACTED]");
     });
 
-    it('should generate consistent request ID', () => {
+    it("should generate consistent request ID", () => {
       const log = createLogger();
       const requestId = log.getRequestId();
 
-      log.info('First log');
-      log.error('Second log');
+      log.info("First log");
+      log.error("Second log");
 
       const log1 = JSON.parse(consoleSpy.info.mock.calls[0][0]);
       const log2 = JSON.parse(consoleSpy.error.mock.calls[0][0]);
@@ -89,25 +84,25 @@ describe('Structured Logger', () => {
       expect(log2.requestId).toBe(requestId);
     });
 
-    it('should create child logger with module context', () => {
+    it("should create child logger with module context", () => {
       const log = createLogger();
-      const childLog = log.child({ module: 'auth' });
+      const childLog = log.child({ module: "auth" });
 
-      childLog.info('Auth message');
+      childLog.info("Auth message");
 
       const logOutput = consoleSpy.info.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
 
-      expect(parsed.module).toBe('auth');
+      expect(parsed.module).toBe("auth");
     });
 
-    it('should respect log level from environment', () => {
-      const log = createLogger({ env: { LOG_LEVEL: 'error' } });
+    it("should respect log level from environment", () => {
+      const log = createLogger({ env: { LOG_LEVEL: "error" } });
 
-      log.debug('Debug message');
-      log.info('Info message');
-      log.warn('Warn message');
-      log.error('Error message');
+      log.debug("Debug message");
+      log.info("Info message");
+      log.warn("Warn message");
+      log.error("Error message");
 
       expect(consoleSpy.debug).not.toHaveBeenCalled();
       expect(consoleSpy.info).not.toHaveBeenCalled();
@@ -116,86 +111,86 @@ describe('Structured Logger', () => {
     });
   });
 
-  describe('createRequestLogger', () => {
-    it('should extract module from request URL', () => {
+  describe("createRequestLogger", () => {
+    it("should extract module from request URL", () => {
       const context = {
-        request: new Request('https://example.com/api/admin/users'),
+        request: new Request("https://example.com/api/admin/users"),
         env: {},
       };
 
       const log = createRequestLogger(context);
-      log.info('Test');
+      log.info("Test");
 
       const logOutput = consoleSpy.info.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
 
-      expect(parsed.module).toBe('/api/admin/users');
+      expect(parsed.module).toBe("/api/admin/users");
     });
   });
 
-  describe('logger (module-level)', () => {
-    it('should provide static logging methods', () => {
-      logger.info('Static log');
+  describe("logger (module-level)", () => {
+    it("should provide static logging methods", () => {
+      logger.info("Static log");
 
       expect(consoleSpy.info).toHaveBeenCalled();
       const logOutput = consoleSpy.info.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
 
-      expect(parsed.message).toBe('Static log');
+      expect(parsed.message).toBe("Static log");
     });
   });
 
-  describe('logError', () => {
-    it('should serialize Error objects', () => {
-      const error = new Error('Test error');
-      logError('Something failed', error);
+  describe("logError", () => {
+    it("should serialize Error objects", () => {
+      const error = new Error("Test error");
+      logError("Something failed", error);
 
       expect(consoleSpy.error).toHaveBeenCalled();
       const logOutput = consoleSpy.error.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
 
-      expect(parsed.error.name).toBe('Error');
-      expect(parsed.error.message).toBe('Test error');
+      expect(parsed.error.name).toBe("Error");
+      expect(parsed.error.message).toBe("Test error");
       expect(parsed.error.stack).toBeDefined();
     });
 
-    it('should work with logger instance', () => {
+    it("should work with logger instance", () => {
       const log = createLogger();
-      const error = new Error('Instance error');
+      const error = new Error("Instance error");
 
-      logError(log, error, { context: 'test' });
+      logError(log, error, { context: "test" });
 
       const logOutput = consoleSpy.error.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
 
-      expect(parsed.message).toBe('Instance error');
-      expect(parsed.context).toBe('test');
+      expect(parsed.message).toBe("Instance error");
+      expect(parsed.context).toBe("test");
     });
   });
 
-  describe('error serialization', () => {
-    it('should handle circular references in metadata', () => {
+  describe("error serialization", () => {
+    it("should handle circular references in metadata", () => {
       const log = createLogger();
-      const circular = { name: 'test' };
+      const circular = { name: "test" };
       circular.self = circular;
 
       // Should not throw
-      expect(() => log.info('Circular test', circular)).not.toThrow();
+      expect(() => log.info("Circular test", circular)).not.toThrow();
     });
 
-    it('should handle Request objects in metadata', () => {
+    it("should handle Request objects in metadata", () => {
       const log = createLogger();
-      const request = new Request('https://example.com/test', {
-        method: 'POST',
+      const request = new Request("https://example.com/test", {
+        method: "POST",
       });
 
-      log.info('Request log', { request });
+      log.info("Request log", { request });
 
       const logOutput = consoleSpy.info.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
 
-      expect(parsed.request.url).toBe('https://example.com/test');
-      expect(parsed.request.method).toBe('POST');
+      expect(parsed.request.url).toBe("https://example.com/test");
+      expect(parsed.request.method).toBe("POST");
     });
   });
 });

--- a/functions/utils/__tests__/mfaSecrets.test.js
+++ b/functions/utils/__tests__/mfaSecrets.test.js
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  decryptTotpSecret,
-  encryptTotpSecret,
-  isEncryptedTotpSecret,
-  loadTotpSecret,
-} from "../mfaSecrets.js";
+import { decryptTotpSecret, encryptTotpSecret, isEncryptedTotpSecret, loadTotpSecret } from "../mfaSecrets.js";
 
 describe("mfaSecrets", () => {
   it("encrypts and decrypts TOTP secrets with a configured key", async () => {
@@ -19,9 +14,9 @@ describe("mfaSecrets", () => {
   });
 
   it("keeps legacy plaintext secrets readable for backward compatibility", async () => {
-    await expect(
-      decryptTotpSecret("JBSWY3DPEHPK3PXP", { ENVIRONMENT: "production" }),
-    ).resolves.toBe("JBSWY3DPEHPK3PXP");
+    await expect(decryptTotpSecret("JBSWY3DPEHPK3PXP", { ENVIRONMENT: "production" })).resolves.toBe(
+      "JBSWY3DPEHPK3PXP",
+    );
   });
 
   it("requires an encryption key to decrypt encrypted secrets in production", async () => {
@@ -30,9 +25,9 @@ describe("mfaSecrets", () => {
       ENVIRONMENT: "production",
     });
 
-    await expect(
-      decryptTotpSecret(encrypted, { ENVIRONMENT: "production" }),
-    ).rejects.toThrow("MFA_TOTP_ENCRYPTION_KEY environment variable is required");
+    await expect(decryptTotpSecret(encrypted, { ENVIRONMENT: "production" })).rejects.toThrow(
+      "MFA_TOTP_ENCRYPTION_KEY environment variable is required",
+    );
   });
 
   it("prepares legacy plaintext secrets for migration when a key is configured", async () => {

--- a/functions/utils/__tests__/publicGate.test.js
+++ b/functions/utils/__tests__/publicGate.test.js
@@ -1,58 +1,39 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import {
-  getPublicDataGateResponse,
-  isPublicDataEnabled,
-} from '../publicGate.js';
+import { getPublicDataGateResponse, isPublicDataEnabled } from "../publicGate.js";
 
-describe('public data gate', () => {
-  it('fails closed when the publish flag is unset', () => {
+describe("public data gate", () => {
+  it("fails closed when the publish flag is unset", () => {
     expect(isPublicDataEnabled({})).toBe(false);
-    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: '' })).toBe(
-      false
-    );
+    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: "" })).toBe(false);
   });
 
-  it('enables public data only for explicit truthy values', () => {
-    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: 'true' })).toBe(
-      true
-    );
-    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: '1' })).toBe(
-      true
-    );
-    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: 'yes' })).toBe(
-      true
-    );
-    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: 'on' })).toBe(
-      true
-    );
+  it("enables public data only for explicit truthy values", () => {
+    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: "true" })).toBe(true);
+    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: "1" })).toBe(true);
+    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: "yes" })).toBe(true);
+    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: "on" })).toBe(true);
 
-    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: 'false' })).toBe(
-      false
-    );
-    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: '0' })).toBe(
-      false
-    );
+    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: "false" })).toBe(false);
+    expect(isPublicDataEnabled({ PUBLIC_DATA_PUBLISH_ENABLED: "0" })).toBe(false);
   });
 
-  it('returns a retryable gate response when public data is disabled', async () => {
+  it("returns a retryable gate response when public data is disabled", async () => {
     const response = getPublicDataGateResponse({});
 
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(503);
-    expect(response.headers.get('Content-Type')).toBe('application/json');
-    expect(response.headers.get('Retry-After')).toBe('3600');
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+    expect(response.headers.get("Retry-After")).toBe("3600");
 
     const payload = await response.json();
     expect(payload).toEqual({
-      error: 'Public data is not yet published',
-      message: 'Event data will be available once publishing is enabled.',
+      error: "Public data is not yet published",
+      message: "Event data will be available once publishing is enabled.",
     });
   });
 
-  it('does not block when public data is explicitly enabled', () => {
-    expect(
-      getPublicDataGateResponse({ PUBLIC_DATA_PUBLISH_ENABLED: 'true' })
-    ).toBeNull();
+  it("does not block when public data is explicitly enabled", () => {
+    expect(getPublicDataGateResponse({ PUBLIC_DATA_PUBLISH_ENABLED: "true" })).toBeNull();
   });
 });

--- a/functions/utils/__tests__/publicUrl.test.js
+++ b/functions/utils/__tests__/publicUrl.test.js
@@ -18,27 +18,19 @@ describe("getPublicBaseUrl", () => {
 
   describe("when PUBLIC_URL is set", () => {
     it("returns PUBLIC_URL as-is when it has no trailing slash", () => {
-      expect(getPublicBaseUrl({ PUBLIC_URL: "https://example.com" })).toBe(
-        "https://example.com",
-      );
+      expect(getPublicBaseUrl({ PUBLIC_URL: "https://example.com" })).toBe("https://example.com");
     });
 
     it("strips a single trailing slash from PUBLIC_URL", () => {
-      expect(getPublicBaseUrl({ PUBLIC_URL: "https://example.com/" })).toBe(
-        "https://example.com",
-      );
+      expect(getPublicBaseUrl({ PUBLIC_URL: "https://example.com/" })).toBe("https://example.com");
     });
 
     it("strips multiple trailing slashes from PUBLIC_URL", () => {
-      expect(getPublicBaseUrl({ PUBLIC_URL: "https://example.com///" })).toBe(
-        "https://example.com",
-      );
+      expect(getPublicBaseUrl({ PUBLIC_URL: "https://example.com///" })).toBe("https://example.com");
     });
 
     it("trims surrounding whitespace from PUBLIC_URL before using it", () => {
-      expect(
-        getPublicBaseUrl({ PUBLIC_URL: "  https://example.com  " }),
-      ).toBe("https://example.com");
+      expect(getPublicBaseUrl({ PUBLIC_URL: "  https://example.com  " })).toBe("https://example.com");
     });
 
     it("does not emit a warning when PUBLIC_URL is set", () => {

--- a/functions/utils/__tests__/rateLimit.test.js
+++ b/functions/utils/__tests__/rateLimit.test.js
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import {
-  checkRateLimit,
-  rateLimitHeaders,
-  rateLimitResponse,
-} from "../rateLimit.js";
+import { checkRateLimit, rateLimitHeaders, rateLimitResponse } from "../rateLimit.js";
 
 // Mock the caches global (Cache API, used for non-sensitive endpoints)
 const mockCache = {
@@ -281,10 +277,7 @@ describe("Rate Limiting", () => {
     it("unknown IP fails closed on fail-closed (auth) endpoints", async () => {
       const db = makeMockDB({ count: 0 });
       const env = { DB: db };
-      const request = new Request(
-        "https://example.com/api/admin/auth/login",
-        {},
-      ); // no IP headers
+      const request = new Request("https://example.com/api/admin/auth/login", {}); // no IP headers
 
       const result = await checkRateLimit(request, env);
 
@@ -309,12 +302,9 @@ describe("Rate Limiting", () => {
     it("/api/bands/<name>/follow is fail-closed (uses D1) with limit 5/300s", async () => {
       const db = makeMockDB({ count: 3 }); // under the 5-req/300s limit
       const env = { DB: db };
-      const request = new Request(
-        "https://example.com/api/bands/my-band/follow",
-        {
-          headers: { "CF-Connecting-IP": "1.2.3.4" },
-        },
-      );
+      const request = new Request("https://example.com/api/bands/my-band/follow", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
+      });
 
       const result = await checkRateLimit(request, env);
 
@@ -328,12 +318,9 @@ describe("Rate Limiting", () => {
     it("/api/bands/<name>/follow fails closed when limit is exceeded", async () => {
       const db = makeMockDB({ count: 6 }); // over the 5-req/300s limit
       const env = { DB: db };
-      const request = new Request(
-        "https://example.com/api/bands/my-band/follow",
-        {
-          headers: { "CF-Connecting-IP": "1.2.3.4" },
-        },
-      );
+      const request = new Request("https://example.com/api/bands/my-band/follow", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
+      });
 
       const result = await checkRateLimit(request, env);
 
@@ -344,12 +331,9 @@ describe("Rate Limiting", () => {
     it("/api/bands/<name>/unfollow is fail-closed with the same tight limit", async () => {
       const db = makeMockDB({ count: 1 });
       const env = { DB: db };
-      const request = new Request(
-        "https://example.com/api/bands/my-band/unfollow",
-        {
-          headers: { "CF-Connecting-IP": "1.2.3.4" },
-        },
-      );
+      const request = new Request("https://example.com/api/bands/my-band/unfollow", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
+      });
 
       const result = await checkRateLimit(request, env);
 
@@ -361,12 +345,9 @@ describe("Rate Limiting", () => {
     it("/api/bands/<name>/confirm-follow is fail-closed with the tight limit", async () => {
       const db = makeMockDB({ count: 1 });
       const env = { DB: db };
-      const request = new Request(
-        "https://example.com/api/bands/my-band/confirm-follow",
-        {
-          headers: { "CF-Connecting-IP": "1.2.3.4" },
-        },
-      );
+      const request = new Request("https://example.com/api/bands/my-band/confirm-follow", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
+      });
 
       const result = await checkRateLimit(request, env);
 
@@ -385,12 +366,9 @@ describe("Rate Limiting", () => {
         }),
       };
       const env = { DB: db };
-      const request = new Request(
-        "https://example.com/api/bands/my-band/follow",
-        {
-          headers: { "CF-Connecting-IP": "1.2.3.4" },
-        },
-      );
+      const request = new Request("https://example.com/api/bands/my-band/follow", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
+      });
 
       const result = await checkRateLimit(request, env);
 
@@ -421,12 +399,10 @@ describe("Rate Limiting", () => {
           return {
             bind: vi.fn().mockReturnValue({
               run: vi.fn().mockResolvedValue({}),
-              first: vi
-                .fn()
-                .mockResolvedValue({
-                  count: 1,
-                  window_start: Math.floor(Date.now() / 1000),
-                }),
+              first: vi.fn().mockResolvedValue({
+                count: 1,
+                window_start: Math.floor(Date.now() / 1000),
+              }),
             }),
           };
         }),
@@ -450,9 +426,7 @@ describe("Rate Limiting", () => {
       expect(db.prepare).toHaveBeenCalledTimes(4);
 
       // Extract the bind arguments from the key upsert calls to confirm distinct keys
-      const bindCalls = db.prepare.mock.results
-        .map((r) => r.value.bind.mock.calls[0])
-        .filter(Boolean);
+      const bindCalls = db.prepare.mock.results.map((r) => r.value.bind.mock.calls[0]).filter(Boolean);
 
       // The first positional arg to bind is the key — should differ for /follow vs /unfollow
       const keys = bindCalls.map((args) => args[0]);

--- a/functions/utils/__tests__/ssrMeta.test.js
+++ b/functions/utils/__tests__/ssrMeta.test.js
@@ -26,7 +26,7 @@ function makeContext({ url = "https://settimes.ca/band/49", assetsOk = true } = 
 }
 
 describe("ssrMeta.escapeAttr", () => {
-  it("escapes &, \", <, >", () => {
+  it('escapes &, ", <, >', () => {
     expect(escapeAttr('Tom & "Jerry" <b>')).toBe("Tom &amp; &quot;Jerry&quot; &lt;b&gt;");
   });
   it("handles null/undefined", () => {

--- a/functions/utils/__tests__/timeConflicts.test.js
+++ b/functions/utils/__tests__/timeConflicts.test.js
@@ -1,83 +1,83 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from "vitest";
 import {
   toMinutes,
   normalizeEndMinutes,
   buildIntervals,
   intervalsOverlap,
   computeNewEndTime,
-} from '../timeConflicts.js'
+} from "../timeConflicts.js";
 
-describe('toMinutes', () => {
-  it('converts HH:MM to total minutes', () => {
-    expect(toMinutes('00:00')).toBe(0)
-    expect(toMinutes('01:00')).toBe(60)
-    expect(toMinutes('23:59')).toBe(1439)
-    expect(toMinutes('18:30')).toBe(1110)
-  })
-})
+describe("toMinutes", () => {
+  it("converts HH:MM to total minutes", () => {
+    expect(toMinutes("00:00")).toBe(0);
+    expect(toMinutes("01:00")).toBe(60);
+    expect(toMinutes("23:59")).toBe(1439);
+    expect(toMinutes("18:30")).toBe(1110);
+  });
+});
 
-describe('normalizeEndMinutes', () => {
-  it('returns end unchanged when end > start (same day)', () => {
-    expect(normalizeEndMinutes(60, 120)).toBe(120)
-  })
+describe("normalizeEndMinutes", () => {
+  it("returns end unchanged when end > start (same day)", () => {
+    expect(normalizeEndMinutes(60, 120)).toBe(120);
+  });
 
-  it('adds 24h when end <= start (midnight crossing)', () => {
-    expect(normalizeEndMinutes(toMinutes('23:30'), toMinutes('00:30'))).toBe(toMinutes('00:30') + 24 * 60)
-  })
+  it("adds 24h when end <= start (midnight crossing)", () => {
+    expect(normalizeEndMinutes(toMinutes("23:30"), toMinutes("00:30"))).toBe(toMinutes("00:30") + 24 * 60);
+  });
 
-  it('handles exact same start and end as midnight crossing', () => {
-    expect(normalizeEndMinutes(60, 60)).toBe(60 + 24 * 60)
-  })
-})
+  it("handles exact same start and end as midnight crossing", () => {
+    expect(normalizeEndMinutes(60, 60)).toBe(60 + 24 * 60);
+  });
+});
 
-describe('buildIntervals', () => {
-  it('produces two mirrored intervals for a same-day set', () => {
-    const intervals = buildIntervals('18:00', '19:00')
-    expect(intervals).toHaveLength(2)
-    expect(intervals[0]).toEqual([18 * 60, 19 * 60])
-    expect(intervals[1]).toEqual([18 * 60 + 24 * 60, 19 * 60 + 24 * 60])
-  })
+describe("buildIntervals", () => {
+  it("produces two mirrored intervals for a same-day set", () => {
+    const intervals = buildIntervals("18:00", "19:00");
+    expect(intervals).toHaveLength(2);
+    expect(intervals[0]).toEqual([18 * 60, 19 * 60]);
+    expect(intervals[1]).toEqual([18 * 60 + 24 * 60, 19 * 60 + 24 * 60]);
+  });
 
-  it('normalizes end for after-midnight sets', () => {
-    const intervals = buildIntervals('23:30', '00:30')
-    expect(intervals[0][0]).toBe(23 * 60 + 30)
-    expect(intervals[0][1]).toBe(24 * 60 + 30) // 00:30 + 24h
-  })
-})
+  it("normalizes end for after-midnight sets", () => {
+    const intervals = buildIntervals("23:30", "00:30");
+    expect(intervals[0][0]).toBe(23 * 60 + 30);
+    expect(intervals[0][1]).toBe(24 * 60 + 30); // 00:30 + 24h
+  });
+});
 
-describe('intervalsOverlap', () => {
-  it('detects overlap when intervals share time', () => {
-    expect(intervalsOverlap([0, 60], [30, 90])).toBe(true)
-  })
+describe("intervalsOverlap", () => {
+  it("detects overlap when intervals share time", () => {
+    expect(intervalsOverlap([0, 60], [30, 90])).toBe(true);
+  });
 
-  it('returns false for non-overlapping intervals', () => {
-    expect(intervalsOverlap([0, 60], [60, 120])).toBe(false)
-    expect(intervalsOverlap([60, 120], [0, 60])).toBe(false)
-  })
+  it("returns false for non-overlapping intervals", () => {
+    expect(intervalsOverlap([0, 60], [60, 120])).toBe(false);
+    expect(intervalsOverlap([60, 120], [0, 60])).toBe(false);
+  });
 
-  it('returns false for completely separate intervals', () => {
-    expect(intervalsOverlap([0, 30], [60, 90])).toBe(false)
-  })
-})
+  it("returns false for completely separate intervals", () => {
+    expect(intervalsOverlap([0, 30], [60, 90])).toBe(false);
+  });
+});
 
-describe('computeNewEndTime', () => {
-  it('preserves duration for same-day sets', () => {
+describe("computeNewEndTime", () => {
+  it("preserves duration for same-day sets", () => {
     // 18:00–19:00 is 60 minutes. Shift to 20:00 → should end at 21:00.
-    expect(computeNewEndTime('18:00', '19:00', '20:00')).toBe('21:00')
-  })
+    expect(computeNewEndTime("18:00", "19:00", "20:00")).toBe("21:00");
+  });
 
-  it('preserves duration for after-midnight sets when shifting earlier', () => {
+  it("preserves duration for after-midnight sets when shifting earlier", () => {
     // 23:40–00:10 is 30 minutes. Shift to 23:00 → should end at 23:30.
-    expect(computeNewEndTime('23:40', '00:10', '23:00')).toBe('23:30')
-  })
+    expect(computeNewEndTime("23:40", "00:10", "23:00")).toBe("23:30");
+  });
 
-  it('preserves duration for after-midnight sets when result also crosses midnight', () => {
+  it("preserves duration for after-midnight sets when result also crosses midnight", () => {
     // 23:30–00:30 is 60 minutes. Shift to 23:40 → should end at 00:40.
-    expect(computeNewEndTime('23:30', '00:30', '23:40')).toBe('00:40')
-  })
+    expect(computeNewEndTime("23:30", "00:30", "23:40")).toBe("00:40");
+  });
 
-  it('handles a set that shifts across midnight', () => {
+  it("handles a set that shifts across midnight", () => {
     // 22:00–23:00 is 60 minutes. Shift to 23:30 → should end at 00:30.
-    expect(computeNewEndTime('22:00', '23:00', '23:30')).toBe('00:30')
-  })
-})
+    expect(computeNewEndTime("22:00", "23:00", "23:30")).toBe("00:30");
+  });
+});

--- a/functions/utils/__tests__/totp.test.js
+++ b/functions/utils/__tests__/totp.test.js
@@ -30,16 +30,10 @@ describe("totp utilities", () => {
   // real authenticator app (Google Authenticator, Authy) would — i.e. it is
   // RFC-correct, not merely self-consistent.
   it("matches RFC 6238 test vectors", async () => {
-    const RFC_SECRET = base32Encode(
-      new TextEncoder().encode("12345678901234567890"),
-    );
+    const RFC_SECRET = base32Encode(new TextEncoder().encode("12345678901234567890"));
     expect(await generateTotpCode(RFC_SECRET, 59 * 1000)).toBe("287082");
-    expect(await generateTotpCode(RFC_SECRET, 1111111109 * 1000)).toBe(
-      "081804",
-    );
-    expect(await generateTotpCode(RFC_SECRET, 1234567890 * 1000)).toBe(
-      "005924",
-    );
+    expect(await generateTotpCode(RFC_SECRET, 1111111109 * 1000)).toBe("081804");
+    expect(await generateTotpCode(RFC_SECRET, 1234567890 * 1000)).toBe("005924");
   });
 
   it("verifies and consumes backup codes", async () => {

--- a/functions/utils/__tests__/validation.test.js
+++ b/functions/utils/__tests__/validation.test.js
@@ -48,9 +48,7 @@ describe("Password Validation", () => {
   it("should enforce uppercase requirement when set", () => {
     const result = validatePassword("lowercase123", { requireUppercase: true });
     expect(result.valid).toBe(false);
-    expect(result.errors).toContain(
-      "Password must contain at least one uppercase letter",
-    );
+    expect(result.errors).toContain("Password must contain at least one uppercase letter");
 
     const result2 = validatePassword("Uppercase123", { requireUppercase: true });
     expect(result2.valid).toBe(true);

--- a/functions/utils/announceDigest.js
+++ b/functions/utils/announceDigest.js
@@ -68,13 +68,7 @@ export async function flushAnnounceDigest(env, DB) {
 
     // Delete every queue entry for this group — whether claimed now or
     // already handled by a concurrent path.
-    await DB.batch(
-      items.map((item) =>
-        DB.prepare("DELETE FROM band_announce_queue WHERE id = ?").bind(
-          item.id,
-        ),
-      ),
-    );
+    await DB.batch(items.map((item) => DB.prepare("DELETE FROM band_announce_queue WHERE id = ?").bind(item.id)));
 
     if (!claimed.length) {
       skipped += items.length;
@@ -135,9 +129,10 @@ export async function flushAnnounceDigest(env, DB) {
       // Release claims so resend-announcement can recover this fan.
       await DB.batch(
         task.claimed.map((item) =>
-          DB.prepare(
-            "DELETE FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?",
-          ).bind(item.performance_id, item.band_follow_id),
+          DB.prepare("DELETE FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?").bind(
+            item.performance_id,
+            item.band_follow_id,
+          ),
         ),
       );
       failed++;

--- a/functions/utils/auth.js
+++ b/functions/utils/auth.js
@@ -13,35 +13,31 @@ export function isDevRequest(request, env = null) {
   // unexpected value, or unset. We never trust the client-controlled Host
   // header to decide this. (#425)
   const environment = (env?.ENVIRONMENT ?? "").trim().toLowerCase();
-  return (
-    environment === "development" ||
-    environment === "dev" ||
-    environment === "test"
-  );
+  return environment === "development" || environment === "dev" || environment === "test";
 }
 
 const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 
 function serializeCookie(name, value, { secure, sameSite, maxAge }) {
-  const parts = [`${name}=${value}`, 'Path=/', 'HttpOnly', `SameSite=${sameSite}`, `Max-Age=${maxAge}`];
-  if (secure) parts.push('Secure');
-  return parts.join('; ');
+  const parts = [`${name}=${value}`, "Path=/", "HttpOnly", `SameSite=${sameSite}`, `Max-Age=${maxAge}`];
+  if (secure) parts.push("Secure");
+  return parts.join("; ");
 }
 
 export function initializeLucia(DB, request = null, env = null) {
   const isDev = request ? isDevRequest(request, env) : false;
-  const cookieName = isDev ? 'session_token' : '__Host-session_token';
+  const cookieName = isDev ? "session_token" : "__Host-session_token";
   const cookieOpts = {
     secure: !isDev,
-    sameSite: isDev ? 'Lax' : 'Strict',
+    sameSite: isDev ? "Lax" : "Strict",
   };
 
   return {
     readSessionCookie(cookieHeader) {
       if (!cookieHeader) return null;
-      for (const part of cookieHeader.split(';')) {
-        const [k, ...rest] = part.trim().split('=');
-        if (k.trim() === cookieName) return rest.join('=').trim() || null;
+      for (const part of cookieHeader.split(";")) {
+        const [k, ...rest] = part.trim().split("=");
+        if (k.trim() === cookieName) return rest.join("=").trim() || null;
       }
       return null;
     },
@@ -52,7 +48,7 @@ export function initializeLucia(DB, request = null, env = null) {
                 u.email, u.role, u.name, u.first_name, u.last_name, u.is_active
          FROM lucia_sessions s
          JOIN users u ON u.id = s.user_id
-         WHERE s.id = ?`
+         WHERE s.id = ?`,
       )
         .bind(sessionId)
         .first();
@@ -60,7 +56,7 @@ export function initializeLucia(DB, request = null, env = null) {
       if (!row) return { session: null, user: null };
 
       if (row.expires_at * 1000 < Date.now()) {
-        await DB.prepare('DELETE FROM lucia_sessions WHERE id = ?').bind(sessionId).run();
+        await DB.prepare("DELETE FROM lucia_sessions WHERE id = ?").bind(sessionId).run();
         return { session: null, user: null };
       }
 
@@ -88,7 +84,7 @@ export function initializeLucia(DB, request = null, env = null) {
       const expiresAt = Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS;
       await DB.prepare(
         `INSERT INTO lucia_sessions (id, user_id, expires_at, created_at, last_activity_at)
-         VALUES (?, ?, ?, datetime('now'), datetime('now'))`
+         VALUES (?, ?, ?, datetime('now'), datetime('now'))`,
       )
         .bind(id, userId, expiresAt)
         .run();
@@ -96,11 +92,11 @@ export function initializeLucia(DB, request = null, env = null) {
     },
 
     async invalidateSession(sessionId) {
-      await DB.prepare('DELETE FROM lucia_sessions WHERE id = ?').bind(sessionId).run();
+      await DB.prepare("DELETE FROM lucia_sessions WHERE id = ?").bind(sessionId).run();
     },
 
     async invalidateUserSessions(userId) {
-      await DB.prepare('DELETE FROM lucia_sessions WHERE user_id = ?').bind(userId).run();
+      await DB.prepare("DELETE FROM lucia_sessions WHERE user_id = ?").bind(userId).run();
     },
 
     createSessionCookie(sessionId) {
@@ -111,7 +107,7 @@ export function initializeLucia(DB, request = null, env = null) {
 
     createBlankSessionCookie() {
       return {
-        serialize: () => serializeCookie(cookieName, '', { ...cookieOpts, maxAge: 0 }),
+        serialize: () => serializeCookie(cookieName, "", { ...cookieOpts, maxAge: 0 }),
       };
     },
   };

--- a/functions/utils/authAttempts.js
+++ b/functions/utils/authAttempts.js
@@ -76,16 +76,19 @@ function getRateLimitBindings(scope, { email, ipAddress, userId, attemptType, wi
   throw new Error(`Unsupported auth rate-limit scope: ${scope}`);
 }
 
-export async function checkAuthRateLimit(DB, {
-  attemptType,
-  email = null,
-  ipAddress,
-  maxFailures = DEFAULT_MAX_FAILURES,
-  scope,
-  userId = null,
-  windowMs = DEFAULT_WINDOW_MS,
-}) {
-  if (scope === 'email' && !email) {
+export async function checkAuthRateLimit(
+  DB,
+  {
+    attemptType,
+    email = null,
+    ipAddress,
+    maxFailures = DEFAULT_MAX_FAILURES,
+    scope,
+    userId = null,
+    windowMs = DEFAULT_WINDOW_MS,
+  },
+) {
+  if (scope === "email" && !email) {
     throw new Error(`checkAuthRateLimit: email is required for scope "email"`);
   }
 
@@ -105,7 +108,7 @@ export async function checkAuthRateLimit(DB, {
 
   if (Number(attempts.count) >= maxFailures) {
     const earliestTs = attempts.earliest_attempt
-      ? new Date(attempts.earliest_attempt.replace(' ', 'T') + 'Z').getTime()
+      ? new Date(attempts.earliest_attempt.replace(" ", "T") + "Z").getTime()
       : Date.now();
     const elapsed = Date.now() - earliestTs;
     const remainingMs = Math.max(0, windowMs - elapsed);
@@ -120,27 +123,22 @@ export async function checkAuthRateLimit(DB, {
   return { allowed: true };
 }
 
-export async function writeAuthAttempt(DB, {
-  attemptType,
-  email = null,
-  failureReason = null,
-  ipAddress = "unknown",
-  success,
-  userAgent = "unknown",
-  userId = null,
-}) {
+export async function writeAuthAttempt(
+  DB,
+  {
+    attemptType,
+    email = null,
+    failureReason = null,
+    ipAddress = "unknown",
+    success,
+    userAgent = "unknown",
+    userId = null,
+  },
+) {
   await DB.prepare(
     `INSERT INTO auth_attempts (user_id, email, ip_address, user_agent, attempt_type, success, failure_reason)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   )
-    .bind(
-      userId,
-      email,
-      ipAddress,
-      userAgent,
-      attemptType,
-      success ? 1 : 0,
-      failureReason,
-    )
+    .bind(userId, email, ipAddress, userAgent, attemptType, success ? 1 : 0, failureReason)
     .run();
 }

--- a/functions/utils/bandFollowNotify.js
+++ b/functions/utils/bandFollowNotify.js
@@ -11,11 +11,7 @@ import { logger } from "./logger.js";
 import { getPublicBaseUrl } from "./publicUrl.js";
 import { escapeHtml } from "./html.js";
 
-export async function notifyBandFollowers(
-  env,
-  DB,
-  { performanceId, bandProfileId, bandName, eventName, followers },
-) {
+export async function notifyBandFollowers(env, DB, { performanceId, bandProfileId, bandName, eventName, followers }) {
   const publicUrl = getPublicBaseUrl(env);
 
   const results = await Promise.allSettled(
@@ -44,9 +40,7 @@ export async function notifyBandFollowers(
       const delivered = result?.delivered === true;
       if (!delivered) {
         // Email failed — release the claim so a future resend can retry.
-        await DB.prepare(
-          "DELETE FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?",
-        )
+        await DB.prepare("DELETE FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?")
           .bind(performanceId, follower.id)
           .run();
       }

--- a/functions/utils/cookies.js
+++ b/functions/utils/cookies.js
@@ -19,12 +19,7 @@ export function setSecureCookie(name, value, options = {}) {
 
   // Apply dev-specific defaults
   const secure = options.secure !== undefined ? options.secure : !isDev;
-  const sameSite =
-    options.sameSite !== undefined
-      ? options.sameSite
-      : isDev
-      ? "Lax"
-      : "Strict";
+  const sameSite = options.sameSite !== undefined ? options.sameSite : isDev ? "Lax" : "Strict";
 
   const parts = [`${name}=${value}`];
 
@@ -61,12 +56,7 @@ export function deleteCookie(name, options = {}) {
   const path = options.path !== undefined ? options.path : "/";
   const isDev = options.isDev !== undefined ? options.isDev : false;
   const secure = options.secure !== undefined ? options.secure : !isDev;
-  const sameSite =
-    options.sameSite !== undefined
-      ? options.sameSite
-      : isDev
-      ? "Lax"
-      : "Strict";
+  const sameSite = options.sameSite !== undefined ? options.sameSite : isDev ? "Lax" : "Strict";
 
   const parts = [`${name}=`];
   if (path) {
@@ -118,4 +108,3 @@ export function getCookie(request, name) {
   const cookies = parseCookies(cookieHeader);
   return cookies[name] || null;
 }
-

--- a/functions/utils/crypto.js
+++ b/functions/utils/crypto.js
@@ -27,13 +27,7 @@ export function timingSafeEqual(a, b) {
  */
 async function deriveKey(password, salt, iterations) {
   const encoder = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(password),
-    "PBKDF2",
-    false,
-    ["deriveBits"],
-  );
+  const keyMaterial = await crypto.subtle.importKey("raw", encoder.encode(password), "PBKDF2", false, ["deriveBits"]);
 
   const derived = await crypto.subtle.deriveBits(
     {
@@ -101,9 +95,7 @@ export async function verifyPassword(password, storedHash) {
     const salt = Uint8Array.from(atob(saltBase64), (c) => c.charCodeAt(0));
 
     const hashArray = await deriveKey(password, salt, iterations);
-    const storedHashArray = Uint8Array.from(atob(hashBase64), (c) =>
-      c.charCodeAt(0),
-    );
+    const storedHashArray = Uint8Array.from(atob(hashBase64), (c) => c.charCodeAt(0));
 
     return timingSafeEqual(hashArray, storedHashArray);
   } catch (error) {

--- a/functions/utils/csrf.js
+++ b/functions/utils/csrf.js
@@ -90,11 +90,7 @@ function buildRequestAdapter(request, env, sessionIdentifierOverride = null) {
     headers: headersAdapter,
     cookies,
     csrfSecret: resolveCsrfSecret(env, request),
-    sessionIdentifier: getSessionIdentifier(
-      request,
-      cookies,
-      sessionIdentifierOverride
-    ),
+    sessionIdentifier: getSessionIdentifier(request, cookies, sessionIdentifierOverride),
   };
 }
 
@@ -127,12 +123,7 @@ function serializeCookie(name, value, options) {
     parts.push("HttpOnly");
   }
   if (options?.sameSite) {
-    const sameSite =
-      options.sameSite === "none"
-        ? "None"
-        : options.sameSite === "lax"
-          ? "Lax"
-          : "Strict";
+    const sameSite = options.sameSite === "none" ? "None" : options.sameSite === "lax" ? "Lax" : "Strict";
     parts.push(`SameSite=${sameSite}`);
   }
   return parts.join("; ");
@@ -149,8 +140,7 @@ export function setCSRFCookie(token, request = null, env = null) {
 export function deleteCSRFCookie(request = null, env = null) {
   const options = getCookieConfig(request, env);
   const secure = options.secure ? "Secure; " : "";
-  const sameSite =
-    options.sameSite === "none" ? "None" : options.sameSite === "lax" ? "Lax" : "Strict";
+  const sameSite = options.sameSite === "none" ? "None" : options.sameSite === "lax" ? "Lax" : "Strict";
   return `csrf_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; ${secure}SameSite=${sameSite}`;
 }
 
@@ -192,7 +182,7 @@ export function validateCSRFMiddleware(request, env = null) {
           error: "CSRF validation failed",
           message: "Invalid or missing CSRF token",
         }),
-        { status: 403, headers }
+        { status: 403, headers },
       );
     }
     return null;
@@ -210,7 +200,7 @@ export function validateCSRFMiddleware(request, env = null) {
         {
           status: 403,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
     return null;
@@ -231,7 +221,7 @@ export function validateCSRFMiddleware(request, env = null) {
       {
         status: 403,
         headers,
-      }
+      },
     );
   }
 

--- a/functions/utils/emailTemplates.js
+++ b/functions/utils/emailTemplates.js
@@ -7,15 +7,7 @@ const BRAND = {
   muted: "#9ca3af",
 };
 
-function renderEmail({
-  title,
-  preheader,
-  intro,
-  ctaLabel,
-  ctaUrl,
-  bodyHtml,
-  footerNote,
-}) {
+function renderEmail({ title, preheader, intro, ctaLabel, ctaUrl, bodyHtml, footerNote }) {
   const preheaderText = preheader ? String(preheader) : "";
   const safeTitle = String(title);
 
@@ -51,7 +43,9 @@ function renderEmail({
                       ${safeTitle}
                     </h1>
                     ${intro ? `<p style="margin:0 0 16px; font-size:15px; color:${BRAND.muted};">${intro}</p>` : ""}
-                    ${ctaLabel && ctaUrl ? `
+                    ${
+                      ctaLabel && ctaUrl
+                        ? `
                       <div style="margin:24px 0;">
                         <a href="${ctaUrl}" style="display:inline-block; background:${BRAND.accent}; color:${BRAND.background}; text-decoration:none; font-weight:700; padding:12px 20px; border-radius:10px;">
                           ${ctaLabel}
@@ -61,7 +55,9 @@ function renderEmail({
                         Or copy this link:<br />
                         <a href="${ctaUrl}" style="color:${BRAND.accent}; text-decoration:none;">${ctaUrl}</a>
                       </div>
-                    ` : ""}
+                    `
+                        : ""
+                    }
                     ${bodyHtml ? `<div style="margin-top:20px; font-size:14px; color:${BRAND.text}; line-height:1.6;">${bodyHtml}</div>` : ""}
                   </td>
                 </tr>
@@ -155,9 +151,7 @@ export function buildResetPasswordEmail({ resetUrl, recipientName }) {
 }
 
 export function buildActivationEmail({ activationUrl, recipientName }) {
-  const intro = recipientName
-    ? `Hi ${recipientName}, welcome to SetTimes!`
-    : "Welcome to SetTimes!";
+  const intro = recipientName ? `Hi ${recipientName}, welcome to SetTimes!` : "Welcome to SetTimes!";
 
   const bodyHtml = `
     <p style="margin:0 0 12px;">Click the button above to activate your account and start managing events.</p>

--- a/functions/utils/logger.js
+++ b/functions/utils/logger.js
@@ -20,59 +20,59 @@ const LOG_LEVELS = {
 // over-redact unrelated keys such as 'emailDelivered').
 const SENSITIVE_KEYS = new Set([
   // Password variants
-  'password',
-  'password_hash',
-  'passwordhash',       // camelCase 'passwordHash'
+  "password",
+  "password_hash",
+  "passwordhash", // camelCase 'passwordHash'
 
   // Token variants
-  'token',
-  'access_token',
-  'accesstoken',        // camelCase 'accessToken'
-  'refresh_token',
-  'refreshtoken',       // camelCase 'refreshToken'
-  'verification_token',
-  'verificationtoken',  // camelCase 'verificationToken'
-  'reset_token',
-  'resettoken',         // camelCase 'resetToken'
-  'invite_token',
-  'invitetoken',        // camelCase 'inviteToken'
-  'api_token',
-  'apitoken',           // camelCase 'apiToken'
+  "token",
+  "access_token",
+  "accesstoken", // camelCase 'accessToken'
+  "refresh_token",
+  "refreshtoken", // camelCase 'refreshToken'
+  "verification_token",
+  "verificationtoken", // camelCase 'verificationToken'
+  "reset_token",
+  "resettoken", // camelCase 'resetToken'
+  "invite_token",
+  "invitetoken", // camelCase 'inviteToken'
+  "api_token",
+  "apitoken", // camelCase 'apiToken'
 
   // Secret variants
-  'secret',
-  'totp_secret',
-  'totpsecret',         // camelCase 'totpSecret'
-  'client_secret',
-  'clientsecret',       // camelCase 'clientSecret'
+  "secret",
+  "totp_secret",
+  "totpsecret", // camelCase 'totpSecret'
+  "client_secret",
+  "clientsecret", // camelCase 'clientSecret'
 
   // Key variants
-  'key',
-  'api_key',
-  'apikey',             // camelCase 'apiKey'
-  'private_key',
-  'privatekey',         // camelCase 'privateKey'
-  'encryption_key',
-  'encryptionkey',      // camelCase 'encryptionKey'
+  "key",
+  "api_key",
+  "apikey", // camelCase 'apiKey'
+  "private_key",
+  "privatekey", // camelCase 'privateKey'
+  "encryption_key",
+  "encryptionkey", // camelCase 'encryptionKey'
 
   // Auth headers / cookies
-  'authorization',
-  'cookie',
-  'bearer',
+  "authorization",
+  "cookie",
+  "bearer",
 
   // Email (exact only – avoids over-redacting 'emailDelivered' etc.)
-  'email',
-  'user_email',
-  'useremail',          // camelCase 'userEmail'
+  "email",
+  "user_email",
+  "useremail", // camelCase 'userEmail'
 
   // IP address variants
-  'ip',
-  'ipaddress',          // camelCase 'ipAddress'
-  'ip_address',
+  "ip",
+  "ipaddress", // camelCase 'ipAddress'
+  "ip_address",
 
   // User-agent variants
-  'useragent',          // camelCase 'userAgent'
-  'user_agent',
+  "useragent", // camelCase 'userAgent'
+  "user_agent",
 ]);
 
 /**
@@ -83,7 +83,7 @@ function getLogLevel(env) {
   if (env?.LOG_LEVEL && LOG_LEVELS[env.LOG_LEVEL] !== undefined) {
     return env.LOG_LEVEL;
   }
-  return env?.ENVIRONMENT === 'production' ? 'info' : 'debug';
+  return env?.ENVIRONMENT === "production" ? "info" : "debug";
 }
 
 /**
@@ -103,11 +103,11 @@ function serializeError(error) {
     return {
       name: error.name,
       message: error.message,
-      stack: error.stack?.split('\n').slice(0, 5).join('\n'), // First 5 lines
+      stack: error.stack?.split("\n").slice(0, 5).join("\n"), // First 5 lines
     };
   }
 
-  if (typeof error === 'object') {
+  if (typeof error === "object") {
     try {
       return JSON.parse(JSON.stringify(error));
     } catch {
@@ -122,7 +122,7 @@ function serializeError(error) {
  * Safely stringify metadata, handling circular references
  */
 function serializeMetadata(meta) {
-  if (!meta || typeof meta !== 'object') return meta;
+  if (!meta || typeof meta !== "object") return meta;
 
   try {
     // Handle common non-serializable types
@@ -130,7 +130,7 @@ function serializeMetadata(meta) {
     for (const [key, value] of Object.entries(meta)) {
       // Redact sensitive keys
       if (SENSITIVE_KEYS.has(key.toLowerCase())) {
-        cleaned[key] = '[REDACTED]';
+        cleaned[key] = "[REDACTED]";
         continue;
       }
 
@@ -140,15 +140,15 @@ function serializeMetadata(meta) {
         cleaned[key] = { status: value.status, statusText: value.statusText };
       } else if (value instanceof Error) {
         cleaned[key] = serializeError(value);
-      } else if (typeof value === 'function') {
-        cleaned[key] = '[Function]';
+      } else if (typeof value === "function") {
+        cleaned[key] = "[Function]";
       } else {
         cleaned[key] = value;
       }
     }
     return JSON.parse(JSON.stringify(cleaned));
   } catch {
-    return '[Unserializable]';
+    return "[Unserializable]";
   }
 }
 
@@ -163,9 +163,9 @@ function formatLogEntry(level, message, meta = {}) {
   };
 
   // Add metadata if present
-  if (meta && typeof meta === 'object' && Object.keys(meta).length > 0) {
+  if (meta && typeof meta === "object" && Object.keys(meta).length > 0) {
     const serialized = serializeMetadata(meta);
-    if (serialized && typeof serialized === 'object') {
+    if (serialized && typeof serialized === "object") {
       Object.assign(entry, serialized);
     }
   }
@@ -195,16 +195,16 @@ export function createLogger(options = {}) {
 
     // Use appropriate console method
     switch (level) {
-      case 'debug':
+      case "debug":
         console.debug(formatted);
         break;
-      case 'info':
+      case "info":
         console.info(formatted);
         break;
-      case 'warn':
+      case "warn":
         console.warn(formatted);
         break;
-      case 'error':
+      case "error":
         console.error(formatted);
         break;
       default:
@@ -213,10 +213,10 @@ export function createLogger(options = {}) {
   };
 
   return {
-    debug: (message, meta) => log('debug', message, meta),
-    info: (message, meta) => log('info', message, meta),
-    warn: (message, meta) => log('warn', message, meta),
-    error: (message, meta) => log('error', message, meta),
+    debug: (message, meta) => log("debug", message, meta),
+    info: (message, meta) => log("info", message, meta),
+    warn: (message, meta) => log("warn", message, meta),
+    error: (message, meta) => log("error", message, meta),
 
     // Create a child logger with additional context
     child: (childOptions) =>
@@ -242,7 +242,7 @@ export function createRequestLogger(context) {
 
   return createLogger({
     env,
-    module: url.pathname.split('/').slice(0, 4).join('/'),
+    module: url.pathname.split("/").slice(0, 4).join("/"),
   });
 }
 
@@ -251,12 +251,10 @@ export function createRequestLogger(context) {
  * Use when you don't have request context
  */
 export const logger = {
-  debug: (message, meta) =>
-    console.debug(formatLogEntry('debug', message, meta)),
-  info: (message, meta) => console.info(formatLogEntry('info', message, meta)),
-  warn: (message, meta) => console.warn(formatLogEntry('warn', message, meta)),
-  error: (message, meta) =>
-    console.error(formatLogEntry('error', message, meta)),
+  debug: (message, meta) => console.debug(formatLogEntry("debug", message, meta)),
+  info: (message, meta) => console.info(formatLogEntry("info", message, meta)),
+  warn: (message, meta) => console.warn(formatLogEntry("warn", message, meta)),
+  error: (message, meta) => console.error(formatLogEntry("error", message, meta)),
 };
 
 /**
@@ -265,12 +263,12 @@ export const logger = {
  */
 export function logError(loggerOrMessage, errorOrMeta, metaOrUndefined) {
   // Handle both (logger, error, meta) and (message, error) signatures
-  if (typeof loggerOrMessage === 'object' && loggerOrMessage.error) {
+  if (typeof loggerOrMessage === "object" && loggerOrMessage.error) {
     // Called as logError(logger, error, meta)
     const log = loggerOrMessage;
     const error = errorOrMeta;
     const meta = metaOrUndefined || {};
-    log.error(error?.message || 'Unknown error', {
+    log.error(error?.message || "Unknown error", {
       ...meta,
       error: serializeError(error),
     });

--- a/functions/utils/mfaSecrets.js
+++ b/functions/utils/mfaSecrets.js
@@ -27,20 +27,11 @@ async function importEncryptionKey(env) {
   const encoded = new TextEncoder().encode(keyMaterial);
   const digest = await crypto.subtle.digest("SHA-256", encoded);
 
-  return crypto.subtle.importKey(
-    "raw",
-    digest,
-    { name: "AES-GCM" },
-    false,
-    ["encrypt", "decrypt"],
-  );
+  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
 }
 
 export function isEncryptedTotpSecret(value) {
-  return (
-    typeof value === "string" &&
-    value.startsWith(`${ENCRYPTED_TOTP_SECRET_PREFIX}:`)
-  );
+  return typeof value === "string" && value.startsWith(`${ENCRYPTED_TOTP_SECRET_PREFIX}:`);
 }
 
 export async function loadTotpSecret(storedSecret, env) {
@@ -89,15 +80,9 @@ export async function encryptTotpSecret(secret, env) {
   const key = await importEncryptionKey(env);
   const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
   const payload = new TextEncoder().encode(normalizedSecret);
-  const encrypted = await crypto.subtle.encrypt(
-    { name: "AES-GCM", iv },
-    key,
-    payload,
-  );
+  const encrypted = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, payload);
 
-  return `${ENCRYPTED_TOTP_SECRET_PREFIX}:${toBase64(iv)}:${toBase64(
-    new Uint8Array(encrypted),
-  )}`;
+  return `${ENCRYPTED_TOTP_SECRET_PREFIX}:${toBase64(iv)}:${toBase64(new Uint8Array(encrypted))}`;
 }
 
 export async function decryptTotpSecret(storedSecret, env) {

--- a/functions/utils/publicGate.js
+++ b/functions/utils/publicGate.js
@@ -1,8 +1,8 @@
-const ENABLE_VALUES = new Set(['true', '1', 'yes', 'on']);
+const ENABLE_VALUES = new Set(["true", "1", "yes", "on"]);
 
 export function isPublicDataEnabled(env) {
   const value = env?.PUBLIC_DATA_PUBLISH_ENABLED;
-  if (value === undefined || value === null || value === '') {
+  if (value === undefined || value === null || value === "") {
     return false;
   }
   return ENABLE_VALUES.has(String(value).toLowerCase());
@@ -15,15 +15,15 @@ export function getPublicDataGateResponse(env) {
 
   return new Response(
     JSON.stringify({
-      error: 'Public data is not yet published',
-      message: 'Event data will be available once publishing is enabled.',
+      error: "Public data is not yet published",
+      message: "Event data will be available once publishing is enabled.",
     }),
     {
       status: 503,
       headers: {
-        'Content-Type': 'application/json',
-        'Retry-After': '3600',
+        "Content-Type": "application/json",
+        "Retry-After": "3600",
       },
-    }
+    },
   );
 }

--- a/functions/utils/rateLimit.js
+++ b/functions/utils/rateLimit.js
@@ -18,8 +18,7 @@ const RATE_LIMIT_PREFIX = "rate-limit:";
 // Band action endpoints that send email and must be fail-closed with a tight limit.
 // Scoped to the /follow|unfollow|confirm-follow suffix so that public GET reads
 // (e.g. /api/bands/<name>) are not affected.
-const BAND_ACTION_RE =
-  /^\/api\/bands\/[^/]+\/(follow|unfollow|confirm-follow)$/;
+const BAND_ACTION_RE = /^\/api\/bands\/[^/]+\/(follow|unfollow|confirm-follow)$/;
 
 // Batch follow endpoints — flat paths under /api/bands/ (not nested under {name}).
 // Same fail-closed treatment as BAND_ACTION_RE: they send email, so D1-backed
@@ -59,11 +58,7 @@ const SKIP_PATTERNS = [
 
 // Endpoints where a rate-limit failure blocks the request (fail closed).
 // These use D1 for globally-consistent counters.
-const FAIL_CLOSED_PATTERNS = [
-  "/api/admin/auth/",
-  "/api/auth/",
-  "/api/subscriptions",
-];
+const FAIL_CLOSED_PATTERNS = ["/api/admin/auth/", "/api/auth/", "/api/subscriptions"];
 
 function shouldFailClosed(pathname) {
   return (
@@ -114,9 +109,7 @@ function getRateLimitConfig(pathname) {
  */
 function getRateLimitKey(ip, pathname) {
   const depth =
-    pathname.startsWith("/api/admin/auth/") ||
-    pathname.startsWith("/api/auth/") ||
-    BAND_ACTION_RE.test(pathname)
+    pathname.startsWith("/api/admin/auth/") || pathname.startsWith("/api/auth/") || BAND_ACTION_RE.test(pathname)
       ? 5
       : 4;
   const basePath = pathname.split("/").slice(0, depth).join("/");
@@ -147,11 +140,7 @@ async function checkRateLimitD1(DB, ip, pathname, config) {
       .bind(key, now, config.window)
       .run();
 
-    const row = await DB.prepare(
-      "SELECT count, window_start FROM rate_limits WHERE key = ?",
-    )
-      .bind(key)
-      .first();
+    const row = await DB.prepare("SELECT count, window_start FROM rate_limits WHERE key = ?").bind(key).first();
 
     const count = row?.count ?? 1;
     const windowStart = row?.window_start ?? now;
@@ -307,10 +296,7 @@ export function rateLimitHeaders(result) {
  * Create 429 Too Many Requests response
  */
 export function rateLimitResponse(result, corsHeaders = {}) {
-  const retryAfter = Math.max(
-    1,
-    result.resetAt - Math.floor(Date.now() / 1000),
-  );
+  const retryAfter = Math.max(1, result.resetAt - Math.floor(Date.now() / 1000));
 
   return new Response(
     JSON.stringify({

--- a/functions/utils/request.js
+++ b/functions/utils/request.js
@@ -1,7 +1,5 @@
 export function getClientIP(request) {
   return (
-    request.headers.get("CF-Connecting-IP") ||
-    request.headers.get("X-Forwarded-For")?.split(",")[0].trim() ||
-    "unknown"
+    request.headers.get("CF-Connecting-IP") || request.headers.get("X-Forwarded-For")?.split(",")[0].trim() || "unknown"
   );
 }

--- a/functions/utils/ssrMeta.js
+++ b/functions/utils/ssrMeta.js
@@ -29,9 +29,7 @@ export function toPlainText(rawInput, maxLength = 200) {
   // --- Strip markdown syntax (order matters) ---
 
   // Code fences (``` ... ```) — remove the fence markers, keep content
-  text = text.replace(/```[\s\S]*?```/g, (m) =>
-    m.replace(/```[^\n]*\n?/g, "").trim(),
-  );
+  text = text.replace(/```[\s\S]*?```/g, (m) => m.replace(/```[^\n]*\n?/g, "").trim());
   // Inline code: `code` → code
   text = text.replace(/`([^`]+)`/g, "$1");
   // Images: ![alt](url) → alt
@@ -65,10 +63,7 @@ export function toPlainText(rawInput, maxLength = 200) {
     "&quot;": '"',
     "&#39;": "'",
   };
-  text = text.replace(
-    /&(?:nbsp|amp|lt|gt|quot|#39);/gi,
-    (m) => ENTITY_MAP[m.toLowerCase()] ?? m,
-  );
+  text = text.replace(/&(?:nbsp|amp|lt|gt|quot|#39);/gi, (m) => ENTITY_MAP[m.toLowerCase()] ?? m);
 
   text = text.replace(/\s+/g, " ").trim();
   if (text.length <= maxLength) return text;

--- a/functions/utils/timeConflicts.js
+++ b/functions/utils/timeConflicts.js
@@ -2,33 +2,32 @@
 // Handles sets that cross midnight by building mirrored intervals.
 
 export function toMinutes(time) {
-  const [hours, minutes] = time.split(':').map(Number)
-  return hours * 60 + minutes
+  const [hours, minutes] = time.split(":").map(Number);
+  return hours * 60 + minutes;
 }
 
 export function normalizeEndMinutes(startMinutes, endMinutes) {
-  return endMinutes <= startMinutes ? endMinutes + 24 * 60 : endMinutes
+  return endMinutes <= startMinutes ? endMinutes + 24 * 60 : endMinutes;
 }
 
 export function buildIntervals(start, end) {
-  const startMinutes = toMinutes(start)
-  const endMinutes = toMinutes(end)
-  const normalizedEnd = normalizeEndMinutes(startMinutes, endMinutes)
+  const startMinutes = toMinutes(start);
+  const endMinutes = toMinutes(end);
+  const normalizedEnd = normalizeEndMinutes(startMinutes, endMinutes);
   return [
     [startMinutes, normalizedEnd],
     [startMinutes + 24 * 60, normalizedEnd + 24 * 60],
-  ]
+  ];
 }
 
 export function intervalsOverlap(a, b) {
-  return a[0] < b[1] && b[0] < a[1]
+  return a[0] < b[1] && b[0] < a[1];
 }
 
 // Shifts start_time while preserving set duration. Handles midnight crossing.
 export function computeNewEndTime(oldStart, oldEnd, newStart) {
-  const fromMins = (m) =>
-    `${String(Math.floor(m / 60) % 24).padStart(2, '0')}:${String(m % 60).padStart(2, '0')}`
-  let dur = toMinutes(oldEnd) - toMinutes(oldStart)
-  if (dur < 0) dur += 24 * 60
-  return fromMins((toMinutes(newStart) + dur) % (24 * 60))
+  const fromMins = (m) => `${String(Math.floor(m / 60) % 24).padStart(2, "0")}:${String(m % 60).padStart(2, "0")}`;
+  let dur = toMinutes(oldEnd) - toMinutes(oldStart);
+  if (dur < 0) dur += 24 * 60;
+  return fromMins((toMinutes(newStart) + dur) % (24 * 60));
 }

--- a/functions/utils/tokens.js
+++ b/functions/utils/tokens.js
@@ -8,9 +8,7 @@
 export function generateToken(length = 32) {
   const array = new Uint8Array(length);
   crypto.getRandomValues(array);
-  return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join(
-    "",
-  );
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 /**
@@ -58,7 +56,6 @@ export function generateSessionToken(userId, rememberMe = false) {
  * @returns {boolean} True if token looks valid
  */
 export function isValidTokenFormat(token) {
-  const uuidRegex =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   return typeof token === "string" && uuidRegex.test(token);
 }

--- a/functions/utils/totp.js
+++ b/functions/utils/totp.js
@@ -61,16 +61,8 @@ async function hotp(secretBytes, counter, digits) {
     counterBytes[i] = remaining & 0xff;
     remaining = Math.floor(remaining / 256);
   }
-  const key = await crypto.subtle.importKey(
-    "raw",
-    secretBytes,
-    { name: "HMAC", hash: "SHA-1" },
-    false,
-    ["sign"],
-  );
-  const mac = new Uint8Array(
-    await crypto.subtle.sign("HMAC", key, counterBytes),
-  );
+  const key = await crypto.subtle.importKey("raw", secretBytes, { name: "HMAC", hash: "SHA-1" }, false, ["sign"]);
+  const mac = new Uint8Array(await crypto.subtle.sign("HMAC", key, counterBytes));
   const offset = mac[mac.length - 1] & 0x0f;
   const binary =
     ((mac[offset] & 0x7f) << 24) |
@@ -130,11 +122,7 @@ export async function verifyTotp(secret, code, window = 1) {
   let matched = false;
   // Walk the full ± window without early-exit so a match's step index doesn't leak.
   for (let offset = -span; offset <= span; offset += 1) {
-    const candidate = await hotp(
-      secretBytes,
-      counter + offset,
-      DEFAULT_TOTP_DIGITS,
-    );
+    const candidate = await hotp(secretBytes, counter + offset, DEFAULT_TOTP_DIGITS);
     if (constantTimeEqual(candidate, normalized)) {
       matched = true;
     }

--- a/functions/utils/trustedDevice.js
+++ b/functions/utils/trustedDevice.js
@@ -13,10 +13,7 @@ const TRUSTED_DEVICE_EXPIRY_DAYS = 30;
  */
 async function sha256Hex(input) {
   const encoder = new TextEncoder();
-  const hashBuffer = await crypto.subtle.digest(
-    "SHA-256",
-    encoder.encode(input),
-  );
+  const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(input));
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
@@ -73,9 +70,7 @@ export async function createTrustedDevice(DB, userId, ipAddress, userAgent) {
   // TEXT comparisons against datetime('now') are lexicographically correct.
   // ISO 8601 with 'T' compares greater than space-separated format at the
   // same instant, which would allow expired devices to pass validation.
-  const expiresAt = new Date(
-    Date.now() + TRUSTED_DEVICE_EXPIRY_DAYS * 24 * 60 * 60 * 1000,
-  )
+  const expiresAt = new Date(Date.now() + TRUSTED_DEVICE_EXPIRY_DAYS * 24 * 60 * 60 * 1000)
     .toISOString()
     .replace("T", " ")
     .slice(0, 19);
@@ -84,15 +79,7 @@ export async function createTrustedDevice(DB, userId, ipAddress, userAgent) {
     `INSERT INTO trusted_devices (user_id, token, device_fingerprint, ua_hash, ip_address, user_agent, expires_at)
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
   )
-    .bind(
-      userId,
-      tokenHash,
-      fingerprint,
-      uaHash,
-      ipAddress,
-      userAgent,
-      expiresAt,
-    )
+    .bind(userId, tokenHash, fingerprint, uaHash, ipAddress, userAgent, expiresAt)
     .run();
 
   return { token, expiresAt };
@@ -135,16 +122,10 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
   //      password-authenticated login — it is not a standalone credential.
   // If the threat model tightens (e.g. admin-only high-value accounts), revisit
   // by adding IP-range/ASN checks rather than exact-IP pinning.
-  const currentFingerprint = await generateDeviceFingerprint(
-    ipAddress,
-    userAgent,
-  );
+  const currentFingerprint = await generateDeviceFingerprint(ipAddress, userAgent);
   const currentUaHash = await generateUaHash(userAgent);
 
-  const fingerprintMatch = timingSafeStringEqual(
-    device.device_fingerprint,
-    currentFingerprint,
-  );
+  const fingerprintMatch = timingSafeStringEqual(device.device_fingerprint, currentFingerprint);
 
   if (device.ua_hash) {
     const uaMatch = timingSafeStringEqual(device.ua_hash, currentUaHash);
@@ -157,10 +138,7 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
     if (!fingerprintMatch) {
       // UA matches but IP changed — normal for DHCP, mobile, VPN users.
       // Fingerprint is refreshed in the update below.
-      logger.debug(
-        "trusted device IP changed for known UA, refreshing fingerprint",
-        { userId: device.user_id },
-      );
+      logger.debug("trusted device IP changed for known UA, refreshing fingerprint", { userId: device.user_id });
     }
   } else if (!fingerprintMatch) {
     logger.debug("trusted device fingerprint mismatch, device not trusted", {
@@ -184,27 +162,21 @@ export async function validateTrustedDevice(DB, token, ipAddress, userAgent) {
  */
 export async function revokeTrustedDevice(DB, token) {
   const tokenHash = await hashTrustedDeviceToken(token);
-  await DB.prepare(`DELETE FROM trusted_devices WHERE token = ?`)
-    .bind(tokenHash)
-    .run();
+  await DB.prepare(`DELETE FROM trusted_devices WHERE token = ?`).bind(tokenHash).run();
 }
 
 /**
  * Remove all trusted devices for a user (e.g., on password change)
  */
 export async function revokeAllTrustedDevices(DB, userId) {
-  await DB.prepare(`DELETE FROM trusted_devices WHERE user_id = ?`)
-    .bind(userId)
-    .run();
+  await DB.prepare(`DELETE FROM trusted_devices WHERE user_id = ?`).bind(userId).run();
 }
 
 /**
  * Clean up expired trusted devices
  */
 export async function cleanupExpiredDevices(DB) {
-  await DB.prepare(
-    `DELETE FROM trusted_devices WHERE expires_at <= datetime('now')`,
-  ).run();
+  await DB.prepare(`DELETE FROM trusted_devices WHERE expires_at <= datetime('now')`).run();
 }
 
 /**
@@ -213,18 +185,10 @@ export async function cleanupExpiredDevices(DB) {
  */
 export function createTrustedDeviceCookie(token, request, env) {
   const isDev = isDevRequest(request, env);
-  const cookieName = isDev
-    ? TRUSTED_DEVICE_COOKIE_NAME_DEV
-    : TRUSTED_DEVICE_COOKIE_NAME_SECURE;
+  const cookieName = isDev ? TRUSTED_DEVICE_COOKIE_NAME_DEV : TRUSTED_DEVICE_COOKIE_NAME_SECURE;
   const maxAge = TRUSTED_DEVICE_EXPIRY_DAYS * 24 * 60 * 60;
 
-  const parts = [
-    `${cookieName}=${token}`,
-    `Path=/`,
-    `Max-Age=${maxAge}`,
-    `SameSite=Strict`,
-    `HttpOnly`,
-  ];
+  const parts = [`${cookieName}=${token}`, `Path=/`, `Max-Age=${maxAge}`, `SameSite=Strict`, `HttpOnly`];
 
   if (!isDev) {
     parts.push("Secure");
@@ -238,9 +202,7 @@ export function createTrustedDeviceCookie(token, request, env) {
  */
 export function deleteTrustedDeviceCookie(request, env) {
   const isDev = isDevRequest(request, env);
-  const cookieName = isDev
-    ? TRUSTED_DEVICE_COOKIE_NAME_DEV
-    : TRUSTED_DEVICE_COOKIE_NAME_SECURE;
+  const cookieName = isDev ? TRUSTED_DEVICE_COOKIE_NAME_DEV : TRUSTED_DEVICE_COOKIE_NAME_SECURE;
   const secure = isDev ? "" : "Secure; ";
 
   return `${cookieName}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; ${secure}SameSite=Strict; HttpOnly`;
@@ -256,10 +218,7 @@ export function getTrustedDeviceToken(request) {
   const cookies = cookieHeader.split(";");
   for (const cookie of cookies) {
     const [name, value] = cookie.trim().split("=");
-    if (
-      name === TRUSTED_DEVICE_COOKIE_NAME_SECURE ||
-      name === TRUSTED_DEVICE_COOKIE_NAME_DEV
-    ) {
+    if (name === TRUSTED_DEVICE_COOKIE_NAME_SECURE || name === TRUSTED_DEVICE_COOKIE_NAME_DEV) {
       return value;
     }
   }

--- a/functions/utils/turnstile.js
+++ b/functions/utils/turnstile.js
@@ -11,21 +11,16 @@
 // the production Pages project, or these endpoints will reject every request.
 import { isDevRequest } from "./auth.js";
 
-const SITEVERIFY_URL =
-  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+const SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
 
 export async function verifyTurnstile(request, env, token) {
   const secret = env?.TURNSTILE_SECRET_KEY;
   if (!secret) {
     if (isDevRequest(request, env)) {
-      console.warn(
-        "[Turnstile] TURNSTILE_SECRET_KEY not set — skipping bot verification (local dev only).",
-      );
+      console.warn("[Turnstile] TURNSTILE_SECRET_KEY not set — skipping bot verification (local dev only).");
       return true;
     }
-    console.error(
-      "[Turnstile] TURNSTILE_SECRET_KEY is required in production; rejecting request.",
-    );
+    console.error("[Turnstile] TURNSTILE_SECRET_KEY is required in production; rejecting request.");
     return false;
   }
 

--- a/functions/utils/validation.js
+++ b/functions/utils/validation.js
@@ -7,21 +7,18 @@ import { validate as validateEmail } from "email-validator";
  * UUID validation regex (RFC 4122 compliant)
  * Validates UUID v1-5 format
  */
-const UUID_REGEX =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /**
  * ISO 8601 date format regex
  * Matches YYYY-MM-DD and full ISO datetime formats
  */
-const ISO_DATE_REGEX =
-  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[+-]\d{2}:\d{2})?)?$/;
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[+-]\d{2}:\d{2})?)?$/;
 
 /**
  * Postal code regex (supports US ZIP and Canadian postal codes)
  */
-const POSTAL_CODE_REGEX =
-  /^(?:\d{5}(?:-\d{4})?|[A-Za-z]\d[A-Za-z]\s*\d[A-Za-z]\d)$/;
+const POSTAL_CODE_REGEX = /^(?:\d{5}(?:-\d{4})?|[A-Za-z]\d[A-Za-z]\s*\d[A-Za-z]\d)$/;
 
 /**
  * Phone number regex (permissive, digits + formatting)
@@ -1134,9 +1131,7 @@ export const VALIDATION_SCHEMAS = {
           requireNumber: true,
           requireSpecial: true,
         });
-        return result.valid
-          ? { valid: true }
-          : { valid: false, error: result.errors[0] };
+        return result.valid ? { valid: true } : { valid: false, error: result.errors[0] };
       },
     },
     firstName: {

--- a/functions/venue/[id].js
+++ b/functions/venue/[id].js
@@ -60,17 +60,13 @@ export async function onRequest(context) {
     url,
     address: {
       "@type": "PostalAddress",
-      ...(venue.address_line1 || venue.address
-        ? { streetAddress: venue.address_line1 || venue.address }
-        : {}),
+      ...(venue.address_line1 || venue.address ? { streetAddress: venue.address_line1 || venue.address } : {}),
       addressLocality: locality,
       addressRegion: venue.region || "ON",
       ...(venue.postal_code ? { postalCode: venue.postal_code } : {}),
       addressCountry: "CA",
     },
-    ...(hasGeo
-      ? { geo: { "@type": "GeoCoordinates", latitude: venue.latitude, longitude: venue.longitude } }
-      : {}),
+    ...(hasGeo ? { geo: { "@type": "GeoCoordinates", latitude: venue.latitude, longitude: venue.longitude } } : {}),
     ...(venue.phone ? { telephone: venue.phone } : {}),
     ...(sameAs.length > 0 ? { sameAs } : {}),
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@vitest/coverage-v8": "^4.1.9",
         "baseline-browser-mapping": "^2.10.40",
         "better-sqlite3": "^12.11.1",
+        "prettier": "^3.9.3",
         "vite": "^8.1.0",
         "vitest": "^4.1.9"
       }
@@ -1779,6 +1780,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pump": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "prebuild": "npm run validate:schema",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "format": "prettier --write \"functions/**/*.{js,json}\" \"scripts/**/*.{js,mjs,json}\"",
+    "format:check": "prettier --check \"functions/**/*.{js,json}\" \"scripts/**/*.{js,mjs,json}\""
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",
@@ -25,7 +27,8 @@
     "baseline-browser-mapping": "^2.10.40",
     "better-sqlite3": "^12.11.1",
     "vite": "^8.1.0",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "prettier": "^3.9.3"
   },
   "dependencies": {
     "csrf-csrf": "^4.0.3",

--- a/scripts/create-admin-invite.js
+++ b/scripts/create-admin-invite.js
@@ -10,14 +10,14 @@
  * For production: node scripts/create-admin-invite.js --prod
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from "crypto";
 
-const isLocal = process.argv.includes('--local');
-const isProd = process.argv.includes('--prod');
+const isLocal = process.argv.includes("--local");
+const isProd = process.argv.includes("--prod");
 
 if (!isLocal && !isProd) {
-  console.error('❌ Error: Please specify --local or --prod');
-  console.error('Usage: node scripts/create-admin-invite.js [--local|--prod]');
+  console.error("❌ Error: Please specify --local or --prod");
+  console.error("Usage: node scripts/create-admin-invite.js [--local|--prod]");
   process.exit(1);
 }
 
@@ -26,29 +26,33 @@ const inviteCode = randomUUID();
 const expiresIn = 7; // days
 const expiryDate = new Date(Date.now() + expiresIn * 24 * 60 * 60 * 1000).toISOString();
 
-console.log('\n🔐 Admin Invite Code Generated\n');
-console.log('═'.repeat(60));
+console.log("\n🔐 Admin Invite Code Generated\n");
+console.log("═".repeat(60));
 console.log(`📧 Invite Code: ${inviteCode}`);
 console.log(`⏰ Expires: ${new Date(expiryDate).toLocaleString()} (7 days)`);
 console.log(`🎯 Role: admin`);
-console.log('═'.repeat(60));
+console.log("═".repeat(60));
 
 if (isLocal) {
-  console.log('\n📝 To use this invite code locally:');
-  console.log('\n1. Insert into your local database:');
-  console.log('\n   wrangler d1 execute settimes-db --local --command=\\');
-  console.log(`   "INSERT INTO invite_codes (code, role, expires_at, is_active) VALUES ('${inviteCode}', 'admin', '${expiryDate}', 1);"`);
-  console.log('\n2. Use this code when signing up at http://localhost:8788/admin');
+  console.log("\n📝 To use this invite code locally:");
+  console.log("\n1. Insert into your local database:");
+  console.log("\n   wrangler d1 execute settimes-db --local --command=\\");
+  console.log(
+    `   "INSERT INTO invite_codes (code, role, expires_at, is_active) VALUES ('${inviteCode}', 'admin', '${expiryDate}', 1);"`,
+  );
+  console.log("\n2. Use this code when signing up at http://localhost:8788/admin");
 } else {
-  console.log('\n📝 To use this invite code in production:');
-  console.log('\n1. Insert into your production database:');
-  console.log('\n   wrangler d1 execute settimes-db --command=\\');
-  console.log(`   "INSERT INTO invite_codes (code, role, expires_at, is_active) VALUES ('${inviteCode}', 'admin', '${expiryDate}', 1);"`);
-  console.log('\n2. Use this code when signing up at your production URL');
+  console.log("\n📝 To use this invite code in production:");
+  console.log("\n1. Insert into your production database:");
+  console.log("\n   wrangler d1 execute settimes-db --command=\\");
+  console.log(
+    `   "INSERT INTO invite_codes (code, role, expires_at, is_active) VALUES ('${inviteCode}', 'admin', '${expiryDate}', 1);"`,
+  );
+  console.log("\n2. Use this code when signing up at your production URL");
 }
 
-console.log('\n⚠️  SECURITY REMINDER:');
-console.log('   - Store this invite code securely (password manager)');
-console.log('   - Do not share it via email or public channels');
-console.log('   - The code can only be used once');
-console.log('   - The code will expire in 7 days\n');
+console.log("\n⚠️  SECURITY REMINDER:");
+console.log("   - Store this invite code securely (password manager)");
+console.log("   - Do not share it via email or public channels");
+console.log("   - The code can only be used once");
+console.log("   - The code will expire in 7 days\n");

--- a/scripts/generate-hash.js
+++ b/scripts/generate-hash.js
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from "crypto";
 
 const SALT_LENGTH = 16;
 const ITERATIONS = 100000;
@@ -6,16 +6,16 @@ const KEY_LENGTH = 32;
 
 async function hashPassword(password) {
   const salt = crypto.randomBytes(SALT_LENGTH);
-  
+
   return new Promise((resolve, reject) => {
-    crypto.pbkdf2(password, salt, ITERATIONS, KEY_LENGTH, 'sha256', (err, derivedKey) => {
+    crypto.pbkdf2(password, salt, ITERATIONS, KEY_LENGTH, "sha256", (err, derivedKey) => {
       if (err) reject(err);
-      
-      const saltBase64 = salt.toString('base64');
-      const hashBase64 = derivedKey.toString('base64');
+
+      const saltBase64 = salt.toString("base64");
+      const hashBase64 = derivedKey.toString("base64");
       resolve(`${saltBase64}:${hashBase64}`);
     });
   });
 }
 
-hashPassword('tyqqeG-3niqke-kafxyt').then(console.log);
+hashPassword("tyqqeG-3niqke-kafxyt").then(console.log);

--- a/scripts/hash-password.mjs
+++ b/scripts/hash-password.mjs
@@ -1,11 +1,11 @@
-import { hashPassword } from '../functions/utils/crypto.js'
+import { hashPassword } from "../functions/utils/crypto.js";
 
-const password = process.argv[2]
+const password = process.argv[2];
 
 if (!password) {
-  console.error('Usage: node scripts/hash-password.mjs <password>')
-  process.exit(1)
+  console.error("Usage: node scripts/hash-password.mjs <password>");
+  process.exit(1);
 }
 
-const hash = await hashPassword(password)
-process.stdout.write(hash)
+const hash = await hashPassword(password);
+process.stdout.write(hash);

--- a/scripts/import-historical-events.mjs
+++ b/scripts/import-historical-events.mjs
@@ -3,163 +3,165 @@
  * Fetches event data from TicketScene URLs and populates the database
  */
 
-import fs from 'fs'
-import path from 'path'
-import { fileURLToPath } from 'url'
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const eventUrls = [
-  'https://ticketscene.ca/events/55263/', // Volume 14 - Oct 12, 2025
-  'https://ticketscene.ca/events/53281/',
-  'https://ticketscene.ca/events/51379/',
-  'https://ticketscene.ca/events/45243/',
-  'https://ticketscene.ca/events/50533/',
-  'https://ticketscene.ca/events/49329/',
-  'https://ticketscene.ca/events/48517/',
-  'https://ticketscene.ca/events/47573/',
-  'https://ticketscene.ca/events/46772/',
-  'https://ticketscene.ca/events/45872/',
-]
+  "https://ticketscene.ca/events/55263/", // Volume 14 - Oct 12, 2025
+  "https://ticketscene.ca/events/53281/",
+  "https://ticketscene.ca/events/51379/",
+  "https://ticketscene.ca/events/45243/",
+  "https://ticketscene.ca/events/50533/",
+  "https://ticketscene.ca/events/49329/",
+  "https://ticketscene.ca/events/48517/",
+  "https://ticketscene.ca/events/47573/",
+  "https://ticketscene.ca/events/46772/",
+  "https://ticketscene.ca/events/45872/",
+];
 
 async function fetchEventData(url) {
-  console.log(`Fetching: ${url}`)
-  const response = await fetch(url)
-  const html = await response.text()
+  console.log(`Fetching: ${url}`);
+  const response = await fetch(url);
+  const html = await response.text();
 
   // Extract event name (e.g., "LONG WEEKEND BAND CRAWL - VOLUME 14")
-  const nameMatch = html.match(/LONG WEEKEND BAND CRAWL[^<\n]*/i)
-  const name = nameMatch ? nameMatch[0].trim() : null
+  const nameMatch = html.match(/LONG WEEKEND BAND CRAWL[^<\n]*/i);
+  const name = nameMatch ? nameMatch[0].trim() : null;
 
   // Extract date - try multiple patterns
   // Pattern 1: "Sunday, August 3, 2025" (from <p><strong>)
-  let dateMatch = html.match(/<strong>(?:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday),?\s+([A-Za-z]+\s+\d+,\s+\d{4})<\/strong>/i)
+  let dateMatch = html.match(
+    /<strong>(?:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday),?\s+([A-Za-z]+\s+\d+,\s+\d{4})<\/strong>/i,
+  );
   // Pattern 2: "SUNDAY OCTOBER 12, 2025" (all caps)
   if (!dateMatch) {
-    dateMatch = html.match(/(?:SUNDAY|MONDAY|TUESDAY|WEDNESDAY|THURSDAY|FRIDAY|SATURDAY)\s+([A-Z]+\s+\d+,\s+\d{4})/i)
+    dateMatch = html.match(/(?:SUNDAY|MONDAY|TUESDAY|WEDNESDAY|THURSDAY|FRIDAY|SATURDAY)\s+([A-Z]+\s+\d+,\s+\d{4})/i);
   }
-  const dateStr = dateMatch ? dateMatch[1] : null
-  const date = dateStr ? new Date(dateStr) : null
+  const dateStr = dateMatch ? dateMatch[1] : null;
+  const date = dateStr ? new Date(dateStr) : null;
 
   // Extract venues (lines starting with "- " followed by venue name and address)
-  const venuesSection = html.match(/Participating venues:[\s\S]*?(?=All tickets|Tickets available|NOTE:|Thank you)/i)
-  const venues = []
+  const venuesSection = html.match(/Participating venues:[\s\S]*?(?=All tickets|Tickets available|NOTE:|Thank you)/i);
+  const venues = [];
   if (venuesSection) {
-    const venueMatches = venuesSection[0].matchAll(/- ([^(]+)\(([^)]+)\)/g)
+    const venueMatches = venuesSection[0].matchAll(/- ([^(]+)\(([^)]+)\)/g);
     for (const match of venueMatches) {
       venues.push({
         name: match[1].trim(),
-        address: match[2].trim()
-      })
+        address: match[2].trim(),
+      });
     }
   }
 
   // Extract bands (after "Featuring:" line until "Participating venues:")
-  const featuringMatch = html.match(/Featuring:\s*([^]+?)(?=Participating venues:|All tickets|Tickets available)/i)
-  let bands = []
+  const featuringMatch = html.match(/Featuring:\s*([^]+?)(?=Participating venues:|All tickets|Tickets available)/i);
+  let bands = [];
   if (featuringMatch) {
     // Split by commas and clean up
     bands = featuringMatch[1]
-      .replace(/\n/g, ' ')
-      .split(',')
-      .map(b => b.trim())
-      .filter(b => b.length > 0 && b.length < 100) // Filter out very long strings
+      .replace(/\n/g, " ")
+      .split(",")
+      .map((b) => b.trim())
+      .filter((b) => b.length > 0 && b.length < 100); // Filter out very long strings
   }
 
   return {
     url,
     name,
-    date: date ? date.toISOString().split('T')[0] : null,
+    date: date ? date.toISOString().split("T")[0] : null,
     venues,
     bands,
-    is_published: true // Historical events are already published
-  }
+    is_published: true, // Historical events are already published
+  };
 }
 
 async function generateSqlInserts(events) {
-  const sql = []
+  const sql = [];
 
   for (let i = 0; i < events.length; i++) {
-    const event = events[i]
-    const eventNum = i + 1
+    const event = events[i];
+    const eventNum = i + 1;
 
     if (!event.name || !event.date) {
-      console.warn(`Skipping event ${event.url} - missing name or date`)
-      continue
+      console.warn(`Skipping event ${event.url} - missing name or date`);
+      continue;
     }
 
     // Insert event
     // Generate slug from name
     const slug = event.name
       .toLowerCase()
-      .replace(/[^a-z0-9\s-]/g, '')
-      .replace(/\s+/g, '-')
-      .replace(/-+/g, '-')
-      .substring(0, 50)
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .substring(0, 50);
 
-    sql.push(`-- Event: ${event.name}`)
-    sql.push(`INSERT OR IGNORE INTO events (name, date, slug, is_published) VALUES (`)
-    sql.push(`  '${event.name.replace(/'/g, "''")}',`)
-    sql.push(`  '${event.date}',`)
-    sql.push(`  '${slug}',`)
-    sql.push(`  1`)
-    sql.push(`);`)
-    sql.push(``)
+    sql.push(`-- Event: ${event.name}`);
+    sql.push(`INSERT OR IGNORE INTO events (name, date, slug, is_published) VALUES (`);
+    sql.push(`  '${event.name.replace(/'/g, "''")}',`);
+    sql.push(`  '${event.date}',`);
+    sql.push(`  '${slug}',`);
+    sql.push(`  1`);
+    sql.push(`);`);
+    sql.push(``);
 
     // Insert venues and get their IDs
     for (let v = 0; v < event.venues.length; v++) {
-      const venue = event.venues[v]
-      sql.push(`INSERT OR IGNORE INTO venues (name, address) VALUES (`)
-      sql.push(`  '${venue.name.replace(/'/g, "''")}',`)
-      sql.push(`  '${venue.address.replace(/'/g, "''")}'`)
-      sql.push(`);`)
+      const venue = event.venues[v];
+      sql.push(`INSERT OR IGNORE INTO venues (name, address) VALUES (`);
+      sql.push(`  '${venue.name.replace(/'/g, "''")}',`);
+      sql.push(`  '${venue.address.replace(/'/g, "''")}'`);
+      sql.push(`);`);
     }
-    sql.push(``)
+    sql.push(``);
 
     // Insert performers (bands)
     for (let b = 0; b < event.bands.length; b++) {
-      const band = event.bands[b]
-      sql.push(`INSERT OR IGNORE INTO performers (name) VALUES (`)
-      sql.push(`  '${band.replace(/'/g, "''")}'`)
-      sql.push(`);`)
+      const band = event.bands[b];
+      sql.push(`INSERT OR IGNORE INTO performers (name) VALUES (`);
+      sql.push(`  '${band.replace(/'/g, "''")}'`);
+      sql.push(`);`);
     }
-    sql.push(``)
-    sql.push(`-- End of ${event.name}`)
-    sql.push(``)
+    sql.push(``);
+    sql.push(`-- End of ${event.name}`);
+    sql.push(``);
   }
 
-  return sql.join('\n')
+  return sql.join("\n");
 }
 
 async function main() {
-  console.log('🎸 Fetching historical Long Weekend Band Crawl events...\n')
+  console.log("🎸 Fetching historical Long Weekend Band Crawl events...\n");
 
-  const events = []
+  const events = [];
   for (const url of eventUrls) {
     try {
-      const eventData = await fetchEventData(url)
-      events.push(eventData)
-      console.log(`✅ ${eventData.name || 'Unknown Event'}`)
-      console.log(`   Date: ${eventData.date || 'Unknown'}`)
-      console.log(`   Venues: ${eventData.venues.length}`)
-      console.log(`   Bands: ${eventData.bands.length}\n`)
+      const eventData = await fetchEventData(url);
+      events.push(eventData);
+      console.log(`✅ ${eventData.name || "Unknown Event"}`);
+      console.log(`   Date: ${eventData.date || "Unknown"}`);
+      console.log(`   Venues: ${eventData.venues.length}`);
+      console.log(`   Bands: ${eventData.bands.length}\n`);
     } catch (error) {
-      console.error(`❌ Failed to fetch ${url}: ${error.message}\n`)
+      console.error(`❌ Failed to fetch ${url}: ${error.message}\n`);
     }
   }
 
-  console.log('\n📝 Generating SQL...\n')
-  const sql = await generateSqlInserts(events)
+  console.log("\n📝 Generating SQL...\n");
+  const sql = await generateSqlInserts(events);
 
   // Write to file
-  const outputPath = path.join(__dirname, '..', 'database', 'historical-events.sql')
+  const outputPath = path.join(__dirname, "..", "database", "historical-events.sql");
 
-  fs.writeFileSync(outputPath, sql)
-  console.log(`✅ SQL written to: ${outputPath}`)
-  console.log(`\n🚀 To import, run: wrangler d1 execute bandcrawl-db --local --file=database/historical-events.sql`)
-  console.log(`\nEvents processed: ${events.length}`)
-  console.log(`Events with complete data: ${events.filter(e => e.name && e.date).length}`)
+  fs.writeFileSync(outputPath, sql);
+  console.log(`✅ SQL written to: ${outputPath}`);
+  console.log(`\n🚀 To import, run: wrangler d1 execute bandcrawl-db --local --file=database/historical-events.sql`);
+  console.log(`\nEvents processed: ${events.length}`);
+  console.log(`Events with complete data: ${events.filter((e) => e.name && e.date).length}`);
 }
 
-main().catch(console.error)
+main().catch(console.error);

--- a/scripts/import-local-band-crawl-schedule.js
+++ b/scripts/import-local-band-crawl-schedule.js
@@ -13,40 +13,33 @@
  * - It never publishes the event (is_published = 0).
  */
 
-import fs from 'node:fs';
-import path from 'node:path';
-import { execFileSync } from 'node:child_process';
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
 
 const args = process.argv.slice(2);
 
 const getArgValue = (flag) => {
   const withEquals = args.find((arg) => arg.startsWith(`${flag}=`));
   if (withEquals) {
-    return withEquals.split('=').slice(1).join('=');
+    return withEquals.split("=").slice(1).join("=");
   }
   const idx = args.indexOf(flag);
   if (idx === -1) return null;
   return args[idx + 1] || null;
 };
 
-const schedulePath = getArgValue('--file') || 'band_crawl_schedule.json';
-const overrideDate = getArgValue('--date');
-const overrideSlug = getArgValue('--slug');
-const allowInvalid = args.includes('--allow-invalid');
-const dryRun = args.includes('--dry-run');
+const schedulePath = getArgValue("--file") || "band_crawl_schedule.json";
+const overrideDate = getArgValue("--date");
+const overrideSlug = getArgValue("--slug");
+const allowInvalid = args.includes("--allow-invalid");
+const dryRun = args.includes("--dry-run");
 
 const PROJECT_ROOT = process.cwd();
-const DB_DIR = path.join(
-  PROJECT_ROOT,
-  '.wrangler',
-  'state',
-  'v3',
-  'd1',
-  'miniflare-D1DatabaseObject',
-);
+const DB_DIR = path.join(PROJECT_ROOT, ".wrangler", "state", "v3", "d1", "miniflare-D1DatabaseObject");
 
 const sqlEscape = (value) => {
-  if (value == null) return 'NULL';
+  if (value == null) return "NULL";
   const text = String(value);
   return `'${text.replace(/'/g, "''")}'`;
 };
@@ -55,11 +48,10 @@ const slugify = (value) =>
   value
     .toLowerCase()
     .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 
-const normalizeName = (value) =>
-  value.toLowerCase().replace(/[^a-z0-9]/g, '');
+const normalizeName = (value) => value.toLowerCase().replace(/[^a-z0-9]/g, "");
 
 const normalizeTime = (value) => {
   if (!value) return null;
@@ -71,44 +63,31 @@ const normalizeTime = (value) => {
   }
   const hours = Number(match[1]);
   const minutes = Number(match[2]);
-  if (
-    Number.isNaN(hours) ||
-    Number.isNaN(minutes) ||
-    hours < 0 ||
-    hours > 23 ||
-    minutes < 0 ||
-    minutes > 59
-  ) {
+  if (Number.isNaN(hours) || Number.isNaN(minutes) || hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
     if (allowInvalid) return raw;
     throw new Error(`Invalid time value: "${raw}"`);
   }
-  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 };
 
 const runSql = (dbFile, sql) => {
-  return execFileSync('sqlite3', ['-batch', dbFile, sql], {
-    encoding: 'utf8',
+  return execFileSync("sqlite3", ["-batch", dbFile, sql], {
+    encoding: "utf8",
   }).trim();
 };
 
 const findDbFile = () => {
   if (!fs.existsSync(DB_DIR)) {
-    throw new Error(
-      'Local database directory not found. Start wrangler dev first to create it.',
-    );
+    throw new Error("Local database directory not found. Start wrangler dev first to create it.");
   }
   const files = fs
     .readdirSync(DB_DIR)
-    .filter((file) => file.endsWith('.sqlite'))
+    .filter((file) => file.endsWith(".sqlite"))
     .map((file) => path.join(DB_DIR, file));
   if (!files.length) {
-    throw new Error(
-      'No local sqlite files found. Start wrangler dev first to create one.',
-    );
+    throw new Error("No local sqlite files found. Start wrangler dev first to create one.");
   }
-  return files
-    .map((file) => ({ file, size: fs.statSync(file).size }))
-    .sort((a, b) => b.size - a.size)[0].file;
+  return files.map((file) => ({ file, size: fs.statSync(file).size })).sort((a, b) => b.size - a.size)[0].file;
 };
 
 const resolveEventDate = (scheduleDate) => {
@@ -127,9 +106,9 @@ const main = () => {
     throw new Error(`Schedule file not found: ${absoluteSchedulePath}`);
   }
 
-  const schedule = JSON.parse(fs.readFileSync(absoluteSchedulePath, 'utf8'));
-  if (!schedule || typeof schedule !== 'object') {
-    throw new Error('Schedule JSON is empty or invalid.');
+  const schedule = JSON.parse(fs.readFileSync(absoluteSchedulePath, "utf8"));
+  if (!schedule || typeof schedule !== "object") {
+    throw new Error("Schedule JSON is empty or invalid.");
   }
 
   const eventName = schedule.event?.trim();
@@ -139,14 +118,12 @@ const main = () => {
 
   const eventDate = resolveEventDate(schedule.date);
   if (!eventDate) {
-    throw new Error(
-      'Event date must be provided as YYYY-MM-DD (use --date).',
-    );
+    throw new Error("Event date must be provided as YYYY-MM-DD (use --date).");
   }
 
   const baseSlug = overrideSlug || slugify(eventName);
   if (!baseSlug) {
-    throw new Error('Unable to derive a slug from the event name.');
+    throw new Error("Unable to derive a slug from the event name.");
   }
 
   const dbFile = findDbFile();
@@ -155,12 +132,12 @@ const main = () => {
   let suffix = 0;
   while (runSql(dbFile, `SELECT id FROM events WHERE slug = ${sqlEscape(slug)} LIMIT 1;`)) {
     suffix += 1;
-    slug = `${baseSlug}-local${suffix === 1 ? '' : `-${suffix}`}`;
+    slug = `${baseSlug}-local${suffix === 1 ? "" : `-${suffix}`}`;
   }
 
   const venues = Array.isArray(schedule.venues) ? schedule.venues : [];
   if (!venues.length) {
-    throw new Error('Schedule JSON has no venues to import.');
+    throw new Error("Schedule JSON has no venues to import.");
   }
 
   const venueNames = new Set();
@@ -197,16 +174,16 @@ const main = () => {
 
   if (invalidTimes.length && !allowInvalid) {
     throw new Error(
-      `Schedule contains invalid times. Fix them or re-run with --allow-invalid.\n${invalidTimes.join('\n')}`,
+      `Schedule contains invalid times. Fix them or re-run with --allow-invalid.\n${invalidTimes.join("\n")}`,
     );
   }
 
   if (!performances.length) {
-    throw new Error('No performances found to import.');
+    throw new Error("No performances found to import.");
   }
 
   if (dryRun) {
-    console.log('Dry run: no database changes were made.');
+    console.log("Dry run: no database changes were made.");
     console.log(`Event: ${eventName}`);
     console.log(`Date: ${eventDate}`);
     console.log(`Slug: ${slug}`);
@@ -223,18 +200,12 @@ const main = () => {
     dbFile,
     `INSERT INTO events (name, date, slug, is_published, city) VALUES (${sqlEscape(eventName)}, ${sqlEscape(eventDate)}, ${sqlEscape(slug)}, 0, ${sqlEscape(schedule.location || null)});`,
   );
-  const eventId = runSql(
-    dbFile,
-    `SELECT id FROM events WHERE slug = ${sqlEscape(slug)} LIMIT 1;`,
-  );
+  const eventId = runSql(dbFile, `SELECT id FROM events WHERE slug = ${sqlEscape(slug)} LIMIT 1;`);
 
   // Ensure venues exist
   const venueIdByName = new Map();
   venueNames.forEach((name) => {
-    const existing = runSql(
-      dbFile,
-      `SELECT id FROM venues WHERE name = ${sqlEscape(name)} LIMIT 1;`,
-    );
+    const existing = runSql(dbFile, `SELECT id FROM venues WHERE name = ${sqlEscape(name)} LIMIT 1;`);
     if (existing) {
       venueIdByName.set(name, Number(existing));
       return;
@@ -243,7 +214,7 @@ const main = () => {
       dbFile,
       `INSERT INTO venues (name, city) VALUES (${sqlEscape(name)}, ${sqlEscape(schedule.location || null)});`,
     );
-    const venueId = runSql(dbFile, 'SELECT last_insert_rowid();');
+    const venueId = runSql(dbFile, "SELECT last_insert_rowid();");
     venueIdByName.set(name, Number(venueId));
   });
 
@@ -265,7 +236,7 @@ const main = () => {
       dbFile,
       `INSERT INTO band_profiles (name, name_normalized) VALUES (${sqlEscape(performance.bandName)}, ${sqlEscape(normalized)});`,
     );
-    const bandId = runSql(dbFile, 'SELECT last_insert_rowid();');
+    const bandId = runSql(dbFile, "SELECT last_insert_rowid();");
     bandIdByNormalized.set(normalized, Number(bandId));
   });
 
@@ -280,7 +251,7 @@ const main = () => {
     );
   });
 
-  console.log('Local schedule import complete.');
+  console.log("Local schedule import complete.");
   console.log(`Event ID: ${eventId}`);
   console.log(`Slug: ${slug}`);
   console.log(`Venues imported: ${venueNames.size}`);

--- a/scripts/reset-admin-password.js
+++ b/scripts/reset-admin-password.js
@@ -6,20 +6,14 @@ const DEFAULT_ITERATIONS = 100000; // CF Workers limit: max 100,000 iterations
 const KEY_LENGTH = 32;
 
 async function hashPassword(password) {
-  const { webcrypto } = await import('crypto');
+  const { webcrypto } = await import("crypto");
   const crypto = webcrypto;
-  
+
   const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
   const encoder = new TextEncoder();
   const passwordBytes = encoder.encode(password);
 
-  const key = await crypto.subtle.importKey(
-    "raw",
-    passwordBytes,
-    { name: "PBKDF2" },
-    false,
-    ["deriveBits"]
-  );
+  const key = await crypto.subtle.importKey("raw", passwordBytes, { name: "PBKDF2" }, false, ["deriveBits"]);
 
   const derivedBits = await crypto.subtle.deriveBits(
     {
@@ -29,12 +23,12 @@ async function hashPassword(password) {
       hash: "SHA-256",
     },
     key,
-    KEY_LENGTH * 8
+    KEY_LENGTH * 8,
   );
 
   const hashArray = new Uint8Array(derivedBits);
-  const saltBase64 = Buffer.from(salt).toString('base64');
-  const hashBase64 = Buffer.from(hashArray).toString('base64');
+  const saltBase64 = Buffer.from(salt).toString("base64");
+  const hashBase64 = Buffer.from(hashArray).toString("base64");
 
   return `pbkdf2$${DEFAULT_ITERATIONS}$${saltBase64}$${hashBase64}`;
 }
@@ -42,15 +36,17 @@ async function hashPassword(password) {
 async function main() {
   const password = process.argv[2];
   if (!password) {
-    console.error('Usage: node scripts/reset-admin-password.js <new-password>');
+    console.error("Usage: node scripts/reset-admin-password.js <new-password>");
     process.exit(1);
   }
 
   const hash = await hashPassword(password);
-  console.log('\n=== Password Hash Generated ===\n');
-  console.log('Hash:', hash);
-  console.log('\n=== Run this SQL in production ===\n');
-  console.log(`npx wrangler d1 execute settimes-prod --remote --command "UPDATE users SET password_hash = '${hash}' WHERE email = 'admin@settimes.ca';"`);
+  console.log("\n=== Password Hash Generated ===\n");
+  console.log("Hash:", hash);
+  console.log("\n=== Run this SQL in production ===\n");
+  console.log(
+    `npx wrangler d1 execute settimes-prod --remote --command "UPDATE users SET password_hash = '${hash}' WHERE email = 'admin@settimes.ca';"`,
+  );
 }
 
 main();

--- a/scripts/seed-e2e-admin.mjs
+++ b/scripts/seed-e2e-admin.mjs
@@ -1,22 +1,22 @@
-import { hashPassword } from '../functions/utils/crypto.js'
+import { hashPassword } from "../functions/utils/crypto.js";
 
-const args = process.argv.slice(2)
-const emailIdx = args.indexOf('--email')
-const passwordIdx = args.indexOf('--password')
+const args = process.argv.slice(2);
+const emailIdx = args.indexOf("--email");
+const passwordIdx = args.indexOf("--password");
 
 if (emailIdx === -1 || passwordIdx === -1 || !args[emailIdx + 1] || !args[passwordIdx + 1]) {
-  console.error('Usage: node scripts/seed-e2e-admin.mjs --email <email> --password <password>')
-  process.exit(1)
+  console.error("Usage: node scripts/seed-e2e-admin.mjs --email <email> --password <password>");
+  process.exit(1);
 }
 
-const email = args[emailIdx + 1]
-const password = args[passwordIdx + 1]
+const email = args[emailIdx + 1];
+const password = args[passwordIdx + 1];
 
 // Escape single quotes for SQLite
-const esc = v => v.replace(/'/g, "''")
+const esc = (v) => v.replace(/'/g, "''");
 
-const hash = await hashPassword(password)
+const hash = await hashPassword(password);
 
 process.stdout.write(
-  `INSERT OR REPLACE INTO users (id, email, name, password_hash, role, is_active, activated_at) VALUES (100, '${esc(email)}', 'E2E Admin', '${esc(hash)}', 'admin', 1, datetime('now'));`
-)
+  `INSERT OR REPLACE INTO users (id, email, name, password_hash, role, is_active, activated_at) VALUES (100, '${esc(email)}', 'E2E Admin', '${esc(hash)}', 'admin', 1, datetime('now'));`,
+);

--- a/scripts/validate-db-schema.js
+++ b/scripts/validate-db-schema.js
@@ -36,9 +36,7 @@ async function ensureFile(rule) {
     throw new Error(`${rule.path} is empty`);
   }
 
-  const missingTables = rule.tables.filter(
-    (table) => !hasCreateTable(sql, table),
-  );
+  const missingTables = rule.tables.filter((table) => !hasCreateTable(sql, table));
   if (missingTables.length) {
     throw new Error(
       `${rule.path} is missing required tables: ${missingTables.join(", ")}. ` +
@@ -46,11 +44,8 @@ async function ensureFile(rule) {
     );
   }
 
-  const missingColumns = Object.entries(rule.requiredColumns || {}).flatMap(
-    ([table, columns]) =>
-      columns
-        .filter((column) => !hasColumn(sql, table, column))
-        .map((column) => `${table}.${column}`),
+  const missingColumns = Object.entries(rule.requiredColumns || {}).flatMap(([table, columns]) =>
+    columns.filter((column) => !hasColumn(sql, table, column)).map((column) => `${table}.${column}`),
   );
 
   if (missingColumns.length) {
@@ -69,10 +64,7 @@ function hasCreateTable(sql, table) {
 }
 
 function hasColumn(sql, table, column) {
-  const tablePattern = new RegExp(
-    `CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${table}\\s*\\((.*?)\\)\\s*;`,
-    "is",
-  );
+  const tablePattern = new RegExp(`CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${table}\\s*\\((.*?)\\)\\s*;`, "is");
   const tableMatch = sql.match(tablePattern);
   if (!tableMatch) return false;
 
@@ -89,9 +81,7 @@ async function main() {
 
     console.log("✅ Database schema validated:");
     for (const summary of summaries) {
-      console.log(
-        `  • ${summary.file} (${summary.tables} required tables present)`,
-      );
+      console.log(`  • ${summary.file} (${summary.tables} required tables present)`);
     }
   } catch (error) {
     console.error("❌ Schema validation failed:");

--- a/scripts/verify-remote-d1-schema.mjs
+++ b/scripts/verify-remote-d1-schema.mjs
@@ -1,102 +1,65 @@
 #!/usr/bin/env node
 
-import { execFile } from 'node:child_process';
-import { access } from 'node:fs/promises';
-import path from 'node:path';
-import { promisify } from 'node:util';
+import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
 const MAX_ERROR_OUTPUT_LENGTH = 500;
 
 const REQUIRED_SCHEMA = {
-  events: ['id', 'slug', 'city', 'is_published', 'reveal_mode'],
-  venues: ['id', 'name', 'city'],
-  band_profiles: ['id', 'name', 'name_normalized', 'genre', 'photo_url'],
+  events: ["id", "slug", "city", "is_published", "reveal_mode"],
+  venues: ["id", "name", "city"],
+  band_profiles: ["id", "name", "name_normalized", "genre", "photo_url"],
   performances: [
-    'id',
-    'event_id',
-    'venue_id',
-    'band_profile_id',
-    'start_time',
-    'end_time',
-    'is_announced',
-    'band_follow_notified',
+    "id",
+    "event_id",
+    "venue_id",
+    "band_profile_id",
+    "start_time",
+    "end_time",
+    "is_announced",
+    "band_follow_notified",
   ],
-  users: [
-    'id',
-    'email',
-    'password_hash',
-    'role',
-    'is_active',
-    'totp_enabled',
-    'totp_secret',
-    'backup_codes',
-  ],
-  lucia_sessions: ['id', 'user_id', 'expires_at', 'ip_address', 'user_agent', 'created_at', 'last_activity_at'],
-  invite_codes: ['id', 'code', 'role', 'is_active', 'expires_at'],
-  password_reset_tokens: [
-    'id',
-    'token',
-    'user_id',
-    'created_by',
-    'used',
-    'expires_at',
-  ],
-  mfa_challenges: [
-    'id',
-    'token',
-    'user_id',
-    'ip_address',
-    'user_agent',
-    'expires_at',
-    'used',
-    'used_at',
-    'created_at',
-  ],
+  users: ["id", "email", "password_hash", "role", "is_active", "totp_enabled", "totp_secret", "backup_codes"],
+  lucia_sessions: ["id", "user_id", "expires_at", "ip_address", "user_agent", "created_at", "last_activity_at"],
+  invite_codes: ["id", "code", "role", "is_active", "expires_at"],
+  password_reset_tokens: ["id", "token", "user_id", "created_by", "used", "expires_at"],
+  mfa_challenges: ["id", "token", "user_id", "ip_address", "user_agent", "expires_at", "used", "used_at", "created_at"],
   auth_attempts: [
-    'id',
-    'user_id',
-    'email',
-    'ip_address',
-    'user_agent',
-    'attempt_type',
-    'success',
-    'failure_reason',
-    'created_at',
+    "id",
+    "user_id",
+    "email",
+    "ip_address",
+    "user_agent",
+    "attempt_type",
+    "success",
+    "failure_reason",
+    "created_at",
   ],
-  auth_audit: ['id', 'action', 'success', 'ip_address', 'user_agent', 'timestamp'],
-  rate_limits: ['key', 'count', 'window_start', 'updated_at'],
-  trusted_devices: ['id', 'token', 'user_id', 'expires_at'],
-  email_otp_codes: ['id', 'user_id', 'code_hash', 'expires_at', 'verified'],
-  audit_log: ['id', 'user_id', 'action', 'resource_type', 'created_at'],
-  band_follows: [
-    'id',
-    'email',
-    'band_profile_id',
-    'verified',
-    'verification_token',
-    'unsubscribe_token',
-    'created_at',
-  ],
+  auth_audit: ["id", "action", "success", "ip_address", "user_agent", "timestamp"],
+  rate_limits: ["key", "count", "window_start", "updated_at"],
+  trusted_devices: ["id", "token", "user_id", "expires_at"],
+  email_otp_codes: ["id", "user_id", "code_hash", "expires_at", "verified"],
+  audit_log: ["id", "user_id", "action", "resource_type", "created_at"],
+  band_follows: ["id", "email", "band_profile_id", "verified", "verification_token", "unsubscribe_token", "created_at"],
 };
 
 const wranglerBin = path.join(
   process.cwd(),
-  'frontend',
-  'node_modules',
-  '.bin',
-  process.platform === 'win32' ? 'wrangler.cmd' : 'wrangler'
+  "frontend",
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "wrangler.cmd" : "wrangler",
 );
 
 function getDatabaseName() {
-  const databaseName =
-    process.argv[2]?.trim() || process.env.D1_DATABASE_NAME?.trim();
+  const databaseName = process.argv[2]?.trim() || process.env.D1_DATABASE_NAME?.trim();
 
   if (!databaseName) {
-    throw new Error(
-      'Provide a D1 database name as the first argument or via D1_DATABASE_NAME.'
-    );
+    throw new Error("Provide a D1 database name as the first argument or via D1_DATABASE_NAME.");
   }
 
   if (!/^[A-Za-z0-9_-]+$/.test(databaseName)) {
@@ -111,7 +74,7 @@ async function checkWranglerExists() {
     await access(wranglerBin);
   } catch {
     throw new Error(
-      `Wrangler binary not found at ${wranglerBin}. Run \`npm ci\` inside the frontend directory to install dependencies.`
+      `Wrangler binary not found at ${wranglerBin}. Run \`npm ci\` inside the frontend directory to install dependencies.`,
     );
   }
 }
@@ -119,12 +82,12 @@ async function checkWranglerExists() {
 async function runWranglerQuery(databaseName, query) {
   const { stdout, stderr } = await execFileAsync(
     wranglerBin,
-    ['d1', 'execute', databaseName, '--remote', '--json', '--command', query],
+    ["d1", "execute", databaseName, "--remote", "--json", "--command", query],
     {
       cwd: process.cwd(),
       env: process.env,
       maxBuffer: 1024 * 1024 * 8,
-    }
+    },
   );
 
   return { stdout, stderr };
@@ -155,7 +118,7 @@ async function verifyTables(databaseName) {
   const tableNames = Object.keys(REQUIRED_SCHEMA);
   const query = `SELECT name FROM sqlite_schema WHERE type = 'table' AND name IN (${tableNames
     .map((table) => `'${table}'`)
-    .join(', ')}) ORDER BY name;`;
+    .join(", ")}) ORDER BY name;`;
   const { stdout, stderr } = await runWranglerQuery(databaseName, query);
   const parsed = parseWranglerJson(stdout);
 
@@ -163,39 +126,30 @@ async function verifyTables(databaseName) {
     const stdoutSnippet = stdout.trim().slice(0, MAX_ERROR_OUTPUT_LENGTH);
     throw new Error(
       [
-        'Could not parse table list from Wrangler output.',
+        "Could not parse table list from Wrangler output.",
         stderr.trim() && `stderr: ${stderr.trim()}`,
         stdoutSnippet && `stdout: ${stdoutSnippet}`,
       ]
         .filter(Boolean)
-        .join('\n')
+        .join("\n"),
     );
   }
 
-  const existingTables = new Set(
-    parsed.rows.map((row) => row[0]).filter(Boolean)
-  );
+  const existingTables = new Set(parsed.rows.map((row) => row[0]).filter(Boolean));
 
-  const missingTables = tableNames.filter(
-    (table) => !existingTables.has(table)
-  );
+  const missingTables = tableNames.filter((table) => !existingTables.has(table));
 
   if (missingTables.length > 0) {
-    throw new Error(
-      `Remote D1 schema is missing required tables: ${missingTables.join(', ')}`
-    );
+    throw new Error(`Remote D1 schema is missing required tables: ${missingTables.join(", ")}`);
   }
 
   return tableNames;
 }
 
 async function verifyColumns(databaseName, table, columns) {
-  const { stdout, stderr } = await runWranglerQuery(
-    databaseName,
-    `PRAGMA table_info(${table});`
-  );
+  const { stdout, stderr } = await runWranglerQuery(databaseName, `PRAGMA table_info(${table});`);
   const parsed = parseWranglerJson(stdout);
-  const nameIndex = parsed.headers.indexOf('name');
+  const nameIndex = parsed.headers.indexOf("name");
 
   if (!parsed.parsedOk || nameIndex === -1) {
     const stdoutSnippet = stdout.trim().slice(0, MAX_ERROR_OUTPUT_LENGTH);
@@ -206,21 +160,15 @@ async function verifyColumns(databaseName, table, columns) {
         stdoutSnippet && `stdout: ${stdoutSnippet}`,
       ]
         .filter(Boolean)
-        .join('\n')
+        .join("\n"),
     );
   }
 
-  const existingColumns = new Set(
-    parsed.rows.map((row) => row[nameIndex]).filter(Boolean)
-  );
-  const missingColumns = columns.filter(
-    (column) => !existingColumns.has(column)
-  );
+  const existingColumns = new Set(parsed.rows.map((row) => row[nameIndex]).filter(Boolean));
+  const missingColumns = columns.filter((column) => !existingColumns.has(column));
 
   if (missingColumns.length > 0) {
-    throw new Error(
-      `Remote D1 schema is missing required columns for ${table}: ${missingColumns.join(', ')}`
-    );
+    throw new Error(`Remote D1 schema is missing required columns for ${table}: ${missingColumns.join(", ")}`);
   }
 }
 
@@ -241,7 +189,7 @@ async function main() {
 
     console.log(`Remote D1 schema verified for ${databaseName}`);
   } catch (error) {
-    console.error('Remote D1 schema verification failed:');
+    console.error("Remote D1 schema verification failed:");
     console.error(error.message);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

- Adds root `.prettierrc` (double-quotes, semi, `printWidth: 120`, `trailingComma: all`) scoped to `functions/` and `scripts/` — the frontend keeps its own `frontend/.prettierrc.json` untouched (single-quote, no-semi)
- Adds `format` / `format:check` scripts to root `package.json` with globs `functions/**/*.{js,json}` and `scripts/**/*.{js,mjs,json}`
- Adds `format-check-backend` job to `quality.yml` — mirrors the existing `format-check` job but installs root deps and runs `npm run format:check`
- Reformats 174 files (pure style: quote normalisation single→double, minor wrap adjustments); net diff is a reduction in lines because multi-line import blocks that fit in 120 chars get collapsed

## Config choices (to minimise churn)
- **Double quotes** — dominant in `functions/` (2090 `"` vs 1898 `'` across the tree); matches the most recently touched files (`authAttempts.js`, `import.js`, `validate-db-schema.js`)
- **printWidth 120** — same as the frontend; keeps long lines in `validate-db-schema.js` (arrays of column names) from being wrapped
- **semi: true / trailingComma: all** — matches existing conventions in the backend code

## Test plan
- [ ] `npm run format:check` at root passes (no files reported)
- [ ] Backend test suite: 558 tests, 68 files, all green
- [ ] `npm run validate:openapi` — 70 documented routes, no drift
- [ ] Frontend format check unchanged — `cd frontend && npm run format:check` still passes

Closes #451 (item 2 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8yAUALTtjKxBfxYqGDErP