### PR TITLE
fix(api): guard NULL venue_id in timeline venue tracking — closes #479

### DIFF
--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -660,3 +660,45 @@ describe("Timeline real-DB — upcoming has no fixed day-window cap (SQL exercis
     expect(found.slug).toBe("timeline-realdb-far-future");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Real-DB regression — venue_count must be 0 (not 1) when every performance's
+// venue_id is NULL. `Map.has(null)` is `false`, so an unguarded
+// `!event.venues.has(row.venue_id)` check inserts a single spurious `null` key,
+// inflating venue_count to 1 instead of 0. The details endpoint
+// (functions/api/events/[id]/details.js) already guards on truthy
+// `row.venue_id` before touching its venues map, which is why the card's
+// venue count flipped from 1 (timeline) to 0 (details) on expand. Regression
+// for #479.
+// ---------------------------------------------------------------------------
+describe("Timeline real-DB — NULL venue_id must not inflate venue_count (#479)", () => {
+  test("venue_count is 0 when all performances have venue_id = NULL", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const today = new Date().toISOString().split("T")[0];
+
+    const event = insertEvent(rawDb, {
+      name: "No Venue Event",
+      slug: "timeline-realdb-null-venue",
+      date: today,
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    // venue_id defaults to null in insertBand — performance has no venue assigned
+    insertBand(rawDb, { name: "Unassigned Band", event_id: event.id });
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const found = data.now.find((e) => e.id === event.id);
+    expect(found).toBeDefined();
+    expect(found.band_count).toBe(1);
+    expect(found.venue_count).toBe(0);
+    expect(found.venues).toEqual([]);
+  });
+});

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -99,8 +99,9 @@ export async function onRequestGet(context) {
             });
           }
 
-          // Track venue
-          if (!event.venues.has(row.venue_id)) {
+          // Track venue (guard against NULL venue_id — a performance with no
+          // venue assigned must not be counted as a venue; see #479)
+          if (row.venue_id && !event.venues.has(row.venue_id)) {
             event.venues.set(row.venue_id, {
               id: row.venue_id,
               name: row.venue_name,
@@ -108,7 +109,9 @@ export async function onRequestGet(context) {
               band_count: 0,
             });
           }
-          event.venues.get(row.venue_id).band_count++;
+          if (row.venue_id) {
+            event.venues.get(row.venue_id).band_count++;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

The timeline endpoint tracked venues in a Map without guarding against NULL venue IDs: `Map.has(null)` is `false`, so an event whose performances all have `venue_id = NULL` gained a single spurious `null` key, inflating `venue_count` to 1. The details endpoint already guards on truthy `row.venue_id`, which is why the Vol. 17 card's count flipped from 1 Venue (collapsed, timeline API) to 0 Venues (expanded, details API). This applies the identical guard to `timeline.js`, so both endpoints agree. Display-layer fix only — assigning real venues to the Vol. 17 lineup is #466.

Closes #479

## What changed

| File | Change |
|------|--------|
| `functions/api/events/timeline.js` | Guard venues-Map insert and `band_count` increment on truthy `row.venue_id` (mirrors `details.js:85–95`) |
| `functions/api/events/__tests__/timeline.test.js` | Real-DB regression test: `venue_count` is 0 (and `venues` empty, `band_count` still 1) when every performance has `venue_id = NULL` |

## Security / correctness notes

None — no auth, data, or rendering surface changed. Venue IDs are positive integer rowids, so the truthy guard can never skip a legitimate venue.

## Verification

- [x] Tests: TDD — new test failed pre-fix (`expected 1 to be +0`), passes post-fix; full backend suite green in Linux container (`docker run … node:22-bookworm … npm test`): 68 files, 570 passed, 6 todo
- [x] ESLint: 0 errors (run in the same container — matches CI environment)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: N/A — frontend untouched (`EventTimeline.jsx`'s fallback is correct once the API returns 0)
- [x] `validate:openapi`: N/A — response shape unchanged (venue_count was always numeric)
- [x] Manual smoke: verified via real-DB test exercising the full handler; Vera independently confirmed the pre-fix failure is genuine (not a tautology) and that both endpoints now agree

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)