### PR TITLE
chore(docs): replace realistic-looking example key with inert placeholder

### DIFF
--- a/.github/instructions/security-and-owasp.instructions.md
+++ b/.github/instructions/security-and-owasp.instructions.md
@@ -409,7 +409,7 @@ Require current password before account deletion, email change, or other sensiti
 
 ```typescript
 // BAD
-const API_KEY = 'sk_live_abc123def456';
+const API_KEY = 'hardcoded-example-key-never-do-this'; // placeholder, not a real key
 
 // GOOD
 const API_KEY = process.env.API_KEY;


### PR DESCRIPTION
## Summary

PR #487 auto-merged before its gitleaks scrub landed — gitleaks turned out not to be a **required** status check, so auto-merge fired over its failure. Main therefore carries a doc example shaped like a live Stripe key (`sk_live_` + high-entropy suffix) in `security-and-owasp.instructions.md`, and the push-to-main secrets run is red. This lands the already-written scrub: an inert placeholder no scanner pattern-matches, same lesson taught. Refs #486.

## What changed

| File | Change |
|------|--------|
| `.github/instructions/security-and-owasp.instructions.md` | `'sk_live_abc123def456'` → `'hardcoded-example-key-never-do-this'` (1 line) |

## Security / correctness notes

The flagged string was a fabricated documentation example, not a real credential — no secret was ever exposed. This is scanner hygiene: gitleaks only inspects added lines, so the deletion in this diff will not re-trip it. Follow-up filed to make the secrets check required so auto-merge can't outrun it again.

## Verification

- [x] Tests: N/A — markdown only
- [x] ESLint: N/A — no JS changed
- [x] Format check: N/A — outside prettier scope
- [x] Build: N/A — frontend untouched
- [x] `validate:openapi`: N/A — spec unchanged
- [x] Manual smoke: `grep -rn "sk_live" .github/` returns nothing on this branch

---
Built by Theo · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)