### PR TITLE
chore(repo): anchor instructions/ gitignore + commit PR template & Copilot instructions — closes #486

### DIFF
--- a/.github/instructions/a11y.instructions.md
+++ b/.github/instructions/a11y.instructions.md
@@ -1,0 +1,731 @@
+---
+applyTo: '**'
+description: 'Comprehensive web accessibility standards based on WCAG 2.2 AA, with 38+ anti-patterns, legal enforcement context (EAA, ADA Title II), WAI-ARIA patterns, and framework-specific fixes for modern web frameworks and libraries.'
+---
+
+# Accessibility Standards
+
+Comprehensive accessibility rules for web application development. Every anti-pattern includes a severity classification, detection method, WCAG 2.2 reference, and corrective code examples.
+
+**Severity levels:**
+
+- **CRITICAL** — Users cannot access content at all. Must be fixed before merge.
+- **IMPORTANT** — Significant barrier for assistive technology users. Fix in same sprint.
+- **SUGGESTION** — Improves usability for assistive technology. Plan for a future iteration.
+
+---
+
+## WCAG 2.2 Quick Reference (AA Level)
+
+### Perceivable
+
+| Criterion | Level | Summary |
+|-----------|-------|---------|
+| 1.1.1 Non-text Content | A | All non-text content has a text alternative. Decorative images use `alt=""`. |
+| 1.2.1 Audio/Video-only | A | Provide transcript (audio) or text alternative (video). |
+| 1.2.2 Captions (Prerecorded) | A | All prerecorded video has synchronized captions. |
+| 1.3.1 Info and Relationships | A | Structure (headings, lists, tables, labels, landmarks) programmatically conveyed. |
+| 1.3.2 Meaningful Sequence | A | When the sequence that content is presented affects its meaning, the visual and programmatic ordering of content should align. |
+| 1.3.3 Sensory Characteristics | A | Instructions don't rely solely on shape, size, position, or sound. |
+| 1.3.4 Orientation | AA | Content is not restricted to single orientation unless essential. |
+| 1.3.5 Identify Input Purpose | AA | Input fields have `autocomplete` attributes when collecting information about the user. |
+| 1.4.1 Use of Color | A | Color is not the only means of conveying info. |
+| 1.4.3 Contrast (Minimum) | AA | Text: 4.5:1 normal, 3:1 large (18pt / 14pt bold). |
+| 1.4.4 Resize Text | AA | Text resizable to 200% without loss of content or functionality. |
+| 1.4.10 Reflow | AA | Sections of content can fit within 320px CSS width viewports without needing to scroll in two dimensions to read. |
+| 1.4.11 Non-text Contrast | AA | UI components and graphics: 3:1 against adjacent colors. |
+| 1.4.12 Text Spacing | AA | No loss of content or functionality with user-overridden line-height (1.5x), or specified paragraph spacing, letter spacing, and word spacing adjustments. |
+| 1.4.13 Content on Hover/Focus | AA | Popup content that appears on hover or focus is: dismissible, hoverable, persistent. |
+
+### Operable
+
+| Criterion | Level | Summary |
+|-----------|-------|---------|
+| 2.1.1 Keyboard | A | All functionality operable via keyboard. |
+| 2.1.2 No Keyboard Trap | A | User can navigate away from any component using keyboard. |
+| 2.2.1 Timing Adjustable | A | Time limits can be extended or disabled. |
+| 2.2.2 Pause, Stop, Hide | A | Auto-updating content can be paused. |
+| 2.3.1 Three Flashes | A | No content flashes more than 3 times per second. |
+| 2.4.1 Bypass Blocks | A | Skip link to bypass repeated navigation. |
+| 2.4.2 Page Titled | A | Pages have descriptive `<title>`. |
+| 2.4.3 Focus Order | A | Focus order preserves meaning and operability. |
+| 2.4.4 Link Purpose | A | Link purpose determinable from text or context. |
+| 2.4.6 Headings and Labels | AA | Headings and labels describe topic or purpose. |
+| 2.4.7 Focus Visible | AA | Keyboard focus indicator is visible. |
+| 2.4.11 Focus Not Obscured | AA | Focused element not entirely hidden by other overlaying elements (such as sticky headers or footers). *(New in 2.2)* |
+| 2.5.1 Pointer Gestures | A | Multi-point gestures have single-pointer alternative. |
+| 2.5.2 Pointer Cancellation | A | Activation on up-event, unless activation can be aborted, reversed, or down-event activation is essential. |
+| 2.5.3 Label in Name | A | Accessible name contains the label text as it is visually presented. |
+| 2.5.4 Motion Actuation | A | Device motion has UI alternative and can be disabled. |
+| 2.5.7 Dragging Movements | AA | Drag-and-drop has click/tap alternative. *(New in 2.2)* |
+| 2.5.8 Target Size (Minimum) | AA | Interactive controls have a target size, or spacing of at least 24x24 CSS px. *(New in 2.2)* |
+
+### Understandable
+
+| Criterion | Level | Summary |
+|-----------|-------|---------|
+| 3.1.1 Language of Page | A | `<html lang="...">` set correctly. |
+| 3.1.2 Language of Parts | AA | Content in different language marked with `lang` attribute. |
+| 3.2.1 On Focus | A | Focus doesn't trigger unexpected context change. |
+| 3.2.2 On Input | A | Changing input doesn't auto-trigger unexpected context change. |
+| 3.2.6 Consistent Help | A | Help mechanisms in same relative order across pages. *(New in 2.2)* |
+| 3.3.1 Error Identification | A | Errors described to user in text. |
+| 3.3.2 Labels or Instructions | A | Labels or instructions provided for user input. |
+| 3.3.3 Error Suggestion | AA | Suggest corrections for detected errors. |
+| 3.3.4 Error Prevention | AA | Submissions are reversible, checked, or confirmed. |
+| 3.3.7 Redundant Entry | A | Don't re-ask for info already provided in same process. *(New in 2.2)* |
+| 3.3.8 Accessible Authentication (Minimum) | AA | No cognitive function test (puzzle CAPTCHA). Allow paste and autofill. *(New in 2.2)* |
+
+### Robust
+
+| Criterion | Level | Summary |
+|-----------|-------|---------|
+| 4.1.2 Name, Role, Value | A | All UI components have accessible name, role, and state. |
+| 4.1.3 Status Messages | AA | Status messages announced by screen readers without receiving focus. |
+
+> **Note:** 4.1.1 Parsing is obsolete in WCAG 2.2 (always satisfied). Issues it covered are now addressed by 1.3.1 and 4.1.2.
+
+> **New AAA criteria in 2.2** (not required for AA, but recommended): 2.4.12 Focus Not Obscured (Enhanced), 2.4.13 Focus Appearance, 3.3.9 Accessible Authentication (Enhanced).
+
+> **Looking ahead:** WCAG 3.0 (W3C Accessibility Guidelines) is in Working Draft (March 2026). It replaces pass/fail with Bronze/Silver/Gold conformance and "Outcomes" instead of "Success Criteria." It is NOT yet a standard — continue targeting WCAG 2.2 AA.
+
+## Legal Enforcement Context (2026)
+
+- **European Accessibility Act (EAA)**: Enforced since June 2025 across all 27 EU member states. Applies to digital products and services. Fines up to EUR 3 million. References EN 301 549 (maps to WCAG 2.1 AA).
+- **ADA Title II (US)**: Digital accessibility rule effective April 2026 for state/local governments serving 50,000+ people (April 2027 for smaller entities). Requires WCAG 2.1 AA.
+- **Section 508 (US Federal)**: References WCAG 2.0 AA (refresh to 2.1/2.2 expected).
+
+**Target**: WCAG 2.2 AA covers all current legal requirements (superset of 2.1 AA and 2.0 AA).
+
+---
+
+## Five Rules of ARIA
+
+1. **Prefer native HTML** — Use `<button>` not `<div role="button">`. Native elements have built-in keyboard, focus, and semantics.
+2. **Don't change native semantics where prohibited** — Don't add `role="heading"` to a `<button>`. Use the correct element.
+3. **All ARIA controls must be keyboard operable** — If `role="button"`, handle Enter and Space key events.
+4. **Don't use `aria-hidden="true"` on focusable elements** — Hidden from assistive tech but still focusable creates a "ghost" element.
+5. **All interactive elements need an accessible name** — Via label, `aria-label`, `aria-labelledby`, or visible text content.
+
+---
+
+## Semantic HTML Anti-Patterns (S1-S8)
+
+### S1: Missing `lang` Attribute on `<html>`
+
+- **Severity**: CRITICAL
+- **Detection**: `<html` without `lang=`
+- **WCAG**: 3.1.1 (A)
+
+```html
+<!-- BAD -->
+<html>
+
+<!-- GOOD -->
+<html lang="en">
+```
+
+Next.js: Set in `app/layout.tsx`. Angular: Set in `src/index.html`. Vue/Nuxt: Set in `app.vue` or `nuxt.config`.
+
+### S2: Multiple `<h1>` Per Page
+
+- **Severity**: SUGGESTION
+- **Detection**: Multiple `<h1>` elements that make the page heading structure unclear
+- **WCAG**: Best practice (supports 1.3.1)
+
+Prefer one `<h1>` per page representing the main topic. Use `<h2>` for sections. Multiple `<h1>` elements are not a strict WCAG violation but can confuse screen reader navigation.
+
+### S3: Heading Level Gaps
+
+- **Severity**: IMPORTANT
+- **Detection**: `<h1>` followed by `<h3>` (skipping `<h2>`)
+- **WCAG**: 1.3.1 (A)
+
+Maintain logical nesting: `h1 > h2 > h3 > h4`. Style headings with CSS, not by choosing a different heading level.
+
+### S4: Div Soup — No Landmark Elements
+
+- **Severity**: IMPORTANT
+- **Detection**: Pages using only `<div>` without `<nav>`, `<main>`, `<header>`, `<footer>`
+- **WCAG**: Best practice (supports 1.3.1, 2.4.1)
+
+```html
+<!-- GOOD -->
+<header>...</header>
+<nav aria-label="Main">...</nav>
+<main>...</main>
+<footer>...</footer>
+```
+
+### S5: Layout Tables Without `role="presentation"`
+
+- **Severity**: IMPORTANT
+- **Detection**: `<table>` without `<th>`, `<caption>`, or `role="presentation"`
+- **WCAG**: 1.3.1 (A)
+
+Use CSS Grid/Flexbox for layout. If table must be used for layout, add `role="presentation"`.
+
+### S6: Data Tables Without Headers
+
+- **Severity**: CRITICAL
+- **Detection**: `<table>` with data rows but no `<th>` elements
+- **WCAG**: 1.3.1 (A)
+
+```html
+<!-- GOOD -->
+<table>
+  <caption>User list</caption>
+  <thead>
+    <tr><th scope="col">Name</th><th scope="col">Email</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Alice</td><td>alice@example.com</td></tr>
+  </tbody>
+</table>
+```
+
+### S7: Non-Descriptive Link Text
+
+- **Severity**: IMPORTANT
+- **Detection**: `>click here<|>read more<|>learn more<|>here<|>more<|>link<`
+- **WCAG**: 2.4.4 (A)
+
+```html
+<!-- BAD -->
+<a href="/pricing">Click here</a>
+
+<!-- GOOD -->
+<a href="/pricing">View pricing plans</a>
+```
+
+### S8: Interactive Elements Without Semantic HTML
+
+- **Severity**: CRITICAL
+- **Detection**: `<div.*(?:onClick|@click|\(click\))`
+- **WCAG**: 4.1.2 (A)
+
+```tsx
+// BAD — not focusable, no role, no keyboard support
+<div onClick={handleClick}>Submit</div>
+
+// GOOD
+<button onClick={handleClick}>Submit</button>
+```
+
+---
+
+## ARIA Anti-Patterns (A1-A8)
+
+### A1: Redundant ARIA on Native Elements
+
+- **Severity**: SUGGESTION
+- **Detection**: `<button.*role="button"|<nav.*role="navigation"|<a.*role="link"`
+- **WCAG**: ARIA Rule 2
+
+Remove redundant ARIA. `<button>` already has `role="button"`.
+
+### A2: `aria-hidden="true"` on Focusable Element
+
+- **Severity**: CRITICAL
+- **Detection**: `aria-hidden="true"` on focusable elements (button, input, a, [tabindex])
+- **WCAG**: ARIA Rule 4
+
+Do not leave focusable elements inside `aria-hidden="true"` content or use `aria-hidden="true"` on focusable elements. Rather, for native controls that support it, such as `<button>` or `<input>`, use `disabled` if disabling the control is the intended behavior. For `<a>` elements or arbitrary elements made focusable with `[tabindex]`, remove focusability instead (for example, remove `href` or `tabindex`). If the content should be completely non-interactive and hidden from assistive technology, use `inert`, `hidden`, or remove it from the DOM.
+
+### A3: Missing Required ARIA Properties
+
+- **Severity**: CRITICAL
+- **Detection**: `role="tab"` without `aria-selected`, `role="checkbox"` without `aria-checked`
+- **WCAG**: 4.1.2 (A)
+
+Required per role: `tab` needs `aria-selected`; `combobox` needs `aria-expanded`/`aria-controls`; `slider` needs `aria-valuemin`/`aria-valuemax`/`aria-valuenow`; `checkbox` needs `aria-checked`.
+
+### A4: Invalid ARIA Role Values
+
+- **Severity**: CRITICAL
+- **Detection**: `role="[^"]*"` with non-existent values
+- **WCAG**: 4.1.2 (A)
+
+Invalid roles are ignored by assistive technology. Common mistakes: `role="input"`, `role="text"`, misspellings.
+
+### A5: ARIA Where Native HTML Works
+
+- **Severity**: IMPORTANT
+- **Detection**: `role="button"` on `<div>`, `role="checkbox"` on `<div>`
+- **WCAG**: ARIA Rule 1
+
+```html
+<!-- BAD — requires manual keyboard, focus, and state management -->
+<div role="checkbox" aria-checked="false" tabindex="0">Accept terms</div>
+
+<!-- GOOD — all behavior built-in -->
+<label><input type="checkbox" /> Accept terms</label>
+```
+
+### A6: Missing `aria-label` on Icon-Only Buttons
+
+- **Severity**: CRITICAL
+- **Detection**: `<button` with SVG/icon child and no text or `aria-label`
+- **WCAG**: 4.1.2 (A)
+
+```html
+<!-- GOOD -->
+<button aria-label="Close dialog"><svg aria-hidden="true">...</svg></button>
+```
+
+### A7: `role="presentation"` on Focusable Elements
+
+- **Severity**: IMPORTANT
+- **Detection**: `role="presentation"` on interactive elements
+- **WCAG**: ARIA Rule 4
+
+Browsers will ignore the presentation role on focusable elements.
+
+### A8: Missing Live Region for Dynamic Content
+
+- **Severity**: IMPORTANT
+- **Detection**: Toast/notification components without `role="alert"`, `role="status"`, or `aria-live`
+- **WCAG**: 4.1.3 (AA)
+
+```html
+<!-- GOOD — content announced when content is injected into a preexisting live region element in the DOM -->
+<div role="status" aria-live="polite">Item saved successfully</div>
+<!-- Use role="alert" (assertive) for errors -->
+<div role="alert">Failed to save. Please try again.</div>
+```
+
+---
+
+## Keyboard and Focus Anti-Patterns (K1-K7)
+
+### K1: `onClick` Without `onKeyDown` on Non-Native Elements
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:onClick|@click|\(click\))` on `<div>` or `<span>` without keyboard handler
+- **WCAG**: 2.1.1 (A)
+
+Use `<button>` instead. If a div is required: add `role="button"`, `tabIndex={0}`, handle Enter and Space key activation.
+
+### K2: Positive `tabindex` Values
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:tabindex="[1-9]\d*"|tabIndex=\{[1-9]\d*\})`
+- **WCAG**: 2.4.3 (A)
+
+Only use `tabindex="0"` (add to tab order) and `tabindex="-1"` (programmatic focus only).
+
+### K3: Focus Trap Without Escape
+
+- **Severity**: CRITICAL
+- **Detection**: Modal/overlay without Escape key handler or focus trapping
+- **WCAG**: 2.1.2 (A)
+
+Use native `<dialog>` with `showModal()` — it prevents keyboard focus from moving to the inert non-dialog content. Additionally, it has built in Escape key to dismiss, and focus will automatically return to the invoking element (if available). If a custom modal dialog implementation is needed: trap Tab within the dialog or use the `inert` attribute for non-dialog content (do not use `inert` on an element that contains the dialog), dismiss on Escape (unless user confirmation of an action is essential), return focus to the trigger element on close, or to best logical location if triggering element is no longer present upon dismissal.
+
+### K4: Missing Skip Link
+
+- **Severity**: IMPORTANT
+- **Detection**: No skip link as first focusable element
+- **WCAG**: 2.4.1 (A)
+
+```html
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<nav>...</nav>
+<main id="main-content" tabindex="-1">...</main>
+```
+
+```css
+.skip-link { position: absolute; top: -40px; left: 0; padding: 8px 16px; background: #000; color: #fff; z-index: 100; }
+.skip-link:focus { top: 0; }
+```
+
+### K5: `outline: none` Without Replacement
+
+- **Severity**: CRITICAL
+- **Detection**: `outline:\s*none|outline:\s*0\b` without `:focus-visible` replacement
+- **WCAG**: 2.4.7 (AA)
+
+```css
+/* GOOD */
+button:focus-visible { outline: 2px solid #005fcc; outline-offset: 2px; }
+```
+
+### K6: Mouse-Only Interactions
+
+- **Severity**: IMPORTANT
+- **Detection**: `onMouseOver|onMouseEnter|@mouseenter` without keyboard equivalent
+- **WCAG**: 2.1.1 (A)
+
+Pair hover with focus events. Use `onFocus`/`onBlur` alongside `onMouseEnter`/`onMouseLeave`.
+
+### K7: Focus Not Returned After Custom Modal Close
+
+- **Severity**: IMPORTANT
+- **Detection**: Custom modal dialog close without restoring focus to trigger
+- **WCAG**: 2.4.3 (A)
+
+Store reference to trigger element or to best logical location if triggering element is no longer present upon close. On modal close, call `triggerElement.focus()`.
+
+---
+
+## Form Anti-Patterns (F1-F6)
+
+### F1: Input Without Associated Label
+
+- **Severity**: CRITICAL
+- **Detection**: `<input|<select|<textarea` without `<label>`, `aria-label`, or `aria-labelledby`
+- **WCAG**: 1.3.1 (A), 3.3.2 (A)
+
+```html
+<!-- GOOD -->
+<label for="email">Email address</label>
+<input id="email" type="email" placeholder="you@example.com" />
+```
+
+### F2: Error Messages Not Linked to Input
+
+- **Severity**: CRITICAL
+- **Detection**: Error elements near inputs without `aria-describedby`
+- **WCAG**: 3.3.1 (A)
+
+```html
+<input id="email" type="email" aria-describedby="email-error" aria-invalid="true" />
+<span id="email-error" class="error">Invalid email format</span>
+```
+
+### F3: Required Field Indicated Only by Color or `*`
+
+- **Severity**: IMPORTANT
+- **Detection**: `required` or `*` without `aria-required="true"` or HTML `required`
+- **WCAG**: 3.3.2 (A), 1.4.1 (A)
+
+```html
+<label for="name">Name <span aria-hidden="true">*</span></label>
+<input id="name" type="text" required />
+<p class="form-note">Fields marked * are required</p>
+```
+
+### F4: No Error Summary or Focus on First Error
+
+- **Severity**: IMPORTANT
+- **Detection**: Form submit handler without focus management on validation failure
+- **WCAG**: 3.3.1 (A)
+
+On submit failure, focus the first invalid field or show and focus an error summary.
+
+### F5: CAPTCHA Without Accessible Alternative
+
+- **Severity**: IMPORTANT
+- **Detection**: Puzzle/image CAPTCHAs without fallback; password fields with `autocomplete='off'` or paste-blocking JavaScript
+- **WCAG**: 3.3.8 (AA)
+
+Use reCAPTCHA v3 (invisible), hCaptcha accessibility mode, or alternative authentication. Never block paste or autofill on password fields — this violates WCAG 3.3.8.
+
+### F6: Placeholder as Label
+
+- **Severity**: IMPORTANT
+- **Detection**: `placeholder=` without accompanying `<label>`, `aria-label`, or `aria-labelledby`
+- **WCAG**: 3.3.2 (A)
+
+Always pair placeholder with a visible `<label>`. Placeholder is a hint, not a label.
+
+---
+
+## Visual and Color Anti-Patterns (V1-V5)
+
+### V1: Insufficient Text Contrast
+
+- **Severity**: CRITICAL
+- **Detection**: Text color combinations below 4.5:1 (normal) or 3:1 (large)
+- **WCAG**: 1.4.3 (AA)
+
+```css
+/* BAD — #999 on #fff is ~2.5:1 */
+.text { color: #999; background: #fff; }
+
+/* GOOD — #595959 on #fff is 7.0:1 */
+.text { color: #595959; background: #fff; }
+```
+
+### V2: Information Conveyed by Color Alone
+
+- **Severity**: CRITICAL
+- **Detection**: Error/success states distinguished only by color
+- **WCAG**: 1.4.1 (A)
+
+Add a secondary indicator: icon, text, pattern, underline, or border.
+
+### V3: Fixed Font Sizes Preventing Resize
+
+- **Severity**: IMPORTANT
+- **Detection**: `font-size:\s*[0-9]*px` (excluding root/base)
+- **WCAG**: 1.4.4 (AA)
+
+Use `rem` or `em` for font sizes. Base font can be `px`, but content fonts should be relative.
+
+### V4: Content Not Reflowing at 320px
+
+- **Severity**: IMPORTANT
+- **Detection**: Fixed-width containers, horizontal scroll at narrow widths
+- **WCAG**: 1.4.10 (AA)
+
+Use responsive layouts (Grid, Flexbox). Test at 320px CSS width. Avoid fixed-width containers.
+
+### V5: Animation Without `prefers-reduced-motion`
+
+- **Severity**: SUGGESTION
+- **Detection**: `animation:|transition:` without `prefers-reduced-motion` media query
+- **WCAG**: 2.3.3 (AAA)
+
+Best practice and AAA enhancement. Gate non-essential animations behind `prefers-reduced-motion` so users who request less motion are not forced to experience interaction-triggered effects.
+
+```css
+@media (prefers-reduced-motion: no-preference) {
+  .card { transition: transform 0.3s ease; }
+  .card:hover { transform: scale(1.05); }
+}
+```
+
+---
+
+## Media Anti-Patterns (D1-D4)
+
+### D1: Informational Image Without Alt Text
+
+- **Severity**: CRITICAL
+- **Detection**: `<img|<Image` without `alt=` attribute
+- **WCAG**: 1.1.1 (A)
+
+Alt text decision tree: decorative = `alt=""`; contains text = include that text; functional = describe action; informational = describe content.
+
+### D2: Decorative Image with Non-Empty Alt
+
+- **Severity**: SUGGESTION
+- **Detection**: Decorative images with meaningful alt text
+- **WCAG**: 1.1.1 (A)
+
+Use `alt=""` for decorative images. Add `aria-hidden="true"` for decorative SVGs.
+
+### D3: Video Without Captions
+
+- **Severity**: CRITICAL
+- **Detection**: `<video` without `<track kind="captions">`
+- **WCAG**: 1.2.2 (A)
+
+```html
+<video src="/tutorial.mp4" controls>
+  <track kind="captions" src="/tutorial-en.vtt" srclang="en" label="English" default />
+</video>
+```
+
+### D4: Audio/Video Autoplay
+
+- **Severity**: IMPORTANT
+- **Detection**: `autoplay` attribute without `muted`
+- **WCAG**: 1.4.2 (A)
+
+Never autoplay audio. If video autoplays, start muted with controls.
+
+---
+
+## Framework-Specific: React / Next.js (RX1-RX4)
+
+### RX1: Missing `htmlFor` on `<label>`
+
+- **Severity**: IMPORTANT
+- **Detection**: `<label.*for="` in JSX (should be `htmlFor`)
+- **WCAG**: 1.3.1 (A), 3.3.2 (A)
+
+### RX2: SPA Route Change Without Focus Management
+
+- **Severity**: IMPORTANT
+- **Detection**: Navigation without focus management or live region
+- **WCAG**: 4.1.3 (AA)
+
+After route change, focus the main heading or announce the new page title via a live region. Next.js includes a built-in route announcer (since v13) that reads `document.title`, then `<h1>`, then pathname. Ensure every page has a unique `<title>`.
+
+### RX3: Fragment Root Causing Focus Loss on Re-render
+
+- **Severity**: SUGGESTION
+- **Detection**: `<>...</>` root with conditional rendering causing DOM restructuring
+- **WCAG**: 2.4.3 (A)
+
+Use `key` prop to preserve DOM identity, or manually restore focus with `useRef` + `useEffect`.
+
+### RX4: Injected HTML Without ARIA Consideration
+
+- **Severity**: IMPORTANT
+- **Detection**: Rich text rendering without accessibility validation
+- **WCAG**: 1.3.1 (A)
+
+Sanitize and validate injected HTML for heading hierarchy, alt text, and ARIA structure.
+
+---
+
+## Framework-Specific: Angular (NG1-NG4)
+
+### NG1: `(click)` on `<div>` Without Role and Keyboard Support
+
+- **Severity**: CRITICAL
+- **Detection**: `(click)` on `<div>` or `<span>` without `role=`, `tabindex`, `(keydown)`
+- **WCAG**: 2.1.1 (A), 4.1.2 (A)
+
+Use `<button>`. If div required: add `role="button"`, `tabindex="0"`, `(keydown.enter)`, `(keydown.space)`.
+
+### NG2: Missing `cdkTrapFocus` in Modal Components
+
+- **Severity**: IMPORTANT
+- **Detection**: Modal components without `cdkTrapFocus`
+- **WCAG**: 2.1.2 (A)
+
+```html
+<div class="modal" cdkTrapFocus [cdkTrapFocusAutoCapture]="true">...</div>
+```
+
+Angular CDK's `Dialog` service handles focus trapping and restoration automatically.
+
+### NG3: Route Change Without LiveAnnouncer
+
+- **Severity**: IMPORTANT
+- **Detection**: Angular Router navigation without `LiveAnnouncer`
+- **WCAG**: 4.1.3 (AA)
+
+```typescript
+router.events.pipe(filter(e => e instanceof NavigationEnd)).subscribe(() => {
+  liveAnnouncer.announce(titleService.getTitle(), 'polite');
+});
+```
+
+### NG4: Template-Driven Forms Without Accessible Validation
+
+- **Severity**: IMPORTANT
+- **Detection**: Forms showing errors without `[attr.aria-invalid]` or `[attr.aria-describedby]`
+- **WCAG**: 3.3.1 (A), 3.3.3 (AA)
+
+Bind `[attr.aria-invalid]` and `[attr.aria-describedby]` to form control state.
+
+---
+
+## Framework-Specific: Vue (VU1-VU3)
+
+### VU1: `@click` on Non-Interactive Element Without Role and Keyboard
+
+- **Severity**: CRITICAL
+- **Detection**: `@click` on `<div>` or `<span>` without `role=`, `tabindex`, `@keydown`
+- **WCAG**: 2.1.1 (A), 4.1.2 (A)
+
+Use `<button>`. Or add `role="button"`, `tabindex="0"`, `@keydown.enter`, `@keydown.space.prevent`.
+
+### VU2: `v-if` Toggle Without Focus Management
+
+- **Severity**: IMPORTANT
+- **Detection**: `v-if` toggling without managing focus via `nextTick`
+- **WCAG**: 2.4.3 (A)
+
+```vue
+<script setup>
+import { ref, watch, nextTick } from 'vue';
+const showPanel = ref(false);
+const panel = ref(null);
+watch(showPanel, async (val) => {
+  if (val) { await nextTick(); panel.value?.focus(); }
+});
+</script>
+```
+
+### VU3: `v-html` Injecting Content Without Accessible Structure
+
+- **Severity**: IMPORTANT
+- **Detection**: `v-html` rendering user or CMS content
+- **WCAG**: 1.3.1 (A)
+
+Sanitize and validate HTML for heading hierarchy, alt text, and ARIA structure before injection.
+
+---
+
+## Keyboard Interaction Reference
+
+| Key | Expected Behavior |
+|-----|-------------------|
+| `Tab` | Move focus to next focusable element in DOM order |
+| `Shift+Tab` | Move focus to previous focusable element |
+| `Enter` | Activate buttons and links |
+| `Space` | Activate buttons, toggle checkboxes, select radio buttons |
+| `Escape` | Close modals, dialogs, popovers, dropdowns |
+| `Arrow Up/Down` | Navigate within menus, listboxes, radio groups, tabs |
+| `Arrow Left/Right` | Navigate within tab bars, sliders, radio groups |
+| `Home` | Move to first item in list, menu, or tab bar |
+| `End` | Move to last item in list, menu, or tab bar |
+
+### Widget-Specific Patterns
+
+| Widget | Tab enters | Internal nav | Activate | Exit |
+|--------|-----------|-------------|----------|------|
+| Tab bar | Focus active tab | Arrow Left/Right | automatic or Enter | Tab out |
+| Menu | Focus first item | Arrow Up/Down | Enter | Escape |
+| Dialog | Focus first element | Tab cycles within | Enter on buttons | Escape |
+| Combobox | Focus input | Arrow Up/Down | Enter selects | Escape closes |
+| Tree view | Focus first node | Arrow keys | Enter/Space | Tab out |
+
+---
+
+## Color Contrast Quick Reference
+
+### Text Contrast (WCAG 1.4.3 AA)
+
+| Text Type | Minimum Ratio |
+|-----------|--------------|
+| Normal text (< 18pt / < 14pt bold) | 4.5:1 |
+| Large text (>= 18pt / >= 14pt bold) | 3:1 |
+| Incidental (disabled, decorative) | No requirement |
+
+### Non-Text Contrast (WCAG 1.4.11 AA)
+
+| Element | Minimum Ratio |
+|---------|--------------|
+| UI components (borders, icons) | 3:1 against adjacent |
+| Graphical objects | 3:1 against adjacent |
+| Focus indicators | 3:1 against background |
+
+---
+
+## Accessibility Checklist (POUR)
+
+### Perceivable
+- [ ] All images have appropriate alt text (descriptive or empty for decorative)
+- [ ] Videos have synchronized captions
+- [ ] Page uses semantic landmarks: `<header>`, `<nav>`, `<main>`, `<footer>`
+- [ ] Headings follow logical hierarchy (h1 > h2 > h3, no gaps)
+- [ ] Text contrast meets 4.5:1 (normal) / 3:1 (large)
+- [ ] UI component contrast meets 3:1
+- [ ] Information not conveyed by color alone
+- [ ] Content reflows at 320px without horizontal scroll
+- [ ] `<html lang="...">` is set correctly
+- [ ] Text resizable to 200% without loss of content
+
+### Operable
+- [ ] All functionality accessible via keyboard
+- [ ] No keyboard traps (Escape closes overlays)
+- [ ] Skip link provided as first focusable element
+- [ ] Focus indicator visible on all interactive elements
+- [ ] Focus order matches visual order
+- [ ] Focus not obscured by sticky headers/footers
+- [ ] Focus returned to trigger after modal close
+- [ ] Touch targets at least 24x24 CSS px
+- [ ] Animations respect `prefers-reduced-motion`
+- [ ] No content flashes more than 3 times per second
+
+### Understandable
+- [ ] All form inputs have associated `<label>` or `aria-label`
+- [ ] Error messages linked to inputs via `aria-describedby`
+- [ ] Required fields indicated with `required` or `aria-required`
+- [ ] Error summary or focus-on-first-error on submit failure
+- [ ] No unexpected context changes on focus or input
+
+### Robust
+- [ ] All interactive elements have accessible name, role, and state
+- [ ] ARIA roles have required properties
+- [ ] No `aria-hidden="true"` on focusable elements
+- [ ] Dynamic content announced via live regions
+- [ ] SPA route changes announced to screen readers
+- [ ] No redundant ARIA on native HTML elements

--- a/.github/instructions/markdown-gfm.instructions.md
+++ b/.github/instructions/markdown-gfm.instructions.md
@@ -1,0 +1,68 @@
+---
+description: 'Markdown formatting for GitHub-flavored markdown (GFM) files'
+applyTo: '**/*.md'
+---
+
+# GitHub Flavored Markdown (GFM)
+
+Apply these rules per the [GFM spec](https://github.github.com/gfm/) when writing or reviewing `.md` files. GFM is a strict superset of CommonMark. GFM spec for reference only. Do not download GFM Spec.
+
+## Preliminaries
+
+- A line ends at a newline (`U+000A`), carriage return (`U+000D`), or end of file. A blank line contains only spaces or tabs.
+- Tabs behave as 4-space tab stops for block structure but are not expanded in content.
+- Replace `U+0000` with the replacement character `U+FFFD`.
+
+## Leaf Blocks
+
+- **Thematic breaks**: 3+ matching `-`, `_`, or `*` characters on a line with 0–3 spaces indent. No other characters on the line. Can interrupt a paragraph.
+- **ATX headings**: 1–6 `#` characters followed by a space or end of line. Optional closing `#` sequence (preceded by a space). 0–3 spaces indent allowed.
+- **Setext headings**: Text underlined with `=` (level 1) or `-` (level 2). Cannot interrupt a paragraph — blank line required after a preceding paragraph.
+- **Indented code blocks**: Lines indented 4+ spaces. Cannot interrupt a paragraph. Content is literal text, not parsed as Markdown.
+- **Fenced code blocks**: Open with 3+ backticks or tildes (do not mix). Closing fence must use same character with at least the same count. Specify language identifier after the opening fence. Content is literal text.
+- **HTML blocks**: Seven types defined by start/end tag conditions. Types 1–6 can interrupt paragraphs; type 7 cannot. Content is passed through as raw HTML.
+  - Type 1: `<script>`, `<pre>`, or `<style>` (case-insensitive) — ends at matching closing tag.
+  - Type 2: `<!--` comment — ends at `-->`.
+  - Type 3: `<?` processing instruction — ends at `?>`.
+  - Type 4: `<!` + uppercase letter (e.g., `<!DOCTYPE>`) — ends at `>`.
+  - Type 5: `<![CDATA[` — ends at `]]>`.
+  - Type 6: Block-level HTML tags (`<div>`, `<table>`, `<p>`, `<h1>`–`<h6>`, `<ul>`, `<ol>`, `<section>`, etc.) — ends at a blank line.
+  - Type 7: Any other complete open or closing tag on its own line — ends at a blank line. Cannot interrupt a paragraph.
+- **Link reference definitions**: `[label]: destination "title"`. Case-insensitive label matching. First definition wins for duplicate labels. Cannot interrupt a paragraph.
+- **Paragraphs**: Consecutive non-blank lines not interpretable as other block constructs. Leading spaces up to 3 are stripped.
+- **Blank lines**: Ignored between blocks; determine whether a list is tight or loose.
+- **Tables** *(extension)*: Header row, delimiter row (`---`, `:---:`, `---:`), zero or more data rows. Delimit cells with `|`. Escape literal pipe as `\|`. Header and delimiter must have matching column count. Broken at first blank line or other block-level structure.
+
+## Container Blocks
+
+- **Block quotes**: Lines prefixed with `>` (optionally followed by a space). Lazy continuation allowed for paragraph text only. A blank line separates consecutive block quotes.
+- **List items**: Bullet markers (`-`, `+`, `*`) or ordered markers (1–9 digits + `.` or `)`). Content column determined by marker width + spaces to first non-whitespace. Sublists must be indented to the content column. An ordered list interrupting a paragraph must start with `1`.
+- **Task list items** *(extension)*: `- [ ]` (unchecked) or `- [x]` (checked) at the start of a list item paragraph. Space between `-` and `[` is required. May be nested.
+- **Lists**: Sequence of same-type list items. Changing bullet character or ordered delimiter starts a new list. A list is loose if any item is separated by a blank line.
+
+## Inlines
+
+- **Backslash escapes**: `\` before any ASCII punctuation character renders the literal character. Not recognized in code spans, code blocks, or autolinks.
+- **Entity and numeric character references**: `&amp;`, `&#123;`, `&#x7B;` — valid HTML5 entities. Not recognized in code spans or code blocks. Cannot replace structural characters.
+- **Code spans**: Backtick-delimited inline code. Line endings convert to spaces. Leading and trailing space stripped when both present. Backslash escapes are literal inside code spans.
+- **Emphasis and strong emphasis**: `*`/`_` for `<em>`, `**`/`__` for `<strong>`. `_` is not allowed for intraword emphasis. Left-flanking / right-flanking delimiter run rules apply. Delimiter run length sum must not be a multiple of 3 when one delimiter can both open and close (unless both lengths are multiples of 3).
+- **Strikethrough** *(extension)*: `~~text~~` — one or two tildes. Does not span across paragraphs. Three or more tildes do not create strikethrough.
+- **Links**: Inline `[text](url "title")` or reference `[text][label]` / `[text][]` / `[text]`. Link text may contain inlines but not other links. Destination in `<…>` allows spaces. No whitespace between link text and `(` or `[`.
+- **Images**: `![alt](src "title")` — same syntax as links prefixed with `!`. Alt text is the plain-string content of the description.
+- **Autolinks**: `<URI>` or `<email>` in angle brackets. Scheme must be 2–32 characters starting with an ASCII letter.
+- **Autolinks** *(extension)*: Bare `http://`, `https://`, `www.` URLs and bare email addresses auto-link without angle brackets. Trailing punctuation excluded; parentheses balanced.
+- **Raw HTML**: Open/close tags, comments (`<!-- -->`), processing instructions (`<? ?>`), declarations (`<!…>`), CDATA (`<![CDATA[…]]>`) are passed through.
+- **Disallowed raw HTML** *(extension)*: `<title>`, `<textarea>`, `<style>`, `<xmp>`, `<iframe>`, `<noembed>`, `<noframes>`, `<script>`, `<plaintext>` have their leading `<` replaced with `&lt;`.
+- **Hard line breaks**: Two+ trailing spaces or `\` before a line ending. Not recognized in code spans or HTML tags.
+- **Soft line breaks**: A line ending not preceded by two+ spaces or `\`. Rendered as a space in browsers.
+
+## Validation Checklist
+
+- [ ] ATX headings use 1–6 `#` followed by a space.
+- [ ] Fenced code blocks specify a language identifier and use matching fence characters and counts.
+- [ ] Tables include header and delimiter rows with matching column count. Alignment set with `:` in the delimiter.
+- [ ] Task list items have a space between `-` and `[ ]` or `[x]`.
+- [ ] Emphasis uses `*` for intraword; `_` only at word boundaries.
+- [ ] Strikethrough uses exactly `~~` (not 3+ tildes).
+- [ ] Links use `[text](url)` or reference syntax with no whitespace before `(` or `[`.
+- [ ] No disallowed raw HTML tags (`<script>`, `<style>`, `<title>`, `<textarea>`, `<xmp>`, `<iframe>`, `<noembed>`, `<noframes>`, `<plaintext>`).

--- a/.github/instructions/nodejs-javascript-vitest.instructions.md
+++ b/.github/instructions/nodejs-javascript-vitest.instructions.md
@@ -1,0 +1,30 @@
+---
+description: "Guidelines for writing Node.js and JavaScript code with Vitest testing"
+applyTo: '**/*.js, **/*.mjs, **/*.cjs'
+---
+
+# Code Generation Guidelines
+
+## Coding standards
+- Use JavaScript with ES2022 features and Node.js (20+) ESM modules
+- Use Node.js built-in modules and avoid external dependencies where possible
+- Ask the user if you require any additional dependencies before adding them
+- Always use async/await for asynchronous code, and use 'node:util' promisify function to avoid callbacks
+- Keep the code simple and maintainable
+- Use descriptive variable and function names
+- Do not add comments unless absolutely necessary, the code should be self-explanatory
+- Never use `null`, always use `undefined` for optional values
+- Prefer functions over classes
+
+## Testing
+- Use Vitest for testing
+- Write tests for all new features and bug fixes
+- Ensure tests cover edge cases and error handling
+- NEVER change the original code to make it easier to test, instead, write tests that cover the original code as it is
+
+## Documentation
+- When adding new features or making significant changes, update the README.md file where necessary
+
+## User interactions
+- Ask questions if you are unsure about the implementation details, design choices, or need clarification on the requirements
+- Always answer in the same language as the question, but use english for the generated content like code, comments or docs

--- a/.github/instructions/performance-optimization.instructions.md
+++ b/.github/instructions/performance-optimization.instructions.md
@@ -1,0 +1,962 @@
+---
+applyTo: '**'
+description: 'Comprehensive web performance standards based on Core Web Vitals (LCP, INP, CLS), with 50+ anti-patterns, detection regex, framework-specific fixes for modern web frameworks, and modern API guidance.'
+---
+
+# Performance Standards
+
+Comprehensive performance rules for web application development. Every anti-pattern includes a severity classification, detection method, Core Web Vitals metric impacted, and corrective code examples.
+
+**Severity levels:**
+
+- **CRITICAL** — Directly degrades a Core Web Vital past the "poor" threshold. Must be fixed before merge.
+- **IMPORTANT** — Measurably impacts user experience. Fix in same sprint.
+- **SUGGESTION** — Optimization opportunity. Plan for a future iteration.
+
+---
+
+## Core Web Vitals Quick Reference
+
+### LCP (Largest Contentful Paint)
+
+**Good: < 2.5s | Needs Improvement: 2.5-4s | Poor: > 4s**
+
+Measures when the largest visible content element finishes rendering. Four sequential phases:
+
+| Phase | Target | What It Measures |
+|-------|--------|-----------------|
+| TTFB | ~40% of budget | Server response time |
+| Resource Load Delay | < 10% | Time between TTFB and LCP resource fetch start |
+| Resource Load Duration | ~40% | Download time for the LCP resource |
+| Element Render Delay | < 10% | Time between download and paint |
+
+### INP (Interaction to Next Paint)
+
+**Good: < 200ms | Needs Improvement: 200-500ms | Poor: > 500ms**
+
+Measures latency of all user interactions, reports the worst. Three phases:
+
+| Phase | Optimization |
+|-------|-------------|
+| Input Delay | Break long tasks, yield to browser |
+| Processing Time | Keep handlers < 50ms |
+| Presentation Delay | Minimize DOM size, avoid forced layout |
+
+> **Diagnostic tool:** Use the Long Animation Frames (LoAF) API (Chrome 123+) to debug INP issues. LoAF provides better attribution than the legacy Long Tasks API, including script source and rendering time.
+
+### CLS (Cumulative Layout Shift)
+
+**Good: < 0.1 | Needs Improvement: 0.1-0.25 | Poor: > 0.25**
+
+Layout shift sources: images without dimensions, dynamically injected content, web font FOUT, late-loading ads. Shifts within 500ms of user interaction are exempt.
+
+---
+
+## Loading and LCP Anti-Patterns (L1-L10)
+
+### L1: Render-Blocking CSS Without Critical Extraction
+
+- **Severity**: CRITICAL
+- **Detection**: `<link.*rel="stylesheet"` in `<head>` loading large CSS
+- **CWV**: LCP
+
+```html
+<!-- BAD -->
+<link rel="stylesheet" href="/styles/main.css" />
+
+<!-- GOOD — inline critical CSS (extracted at build time), preload the rest -->
+<style>/* critical above-fold CSS, inlined by a tool like Critters/Beasties */</style>
+<link rel="preload" href="/styles/main.css" as="style" />
+<link rel="stylesheet" href="/styles/main.css" />
+```
+
+Prefer build-time critical CSS extraction (e.g., Critters, Beasties, Next.js `experimental.optimizeCss`) plus a normal `<link rel="stylesheet">`. Avoid the older `media="print" onload="this.media='all'"` trick: inline event handlers are blocked under a strict CSP (no `'unsafe-inline'` / no `script-src-attr 'unsafe-inline'`), which would prevent the stylesheet from ever activating and cause a styling regression. If non-critical CSS truly must be deferred, load it via an **external** script that swaps `media`, not an inline handler.
+
+### L2: Render-Blocking Synchronous Script
+
+- **Severity**: CRITICAL
+- **Detection**: `<script.*src=` without `async|defer|type="module"`
+- **CWV**: LCP
+
+```html
+<!-- BAD -->
+<script src="/vendor/analytics.js"></script>
+
+<!-- GOOD -->
+<script src="/vendor/analytics.js" defer></script>
+```
+
+### L3: Missing Preconnect to Critical Origins
+
+- **Severity**: IMPORTANT
+- **Detection**: Third-party API/CDN URLs without `<link rel="preconnect">`
+- **CWV**: LCP
+
+```html
+<link rel="preconnect" href="https://api.example.com" />
+<link rel="dns-prefetch" href="https://analytics.example.com" />
+```
+
+### L4: Missing Preload for LCP Resource
+
+- **Severity**: CRITICAL
+- **Detection**: LCP image/font not preloaded
+- **CWV**: LCP
+
+```html
+<link rel="preload" as="image" href="/hero.webp" fetchpriority="high" />
+```
+
+### L5: Client-Side Data Fetching for Main Content
+
+- **Severity**: CRITICAL
+- **Detection**: `useEffect.*fetch|useEffect.*axios|ngOnInit.*subscribe`
+- **CWV**: LCP
+
+```tsx
+// BAD — content appears after JS execution + API call
+'use client';
+function Page() {
+  const [data, setData] = useState(null);
+  useEffect(() => { fetch('/api/data').then(r => r.json()).then(setData); }, []);
+  return <div>{data?.title}</div>;
+}
+
+// GOOD — Server Component fetches data before HTML is sent
+async function Page() {
+  const data = await fetch('https://api.example.com/data').then(r => r.json());
+  return <div>{data.title}</div>;
+}
+```
+
+### L6: Excessive Redirect Chains
+
+- **Severity**: IMPORTANT
+- **Detection**: Multiple sequential redirects (HTTP 301/302 chains)
+- **CWV**: LCP
+
+Each redirect adds 200-300ms. Maximum one redirect.
+
+### L7: Missing fetchpriority on LCP Element
+
+- **Severity**: IMPORTANT
+- **Detection**: Above-fold hero image without `fetchpriority="high"` or `priority` prop
+- **CWV**: LCP
+
+```tsx
+// Next.js
+<Image src="/hero.webp" alt="Hero" width={1200} height={600} priority />
+
+// Angular
+<img ngSrc="/hero.webp" alt="Hero" width="1200" height="600" priority>
+
+// Plain HTML
+<img src="/hero.webp" alt="Hero" width="1200" height="600" fetchpriority="high" />
+```
+
+### L8: Third-Party Scripts in Head Without Async/Defer
+
+- **Severity**: IMPORTANT
+- **Detection**: `<script.*src="https://` without `async|defer`
+- **CWV**: LCP
+
+Defer non-essential scripts. Use facade pattern for chat widgets.
+
+### L9: Oversized Initial HTML (>14KB)
+
+- **Severity**: SUGGESTION
+- **Detection**: Server-rendered HTML larger than 14KB
+- **CWV**: LCP
+
+Reduce inline CSS/JS, remove whitespace, use streaming SSR with Suspense boundaries.
+
+### L10: Missing Compression
+
+- **Severity**: IMPORTANT
+- **Detection**: Server not returning `content-encoding: br` or `gzip`
+- **CWV**: LCP
+
+Enable Brotli (15-25% better than gzip) at CDN/server level.
+
+---
+
+## Rendering and Hydration Anti-Patterns (R1-R8)
+
+### R1: Entire Component Tree Marked "use client"
+
+- **Severity**: CRITICAL
+- **Detection**: `"use client"` at top-level layout or page component
+- **CWV**: LCP + INP
+
+Push `"use client"` down to leaf components that need interactivity.
+
+### R2: Missing Suspense Boundaries for Async Data
+
+- **Severity**: IMPORTANT
+- **Detection**: Server Components doing data fetching without `<Suspense>`
+- **CWV**: LCP
+
+```tsx
+// GOOD — stream shell immediately, fill in data progressively
+async function Page() {
+  const user = await getUser();
+  return (
+    <div>
+      <Header user={user} />
+      <Suspense fallback={<PostsSkeleton />}>
+        <Posts />
+      </Suspense>
+    </div>
+  );
+}
+```
+
+### R3: Hydration Mismatch from Dynamic Client Content
+
+- **Severity**: IMPORTANT
+- **Detection**: `Date.now()|Math.random()|window\.innerWidth` in SSR components
+- **CWV**: CLS
+
+Use `useEffect` for client-only values, or `suppressHydrationWarning` for known differences.
+
+### R4: Missing Streaming for Slow Data Sources
+
+- **Severity**: IMPORTANT
+- **Detection**: Page awaiting all data before sending HTML
+- **CWV**: LCP (TTFB)
+
+Use streaming SSR with Suspense boundaries. Shell streams immediately; slow data fills in progressively.
+
+### R5: Unstable References Causing Re-renders
+
+- **Severity**: IMPORTANT
+- **Detection**: `style=\{\{|onClick=\{\(\) =>` inline in JSX
+- **CWV**: INP
+
+React 19+ with React Compiler enabled (separate babel/SWC build plugin): auto-memoized. Without Compiler: extract or memoize with `useMemo`/`useCallback`. Angular: OnPush. Vue: `computed()`.
+
+### R6: Missing Virtualization for Long Lists
+
+- **Severity**: IMPORTANT
+- **Detection**: `.map(` rendering >100 items without virtual scrolling
+- **CWV**: INP
+
+Use TanStack Virtual, react-window, Angular CDK Virtual Scroll, or vue-virtual-scroller.
+
+### R7: SSR of Immediately-Hidden Content
+
+- **Severity**: SUGGESTION
+- **Detection**: Server-rendering `display: none` components
+- **CWV**: LCP (TTFB)
+
+Use client-side rendering for modals, drawers, dropdowns. Angular: `@defer`. React: `React.lazy`.
+
+### R8: Missing `key` Prop on List Items
+
+- **Severity**: IMPORTANT
+- **Detection**: `.map(` without `key=` prop
+- **CWV**: INP
+
+```tsx
+// GOOD — stable unique key
+{items.map(item => <Row key={item.id} data={item} />)}
+```
+
+Never use array index as key if list can reorder.
+
+---
+
+## JavaScript Runtime and INP Anti-Patterns (J1-J8)
+
+### J1: Long Synchronous Task in Event Handler
+
+- **Severity**: CRITICAL
+- **Detection**: Event handlers with heavy computation (>50ms)
+- **CWV**: INP
+
+```typescript
+// GOOD — yield to browser
+async function handleClick() {
+  setLoading(true);
+  await (globalThis.scheduler?.yield?.() ?? new Promise(r => setTimeout(r, 0)));
+  const result = expensiveComputation(data);
+  setResult(result);
+}
+```
+
+Move heavy work to Web Worker for best results.
+
+> **Note:** `scheduler.yield()` is supported in Chrome 129+, Firefox 129+, but NOT Safari as of April 2026. Fallback: `await (globalThis.scheduler?.yield?.() ?? new Promise(r => setTimeout(r, 0)))`.
+
+### J2: Layout Thrashing
+
+- **Severity**: CRITICAL
+- **Detection**: `offsetHeight|offsetWidth|getBoundingClientRect|clientHeight` in loops
+- **CWV**: INP
+
+```typescript
+// GOOD — batch reads then batch writes
+const heights = elements.map(el => el.offsetHeight);
+elements.forEach((el, i) => { el.style.height = `${heights[i] + 10}px`; });
+```
+
+### J3: setInterval/setTimeout Without Cleanup
+
+- **Severity**: IMPORTANT
+- **Detection**: `setInterval|setTimeout` without cleanup
+- **Impact**: Memory
+
+```tsx
+useEffect(() => {
+  const id = setInterval(() => fetchData(), 5000);
+  return () => clearInterval(id);
+}, []);
+```
+
+### J4: addEventListener Without removeEventListener
+
+- **Severity**: IMPORTANT
+- **Detection**: `addEventListener` without cleanup
+- **Impact**: Memory
+
+```tsx
+useEffect(() => {
+  const controller = new AbortController();
+  window.addEventListener('resize', handleResize, { signal: controller.signal });
+  return () => controller.abort();
+}, []);
+```
+
+### J5: Detached DOM Node References
+
+- **Severity**: SUGGESTION
+- **Detection**: Variables holding references to removed DOM elements
+- **Impact**: Memory
+
+Set references to `null` when elements are removed.
+
+### J6: Synchronous XHR
+
+- **Severity**: CRITICAL
+- **Detection**: `XMLHttpRequest` with synchronous flag
+- **CWV**: INP
+
+Use `fetch()` (always async).
+
+### J7: Heavy Computation on Main Thread
+
+- **Severity**: IMPORTANT
+- **Detection**: CPU-intensive operations in component code
+- **CWV**: INP
+
+Move to Web Worker or break into chunks with `scheduler.yield()`.
+
+### J8: Missing Effect Cleanup
+
+- **Severity**: IMPORTANT
+- **Detection**: `useEffect` without return cleanup; `subscribe` without unsubscribe
+- **Impact**: Memory
+
+React: return cleanup from `useEffect`. Angular: `takeUntilDestroyed()`. Vue: `onUnmounted`.
+
+---
+
+## CSS Performance Anti-Patterns (C1-C7)
+
+### C1: Animation Using Layout-Triggering Properties
+
+- **Severity**: CRITICAL
+- **Detection**: `animation:|transition:` with `top|left|width|height|margin|padding`
+- **CWV**: INP
+
+```css
+/* BAD — main thread, <60fps */
+.card { transition: width 0.3s, height 0.3s; }
+
+/* GOOD — GPU compositor, 60fps */
+.card { transition: transform 0.3s, opacity 0.3s; }
+.card:hover { transform: scale(1.05); }
+```
+
+### C2: Missing content-visibility for Off-Screen Sections
+
+- **Severity**: SUGGESTION
+- **Detection**: Long pages without `content-visibility: auto`
+- **CWV**: INP
+
+```css
+.below-fold-section {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 500px;
+}
+```
+
+### C3: will-change Applied Permanently
+
+- **Severity**: SUGGESTION
+- **Detection**: `will-change:` in base CSS (not `:hover|:focus`)
+- **Impact**: Memory
+
+Apply on interaction only or let browser optimize automatically.
+
+### C4: Large Unused CSS
+
+- **Severity**: IMPORTANT
+- **Detection**: CSS where >50% of rules are unused
+- **CWV**: LCP
+
+Use PurgeCSS, Tailwind purge, or critters. Code-split CSS per route.
+
+### C5: Universal Selector in Hot Paths
+
+- **Severity**: SUGGESTION
+- **Detection**: `\* \{` in CSS
+- **CWV**: INP
+
+```css
+/* GOOD — zero-specificity reset */
+:where(*, *::before, *::after) { box-sizing: border-box; }
+```
+
+### C6: Missing CSS Containment
+
+- **Severity**: SUGGESTION
+- **Detection**: Complex components without `contain` property
+- **CWV**: INP
+
+```css
+.sidebar { contain: layout style paint; }
+```
+
+### C7: Route Transitions Without View Transitions API
+
+- **Severity**: SUGGESTION
+- **Detection**: SPA route changes without View Transitions API
+- **CWV**: CLS (perceived)
+
+```javascript
+// Use View Transitions for smooth route changes (with feature check)
+if (document.startViewTransition) {
+  document.startViewTransition(() => {
+    // update DOM / navigate
+  });
+} else {
+  // fallback: update DOM directly
+}
+```
+
+Same-document transitions supported in all major browsers. Cross-document supported in Chrome/Edge 126+, Safari 18.5+. Always feature-check before calling — unsupported browsers will throw without the guard.
+
+---
+
+## Images, Media and Fonts Anti-Patterns (I1-I8)
+
+### I1: Images Without Dimensions
+
+- **Severity**: CRITICAL
+- **Detection**: `<img` without `width=` and `height=`
+- **CWV**: CLS
+
+Always set `width` and `height` on images, or use `aspect-ratio` in CSS.
+
+### I2: Lazy Loading Above-Fold Images
+
+- **Severity**: CRITICAL
+- **Detection**: `loading="lazy"` on hero/banner images
+- **CWV**: LCP
+
+```html
+<!-- GOOD — eager load with high priority -->
+<img src="/hero.webp" alt="Hero" fetchpriority="high" />
+```
+
+### I3: Legacy Format Only (JPEG/PNG)
+
+- **Severity**: IMPORTANT
+- **Detection**: Images without WebP/AVIF alternatives
+- **CWV**: LCP
+
+```html
+<picture>
+  <source srcset="/hero.avif" type="image/avif" />
+  <source srcset="/hero.webp" type="image/webp" />
+  <img src="/hero.jpg" alt="Hero" width="1200" height="600" />
+</picture>
+```
+
+### I4: Missing Responsive srcset/sizes
+
+- **Severity**: IMPORTANT
+- **Detection**: `<img` without `srcset`
+- **CWV**: LCP
+
+```html
+<img src="/hero-800.jpg" alt="Hero"
+     srcset="/hero-400.jpg 400w, /hero-800.jpg 800w, /hero-1200.jpg 1200w"
+     sizes="(max-width: 600px) 400px, (max-width: 1024px) 800px, 1200px" />
+```
+
+### I5: Font Without font-display
+
+- **Severity**: IMPORTANT
+- **Detection**: `@font-face` without `font-display`
+- **CWV**: CLS
+
+```css
+@font-face {
+  font-family: 'CustomFont';
+  src: url('/fonts/custom.woff2') format('woff2');
+  font-display: swap; /* or "optional" for best CLS */
+}
+```
+
+### I6: Critical Font Not Preloaded
+
+- **Severity**: IMPORTANT
+- **Detection**: Custom font without `<link rel="preload">`
+- **CWV**: LCP + CLS
+
+```html
+<link rel="preload" href="/fonts/main.woff2" as="font" type="font/woff2" crossorigin />
+```
+
+### I7: Full Font Loaded When Subset Suffices
+
+- **Severity**: SUGGESTION
+- **Detection**: Font files > 50KB WOFF2
+- **CWV**: LCP
+
+Use `unicode-range`, subset with glyphhanger, or `next/font` (auto-subsets Google Fonts).
+
+### I8: Unoptimized SVGs
+
+- **Severity**: SUGGESTION
+- **Detection**: SVGs with editor metadata
+- **CWV**: LCP (minor)
+
+```bash
+npx svgo input.svg -o output.svg
+```
+
+---
+
+## Bundle and Tree Shaking Anti-Patterns (B1-B6)
+
+### B1: Barrel File Importing Entire Module
+
+- **Severity**: IMPORTANT
+- **Detection**: `from '\.\/(?:.*\/index|components)'`
+- **CWV**: INP
+
+```typescript
+// BAD
+import { Button } from './components';
+
+// GOOD — direct import
+import { Button } from './components/Button';
+```
+
+### B2: CommonJS require() Preventing Tree Shaking
+
+- **Severity**: IMPORTANT
+- **Detection**: `require(` in frontend code
+- **CWV**: INP
+
+Use ESM `import/export`. Replace `require` with `import`.
+
+### B3: Large Dependency for Small Utility
+
+- **Severity**: IMPORTANT
+- **Detection**: `from "moment"|from "lodash"` (full imports)
+- **CWV**: INP
+
+```typescript
+// GOOD — tree-shakeable alternatives
+import { format } from 'date-fns';
+import { pick } from 'lodash-es';
+
+// BEST — native JS
+const formatted = new Intl.DateTimeFormat('en').format(date);
+```
+
+### B4: Missing Dynamic Import for Route Splitting
+
+- **Severity**: CRITICAL
+- **Detection**: All route components imported statically
+- **CWV**: INP
+
+```tsx
+// Next.js: automatic with file-based routing
+// React:
+const Page = React.lazy(() => import('./pages/Page'));
+// Angular:
+{ path: 'settings', loadComponent: () => import('./pages/settings.component') }
+// Vue:
+const Page = defineAsyncComponent(() => import('./pages/Page.vue'));
+```
+
+### B5: Missing sideEffects in package.json
+
+- **Severity**: SUGGESTION
+- **Detection**: Library package.json without `"sideEffects"` field
+- **CWV**: INP
+
+```json
+{ "sideEffects": false }
+```
+
+### B6: Duplicate Dependencies
+
+- **Severity**: SUGGESTION
+- **Detection**: Same library at multiple versions
+- **CWV**: INP
+
+```bash
+npm dedupe
+```
+
+---
+
+## Framework-Specific: Next.js (NX1-NX6)
+
+### NX1: Not Using next/image
+
+- **Severity**: IMPORTANT
+- **Detection**: `<img ` in `.tsx` instead of `<Image>`
+- **CWV**: LCP + CLS
+
+```tsx
+import Image from 'next/image';
+<Image src="/hero.jpg" alt="Hero" width={1200} height={600} priority />
+```
+
+### NX2: Not Using Cache Components for Partial Prerendering
+
+- **Severity**: IMPORTANT
+- **Detection**: Pages without `"use cache"` directive in Next.js 16+ projects
+- **CWV**: LCP
+
+```typescript
+// BAD — entire page is dynamic
+export default async function Page() {
+  const data = await fetchData(); // blocks full page render
+  return <div>{data.title}</div>;
+}
+
+// GOOD — enable Partial Prerendering with "use cache"
+// next.config.ts: { cacheComponents: true }
+"use cache";
+export default async function Page() {
+  const data = await fetchData(); // static shell renders instantly, dynamic holes stream
+  return <div>{data.title}</div>;
+}
+```
+
+Enable in `next.config.ts` with `cacheComponents: true`. Use `"use cache"` at file, component, or function level. Static shell loads instantly; dynamic content streams via Suspense boundaries.
+
+### NX3: Unnecessary "use client" on Server-Renderable Component
+
+- **Severity**: IMPORTANT
+- **Detection**: `"use client"` on components without hooks or browser APIs
+- **CWV**: INP
+
+Remove `"use client"` from components that only render static content.
+
+### NX4: Data Fetching in useEffect Instead of Server-Side
+
+- **Severity**: CRITICAL
+- **Detection**: `useEffect` + `fetch` in Next.js App Router pages
+- **CWV**: LCP
+
+Fetch data in Server Components directly (async function body).
+
+### NX5: Missing next/font
+
+- **Severity**: IMPORTANT
+- **Detection**: `fonts.googleapis|fonts.gstatic` in CSS/HTML
+- **CWV**: CLS + LCP
+
+```tsx
+import { Inter } from 'next/font/google';
+const inter = Inter({ subsets: ['latin'] });
+```
+
+### NX6: Missing "use cache" for Cacheable Server Functions
+
+- **Severity**: IMPORTANT
+- **Detection**: Async server functions without `"use cache"` in Next.js 16+ with `cacheComponents: true`
+- **CWV**: LCP
+
+```typescript
+// BAD — data fetched on every request
+async function getProducts() {
+  return await db.products.findMany();
+}
+
+// GOOD — cached with revalidation
+"use cache";
+import { cacheLife } from 'next/cache';
+async function getProducts() {
+  cacheLife('hours');
+  return await db.products.findMany();
+}
+```
+
+`"use cache"` replaces the old `unstable_cache` and `fetch` cache options. Use `cacheLife()` and `cacheTag()` for fine-grained control.
+
+---
+
+## Framework-Specific: Angular (NG1-NG6)
+
+### NG1: Default Change Detection on Presentational Components
+
+- **Severity**: IMPORTANT
+- **Detection**: Components without `ChangeDetectionStrategy.OnPush` (Angular <19) or without signals (Angular 19+)
+- **CWV**: INP
+
+```typescript
+// Angular <19: Use OnPush
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  ...
+})
+
+// Angular 19+: Prefer zoneless with signals
+// app.config.ts: provideZonelessChangeDetection()
+@Component({ ... })
+export class ProductCard {
+  product = input.required<Product>(); // signal input
+  price = computed(() => this.product().price * 1.19); // derived signal
+}
+```
+
+Angular 19+: prefer zoneless change detection with signals. OnPush is unnecessary when using signal-based reactivity. Angular 20+ has stable zoneless support.
+
+### NG2: Not Using NgOptimizedImage
+
+- **Severity**: IMPORTANT
+- **Detection**: `<img` without `ngSrc` in `.component.html`
+- **CWV**: LCP + CLS
+
+```html
+<img ngSrc="/hero.jpg" alt="Hero" width="1200" height="600" priority />
+```
+
+### NG3: Missing @defer for Below-Fold Content
+
+- **Severity**: SUGGESTION
+- **Detection**: Heavy below-fold components loaded eagerly (Angular 17+)
+- **CWV**: INP
+
+```html
+@defer (on viewport) {
+  <app-heavy-chart [data]="chartData" />
+} @placeholder {
+  <div class="chart-skeleton"></div>
+}
+```
+
+### NG4: Not Using Signals for Reactive State
+
+- **Severity**: SUGGESTION
+- **Detection**: Class properties without signals in Angular 19+
+- **CWV**: INP
+
+Use `signal()` for reactive state, `computed()` for derived values. Signal APIs (`signal()`, `computed()`, `effect()`) are stable since Angular 20.
+
+### NG5: Full Hydration Without Incremental Hydration
+
+- **Severity**: IMPORTANT
+- **Detection**: SSR app without `withIncrementalHydration()` in Angular 19+
+- **CWV**: LCP, INP
+
+```typescript
+// BAD — full hydration blocks interactivity
+provideClientHydration()
+
+// GOOD — incremental hydration with triggers
+provideClientHydration(withIncrementalHydration())
+```
+
+Use `@defer` triggers (`on viewport`, `on interaction`) to hydrate components on demand. Reduces TTI by deferring non-critical component hydration.
+
+### NG6: Still Using zone.js in Angular 20+ Projects
+
+- **Severity**: SUGGESTION
+- **Detection**: `zone.js` in polyfills array, no `provideZonelessChangeDetection()` in Angular 20+
+- **CWV**: INP
+
+```typescript
+// app.config.ts
+export const appConfig = {
+  providers: [
+    provideZonelessChangeDetection(), // removes ~15-30KB from bundle
+    // ...
+  ]
+};
+```
+
+Zoneless change detection with signals reduces bundle size and improves runtime performance. Stable since Angular 20.
+
+---
+
+## Framework-Specific: React (RX1-RX4)
+
+### RX1: Missing React Compiler Adoption
+
+- **Severity**: SUGGESTION
+- **Detection**: Manual `useMemo|useCallback` in React 19+ project
+- **CWV**: INP
+
+Enable React Compiler (v19+) for auto-memoization. Remove manual wrappers.
+
+### RX2: Missing useTransition for Expensive Updates
+
+- **Severity**: IMPORTANT
+- **Detection**: State updates causing expensive re-renders without `useTransition`
+- **CWV**: INP
+
+```tsx
+const [isPending, startTransition] = useTransition();
+function handleFilter(value) {
+  startTransition(() => setFilter(value));
+}
+```
+
+### RX3: Missing useDeferredValue for Expensive Rendering
+
+- **Severity**: IMPORTANT
+- **Detection**: Expensive rendering from rapidly-changing input
+- **CWV**: INP
+
+```tsx
+const deferredQuery = useDeferredValue(query);
+const results = expensiveFilter(items, deferredQuery);
+```
+
+### RX4: Missing React.lazy for Route Splitting
+
+- **Severity**: IMPORTANT
+- **Detection**: Route components imported statically
+- **CWV**: INP
+
+```tsx
+const Settings = React.lazy(() => import('./pages/Settings'));
+```
+
+---
+
+## Framework-Specific: Vue (VU1-VU4)
+
+### VU1: reactive() on Large Data Structures
+
+- **Severity**: IMPORTANT
+- **Detection**: `reactive(` on large arrays or deep objects
+- **CWV**: INP
+
+Use `shallowRef()` or `shallowReactive()` for large data.
+
+### VU2: Missing v-memo on Expensive List Renders
+
+- **Severity**: SUGGESTION
+- **Detection**: Large lists without `v-memo`
+- **CWV**: INP
+
+```vue
+<div v-for="item in items" :key="item.id" v-memo="[item.id, item.updatedAt]">
+  <ExpensiveItem :data="item" />
+</div>
+```
+
+### VU3: Missing defineAsyncComponent
+
+- **Severity**: IMPORTANT
+- **Detection**: Heavy components imported statically
+- **CWV**: INP
+
+```typescript
+const HeavyChart = defineAsyncComponent(() => import('./HeavyChart.vue'));
+```
+
+### VU4: Not Using Vapor Mode for Performance-Critical Components
+
+- **Severity**: SUGGESTION
+- **Detection**: Performance-critical components using virtual DOM in Vue 3.6+
+- **CWV**: INP
+
+Vue 3.6+ Vapor Mode compiles templates to direct DOM operations, bypassing the virtual DOM. Use for performance-critical subtrees. Can be mixed with standard components.
+
+---
+
+## Resource Hints Quick Reference
+
+| Hint | Purpose | When to Use |
+|------|---------|-------------|
+| `preconnect` | DNS + TCP + TLS early | Critical third-party origins (API, CDN, fonts) |
+| `preload` | Fetch immediately, high priority | LCP image, critical font |
+| `prefetch` | Low priority for future navigation | Next-page assets |
+| `dns-prefetch` | DNS resolution only | Non-critical third-party origins |
+| `modulepreload` | Preload + parse ES module | Critical JS modules |
+| `<script type="speculationrules">` | Prefetch/prerender next navigation | Likely next pages (Chrome 121+, progressive enhancement) |
+
+---
+
+## Image Optimization Quick Reference
+
+| Aspect | Recommendation |
+|--------|---------------|
+| Format | WebP (25-34% smaller), AVIF (50% smaller) |
+| LCP image | `fetchpriority="high"` or framework `priority` prop |
+| Below-fold | `loading="lazy"` |
+| Dimensions | Always set `width` + `height` |
+| Responsive | `srcset` + `sizes` or framework Image component |
+| Compression | Quality 75-85 for photos |
+
+---
+
+## Font Loading Quick Reference
+
+| Strategy | Best For | CLS Impact |
+|----------|---------|-----------|
+| `font-display: swap` | Body text | Slight FOUT, minimal CLS |
+| `font-display: optional` | All fonts (best CLS) | No FOUT, no CLS |
+| `next/font` | Next.js projects | Zero CLS |
+| Variable fonts | Multiple weights | Single file for all weights |
+
+Rules: preload 1-2 critical fonts only, use WOFF2, subset to needed characters, self-host when possible.
+
+---
+
+## Performance Checklist (CWV)
+
+### LCP (< 2.5s)
+- [ ] LCP image has `fetchpriority="high"` or `priority` prop
+- [ ] LCP image preloaded if not in HTML source
+- [ ] No `loading="lazy"` on above-fold images
+- [ ] Critical CSS inlined or extracted
+- [ ] No render-blocking scripts (use `defer` or `async`)
+- [ ] Preconnect to critical third-party origins
+- [ ] Main content server-rendered (not client-side fetched)
+- [ ] Images in modern format (WebP/AVIF) with responsive `srcset`
+- [ ] Compression enabled (Brotli preferred)
+- [ ] Fonts preloaded with `font-display: swap` or `optional`
+
+### INP (< 200ms)
+- [ ] Event handlers complete in < 50ms
+- [ ] Long tasks broken into smaller chunks
+- [ ] Route-based code splitting implemented
+- [ ] Heavy computation moved to Web Workers
+- [ ] Lists with > 100 items virtualized
+- [ ] No barrel file imports (direct component imports)
+- [ ] ESM imports used (not CommonJS `require`)
+- [ ] `"use client"` only on components that need interactivity
+- [ ] Layout-triggering CSS properties not animated
+- [ ] Effect cleanup implemented (no leaking listeners/timers)
+
+### CLS (< 0.1)
+- [ ] All images have `width` and `height` attributes
+- [ ] Fonts use `font-display: swap` or `optional`
+- [ ] No content injected above existing content dynamically
+- [ ] Ads/embeds have reserved space
+- [ ] No hydration mismatches
+- [ ] `content-visibility: auto` has `contain-intrinsic-size`

--- a/.github/instructions/playwright-typescript.instructions.md
+++ b/.github/instructions/playwright-typescript.instructions.md
@@ -1,0 +1,86 @@
+---
+description: 'Playwright test generation instructions'
+applyTo: '**'
+---
+
+## Test Writing Guidelines
+
+### Code Quality Standards
+- **Locators**: Prioritize user-facing, role-based locators (`getByRole`, `getByLabel`, `getByText`, etc.) for resilience and accessibility. Use `test.step()` to group interactions and improve test readability and reporting.
+- **Assertions**: Use auto-retrying web-first assertions. These assertions start with the `await` keyword (e.g., `await expect(locator).toHaveText()`). Avoid `expect(locator).toBeVisible()` unless specifically testing for visibility changes.
+- **Timeouts**: Rely on Playwright's built-in auto-waiting mechanisms. Avoid hard-coded waits or increased default timeouts.
+- **Clarity**: Use descriptive test and step titles that clearly state the intent. Add comments only to explain complex logic or non-obvious interactions.
+
+
+### Test Structure
+- **Imports**: Start with `import { test, expect } from '@playwright/test';`.
+- **Organization**: Group related tests for a feature under a `test.describe()` block.
+- **Hooks**: Use `beforeEach` for setup actions common to all tests in a `describe` block (e.g., navigating to a page).
+- **Titles**: Follow a clear naming convention, such as `Feature - Specific action or scenario`.
+
+
+### File Organization
+- **Location**: Store all test files in the `tests/` directory.
+- **Naming**: Use the convention `<feature-or-page>.spec.ts` (e.g., `login.spec.ts`, `search.spec.ts`).
+- **Scope**: Aim for one test file per major application feature or page.
+
+### Assertion Best Practices
+- **UI Structure**: Use `toMatchAriaSnapshot` to verify the accessibility tree structure of a component. This provides a comprehensive and accessible snapshot.
+- **Element Counts**: Use `toHaveCount` to assert the number of elements found by a locator.
+- **Text Content**: Use `toHaveText` for exact text matches and `toContainText` for partial matches.
+- **Navigation**: Use `toHaveURL` to verify the page URL after an action.
+
+
+## Example Test Structure
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Movie Search Feature', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the application before each test
+    await page.goto('https://debs-obrien.github.io/playwright-movies-app');
+  });
+
+  test('Search for a movie by title', async ({ page }) => {
+    await test.step('Activate and perform search', async () => {
+      await page.getByRole('search').click();
+      const searchInput = page.getByRole('textbox', { name: 'Search Input' });
+      await searchInput.fill('Garfield');
+      await searchInput.press('Enter');
+    });
+
+    await test.step('Verify search results', async () => {
+      // Verify the accessibility tree of the search results
+      await expect(page.getByRole('main')).toMatchAriaSnapshot(`
+        - main:
+          - heading "Garfield" [level=1]
+          - heading "search results" [level=2]
+          - list "movies":
+            - listitem "movie":
+              - link "poster of The Garfield Movie The Garfield Movie rating":
+                - /url: /playwright-movies-app/movie?id=tt5779228&page=1
+                - img "poster of The Garfield Movie"
+                - heading "The Garfield Movie" [level=2]
+      `);
+    });
+  });
+});
+```
+
+## Test Execution Strategy
+
+1. **Initial Run**: Execute tests with `npx playwright test --project=chromium`
+2. **Debug Failures**: Analyze test failures and identify root causes
+3. **Iterate**: Refine locators, assertions, or test logic as needed
+4. **Validate**: Ensure tests pass consistently and cover the intended functionality
+5. **Report**: Provide feedback on test results and any issues discovered
+
+## Quality Checklist
+
+Before finalizing tests, ensure:
+- [ ] All locators are accessible and specific and avoid strict mode violations
+- [ ] Tests are grouped logically and follow a clear structure
+- [ ] Assertions are meaningful and reflect user expectations
+- [ ] Tests follow consistent naming conventions
+- [ ] Code is properly formatted and commented

--- a/.github/instructions/pull-request-standards.instructions.md
+++ b/.github/instructions/pull-request-standards.instructions.md
@@ -1,0 +1,150 @@
+---
+applyTo: '**'
+description: >
+  Standards for opening, reviewing, and merging GitHub Pull Requests in the
+  settimesdotca multi-agent dev studio. Covers title conventions, body structure,
+  test plan discipline, labels, agent attribution, and what to check before merge.
+---
+
+# Pull Request Standards
+
+These rules apply to every PR opened by any agent (Sonny, Theo, Cass, or others)
+or by a human contributor.
+
+---
+
+## Title
+
+Use the same conventional-commit prefix as the branch/commit:
+
+```
+fix(admin): gate bulk apply on ignore_conflicts — closes #474
+feat(bands): render bios as Markdown (safe: marked → DOMPurify)
+ci: add ESLint gating for functions/ + scripts/
+chore(content): remove Ottawa references from seed/test fixtures
+```
+
+- Be specific about *what* changed, not just *that* it changed.
+- If the PR closes an issue, put `— closes #N` in the title **and** `Closes #N`
+  on its own line in the body (GitHub only auto-closes from the body, not the title).
+
+---
+
+## Body — required sections
+
+Use `.github/pull_request_template.md` as the starting point. Fill every section;
+write "None" rather than deleting a section.
+
+### Summary
+One concise paragraph. Answer: what changed, why, and what issue it closes.
+`Closes #N` must appear on its own line here (or in a `## Linked issues` section).
+
+### What changed
+For PRs touching more than ~3 files in meaningfully different ways, add a table:
+
+```markdown
+| File | Change |
+|------|--------|
+| `frontend/src/utils/markdown.js` | New util: `renderMarkdownToSafeHtml`, `stripMarkdownToText` |
+| `frontend/src/pages/BandProfilePage.jsx` | Calls new util for bio render + meta |
+| `functions/utils/ssrMeta.js` | `toPlainText` gains markdown-strip regex pass |
+```
+
+Skip the table for single-concern PRs where the diff speaks for itself.
+
+### Security / correctness notes
+Always present. Document XSS vectors, auth checks, CSRF implications, or
+data-integrity invariants touched. If none apply, write "None — no auth, data, or
+rendering surface changed."
+
+This section is what Cass (security reviewer) reads first.
+
+### Verification
+All checkboxes **must be ticked before merge** — an unchecked test plan is not a
+test plan. Applicable checks for this repo:
+
+```markdown
+- [ ] Tests: N pass, 0 failures
+- [ ] ESLint: 0 errors
+- [ ] Format check: clean
+- [ ] Build: green
+- [ ] validate:openapi: no drift  ← only if api-spec.yaml touched
+- [ ] Manual smoke: <what was clicked/tested>
+```
+
+For backend-only PRs omit the build line. For frontend-only PRs omit
+validate:openapi. Always include the test count — it tells reviewers the suite
+didn't silently shrink.
+
+---
+
+## Labels
+
+Apply labels when opening the PR — not after. Required: one type label + one
+priority label.
+
+| Category | Labels |
+|----------|--------|
+| Type | `bug` `enhancement` `ci` `documentation` `chore` `security` |
+| Priority | `priority:p1` `priority:p2` `priority:p3` |
+| Scope (optional) | `frontend` `backend` `content` `admin` |
+
+Example: a bug fix visible to event attendees → `bug` + `priority:p1`.
+
+```bash
+gh pr create --label "bug,priority:p1"
+```
+
+---
+
+## Agent attribution
+
+One line at the bottom of the body, after a `---` divider. Drop the session URL —
+it adds noise and leaks a private identifier.
+
+```
+Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
+```
+
+Use the agent's name that actually did the work. If only one agent was involved:
+
+```
+Built and reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
+```
+
+---
+
+## Before opening the PR
+
+Run the applicable checklist from CLAUDE.md's "Before every commit" section.
+The full gate before merge:
+
+1. `npm run format:check` (backend) and `cd frontend && npm run format:check`
+2. `npm run lint`
+3. `npm test` (backend, may require Linux/CI) and `cd frontend && npm test -- --run`
+4. `npm run build --prefix frontend`
+5. `npm run validate:openapi` if `docs/api-spec.yaml` changed
+6. `git fetch origin && git rebase origin/main` — do this **every push**, not just on open
+
+---
+
+## After opening the PR
+
+- If the PR touches `functions/utils/auth.js`, session endpoints, or follow/confirm-follow
+  flows → invoke `cloudflare-security-reviewer` agent before merging.
+- If the PR modifies `migrations/` → verify `database/setup-complete.sql` stays in sync.
+- If the PR touches public SEO pages → check structured data and `document.title` assignments.
+- Tick all verification checkboxes in the PR body before merging — never merge with open `- [ ]` items.
+
+---
+
+## Anti-patterns to avoid
+
+| Anti-pattern | Why it matters |
+|--------------|----------------|
+| `Closes #N` only in the title, not the body | GitHub does not auto-close from the title |
+| Unchecked `- [ ]` items at merge time | Indistinguishable from a test plan that was skipped |
+| No labels | PRs are unsortable; priority is invisible in the queue |
+| Session URL in attribution footer | Leaks a private identifier; noise for reviewers |
+| Large PR with no "What changed" table | Hard to bisect regressions across unrelated concerns |
+| Merging without rebasing `origin/main` | Causes "Update branch" round-trips; blocks fast-forward merge |

--- a/.github/instructions/security-and-owasp.instructions.md
+++ b/.github/instructions/security-and-owasp.instructions.md
@@ -1,0 +1,1057 @@
+---
+applyTo: '**'
+description: 'Comprehensive secure coding standards based on OWASP Top 10 2025, with 55+ anti-patterns, detection regex, framework-specific fixes for modern web and backend frameworks, and AI/LLM security guidance.'
+---
+
+# Security Standards
+
+Comprehensive security rules for web application development. Every anti-pattern includes a severity classification, detection method, OWASP 2025 reference, and corrective code examples.
+
+**Severity levels:**
+
+- **CRITICAL** — Exploitable vulnerability. Must be fixed before merge.
+- **IMPORTANT** — Significant risk. Should be fixed in the same sprint.
+- **SUGGESTION** — Defense-in-depth improvement. Plan for a future iteration.
+
+---
+
+## OWASP Top 10 — 2025 Quick Reference
+
+| # | Category | Key Mitigation |
+|---|----------|----------------|
+| A01 | Broken Access Control | Auth middleware on every endpoint, RBAC, ownership checks |
+| A02 | Security Misconfiguration | Security headers, no debug in prod, no default credentials |
+| A03 | Software Supply Chain Failures *(NEW)* | `npm audit`, lockfile integrity, SBOM, SLSA provenance |
+| A04 | Cryptographic Failures | Argon2id/bcrypt for passwords, TLS everywhere, no secrets in code |
+| A05 | Injection | Parameterized queries, input validation, no raw HTML with user input |
+| A06 | Insecure Design | Threat modeling, secure design patterns, abuse case testing |
+| A07 | Authentication Failures | Rate-limit login, secure session management, MFA |
+| A08 | Software or Data Integrity Failures | SRI for CDN scripts, signed artifacts, no insecure deserialization |
+| A09 | Security Logging and Alerting Failures | Log security events, no PII in logs, correlation IDs, active alerting |
+| A10 | Mishandling of Exceptional Conditions *(NEW)* | Handle all errors, no stack traces in prod, fail-secure |
+
+---
+
+## Injection Anti-Patterns (I1-I8)
+
+### I1: SQL Injection via String Concatenation
+
+- **Severity**: CRITICAL
+- **Detection**: `\$\{.*\}.*(?:SELECT|INSERT|UPDATE|DELETE|FROM|WHERE)`
+- **OWASP**: A05
+
+```typescript
+// BAD
+const unsafeResult = await db.query(`SELECT * FROM users WHERE id = ${userId}`);
+
+// GOOD — parameterized query
+const safeResult = await db.query('SELECT * FROM users WHERE id = $1', [userId]);
+```
+
+### I2: NoSQL Injection (MongoDB Operator Injection)
+
+- **Severity**: CRITICAL
+- **Detection**: `\{\s*\$(?:gt|gte|lt|lte|ne|in|nin|regex|where|exists)`
+- **OWASP**: A05
+
+```typescript
+// BAD — attacker sends { "password": { "$gt": "" } }
+const user = await User.findOne({ username: req.body.username, password: req.body.password });
+
+// GOOD — validate and cast input types
+const username = String(req.body.username);
+const password = String(req.body.password);
+const user = await User.findOne({ username });
+const valid = user && await verifyPassword(user.passwordHash, password);
+```
+
+### I3: Command Injection (exec with User Input)
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:exec|execSync|execFile|execFileSync)\s*\(.*(?:req\.|params\.|query\.|body\.)`
+- **OWASP**: A05
+
+```typescript
+// BAD — shell interpolation, sync call blocks the event loop
+import { execFileSync } from 'node:child_process';
+const unsafeOutput = execFileSync('sh', ['-c', `ls -la ${req.query.dir}`]);
+
+// GOOD — async execFile, arguments array, no shell, bounded time/output
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+const pExecFile = promisify(execFile);
+
+const dir = String(req.query.dir ?? '');
+if (!dir || dir.startsWith('-')) throw new Error('Invalid directory');
+const { stdout: safeOutput } = await pExecFile('ls', ['-la', '--', dir], {
+  timeout: 5_000,      // fail fast on hung processes
+  maxBuffer: 1 << 20,  // 1 MiB cap to prevent memory exhaustion
+});
+
+// BEST — allowlist validation on top of the async, bounded call above
+const allowedDirs = ['/data', '/public'];
+if (!allowedDirs.includes(dir)) throw new Error('Invalid directory');
+```
+
+Prefer async `execFile`/`spawn` over `execFileSync` in server handlers: the sync variant blocks Node's event loop and can amplify DoS impact. Always pass a `timeout` and `maxBuffer` to bound execution.
+
+### I4: XSS via Unsanitized HTML Rendering
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:v-html|\[innerHTML\]|dangerouslySetInner|bypassSecurityTrust)`
+- **OWASP**: A05
+
+Applies to all frontend frameworks. Each has an API that bypasses default XSS protection:
+
+- **React**: `dangerouslySetInnerHTML` prop with raw user content
+- **Angular**: `[innerHTML]` binding or `bypassSecurityTrustHtml` with unsanitized input
+- **Vue**: `v-html` directive with user-controlled content
+
+```typescript
+// GOOD — sanitize with DOMPurify before rendering any raw HTML
+import DOMPurify from 'dompurify';
+const clean = DOMPurify.sanitize(userContent);
+
+// BEST — use text interpolation when HTML is not needed
+// React:   {userContent}
+// Angular: {{ userContent }}
+// Vue:     {{ userContent }}
+```
+
+### I5: SSRF via User-Controlled URLs
+
+- **Severity**: CRITICAL
+- **Detection**: `fetch\((?:req\.|params\.|query\.|body\.|url|href)`
+- **OWASP**: A01
+
+```typescript
+// BAD
+const data = await fetch(req.body.url);
+
+// GOOD — scheme allowlist + hostname allowlist + DNS/IP validation (see TOCTOU note)
+import { promises as dns } from 'node:dns';
+
+function isPrivateIP(ip: string): boolean {
+  // Normalize IPv4-mapped IPv6 (e.g., ::ffff:127.0.0.1 → 127.0.0.1)
+  const normalized = ip.startsWith('::ffff:') ? ip.slice(7) : ip;
+  // IPv4 private/reserved/loopback ranges
+  if (/^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|0\.|169\.254\.)/.test(normalized)) return true;
+  // IPv6 loopback, link-local (fe80::/10), and unique-local
+  if (/^(::1|fe[89ab]|fc|fd)/i.test(normalized)) return true;
+  return false;
+}
+
+const parsed = new URL(req.body.url);
+if (parsed.protocol !== 'https:') throw new Error('Only HTTPS allowed');
+const allowedHosts = ['api.example.com', 'cdn.example.com'];
+if (!allowedHosts.includes(parsed.hostname)) throw new Error('Host not allowed');
+// Resolve all A/AAAA records to prevent DNS rebinding via multiple IPs
+const resolved = await dns.lookup(parsed.hostname, { all: true });
+if (resolved.length === 0 || resolved.some(({ address }) => isPrivateIP(address))) {
+  throw new Error('Private or reserved IPs not allowed');
+}
+// Note: for production, pin the resolved IP in the HTTP client to prevent
+// TOCTOU rebinding between this check and fetch(). See undici Agent docs.
+const data = await fetch(parsed.toString(), { redirect: 'error' });
+```
+
+### I6: Path Traversal in File Operations
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:readFile|readFileSync|createReadStream|path\.join)\s*\(.*(?:req\.|params\.|query\.|body\.)`
+- **OWASP**: A01
+
+```typescript
+// BAD
+const file = fs.readFileSync(`/data/${req.params.filename}`);
+
+// GOOD — resolve and validate within allowed directory
+import path from 'path';
+const basePath = '/data';
+const filePath = path.resolve(basePath, req.params.filename);
+if (!filePath.startsWith(basePath + path.sep)) throw new Error('Path traversal detected');
+const file = fs.readFileSync(filePath);
+```
+
+### I7: Template Injection
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:render|compile|template)\s*\(.*(?:req\.|params\.|query\.|body\.)`
+- **OWASP**: A05
+
+```typescript
+// BAD — user input as template source
+const html = ejs.render(req.body.template, data);
+
+// GOOD — predefined templates, user input only as data
+const html = ejs.renderFile('./templates/page.ejs', { content: req.body.content });
+```
+
+### I8: XXE Injection (XML External Entity)
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:parseXml|DOMParser|xml2js|libxmljs).*(?:req\.|body\.|file)`
+- **OWASP**: A05
+
+```typescript
+// GOOD — disable external entities in XML parser
+import { XMLParser } from 'fast-xml-parser';
+const parser = new XMLParser({
+  allowBooleanAttributes: true,
+  processEntities: false,
+  htmlEntities: false,
+});
+const result = parser.parse(req.body.xml);
+```
+
+---
+
+## Authentication Anti-Patterns (AU1-AU8)
+
+### AU1: JWT Algorithm Confusion (alg:none)
+
+- **Severity**: CRITICAL
+- **Detection**: `jwt\.verify\((?![^)]*\balgorithms\b)[^)]*\)`
+- **OWASP**: A07
+
+```typescript
+// BAD — accepts any algorithm including "none"
+const decoded = jwt.verify(token, secret);
+
+// GOOD — enforce specific algorithm
+const decoded = jwt.verify(token, publicKey, { algorithms: ['RS256'] });
+```
+
+### AU2: JWT Without Expiration Check
+
+- **Severity**: CRITICAL
+- **Detection**: `jwt\.sign\((?![^)]*\b(?:expiresIn|exp)\b)[^)]*\)`
+- **OWASP**: A07
+
+```typescript
+// BAD — token never expires
+const token = jwt.sign({ userId: user.id }, secret);
+
+// GOOD — short-lived token
+const token = jwt.sign({ userId: user.id }, secret, { expiresIn: '15m' });
+```
+
+### AU3: JWT Stored in localStorage
+
+- **Severity**: IMPORTANT
+- **Detection**: `localStorage\.setItem\(.*(?:token|jwt|auth|session)`
+- **OWASP**: A07
+
+```typescript
+// BAD — accessible via XSS
+localStorage.setItem('accessToken', token);
+
+// GOOD — httpOnly cookie set by server
+res.cookie('token', token, { httpOnly: true, secure: true, sameSite: 'strict' });
+```
+
+### AU4: Plaintext / Fast Hash for Passwords (MD5/SHA-1/SHA-256)
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:createHash|md5|sha1|sha256)\s*\(.*password`
+- **OWASP**: A04
+
+```typescript
+// BAD — fast hash, no salt
+const sha256Hash = crypto.createHash('sha256').update(password).digest('hex');
+
+// GOOD — Argon2id (OWASP recommended)
+import { hash as argon2Hash, argon2id } from 'argon2';
+const hashed = await argon2Hash(password, { type: argon2id, memoryCost: 65536, timeCost: 3 });
+```
+
+### AU5: Missing Brute-Force Protection on Login
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:post|router\.post)\s*\(\s*['"]\/(?:login|signin|auth|register|reset)`
+- **OWASP**: A07
+
+```typescript
+// BAD — no rate limiting
+app.post('/api/auth/login', loginHandler);
+
+// GOOD
+import rateLimit from 'express-rate-limit';
+const authLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 5 });
+app.post('/api/auth/login', authLimiter, loginHandler);
+```
+
+### AU6: Missing Session Regeneration on Login (Session Fixation)
+
+- **Severity**: IMPORTANT
+- **Detection**: `(?:session|req\.session)\s*\.\s*(?:userId|user|authenticated)\s*=`
+- **OWASP**: A07
+
+```typescript
+// GOOD — regenerate session ID on successful login to prevent fixation
+req.session.regenerate((err) => {
+  if (err) return next(err);
+  req.session.userId = user.id;
+  req.session.save(next);
+});
+```
+
+Related: on password change or elevation, also invalidate all other active sessions for the user (e.g., by bumping a `tokenVersion` column and rejecting sessions with a stale version, or by iterating the session store and destroying entries keyed to that user).
+
+### AU7: OAuth Without State Parameter
+
+- **Severity**: CRITICAL
+- **Detection**: `authorize\?(?![^\n#]*\bstate=)[^\n#]*`
+- **OWASP**: A07
+
+```typescript
+// GOOD — include state parameter for CSRF protection
+const state = crypto.randomBytes(32).toString('hex');
+session.oauthState = state;
+const authUrl = `https://provider.com/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&state=${state}`;
+```
+
+### AU8: Missing PKCE for Public OAuth Clients
+
+- **Severity**: IMPORTANT
+- **Detection**: `(?:authorization_code|code).*(?!.*code_challenge)`
+- **OWASP**: A07
+
+Use PKCE (Proof Key for Code Exchange) with S256 challenge method for all public clients (SPAs, mobile).
+
+---
+
+## Authorization Anti-Patterns (AZ1-AZ6)
+
+### AZ1: Missing Auth Middleware on New Endpoints
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:app|router)\.\w+\s*\(\s*['"]\/api\/(?:admin|users|settings)`
+- **OWASP**: A01
+
+```typescript
+// BAD
+router.delete('/api/users/:id', deleteUser);
+
+// GOOD
+router.delete('/api/users/:id', authenticate, authorize('admin'), deleteUser);
+```
+
+### AZ2: Client-Side Only Authorization
+
+- **Severity**: CRITICAL
+- **Detection**: Component guards without server-side checks
+- **OWASP**: A01
+
+Frontend guards are UX only. ALWAYS verify on server.
+
+### AZ3: IDOR (Insecure Direct Object Reference)
+
+- **Severity**: CRITICAL
+- **Detection**: `params\.(?:id|userId|orderId)` without ownership check
+- **OWASP**: A01
+
+```typescript
+// GOOD — verify ownership
+router.get('/api/orders/:orderId', authenticate, async (req, res) => {
+  const order = await Order.findById(req.params.orderId);
+  if (!order || order.userId !== req.user.id) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  res.json(order);
+});
+```
+
+### AZ4: Mass Assignment
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:create|update|findOneAndUpdate)\s*\(\s*req\.body\s*\)`
+- **OWASP**: A01
+
+```typescript
+// BAD
+await User.findByIdAndUpdate(id, req.body);
+
+// GOOD — explicitly pick allowed fields
+const { name, email, avatar } = req.body;
+await User.findByIdAndUpdate(id, { name, email, avatar });
+```
+
+### AZ5: Privilege Escalation via Role Parameter
+
+- **Severity**: CRITICAL
+- **Detection**: `req\.body\.role|req\.body\.isAdmin|req\.body\.permissions`
+- **OWASP**: A01
+
+```typescript
+// GOOD — ignore role from input
+const { name, email, password } = req.body;
+const user = await User.create({ name, email, password, role: 'user' });
+```
+
+### AZ6: Missing Re-Authentication for Sensitive Operations
+
+- **Severity**: IMPORTANT
+- **Detection**: `(?:delete|destroy|remove).*(?:account|user|organization)` without re-auth
+- **OWASP**: A01
+
+Require current password before account deletion, email change, or other sensitive operations.
+
+---
+
+## Secrets Anti-Patterns (S1-S6)
+
+### S1: Hardcoded API Keys / Tokens
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:password|secret|api_key|token|apiKey)\s*[:=]\s*['"][A-Za-z0-9+/=]{8,}['"]`
+- **OWASP**: A04
+
+```typescript
+// BAD
+const API_KEY = 'sk_live_abc123def456';
+
+// GOOD
+const API_KEY = process.env.API_KEY;
+```
+
+### S2: .env Committed to Git
+
+- **Severity**: CRITICAL
+- **Detection**: `git ls-files .env` (should return empty)
+- **OWASP**: A04
+
+```gitignore
+# .gitignore
+.env
+.env.local
+.env.*.local
+*.pem
+*.key
+```
+
+### S3: Server Secrets Exposed to Client
+
+- **Severity**: CRITICAL
+- **Detection**: `NEXT_PUBLIC_.*(?:SECRET|PRIVATE|PASSWORD|KEY(?!.*PUBLIC))`
+- **OWASP**: A02
+
+```bash
+# BAD
+NEXT_PUBLIC_DATABASE_URL=postgresql://...
+
+# GOOD
+DATABASE_URL=postgresql://...
+NEXT_PUBLIC_API_URL=https://api.example.com
+```
+
+Angular: do not put secrets in `environment.ts` files bundled into the client.
+
+### S4: Default Credentials in Config
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:admin|root|default|test).*(?:password|pass|pwd)\s*[:=]\s*['"](?:admin|root|password|1234|test)`
+- **OWASP**: A02
+
+Use environment variables with validation (zod schema).
+
+### S5: Secrets in CI/CD Pipeline Logs
+
+- **Severity**: IMPORTANT
+- **Detection**: `(?:echo|console\.log|print).*(?:\$SECRET|\$TOKEN|\$PASSWORD|process\.env)`
+- **OWASP**: A09
+
+Use masked secrets in CI. Never echo environment variables containing secrets.
+
+### S6: Sensitive Data in Error Responses / Stack Traces
+
+- **Severity**: IMPORTANT
+- **Detection**: `(?:stack|trace|query|sql).*(?:res\.json|res\.send|c\.JSON)`
+- **OWASP**: A10
+
+```typescript
+// GOOD — generic error to client, details only in logs
+app.use((err, req, res, _next) => {
+  logger.error({ err, path: req.path, method: req.method });
+  const isDev = process.env.NODE_ENV === 'development';
+  res.status(500).json({
+    error: 'Internal Server Error',
+    ...(isDev && { message: err.message }),
+  });
+});
+```
+
+---
+
+## Headers Anti-Patterns (H1-H8)
+
+### H1: Missing Content-Security-Policy
+
+- **Severity**: IMPORTANT
+- **Detection**: Absence of `Content-Security-Policy` header
+- **OWASP**: A02
+
+### H2: CSP with unsafe-inline and unsafe-eval
+
+- **Severity**: IMPORTANT
+- **Detection**: `Content-Security-Policy.*(?:'unsafe-inline'|'unsafe-eval')`
+- **OWASP**: A02
+
+Use nonce-based CSP: `script-src 'self' 'nonce-{SERVER_GENERATED}'`
+
+### H3: Missing Strict-Transport-Security
+
+- **Severity**: IMPORTANT
+- **Detection**: Absence of `Strict-Transport-Security` header
+- **OWASP**: A02
+
+Value: `max-age=31536000; includeSubDomains; preload`
+
+### H4: Missing X-Content-Type-Options
+
+- **Severity**: IMPORTANT
+- **Detection**: Absence of `X-Content-Type-Options: nosniff`
+- **OWASP**: A02
+
+### H5: Missing X-Frame-Options
+
+- **Severity**: IMPORTANT
+- **Detection**: Absence of `X-Frame-Options` header
+- **OWASP**: A02
+
+Value: `DENY`. Also set `Content-Security-Policy: frame-ancestors 'none'`.
+
+### H6: Permissive Referrer-Policy
+
+- **Severity**: SUGGESTION
+- **Detection**: `Referrer-Policy.*(?:unsafe-url|no-referrer-when-downgrade)`
+- **OWASP**: A02
+
+Use: `strict-origin-when-cross-origin`
+
+### H7: Missing Permissions-Policy
+
+- **Severity**: SUGGESTION
+- **Detection**: Absence of `Permissions-Policy` header
+- **OWASP**: A02
+
+Value: `camera=(), microphone=(), geolocation=(), payment=()`
+
+### H8: CORS Wildcard with Credentials
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:cors|Access-Control-Allow-Origin).*\*`
+- **OWASP**: A02
+
+```typescript
+// GOOD
+app.use(cors({
+  origin: ['https://app.example.com', 'https://staging.example.com'],
+  credentials: true,
+}));
+```
+
+---
+
+## Frontend Anti-Patterns (FE1-FE8)
+
+### FE1: Unsanitized HTML Rendering
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:innerHTML|v-html|dangerouslySetInner)` without DOMPurify
+- **OWASP**: A05
+
+Always sanitize with DOMPurify before rendering user-controlled HTML. See I4.
+
+### FE2: Dynamic Code Evaluation with User Input
+
+- **Severity**: CRITICAL
+- **Detection**: `eval\s*\(`
+- **OWASP**: A05
+
+Use structured data parsers (JSON.parse) instead.
+
+### FE3: postMessage Without Origin Validation
+
+- **Severity**: IMPORTANT
+- **Detection**: `addEventListener\s*\(\s*['"]message['"].*(?!.*origin)`
+- **OWASP**: A01
+
+```typescript
+window.addEventListener('message', (event) => {
+  if (event.origin !== 'https://trusted.example.com') return;
+  processData(event.data);
+});
+```
+
+### FE4: Prototype Pollution
+
+- **Severity**: IMPORTANT
+- **Detection**: `(?:__proto__|constructor\.prototype|Object\.assign)\s*.*(?:req\.|body\.|query\.)`
+- **OWASP**: A05
+
+Validate and filter keys from user input before merging into objects.
+
+### FE5: Open Redirect
+
+- **Severity**: IMPORTANT
+- **Detection**: `(?:window\.location|location\.href|router\.push)\s*=\s*(?:req\.|params\.|query\.)`
+- **OWASP**: A01
+
+```typescript
+// GOOD — relative paths only
+const redirect = new URLSearchParams(window.location.search).get('redirect');
+if (redirect?.startsWith('/') && !redirect.startsWith('//')) {
+  window.location.href = redirect;
+}
+```
+
+### FE6: Sensitive Data in localStorage
+
+- **Severity**: IMPORTANT
+- **Detection**: `localStorage\.setItem\(.*(?:token|session|credit|ssn|password)`
+- **OWASP**: A07
+
+Use httpOnly cookies for tokens.
+
+### FE7: Missing CSRF Token
+
+- **Severity**: IMPORTANT
+- **Detection**: POST/PUT/DELETE forms without CSRF token or SameSite cookie
+- **OWASP**: A01
+
+Use double-submit cookie or synchronizer token. Next.js Server Actions have built-in CSRF via Origin header.
+
+### FE8: Client-Only Input Validation
+
+- **Severity**: IMPORTANT
+- **Detection**: Form validation only in frontend
+- **OWASP**: A05
+
+ALWAYS validate on server too. Use zod, joi, or class-validator.
+
+---
+
+## Dependencies Anti-Patterns (D1-D5)
+
+### D1: Known Vulnerable Dependency
+
+- **Severity**: CRITICAL
+- **Detection**: `npm audit --audit-level=high` exits non-zero
+- **OWASP**: A03
+
+### D2: Lockfile Out of Sync
+
+- **Severity**: IMPORTANT
+- **Detection**: `npm ci` fails
+- **OWASP**: A08
+
+### D3: Typosquatting Risk
+
+- **Severity**: IMPORTANT
+- **Detection**: Manual review of new dependency names
+- **OWASP**: A03
+
+### D4: Postinstall Scripts in New Dependency
+
+- **Severity**: IMPORTANT
+- **Detection**: `"postinstall"` in new dependency's package.json
+- **OWASP**: A03
+
+### D5: Unpinned Versions in Production
+
+- **Severity**: SUGGESTION
+- **Detection**: `":\s*["']\*["']|":\s*["']latest["']`
+- **OWASP**: A03
+
+---
+
+## API Anti-Patterns (AP1-AP6)
+
+### AP1: New Endpoint Without Rate Limiting
+
+- **Severity**: IMPORTANT
+- **OWASP**: A05
+
+### AP2: GraphQL Without Depth Limiting
+
+- **Severity**: IMPORTANT
+- **Detection**: `new ApolloServer` without depth/complexity limits
+- **OWASP**: A05
+
+```typescript
+import depthLimit from 'graphql-depth-limit';
+const server = new ApolloServer({
+  schema,
+  validationRules: [depthLimit(5)],
+  introspection: process.env.NODE_ENV !== 'production',
+});
+```
+
+### AP3: File Upload Without Validation
+
+- **Severity**: IMPORTANT
+- **Detection**: `multer|formidable|busboy` without type/size checks
+- **OWASP**: A05
+
+```typescript
+const upload = multer({
+  dest: 'uploads/',
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    const allowed = ['image/jpeg', 'image/png', 'image/webp'];
+    cb(null, allowed.includes(file.mimetype));
+  },
+});
+```
+
+### AP4: Webhook Without Signature Verification
+
+- **Severity**: CRITICAL
+- **OWASP**: A08
+
+Always verify webhook signatures (Stripe, GitHub HMAC, etc.).
+
+### AP5: API Exposing Internal Info
+
+- **Severity**: IMPORTANT
+- **Detection**: `(?:stack|trace|query|sql).*(?:res\.json|res\.send)`
+- **OWASP**: A10
+
+### AP6: Missing Request Body Size Limit
+
+- **Severity**: IMPORTANT
+- **Detection**: `express\.json\(\)` without `limit`
+- **OWASP**: A05
+
+```typescript
+app.use(express.json({ limit: '100kb' }));
+```
+
+---
+
+## AI/LLM Security Anti-Patterns (AI1-AI3)
+
+### AI1: Prompt Injection via User Input
+
+- **Severity**: CRITICAL
+- **Detection**: User input concatenated into LLM prompts without sanitization
+- **OWASP**: A05 (Injection)
+
+```typescript
+// BAD — user input directly in prompt
+const response = await llm.complete(`Summarize this: ${userInput}`);
+
+// GOOD — structured input with system/user message separation
+const response = await llm.complete({
+  system: "You are a summarization assistant. Only summarize the provided text.",
+  user: userInput,
+});
+```
+
+### AI2: LLM Output Used in SQL/Shell Without Sanitization
+
+- **Severity**: CRITICAL
+- **Detection**: LLM response passed to `db.query()`, `exec()`, or template literals without validation
+- **OWASP**: A05 (Injection)
+
+Never trust LLM output as safe. Treat it as untrusted user input — parameterize queries, escape shell arguments, sanitize HTML before rendering.
+
+### AI3: Missing Output Validation from LLM Responses
+
+- **Severity**: IMPORTANT
+- **Detection**: LLM response rendered or executed without schema validation
+- **OWASP**: A08 (Software or Data Integrity Failures)
+
+Validate LLM output against expected schemas (Zod, JSON Schema) before using in application logic. Reject responses that don't match expected structure.
+
+---
+
+## Logging Anti-Patterns (L1-L4)
+
+### L1: Security Events Not Logged
+
+- **Severity**: IMPORTANT
+- **OWASP**: A09
+
+Log: auth failures, access denied, rate limit hits, input validation failures, password changes.
+
+### L2: Sensitive Data in Logs
+
+- **Severity**: CRITICAL
+- **Detection**: `(?:log|logger)\.\w+\(.*(?:password|token|secret|ssn|credit)`
+- **OWASP**: A09
+
+```typescript
+import pino from 'pino';
+const logger = pino({ redact: ['req.headers.authorization', 'req.body.password'] });
+```
+
+### L3: Missing Trace IDs
+
+- **Severity**: SUGGESTION
+- **OWASP**: A09
+
+### L4: Log Injection
+
+- **Severity**: IMPORTANT
+- **Detection**: `console\.log\(.*\+.*(?:req\.|user\.|body\.)`
+- **OWASP**: A09
+
+Use structured logging (JSON, auto-escaped) instead of string concatenation.
+
+---
+
+## Framework-Specific: React / Next.js (RX1-RX4)
+
+### RX1: Server Action Without Auth
+
+- **Severity**: CRITICAL
+- **Detection**: `'use server'` function without `auth()` or session check
+- **OWASP**: A01
+
+```typescript
+'use server';
+import { auth } from '@/auth';
+export async function deleteUser(id: string) {
+  const session = await auth();
+  if (!session?.user || session.user.role !== 'admin') throw new Error('Unauthorized');
+  await db.user.delete({ where: { id } });
+}
+```
+
+### RX2: process.env Without NEXT_PUBLIC_ in Client
+
+- **Severity**: IMPORTANT
+- **Detection**: `'use client'` file accessing `process.env` without `NEXT_PUBLIC_`
+- **OWASP**: A02
+
+### RX3: RSC Serialization Leaking Data
+
+- **Severity**: IMPORTANT
+- **OWASP**: A01
+
+Pick only needed fields before passing DB objects to Client Components.
+
+### RX4: middleware.ts Not Protecting API Routes
+
+- **Severity**: IMPORTANT
+- **Detection**: `config.matcher` not covering `/api/`
+- **OWASP**: A01
+
+---
+
+## Framework-Specific: Angular (NG1-NG3)
+
+### NG1: bypassSecurityTrustHtml with User Input
+
+- **Severity**: CRITICAL
+- **Detection**: `bypassSecurityTrust(?:Html|Script|Style|Url|ResourceUrl)`
+- **OWASP**: A05
+
+Sanitize with DOMPurify BEFORE calling bypassSecurityTrust.
+
+### NG2: Template Expression Injection
+
+- **Severity**: IMPORTANT
+- **OWASP**: A05
+
+Do not use JitCompilerFactory with user-controlled templates.
+
+### NG3: HttpInterceptor Not Attaching Auth
+
+- **Severity**: IMPORTANT
+- **OWASP**: A07
+
+Use a centralized `HttpInterceptorFn` for auth tokens.
+
+---
+
+## Framework-Specific: Express (EX1-EX4)
+
+### EX1: Missing helmet.js
+
+- **Severity**: IMPORTANT
+- **OWASP**: A02
+
+```typescript
+import helmet from 'helmet';
+app.use(helmet());
+app.disable('x-powered-by');
+```
+
+### EX2: express.json() Without Body Size Limit
+
+- **Severity**: IMPORTANT
+- **OWASP**: A05
+
+```typescript
+app.use(express.json({ limit: '100kb' }));
+```
+
+### EX3: Cookie Without Secure Flags
+
+- **Severity**: IMPORTANT
+- **OWASP**: A07
+
+```typescript
+res.cookie('session', value, {
+  httpOnly: true, secure: true, sameSite: 'strict', maxAge: 3600000, path: '/',
+});
+```
+
+### EX4: Error Handler Exposing Stack Trace
+
+- **Severity**: IMPORTANT
+- **OWASP**: A10
+
+Only expose error details in development mode.
+
+---
+
+## Framework-Specific: Go (GO1-GO3)
+
+### GO1: math/rand for Security Operations
+
+- **Severity**: CRITICAL
+- **Detection**: `math/rand` import in security-related files
+- **OWASP**: A04
+
+Use `crypto/rand` for cryptographically secure random values.
+
+### GO2: TLS InsecureSkipVerify
+
+- **Severity**: CRITICAL
+- **Detection**: `InsecureSkipVerify:\s*true`
+- **OWASP**: A04
+
+Use system CA pool (default) instead.
+
+### GO3: String Interpolation in SQL
+
+- **Severity**: CRITICAL
+- **Detection**: `fmt\.Sprintf\s*\(.*(?:SELECT|INSERT|UPDATE|DELETE|FROM|WHERE)`
+- **OWASP**: A05
+
+```go
+// GOOD — parameterized
+db.Where("id = ?", userID).Find(&user)
+```
+
+---
+
+## Security Headers Template
+
+### helmet.js (Express)
+
+```typescript
+import helmet from 'helmet';
+
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'"],
+      imgSrc: ["'self'", "data:", "https:"],
+      fontSrc: ["'self'"],
+      connectSrc: ["'self'"],
+      frameAncestors: ["'none'"],
+      objectSrc: ["'none'"],
+      baseUri: ["'self'"],
+      formAction: ["'self'"],
+      upgradeInsecureRequests: [],
+    },
+  },
+  hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
+  frameguard: { action: 'deny' },
+  referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+  crossOriginOpenerPolicy: { policy: 'same-origin' },
+  crossOriginResourcePolicy: { policy: 'same-origin' },
+}));
+app.disable('x-powered-by');
+```
+
+---
+
+## JWT Validation Checklist
+
+1. Verify signature with expected algorithm — reject `alg: none`
+2. Enforce algorithm: `algorithms: ['RS256']` or `['ES256']`
+3. Check `exp` — reject expired tokens
+4. Check `iat` — reject tokens issued too far in the past
+5. Check `aud` — reject tokens not intended for this service
+6. Check `iss` — reject tokens from unknown issuers
+7. Store in httpOnly cookie — not localStorage
+8. Use short-lived access tokens (15 min) + refresh token rotation
+9. Rotate signing keys periodically
+
+---
+
+## Secure Cookie Flags
+
+```
+Set-Cookie: session=value; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=3600
+```
+
+| Flag | Purpose | When to use |
+|------|---------|-------------|
+| `HttpOnly` | Not accessible via JavaScript (prevents XSS token theft) | Always |
+| `Secure` | Only sent over HTTPS | Always |
+| `SameSite=Strict` | Only sent on same-site requests (strongest CSRF) | Auth/session cookies |
+| `SameSite=Lax` | Sent on top-level navigations (moderate CSRF) | Cookies that need cross-site top-level nav (e.g., OAuth return) |
+| `Path=/` | Limit cookie scope | Always |
+| `Max-Age` | Explicit expiration (prefer over `Expires`) | Always |
+
+---
+
+## Security Checklist
+
+### Authentication and Sessions
+- [ ] Passwords hashed with Argon2id or bcrypt (cost >= 12)
+- [ ] JWT signed with RS256/ES256, algorithm enforced on verify
+- [ ] Access tokens expire in <= 15 minutes
+- [ ] Refresh tokens: one-time use, rotated, stored in httpOnly cookie
+- [ ] Rate limiting on login, registration, and password reset
+- [ ] Session regenerated after authentication
+- [ ] MFA available for privileged accounts
+
+### Authorization
+- [ ] Every API endpoint has auth middleware
+- [ ] Ownership checks on all resource access (prevent IDOR)
+- [ ] Server-side authorization (frontend guards are UX only)
+- [ ] Mass assignment prevented (explicit field selection)
+- [ ] Re-authentication required for sensitive operations
+
+### Input and Output
+- [ ] All user input validated server-side (zod/joi/class-validator)
+- [ ] Parameterized queries for all database operations
+- [ ] HTML output sanitized (DOMPurify) when rendering user content
+- [ ] Error responses do not expose stack traces in production
+
+### Secrets
+- [ ] No hardcoded secrets in source code
+- [ ] `.env` files in `.gitignore`
+- [ ] Server secrets not exposed to client (no NEXT_PUBLIC_ on secrets)
+- [ ] Environment variables validated at startup
+
+### Headers
+- [ ] Content-Security-Policy configured (nonce-based preferred)
+- [ ] Strict-Transport-Security with preload
+- [ ] X-Content-Type-Options: nosniff
+- [ ] X-Frame-Options: DENY
+- [ ] Referrer-Policy: strict-origin-when-cross-origin
+- [ ] Permissions-Policy restricting unused APIs
+- [ ] CORS restricted to known origins
+
+### Dependencies
+- [ ] `npm audit` (or equivalent) passing in CI
+- [ ] Lockfile committed and verified with `npm ci`
+- [ ] New dependencies reviewed for typosquatting and postinstall scripts
+- [ ] No wildcard or "latest" versions in production
+
+### Logging
+- [ ] Security events logged (auth failures, access denied, rate limits)
+- [ ] No sensitive data in logs (passwords, tokens, PII)
+- [ ] Structured logging with correlation IDs
+- [ ] Alerts configured for anomalous patterns

--- a/.github/instructions/self-explanatory-code-commenting.instructions.md
+++ b/.github/instructions/self-explanatory-code-commenting.instructions.md
@@ -1,0 +1,162 @@
+---
+description: 'Guidelines for GitHub Copilot to write comments to achieve self-explanatory code with less comments. Examples are in JavaScript but it should work on any language that has comments.'
+applyTo: '**'
+---
+
+# Self-explanatory Code Commenting Instructions
+
+## Core Principle
+**Write code that speaks for itself. Comment only when necessary to explain WHY, not WHAT.**
+We do not need comments most of the time.
+
+## Commenting Guidelines
+
+### ❌ AVOID These Comment Types
+
+**Obvious Comments**
+```javascript
+// Bad: States the obvious
+let counter = 0;  // Initialize counter to zero
+counter++;  // Increment counter by one
+```
+
+**Redundant Comments**
+```javascript
+// Bad: Comment repeats the code
+function getUserName() {
+    return user.name;  // Return the user's name
+}
+```
+
+**Outdated Comments**
+```javascript
+// Bad: Comment doesn't match the code
+// Calculate tax at 5% rate
+const tax = price * 0.08;  // Actually 8%
+```
+
+### ✅ WRITE These Comment Types
+
+**Complex Business Logic**
+```javascript
+// Good: Explains WHY this specific calculation
+// Apply progressive tax brackets: 10% up to 10k, 20% above
+const tax = calculateProgressiveTax(income, [0.10, 0.20], [10000]);
+```
+
+**Non-obvious Algorithms**
+```javascript
+// Good: Explains the algorithm choice
+// Using Floyd-Warshall for all-pairs shortest paths
+// because we need distances between all nodes
+for (let k = 0; k < vertices; k++) {
+    for (let i = 0; i < vertices; i++) {
+        for (let j = 0; j < vertices; j++) {
+            // ... implementation
+        }
+    }
+}
+```
+
+**Regex Patterns**
+```javascript
+// Good: Explains what the regex matches
+// Match email format: username@domain.extension
+const emailPattern = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+```
+
+**API Constraints or Gotchas**
+```javascript
+// Good: Explains external constraint
+// GitHub API rate limit: 5000 requests/hour for authenticated users
+await rateLimiter.wait();
+const response = await fetch(githubApiUrl);
+```
+
+## Decision Framework
+
+Before writing a comment, ask:
+1. **Is the code self-explanatory?** → No comment needed
+2. **Would a better variable/function name eliminate the need?** → Refactor instead
+3. **Does this explain WHY, not WHAT?** → Good comment
+4. **Will this help future maintainers?** → Good comment
+
+## Special Cases for Comments
+
+### Public APIs
+```javascript
+/**
+ * Calculate compound interest using the standard formula.
+ * 
+ * @param {number} principal - Initial amount invested
+ * @param {number} rate - Annual interest rate (as decimal, e.g., 0.05 for 5%)
+ * @param {number} time - Time period in years
+ * @param {number} compoundFrequency - How many times per year interest compounds (default: 1)
+ * @returns {number} Final amount after compound interest
+ */
+function calculateCompoundInterest(principal, rate, time, compoundFrequency = 1) {
+    // ... implementation
+}
+```
+
+### Configuration and Constants
+```javascript
+// Good: Explains the source or reasoning
+const MAX_RETRIES = 3;  // Based on network reliability studies
+const API_TIMEOUT = 5000;  // AWS Lambda timeout is 15s, leaving buffer
+```
+
+### Annotations
+```javascript
+// TODO: Replace with proper user authentication after security review
+// FIXME: Memory leak in production - investigate connection pooling
+// HACK: Workaround for bug in library v2.1.0 - remove after upgrade
+// NOTE: This implementation assumes UTC timezone for all calculations
+// WARNING: This function modifies the original array instead of creating a copy
+// PERF: Consider caching this result if called frequently in hot path
+// SECURITY: Validate input to prevent SQL injection before using in query
+// BUG: Edge case failure when array is empty - needs investigation
+// REFACTOR: Extract this logic into separate utility function for reusability
+// DEPRECATED: Use newApiFunction() instead - this will be removed in v3.0
+```
+
+## Anti-Patterns to Avoid
+
+### Dead Code Comments
+```javascript
+// Bad: Don't comment out code
+// const oldFunction = () => { ... };
+const newFunction = () => { ... };
+```
+
+### Changelog Comments
+```javascript
+// Bad: Don't maintain history in comments
+// Modified by John on 2023-01-15
+// Fixed bug reported by Sarah on 2023-02-03
+function processData() {
+    // ... implementation
+}
+```
+
+### Divider Comments
+```javascript
+// Bad: Don't use decorative comments
+//=====================================
+// UTILITY FUNCTIONS
+//=====================================
+```
+
+## Quality Checklist
+
+Before committing, ensure your comments:
+- [ ] Explain WHY, not WHAT
+- [ ] Are grammatically correct and clear
+- [ ] Will remain accurate as code evolves
+- [ ] Add genuine value to code understanding
+- [ ] Are placed appropriately (above the code they describe)
+- [ ] Use proper spelling and professional language
+
+## Summary
+
+Remember: **The best comment is the one you don't need to write because the code is self-documenting.**

--- a/.github/instructions/tailwind-v4-vite.instructions.md
+++ b/.github/instructions/tailwind-v4-vite.instructions.md
@@ -1,0 +1,243 @@
+---
+description: 'Tailwind CSS v4+ installation and configuration for Vite projects using the official @tailwindcss/vite plugin'
+applyTo: 'vite.config.ts, vite.config.js, **/*.css, **/*.tsx, **/*.ts, **/*.jsx, **/*.js'
+---
+
+# Tailwind CSS v4+ Installation with Vite
+
+Instructions for installing and configuring Tailwind CSS version 4 and above using the official Vite plugin. Tailwind CSS v4 introduces a simplified setup that eliminates the need for PostCSS configuration and tailwind.config.js in most cases.
+
+## Key Changes in Tailwind CSS v4
+
+- **No PostCSS configuration required** when using the Vite plugin
+- **No tailwind.config.js required** - configuration is done via CSS
+- **New @tailwindcss/vite plugin** replaces the PostCSS-based approach
+- **CSS-first configuration** using `@theme` directive
+- **Automatic content detection** - no need to specify content paths
+
+## Installation Steps
+
+### Step 1: Install Dependencies
+
+Install `tailwindcss` and the `@tailwindcss/vite` plugin:
+
+```bash
+npm install tailwindcss @tailwindcss/vite
+```
+
+### Step 2: Configure Vite Plugin
+
+Add the `@tailwindcss/vite` plugin to your Vite configuration file:
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [
+    tailwindcss(),
+  ],
+})
+```
+
+For React projects with Vite:
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [
+    react(),
+    tailwindcss(),
+  ],
+})
+```
+
+### Step 3: Import Tailwind CSS
+
+Add the Tailwind CSS import to your main CSS file (e.g., `src/index.css` or `src/App.css`):
+
+```css
+@import "tailwindcss";
+```
+
+### Step 4: Verify CSS Import in Entry Point
+
+Ensure your main CSS file is imported in your application entry point:
+
+```typescript
+// src/main.tsx or src/main.ts
+import './index.css'
+```
+
+### Step 5: Start Development Server
+
+Run the development server to verify installation:
+
+```bash
+npm run dev
+```
+
+## What NOT to Do in Tailwind v4
+
+### Do NOT Create tailwind.config.js
+
+Tailwind v4 uses CSS-first configuration. Do not create a `tailwind.config.js` file unless you have specific legacy requirements.
+
+```javascript
+// ❌ NOT NEEDED in Tailwind v4
+module.exports = {
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+```
+
+### Do NOT Create postcss.config.js for Tailwind
+
+When using the `@tailwindcss/vite` plugin, PostCSS configuration for Tailwind is not required.
+
+```javascript
+// ❌ NOT NEEDED when using @tailwindcss/vite
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}
+```
+
+### Do NOT Use Old Directives
+
+The old `@tailwind` directives are replaced by a single import:
+
+```css
+/* ❌ OLD - Do not use in Tailwind v4 */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* ✅ NEW - Use this in Tailwind v4 */
+@import "tailwindcss";
+```
+
+## CSS-First Configuration (Tailwind v4)
+
+### Custom Theme Configuration
+
+Use the `@theme` directive in your CSS to customize your design tokens:
+
+```css
+@import "tailwindcss";
+
+@theme {
+  --color-primary: #3b82f6;
+  --color-secondary: #64748b;
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --radius-lg: 0.75rem;
+}
+```
+
+### Adding Custom Utilities
+
+Define custom utilities directly in CSS:
+
+```css
+@import "tailwindcss";
+
+@utility content-auto {
+  content-visibility: auto;
+}
+
+@utility scrollbar-hidden {
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+```
+
+### Adding Custom Variants
+
+Define custom variants in CSS:
+
+```css
+@import "tailwindcss";
+
+@variant hocus (&:hover, &:focus);
+@variant group-hocus (:merge(.group):hover &, :merge(.group):focus &);
+```
+
+## Verification Checklist
+
+After installation, verify:
+
+- [ ] `tailwindcss` and `@tailwindcss/vite` are in `package.json` dependencies
+- [ ] `vite.config.ts` includes the `tailwindcss()` plugin
+- [ ] Main CSS file contains `@import "tailwindcss";`
+- [ ] CSS file is imported in the application entry point
+- [ ] Development server runs without errors
+- [ ] Tailwind utility classes (e.g., `text-blue-500`, `p-4`) render correctly
+
+## Example Usage
+
+Test the installation with a simple component:
+
+```tsx
+export function TestComponent() {
+  return (
+    <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+      <h1 className="text-3xl font-bold text-blue-600 underline">
+        Hello, Tailwind CSS v4!
+      </h1>
+    </div>
+  )
+}
+```
+
+## Troubleshooting
+
+### Styles Not Applying
+
+1. Verify CSS import statement is `@import "tailwindcss";` (not old directives)
+2. Ensure CSS file is imported in your entry point
+3. Check Vite config includes the `tailwindcss()` plugin
+4. Clear Vite cache: `rm -rf node_modules/.vite && npm run dev`
+
+### Plugin Not Found Error
+
+If you see "Cannot find module '@tailwindcss/vite'":
+
+```bash
+npm install @tailwindcss/vite
+```
+
+### TypeScript Errors
+
+If TypeScript cannot find types for the Vite plugin, ensure you have the correct import:
+
+```typescript
+import tailwindcss from '@tailwindcss/vite'
+```
+
+## Migration from Tailwind v3
+
+If migrating from Tailwind v3:
+
+1. Remove `tailwind.config.js` (move customizations to CSS `@theme`)
+2. Remove `postcss.config.js` (if only used for Tailwind)
+3. Uninstall old packages: `npm uninstall postcss autoprefixer`
+4. Install new packages: `npm install tailwindcss @tailwindcss/vite`
+5. Replace `@tailwind` directives with `@import "tailwindcss";`
+6. Update Vite config to use `@tailwindcss/vite` plugin
+
+## Reference
+
+- Official Documentation: https://tailwindcss.com/docs/installation/using-vite
+- Tailwind CSS v4 Upgrade Guide: https://tailwindcss.com/docs/upgrade-guide

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- One paragraph: what changed and why. Link the issue this closes. -->
+
+Closes #
+
+## What changed
+<!-- For multi-file PRs, a table helps reviewers navigate the diff. Remove if the summary is sufficient. -->
+
+| File | Change |
+|------|--------|
+| | |
+
+## Security / correctness notes
+<!-- XSS, auth, CSRF, data-integrity implications. Write "None" if not applicable — don't omit. -->
+
+## Verification
+
+- [ ] Tests: N pass, 0 failures (`npm test` / `cd frontend && npm test -- --run`)
+- [ ] ESLint: 0 errors (`npm run lint`)
+- [ ] Format check: clean (`npm run format:check` / `cd frontend && npm run format:check`)
+- [ ] Build: green (`npm run build --prefix frontend`)
+- [ ] `validate:openapi`: no drift (if `docs/api-spec.yaml` changed)
+- [ ] Manual smoke: <!-- describe what you clicked / verified in the browser -->
+
+---
+<!-- Agent attribution — keep on one line, drop the session URL -->
+Built by [Agent] · Reviewed by [Agent] · 🤖 [Claude Code](https://claude.ai/claude-code)

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,8 @@ e2e/.auth/
 workers-mcp-server/
 chatmodes/
 claudedocs/
-instructions/
+# Root-level only — .github/instructions/ is tracked (Copilot path instructions)
+/instructions/
 prompts/
 plugins/
 .github/chatmodes/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,20 @@ git rebase origin/main      # keep branch current with main
 
 Do this **every time you push**, not just when opening the PR. Dependabot merges deps bumps to `main` frequently — if you push without rebasing, GitHub will require an "Update branch" click before merging, which adds round-trips. Rebasing before each push eliminates this entirely.
 
+### Opening a pull request
+
+Full PR standards are in `.github/instructions/pull-request-standards.instructions.md`. Key points:
+
+- **Use the PR template** — GitHub loads `.github/pull_request_template.md` automatically. Fill every section; write "None" rather than deleting a section.
+- **Title:** conventional-commit prefix + specific description. Put `Closes #N` on its own line in the body (GitHub does not auto-close from the title).
+- **Labels:** always apply one type label (`bug`, `enhancement`, `ci`, `documentation`, `chore`, `security`) + one priority label (`priority:p1/p2/p3`) when opening — not after.
+- **Verification checkboxes:** tick every `- [ ]` item before merging. An unchecked test plan is indistinguishable from a skipped one.
+- **Attribution:** one line, no session URL: `Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)`
+
+```bash
+gh pr create --label "bug,priority:p1"   # example
+```
+
 ---
 
 ## Security Notes


### PR DESCRIPTION
## Summary

The unanchored `instructions/` pattern in `.gitignore` (meant for the root-level developer-specific dir) also matched `.github/instructions/` at any depth, silently hiding 9 curated Copilot instruction files — including `pull-request-standards.instructions.md`, which CLAUDE.md explicitly references. The PR template and the CLAUDE.md "Opening a pull request" section were likewise sitting uncommitted, so the PR-standards rule existed on exactly one machine. This anchors the pattern to `/instructions/` and commits everything, making the standard durable.

Closes #486

## What changed

| File | Change |
|------|--------|
| `.gitignore` | `instructions/` → `/instructions/` (root-level only), with comment |
| `CLAUDE.md` | New "Opening a pull request" section (template, labels, attribution) |
| `.github/pull_request_template.md` | New — auto-loaded by GitHub on PR creation |
| `.github/instructions/*.instructions.md` | 9 previously-hidden Copilot instruction files committed |

`.github/chatmodes/`, `.github/prompts/`, `.github/agents/` remain deliberately ignored (developer-local). `docs/prompts/` remains swallowed by the still-unanchored `prompts/` pattern — the two files there are ad-hoc debug prompts, left as-is intentionally.

## Security / correctness notes

None — no auth, data, or rendering surface changed. Config and markdown only.

## Verification

- [x] Tests: N/A — no code paths touched (docs/config only)
- [x] ESLint: N/A — no JS changed
- [x] Format check: N/A — files outside prettier scope (functions/, scripts/, frontend/src)
- [x] Build: N/A — frontend untouched
- [x] `validate:openapi`: N/A — spec unchanged
- [x] Manual smoke: `git check-ignore .github/instructions/*.md` now reports nothing; all 9 files visible to `git status` and committed; tracked-file list verified with `git ls-files`

---
Built by Theo · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)