### PR TITLE
fix(api): guard non-numeric limit param in public events endpoint — closes #480

### DIFF
--- a/functions/api/events/__tests__/public.test.js
+++ b/functions/api/events/__tests__/public.test.js
@@ -3,6 +3,26 @@ import { onRequestGet } from "../public.js";
 import { MockD1Database } from "../../subscriptions/__tests__/mocks/d1.js";
 import { createMockEvent, createMockVenue, createMockBand, seedMockData } from "./helpers.js";
 
+// Generates `count` unique, published, upcoming events (distinct future dates)
+// so tests can distinguish "default limit applied" from "all rows returned".
+function createMockEvents(count, overrides = {}) {
+  const events = [];
+  for (let i = 0; i < count; i++) {
+    const date = new Date();
+    date.setDate(date.getDate() + 1 + i);
+    events.push(
+      createMockEvent({
+        id: i + 1,
+        slug: `event-${i + 1}`,
+        name: `Event ${i + 1}`,
+        date: date.toISOString().split("T")[0],
+        ...overrides,
+      }),
+    );
+  }
+  return events;
+}
+
 describe("GET /api/events/public", () => {
   let mockDB;
   let mockEnv;
@@ -219,5 +239,85 @@ describe("GET /api/events/public", () => {
     const dates = data.events.map((e) => e.date);
     const sorted = [...dates].sort();
     expect(dates).toEqual(sorted);
+  });
+
+  describe("limit parameter guard (#480)", () => {
+    it("falls back to the default (50) when limit is non-numeric (?limit=abc)", async () => {
+      // Seed more than the default so an unguarded NaN -> LIMIT NULL bypass
+      // (which returns every row) is distinguishable from the correct 50-row default.
+      const events = createMockEvents(60);
+      seedMockData(mockDB, events, [], []);
+
+      const request = new Request("http://localhost/api/events/public?limit=abc");
+      const context = { request, env: mockEnv };
+
+      const response = await onRequestGet(context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.filters.limit).toBe(50);
+      expect(data.events).toHaveLength(50);
+      expect(data.count).toBe(50);
+    });
+
+    it("falls back to the default (50) when limit is 0", async () => {
+      const events = createMockEvents(60);
+      seedMockData(mockDB, events, [], []);
+
+      const request = new Request("http://localhost/api/events/public?limit=0");
+      const context = { request, env: mockEnv };
+
+      const response = await onRequestGet(context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.filters.limit).toBe(50);
+      expect(data.events).toHaveLength(50);
+    });
+
+    it("falls back to the default (50) when limit is negative", async () => {
+      const events = createMockEvents(60);
+      seedMockData(mockDB, events, [], []);
+
+      const request = new Request("http://localhost/api/events/public?limit=-5");
+      const context = { request, env: mockEnv };
+
+      const response = await onRequestGet(context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.filters.limit).toBe(50);
+      expect(data.events).toHaveLength(50);
+    });
+
+    it("caps limit at 100 when a larger value is requested", async () => {
+      const events = createMockEvents(105);
+      seedMockData(mockDB, events, [], []);
+
+      const request = new Request("http://localhost/api/events/public?limit=200");
+      const context = { request, env: mockEnv };
+
+      const response = await onRequestGet(context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.filters.limit).toBe(100);
+      expect(data.events).toHaveLength(100);
+    });
+
+    it("honours a valid in-range limit (?limit=7)", async () => {
+      const events = createMockEvents(10);
+      seedMockData(mockDB, events, [], []);
+
+      const request = new Request("http://localhost/api/events/public?limit=7");
+      const context = { request, env: mockEnv };
+
+      const response = await onRequestGet(context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.filters.limit).toBe(7);
+      expect(data.events).toHaveLength(7);
+    });
   });
 });

--- a/functions/api/events/public.js
+++ b/functions/api/events/public.js
@@ -15,7 +15,8 @@ export async function onRequestGet(context) {
   // Query parameters
   const city = url.searchParams.get("city") || "all";
   const genre = url.searchParams.get("genre") || "all";
-  const limit = Math.min(parseInt(url.searchParams.get("limit") || "50"), 100);
+  const rawLimit = parseInt(url.searchParams.get("limit") || "50", 10);
+  const limit = Number.isFinite(rawLimit) && rawLimit >= 1 ? Math.min(rawLimit, 100) : 50;
   const upcoming = url.searchParams.get("upcoming") !== "false"; // Default true
 
   try {


### PR DESCRIPTION
## Summary

`/api/events/public` parsed `?limit=` with a bare `parseInt` + `Math.min`: a non-numeric value produced NaN, which D1 binds as `null`, and SQLite treats `LIMIT NULL` as **no limit** — one unauthenticated request with `?limit=abc` returned the entire published-events table (D1 quota-exhaustion risk). The limit is now guarded: invalid, zero, or negative input falls back to the default 50; valid input is capped at 100. Falling back to the default (rather than clamping to 1) follows the issue's acceptance criteria.

Closes #480

## What changed

| File | Change |
|------|--------|
| `functions/api/events/public.js` | `parseInt(..., 10)` + `Number.isFinite(rawLimit) && rawLimit >= 1 ? Math.min(rawLimit, 100) : 50` |
| `functions/api/events/__tests__/public.test.js` | `createMockEvents(count)` helper + 5 tests: `abc`→50, `0`→50, `-5`→50, `200`→100, `7`→7 (asserting both `filters.limit` and actual row counts against 60–105 seeded rows) |

## Security / correctness notes

Closes an unauthenticated unbounded-read vector. The guard was simulated against 19 adversarial inputs (`Infinity`, whitespace, `1e3`, `+7`, floats, 21-digit numbers, empty string, hex/binary literals) — every one resolves to a bounded integer in [1,100] or the default; nothing reaches the D1 bind as NaN/null/negative. Radix 10 removes prefix-parsing ambiguity.

## Verification

- [x] Tests: TDD — 3 guard tests failed pre-fix (`filters.limit` was `null`, the literal NaN→null manifestation), all 13 pass post-fix; full backend suite green **both** native and in Linux container: 68 files, 574 passed, 6 todo
- [x] ESLint: 0 errors
- [x] Format check: clean (`npm run format:check`)
- [x] Build: N/A — frontend untouched
- [x] `validate:openapi`: N/A — response shape unchanged (`filters.limit` was always meant to be numeric; now it always is)
- [x] Manual smoke: Vera empirically confirmed the mock's LIMIT semantics make these tests fail on regression (reverted guard → 60 rows returned)

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)