### PR TITLE
fix(admin): gate bulk band apply on ignore_conflicts — run conflict detection (Closes #474)

### DIFF
--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -2084,6 +2084,55 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/ServerError"
+    patch:
+      tags:
+        - Admin - Bands
+      summary: Bulk update performances (change_time, move_venue, or delete)
+      description: >
+        Applies a bulk action to a set of performances. For `change_time` and
+        `move_venue`, scheduling conflicts are checked **before** any write. If
+        conflicts are found and `ignore_conflicts` is not `true`, the request is
+        rejected with **409** and no changes are applied. Pass
+        `ignore_conflicts: true` to force the apply despite conflicts. The
+        `delete` action has no conflict check.
+      security:
+        - AdminSessionCookie: []
+          CsrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BulkPatchRequest"
+      responses:
+        "200":
+          description: Bulk operation applied successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericRecord"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: >
+            Scheduling conflicts detected; no changes were applied. Re-submit
+            with `ignore_conflicts: true` to force the apply.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: conflicts
+                  conflicts:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/BulkConflict"
+        "500":
+          $ref: "#/components/responses/ServerError"
     delete:
       tags:
         - Admin - Bands
@@ -3879,6 +3928,56 @@ components:
         warning:
           type: string
           nullable: true
+
+    BulkPatchRequest:
+      type: object
+      required:
+        - band_ids
+        - action
+      properties:
+        band_ids:
+          type: array
+          maxItems: 200
+          items:
+            type: integer
+          description: Performance IDs to update
+        action:
+          type: string
+          enum:
+            - move_venue
+            - change_time
+            - delete
+        venue_id:
+          type: integer
+          nullable: true
+          description: Required for move_venue
+        start_time:
+          type: string
+          nullable: true
+          description: "Required for change_time; HH:MM format"
+        ignore_conflicts:
+          type: boolean
+          default: false
+          description: >
+            When true, skips conflict detection and forces the apply.
+            When false or absent, the request is rejected with 409 if
+            scheduling conflicts exist.
+
+    BulkConflict:
+      type: object
+      properties:
+        band_id:
+          type: integer
+        type:
+          type: string
+          enum:
+            - conflict
+            - overlap
+        message:
+          type: string
+        severity:
+          type: string
+          example: error
 
     BulkPreviewRequest:
       type: object

--- a/functions/api/admin/bands/__tests__/bulk.test.js
+++ b/functions/api/admin/bands/__tests__/bulk.test.js
@@ -1,5 +1,6 @@
 // Bulk band operations endpoint tests
-// DELETE /api/admin/bands/bulk
+// DELETE /api/admin/bands/bulk   – existing coverage
+// PATCH  /api/admin/bands/bulk   – conflict-gating coverage (issue #474)
 import { describe, expect, test, vi } from "vitest";
 
 vi.mock("../../_middleware.js", () => ({
@@ -19,8 +20,12 @@ vi.mock("../../_middleware.js", () => ({
   auditLog: vi.fn(async () => {}),
 }));
 
-import { onRequestDelete } from "../bulk.js";
-import { createTestEnv } from "../../../test-utils.js";
+import { onRequestDelete, onRequestPatch } from "../bulk.js";
+import { createTestEnv, insertBand, insertVenue, insertEvent } from "../../../test-utils.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function deleteRequest(env, bandIds) {
   return onRequestDelete({
@@ -34,6 +39,22 @@ function deleteRequest(env, bandIds) {
   });
 }
 
+function patchRequest(env, body, role = "editor") {
+  return onRequestPatch({
+    request: new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "x-test-role": role, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+    data: { user: { userId: 1, email: "a@b.c", role } },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DELETE tests (existing)
+// ---------------------------------------------------------------------------
+
 describe("DELETE /api/admin/bands/bulk", () => {
   test("reports success:false when some ids could not be deleted", async () => {
     const { env } = createTestEnv();
@@ -43,5 +64,296 @@ describe("DELETE /api/admin/bands/bulk", () => {
     expect(body.success).toBe(false);
     expect(body.errors).toBeTruthy();
     expect(body.deletedCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH – conflict-gating tests (issue #474)
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/admin/bands/bulk – change_time conflict gating", () => {
+  // Scenario:
+  //   Venue V1, Event E1
+  //   Band A: 18:00-19:00 at V1 (the band being changed, 1-hr set)
+  //   Band B: 20:00-21:00 at V1 (existing, NOT in batch)
+  //   Change A's start to 20:30 → new slot 20:30-21:30 → overlaps B (20:00-21:00)
+
+  function makeChangeTimeConflictFixture() {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Conflict Event", slug: "conflict-event", status: "draft" });
+    const venue = insertVenue(rawDb, { name: "Main Stage" });
+    const bandA = insertBand(rawDb, {
+      name: "Band Alpha",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
+    // Band B is at the same venue/event but NOT in the batch
+    insertBand(rawDb, {
+      name: "Band Beta",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    return { env, rawDb, bandA };
+  }
+
+  test("returns 409 with conflicts when ignore_conflicts is absent", async () => {
+    const { env, bandA } = makeChangeTimeConflictFixture();
+    const res = await patchRequest(env, {
+      band_ids: [bandA.id],
+      action: "change_time",
+      start_time: "20:30",
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("conflicts");
+    expect(Array.isArray(body.conflicts)).toBe(true);
+    expect(body.conflicts.length).toBeGreaterThan(0);
+    expect(body.conflicts[0].severity).toBe("error");
+  });
+
+  test("returns 409 with conflicts when ignore_conflicts is false", async () => {
+    const { env, bandA } = makeChangeTimeConflictFixture();
+    const res = await patchRequest(env, {
+      band_ids: [bandA.id],
+      action: "change_time",
+      start_time: "20:30",
+      ignore_conflicts: false,
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("conflicts");
+    expect(body.conflicts.length).toBeGreaterThan(0);
+  });
+
+  test("leaves DB unchanged when returning 409 (no partial apply)", async () => {
+    const { env, rawDb, bandA } = makeChangeTimeConflictFixture();
+    const resBefore = rawDb.prepare("SELECT start_time, end_time FROM performances WHERE id = ?").get(bandA.id);
+
+    const res = await patchRequest(env, {
+      band_ids: [bandA.id],
+      action: "change_time",
+      start_time: "20:30",
+    });
+    expect(res.status).toBe(409);
+
+    const resAfter = rawDb.prepare("SELECT start_time, end_time FROM performances WHERE id = ?").get(bandA.id);
+    expect(resAfter.start_time).toBe(resBefore.start_time);
+    expect(resAfter.end_time).toBe(resBefore.end_time);
+  });
+
+  test("applies change when ignore_conflicts is true, even with conflicts", async () => {
+    const { env, rawDb, bandA } = makeChangeTimeConflictFixture();
+    const res = await patchRequest(env, {
+      band_ids: [bandA.id],
+      action: "change_time",
+      start_time: "20:30",
+      ignore_conflicts: true,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // Verify DB was updated
+    const updated = rawDb.prepare("SELECT start_time, end_time FROM performances WHERE id = ?").get(bandA.id);
+    expect(updated.start_time).toBe("20:30");
+    // Duration was 1 hr, so new end = 21:30
+    expect(updated.end_time).toBe("21:30");
+  });
+
+  test("applies change with no conflicts regardless of ignore_conflicts flag", async () => {
+    // Band A alone — no other band at the venue — there is no conflict
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Clean Event", slug: "clean-event", status: "draft" });
+    const venue = insertVenue(rawDb, { name: "Solo Stage" });
+    const bandA = insertBand(rawDb, {
+      name: "Solo Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
+
+    const res = await patchRequest(env, {
+      band_ids: [bandA.id],
+      action: "change_time",
+      start_time: "22:00",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    const updated = rawDb.prepare("SELECT start_time, end_time FROM performances WHERE id = ?").get(bandA.id);
+    expect(updated.start_time).toBe("22:00");
+    expect(updated.end_time).toBe("23:00");
+  });
+});
+
+describe("PATCH /api/admin/bands/bulk – move_venue conflict gating", () => {
+  // Scenario:
+  //   Venue V1, Venue V2, Event E1
+  //   Band A: 18:00-19:00 at V1 (being moved to V2)
+  //   Band B: 18:30-19:30 at V2 (existing at V2, NOT in batch)
+  //   Moving A to V2 → A(18:00-19:00) overlaps B(18:30-19:30)
+
+  function makeMoveVenueConflictFixture() {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Venue Move Event", slug: "venue-move-event", status: "draft" });
+    const venueA = insertVenue(rawDb, { name: "Original Venue" });
+    const venueB = insertVenue(rawDb, { name: "Target Venue" });
+    const bandA = insertBand(rawDb, {
+      name: "Moving Band",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
+    // Existing band already at target venue — creates a conflict
+    insertBand(rawDb, {
+      name: "Resident Band",
+      event_id: event.id,
+      venue_id: venueB.id,
+      start_time: "18:30",
+      end_time: "19:30",
+    });
+    return { env, rawDb, bandA, venueBId: venueB.id };
+  }
+
+  test("returns 409 with conflicts when ignore_conflicts is absent", async () => {
+    const { env, bandA, venueBId } = makeMoveVenueConflictFixture();
+    const res = await patchRequest(env, {
+      band_ids: [bandA.id],
+      action: "move_venue",
+      venue_id: venueBId,
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("conflicts");
+    expect(Array.isArray(body.conflicts)).toBe(true);
+    expect(body.conflicts.length).toBeGreaterThan(0);
+    expect(body.conflicts[0].severity).toBe("error");
+  });
+
+  test("leaves DB unchanged when returning 409 (no partial apply)", async () => {
+    const { env, rawDb, bandA, venueBId } = makeMoveVenueConflictFixture();
+    const originalVenueId = rawDb.prepare("SELECT venue_id FROM performances WHERE id = ?").get(bandA.id).venue_id;
+
+    const res = await patchRequest(env, {
+      band_ids: [bandA.id],
+      action: "move_venue",
+      venue_id: venueBId,
+    });
+    expect(res.status).toBe(409);
+
+    const afterVenueId = rawDb.prepare("SELECT venue_id FROM performances WHERE id = ?").get(bandA.id).venue_id;
+    expect(afterVenueId).toBe(originalVenueId);
+  });
+
+  test("applies move when ignore_conflicts is true, even with conflicts", async () => {
+    const { env, rawDb, bandA, venueBId } = makeMoveVenueConflictFixture();
+    const res = await patchRequest(env, {
+      band_ids: [bandA.id],
+      action: "move_venue",
+      venue_id: venueBId,
+      ignore_conflicts: true,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    const updated = rawDb.prepare("SELECT venue_id FROM performances WHERE id = ?").get(bandA.id);
+    expect(updated.venue_id).toBe(venueBId);
+  });
+
+  test("applies move with no conflict regardless of ignore_conflicts flag", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Empty Target Event", slug: "empty-target-event", status: "draft" });
+    const venueA = insertVenue(rawDb, { name: "Source Venue" });
+    const venueC = insertVenue(rawDb, { name: "Empty Target Venue" });
+    const bandA = insertBand(rawDb, {
+      name: "Uncontested Band",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
+
+    const res = await patchRequest(env, {
+      band_ids: [bandA.id],
+      action: "move_venue",
+      venue_id: venueC.id,
+    });
+    expect(res.status).toBe(200);
+    const updated = rawDb.prepare("SELECT venue_id FROM performances WHERE id = ?").get(bandA.id);
+    expect(updated.venue_id).toBe(venueC.id);
+  });
+});
+
+describe("PATCH /api/admin/bands/bulk – after-midnight conflict detection", () => {
+  // Ensure buildIntervals handles midnight-crossing sets correctly in the gating path.
+  // Band A: 23:30-00:30 at V1 (crosses midnight; being moved)
+  // Band B: 23:45-01:00 at V2 (crosses midnight; existing at target)
+  // The sets overlap in the post-midnight window.
+
+  test("detects conflict between after-midnight sets on move_venue", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Late Night Event", slug: "late-night-event", status: "draft" });
+    const venueA = insertVenue(rawDb, { name: "Source Late Venue" });
+    const venueB = insertVenue(rawDb, { name: "Target Late Venue" });
+
+    const bandA = insertBand(rawDb, {
+      name: "Midnight Mover",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "23:30",
+      end_time: "00:30",
+    });
+    insertBand(rawDb, {
+      name: "Midnight Resident",
+      event_id: event.id,
+      venue_id: venueB.id,
+      start_time: "23:45",
+      end_time: "01:00",
+    });
+
+    const res = await patchRequest(env, {
+      band_ids: [bandA.id],
+      action: "move_venue",
+      venue_id: venueB.id,
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("conflicts");
+    expect(body.conflicts.length).toBeGreaterThan(0);
+  });
+});
+
+describe("PATCH /api/admin/bands/bulk – delete action", () => {
+  // delete has no conflict check; must still work normally.
+  test("delete action is unaffected by conflict-gating logic", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Delete Event", slug: "delete-event", status: "draft" });
+    const venue = insertVenue(rawDb, { name: "Delete Venue" });
+    const band = insertBand(rawDb, {
+      name: "Doomed Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
+
+    const res = await patchRequest(env, {
+      band_ids: [band.id],
+      action: "delete",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    const row = rawDb.prepare("SELECT id FROM performances WHERE id = ?").get(band.id);
+    expect(row).toBeUndefined();
   });
 });

--- a/functions/api/admin/bands/bulk-preview.js
+++ b/functions/api/admin/bands/bulk-preview.js
@@ -1,5 +1,5 @@
 import { checkPermission } from "../_middleware.js";
-import { buildIntervals, computeNewEndTime, intervalsOverlap } from "../../../utils/timeConflicts.js";
+import { detectBulkConflicts } from "../../../utils/timeConflicts.js";
 import { validateIdArray, isValidTime } from "../../../utils/validation.js";
 
 const MAX_BULK_PREVIEW_IDS = 200;
@@ -102,72 +102,13 @@ export async function onRequestPost(context) {
       });
     }
 
-    // Conflict detection: fetch all existing performances at target venue per event,
-    // then check for overlaps in JS (handles after-midnight sets correctly).
-    const eventIds = [...new Set(mutableBandResults.map((b) => b.event_id))];
-    const venuePerformancesByEvent = new Map();
-    for (const eventId of eventIds) {
-      const rows = await env.DB.prepare(
-        `SELECT p.id, p.start_time, p.end_time, bp.name
-         FROM performances p
-         JOIN band_profiles bp ON p.band_profile_id = bp.id
-         WHERE p.venue_id = ? AND p.event_id = ? AND p.id NOT IN (${placeholders})`,
-      )
-        .bind(venue_id, eventId, ...validatedBandIds)
-        .all();
-      venuePerformancesByEvent.set(eventId, rows.results || []);
-    }
-
-    for (const band of mutableBandResults) {
-      if (!band.start_time || !band.end_time) continue;
-      const bandIntervals = buildIntervals(band.start_time, band.end_time);
-      const existing = venuePerformancesByEvent.get(band.event_id) || [];
-      for (const other of existing) {
-        if (!other.start_time || !other.end_time) continue;
-        const otherIntervals = buildIntervals(other.start_time, other.end_time);
-        if (bandIntervals.some((a) => otherIntervals.some((b) => intervalsOverlap(a, b)))) {
-          const isExact = other.start_time === band.start_time && other.end_time === band.end_time;
-          conflicts.push({
-            band_id: band.id,
-            type: isExact ? "conflict" : "overlap",
-            message: isExact
-              ? `"${band.name}" has the exact same time as "${other.name}" at the new venue (${other.start_time}-${other.end_time})`
-              : `"${band.name}" overlaps with "${other.name}" at new venue (${other.start_time}-${other.end_time})`,
-            severity: "error",
-          });
-        }
-      }
-    }
-
-    // Check pairs within the batch for conflicts at the new venue.
-    // The pre-existing query excludes all batch members to avoid false positives from
-    // their current positions, so batch members are invisible to each other. We must
-    // compare them pairwise here. One entry per pair (not two mirror entries) to avoid
-    // duplicate messages in the preview modal.
-    for (let i = 0; i < mutableBandResults.length; i++) {
-      const bandA = mutableBandResults[i];
-      if (!bandA.start_time || !bandA.end_time) continue;
-      const intervalsA = buildIntervals(bandA.start_time, bandA.end_time);
-
-      for (let j = i + 1; j < mutableBandResults.length; j++) {
-        const bandB = mutableBandResults[j];
-        if (!bandB.start_time || !bandB.end_time) continue;
-        if (bandA.event_id !== bandB.event_id) continue;
-
-        const intervalsB = buildIntervals(bandB.start_time, bandB.end_time);
-        if (!intervalsA.some((a) => intervalsB.some((b) => intervalsOverlap(a, b)))) continue;
-
-        const isExact = bandA.start_time === bandB.start_time && bandA.end_time === bandB.end_time;
-        conflicts.push({
-          band_id: bandA.id,
-          type: isExact ? "conflict" : "overlap",
-          message: isExact
-            ? `"${bandA.name}" and "${bandB.name}" have the exact same time (both being moved to ${venue.name})`
-            : `"${bandA.name}" and "${bandB.name}" overlap (both being moved to ${venue.name})`,
-          severity: "error",
-        });
-      }
-    }
+    // Scheduling conflict detection via shared utility (handles after-midnight sets).
+    const schedulingConflicts = await detectBulkConflicts(env, {
+      action,
+      bandIds: validatedBandIds,
+      params: { venue_id },
+    });
+    conflicts.push(...schedulingConflicts);
   } else if (action === "change_time") {
     const { start_time } = params;
 
@@ -189,79 +130,13 @@ export async function onRequestPost(context) {
       });
     }
 
-    // Conflict detection: fetch existing performances at each band's venue per event,
-    // then check overlaps in JS using computeNewEndTime (preserves duration, handles midnight).
-    const changeTimeVenueKey = (venueId, eventId) => `${venueId}:${eventId}`;
-    const changeTimeCache = new Map();
-
-    for (const band of mutableBandResults) {
-      if (!band.start_time || !band.end_time || !band.venue_id) continue;
-
-      const newEndTime = computeNewEndTime(band.start_time, band.end_time, start_time);
-      const cacheKey = changeTimeVenueKey(band.venue_id, band.event_id);
-
-      if (!changeTimeCache.has(cacheKey)) {
-        const rows = await env.DB.prepare(
-          `SELECT p.id, p.start_time, p.end_time, bp.name
-           FROM performances p
-           JOIN band_profiles bp ON p.band_profile_id = bp.id
-           WHERE p.venue_id = ? AND p.event_id = ? AND p.id NOT IN (${placeholders})`,
-        )
-          .bind(band.venue_id, band.event_id, ...validatedBandIds)
-          .all();
-        changeTimeCache.set(cacheKey, rows.results || []);
-      }
-
-      const existing = changeTimeCache.get(cacheKey);
-      const bandIntervals = buildIntervals(start_time, newEndTime);
-
-      for (const other of existing) {
-        if (!other.start_time || !other.end_time) continue;
-        const otherIntervals = buildIntervals(other.start_time, other.end_time);
-        if (bandIntervals.some((a) => otherIntervals.some((b) => intervalsOverlap(a, b)))) {
-          const isExact = other.start_time === start_time && other.end_time === newEndTime;
-          conflicts.push({
-            band_id: band.id,
-            type: isExact ? "conflict" : "overlap",
-            message: isExact
-              ? `"${band.name}" has the exact same time as "${other.name}" at venue (${other.start_time}-${other.end_time})`
-              : `"${band.name}" overlaps with "${other.name}" at venue (${other.start_time}-${other.end_time})`,
-            severity: "error",
-          });
-        }
-      }
-    }
-
-    // Check pairs that share venue+event — both receive the same new start_time so they
-    // will always overlap at minimum. The pre-existing cache excludes all batch members,
-    // making them invisible to each other. One entry per pair to avoid duplicate messages
-    // in the preview modal.
-    for (let i = 0; i < mutableBandResults.length; i++) {
-      const bandA = mutableBandResults[i];
-      if (!bandA.start_time || !bandA.end_time || !bandA.venue_id) continue;
-
-      for (let j = i + 1; j < mutableBandResults.length; j++) {
-        const bandB = mutableBandResults[j];
-        if (!bandB.start_time || !bandB.end_time || !bandB.venue_id) continue;
-        if (bandA.venue_id !== bandB.venue_id || bandA.event_id !== bandB.event_id) continue;
-
-        const newEndA = computeNewEndTime(bandA.start_time, bandA.end_time, start_time);
-        const newEndB = computeNewEndTime(bandB.start_time, bandB.end_time, start_time);
-        const intervalsA = buildIntervals(start_time, newEndA);
-        const intervalsB = buildIntervals(start_time, newEndB);
-        if (!intervalsA.some((a) => intervalsB.some((b) => intervalsOverlap(a, b)))) continue;
-
-        const isExact = newEndA === newEndB;
-        conflicts.push({
-          band_id: bandA.id,
-          type: isExact ? "conflict" : "overlap",
-          message: isExact
-            ? `"${bandA.name}" and "${bandB.name}" have the exact same time at venue after time change`
-            : `"${bandA.name}" and "${bandB.name}" overlap at venue after time change`,
-          severity: "error",
-        });
-      }
-    }
+    // Scheduling conflict detection via shared utility (handles after-midnight sets).
+    const schedulingConflicts = await detectBulkConflicts(env, {
+      action,
+      bandIds: validatedBandIds,
+      params: { start_time },
+    });
+    conflicts.push(...schedulingConflicts);
   } else if (action === "delete") {
     // Build changes list for deletion
     for (const band of mutableBandResults) {

--- a/functions/api/admin/bands/bulk.js
+++ b/functions/api/admin/bands/bulk.js
@@ -1,6 +1,6 @@
 import { auditLog, checkPermission } from "../_middleware.js";
 import { getClientIP } from "../../../utils/request.js";
-import { computeNewEndTime } from "../../../utils/timeConflicts.js";
+import { computeNewEndTime, detectBulkConflicts } from "../../../utils/timeConflicts.js";
 import { isValidTime, validateIdArray } from "../../../utils/validation.js";
 
 const MAX_BULK_BAND_IDS = 200;
@@ -403,11 +403,7 @@ export async function onRequestPatch(context) {
       headers: { "Content-Type": "application/json" },
     });
   }
-  // NOTE: ignore_conflicts is accepted by the API (frontend sends it via bulkUpdate) but the
-  // PATCH handler does not currently perform conflict detection — so the flag has no effect.
-  // This is a known gap: conflict detection should be run here for change_time/move_venue actions
-  // and the flag should gate whether a conflict aborts the request. Track as a separate issue.
-  const { band_ids, action, ignore_conflicts: _ignore_conflicts, ...params } = body;
+  const { band_ids, action, ignore_conflicts, ...params } = body;
 
   if (!Array.isArray(band_ids) || band_ids.length === 0) {
     return new Response(JSON.stringify({ error: "Invalid band_ids" }), {
@@ -481,6 +477,23 @@ export async function onRequestPatch(context) {
         });
       }
 
+      // Conflict detection runs BEFORE any write. When ignore_conflicts is not
+      // explicitly true, reject with 409 if scheduling conflicts exist so the
+      // caller can re-confirm before applying.
+      if (ignore_conflicts !== true) {
+        const conflicts = await detectBulkConflicts(env, {
+          action,
+          bandIds: validatedBandIds,
+          params: { venue_id },
+        });
+        if (conflicts.length > 0) {
+          return new Response(JSON.stringify({ error: "conflicts", conflicts }), {
+            status: 409,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+      }
+
       // Build batch update statements (ATOMIC - all or nothing)
       const statements = validatedBandIds.map((id) =>
         env.DB.prepare("UPDATE performances SET venue_id = ? WHERE id = ?").bind(venue_id, id),
@@ -496,6 +509,22 @@ export async function onRequestPatch(context) {
           status: 400,
           headers: { "Content-Type": "application/json" },
         });
+      }
+
+      // Conflict detection runs BEFORE any write. When ignore_conflicts is not
+      // explicitly true, reject with 409 if scheduling conflicts exist.
+      if (ignore_conflicts !== true) {
+        const conflicts = await detectBulkConflicts(env, {
+          action,
+          bandIds: validatedBandIds,
+          params: { start_time },
+        });
+        if (conflicts.length > 0) {
+          return new Response(JSON.stringify({ error: "conflicts", conflicts }), {
+            status: 409,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
       }
 
       // Fetch current times so we can compute new end_time in JS.

--- a/functions/utils/timeConflicts.js
+++ b/functions/utils/timeConflicts.js
@@ -31,3 +31,193 @@ export function computeNewEndTime(oldStart, oldEnd, newStart) {
   if (dur < 0) dur += 24 * 60;
   return fromMins((toMinutes(newStart) + dur) % (24 * 60));
 }
+
+/**
+ * Detect scheduling conflicts for a bulk move_venue or change_time operation.
+ *
+ * Encapsulates the DB queries, existing-performance checks, and within-batch
+ * pair checks. Handles after-midnight sets correctly via buildIntervals.
+ * Archived-event conflicts are NOT included — callers handle those separately.
+ *
+ * @param {Object} env - Cloudflare env with DB binding
+ * @param {Object} opts
+ * @param {string} opts.action - "move_venue" or "change_time"
+ * @param {number[]} opts.bandIds - Validated integer performance IDs (non-empty)
+ * @param {Object} opts.params - { venue_id } for move_venue, { start_time } for change_time
+ * @returns {Promise<Array>} Array of conflict objects ({ band_id, type, message, severity })
+ */
+export async function detectBulkConflicts(env, { action, bandIds, params }) {
+  if (!bandIds || bandIds.length === 0) return [];
+
+  const conflicts = [];
+  const placeholders = bandIds.map(() => "?").join(",");
+
+  // Fetch performance data for the batch (non-archived only).
+  // Archived-event filtering is intentionally skipped here; callers that need
+  // archived-event error messages (bulk-preview) handle that themselves.
+  const bands = await env.DB.prepare(
+    `SELECT p.id, p.start_time, p.end_time, p.venue_id, p.event_id, bp.name, e.status AS event_status
+     FROM performances p
+     JOIN band_profiles bp ON p.band_profile_id = bp.id
+     JOIN events e ON p.event_id = e.id
+     WHERE p.id IN (${placeholders})`,
+  )
+    .bind(...bandIds)
+    .all();
+
+  const bandResults = (bands.results || []).filter((b) => b.event_status !== "archived");
+
+  if (action === "move_venue") {
+    const { venue_id } = params;
+
+    const venue = await env.DB.prepare("SELECT name FROM venues WHERE id = ?").bind(venue_id).first();
+    // Venue existence is validated by callers before this function runs; if
+    // somehow absent just return no conflicts rather than throwing.
+    if (!venue) return [];
+
+    // Fetch existing performances at the target venue per event, excluding all
+    // batch members so they are invisible to the per-band check below (they are
+    // handled pairwise instead to avoid double-reporting).
+    const eventIds = [...new Set(bandResults.map((b) => b.event_id))];
+    const venuePerformancesByEvent = new Map();
+    for (const eventId of eventIds) {
+      const rows = await env.DB.prepare(
+        `SELECT p.id, p.start_time, p.end_time, bp.name
+         FROM performances p
+         JOIN band_profiles bp ON p.band_profile_id = bp.id
+         WHERE p.venue_id = ? AND p.event_id = ? AND p.id NOT IN (${placeholders})`,
+      )
+        .bind(venue_id, eventId, ...bandIds)
+        .all();
+      venuePerformancesByEvent.set(eventId, rows.results || []);
+    }
+
+    // Check each batch member against existing performances at the target venue.
+    for (const band of bandResults) {
+      if (!band.start_time || !band.end_time) continue;
+      const bandIntervals = buildIntervals(band.start_time, band.end_time);
+      const existing = venuePerformancesByEvent.get(band.event_id) || [];
+      for (const other of existing) {
+        if (!other.start_time || !other.end_time) continue;
+        const otherIntervals = buildIntervals(other.start_time, other.end_time);
+        if (bandIntervals.some((a) => otherIntervals.some((b) => intervalsOverlap(a, b)))) {
+          const isExact = other.start_time === band.start_time && other.end_time === band.end_time;
+          conflicts.push({
+            band_id: band.id,
+            type: isExact ? "conflict" : "overlap",
+            message: isExact
+              ? `"${band.name}" has the exact same time as "${other.name}" at the new venue (${other.start_time}-${other.end_time})`
+              : `"${band.name}" overlaps with "${other.name}" at new venue (${other.start_time}-${other.end_time})`,
+            severity: "error",
+          });
+        }
+      }
+    }
+
+    // Pairwise check within the batch (same event). Batch members are excluded
+    // from the existing-performances query above, so they are invisible to each
+    // other there; we must compare them here. One entry per pair to avoid
+    // duplicates.
+    for (let i = 0; i < bandResults.length; i++) {
+      const bandA = bandResults[i];
+      if (!bandA.start_time || !bandA.end_time) continue;
+      const intervalsA = buildIntervals(bandA.start_time, bandA.end_time);
+
+      for (let j = i + 1; j < bandResults.length; j++) {
+        const bandB = bandResults[j];
+        if (!bandB.start_time || !bandB.end_time) continue;
+        if (bandA.event_id !== bandB.event_id) continue;
+
+        const intervalsB = buildIntervals(bandB.start_time, bandB.end_time);
+        if (!intervalsA.some((a) => intervalsB.some((b) => intervalsOverlap(a, b)))) continue;
+
+        const isExact = bandA.start_time === bandB.start_time && bandA.end_time === bandB.end_time;
+        conflicts.push({
+          band_id: bandA.id,
+          type: isExact ? "conflict" : "overlap",
+          message: isExact
+            ? `"${bandA.name}" and "${bandB.name}" have the exact same time (both being moved to ${venue.name})`
+            : `"${bandA.name}" and "${bandB.name}" overlap (both being moved to ${venue.name})`,
+          severity: "error",
+        });
+      }
+    }
+  } else if (action === "change_time") {
+    const { start_time } = params;
+
+    // Cache existing performances per (venue, event) pair so we query each
+    // unique combination at most once.
+    const changeTimeVenueKey = (venueId, eventId) => `${venueId}:${eventId}`;
+    const changeTimeCache = new Map();
+
+    for (const band of bandResults) {
+      if (!band.start_time || !band.end_time || !band.venue_id) continue;
+
+      const newEndTime = computeNewEndTime(band.start_time, band.end_time, start_time);
+      const cacheKey = changeTimeVenueKey(band.venue_id, band.event_id);
+
+      if (!changeTimeCache.has(cacheKey)) {
+        const rows = await env.DB.prepare(
+          `SELECT p.id, p.start_time, p.end_time, bp.name
+           FROM performances p
+           JOIN band_profiles bp ON p.band_profile_id = bp.id
+           WHERE p.venue_id = ? AND p.event_id = ? AND p.id NOT IN (${placeholders})`,
+        )
+          .bind(band.venue_id, band.event_id, ...bandIds)
+          .all();
+        changeTimeCache.set(cacheKey, rows.results || []);
+      }
+
+      const existing = changeTimeCache.get(cacheKey);
+      const bandIntervals = buildIntervals(start_time, newEndTime);
+
+      for (const other of existing) {
+        if (!other.start_time || !other.end_time) continue;
+        const otherIntervals = buildIntervals(other.start_time, other.end_time);
+        if (bandIntervals.some((a) => otherIntervals.some((b) => intervalsOverlap(a, b)))) {
+          const isExact = other.start_time === start_time && other.end_time === newEndTime;
+          conflicts.push({
+            band_id: band.id,
+            type: isExact ? "conflict" : "overlap",
+            message: isExact
+              ? `"${band.name}" has the exact same time as "${other.name}" at venue (${other.start_time}-${other.end_time})`
+              : `"${band.name}" overlaps with "${other.name}" at venue (${other.start_time}-${other.end_time})`,
+            severity: "error",
+          });
+        }
+      }
+    }
+
+    // Pairwise check for batch members that share venue + event. All receive the
+    // same new start_time so any pair at the same venue/event will overlap at
+    // minimum. One entry per pair to avoid duplicates.
+    for (let i = 0; i < bandResults.length; i++) {
+      const bandA = bandResults[i];
+      if (!bandA.start_time || !bandA.end_time || !bandA.venue_id) continue;
+
+      for (let j = i + 1; j < bandResults.length; j++) {
+        const bandB = bandResults[j];
+        if (!bandB.start_time || !bandB.end_time || !bandB.venue_id) continue;
+        if (bandA.venue_id !== bandB.venue_id || bandA.event_id !== bandB.event_id) continue;
+
+        const newEndA = computeNewEndTime(bandA.start_time, bandA.end_time, start_time);
+        const newEndB = computeNewEndTime(bandB.start_time, bandB.end_time, start_time);
+        const intervalsA = buildIntervals(start_time, newEndA);
+        const intervalsB = buildIntervals(start_time, newEndB);
+        if (!intervalsA.some((a) => intervalsB.some((b) => intervalsOverlap(a, b)))) continue;
+
+        const isExact = newEndA === newEndB;
+        conflicts.push({
+          band_id: bandA.id,
+          type: isExact ? "conflict" : "overlap",
+          message: isExact
+            ? `"${bandA.name}" and "${bandB.name}" have the exact same time at venue after time change`
+            : `"${bandA.name}" and "${bandB.name}" overlap at venue after time change`,
+          severity: "error",
+        });
+      }
+    }
+  }
+
+  return conflicts;
+}

--- a/functions/utils/timeConflicts.js
+++ b/functions/utils/timeConflicts.js
@@ -52,9 +52,9 @@ export async function detectBulkConflicts(env, { action, bandIds, params }) {
   const conflicts = [];
   const placeholders = bandIds.map(() => "?").join(",");
 
-  // Fetch performance data for the batch (non-archived only).
-  // Archived-event filtering is intentionally skipped here; callers that need
-  // archived-event error messages (bulk-preview) handle that themselves.
+  // Fetch all performance data for the batch (including archived events), then
+  // filter out archived-event rows before scheduling-conflict checks. Callers
+  // that need archived-event error messages (bulk-preview) handle those separately.
   const bands = await env.DB.prepare(
     `SELECT p.id, p.start_time, p.end_time, p.venue_id, p.event_id, bp.name, e.status AS event_status
      FROM performances p


### PR DESCRIPTION
## The bug (#474)
Admin **bulk band apply** (`bulk.js` `onRequestPatch`) accepted `ignore_conflicts` but never ran scheduling-conflict detection — it applied `change_time`/`move_venue` unconditionally and silently dropped the flag. An admin who previewed conflicts and chose *not* to ignore them still got the changes applied, creating scheduling conflicts. (Surfaced by Copilot on #473 + Sonny's investigation.)

## Fix
- **Extracted** the conflict-detection orchestration (previously inline in `bulk-preview.js`) into a shared `detectBulkConflicts(env, { action, bandIds, params })` in `functions/utils/timeConflicts.js` — existing-performance-at-venue check + within-batch pairwise check, after-midnight handling via `buildIntervals`.
- **`bulk-preview.js`** now delegates scheduling detection to it (archived-event conflicts stay inline); response shape is byte-identical.
- **`bulk.js` apply** now gates: for `move_venue`/`change_time`, when `ignore_conflicts !== true`, run detection and return **409** `{ error: "conflicts", conflicts }` if any exist — **strictly before** the atomic `DB.batch`, so a rejection applies nothing. `ignore_conflicts === true` skips detection; `delete` is unaffected.

## Correctness properties
- Detection runs after validation, before any write; no partial apply possible.
- `ignore_conflicts !== true` is **fail-safe** — absent/`false`/any non-`true` value → conflicts are checked; only literal `true` overrides.
- After-midnight sets handled (buildIntervals); `checkPermission` unchanged.

## Tests
11 new in `bulk.test.js` (12 total): conflict → 409 with flag absent/`false` (+ DB asserted unchanged), `true` → 200 with DB asserted changed, no-conflict → 200, **after-midnight** move → 409, `delete` unaffected.

## Note (intentional trade-off)
Preview now runs detection via the shared helper, which queries band data independently — so preview does one extra query. Accepted for a clean, self-contained shared function; correctness-neutral.

## Verification
**569 tests pass**, `eslint` 0 errors, `format:check` clean, `validate:openapi` no drift (added the PATCH entry + 409 + `BulkPatchRequest`/`BulkConflict` schemas). Built by Sonny; **pre-PR reviewed by Theo (orchestrator)** — correctness + nit sweep, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
