### PR TITLE
fix(security): rate-limit /api/metrics through the D1 fail-closed path — closes #482

### DIFF
--- a/functions/utils/__tests__/rateLimit.test.js
+++ b/functions/utils/__tests__/rateLimit.test.js
@@ -246,6 +246,54 @@ describe("Rate Limiting", () => {
       expect(result.allowed).toBe(false);
       expect(result.remaining).toBe(0);
     });
+
+    it("/api/metrics is fail-closed (uses D1) when env.DB is present (#482 write-amplification control)", async () => {
+      const db = makeMockDB({ count: 3 }); // under the 40-req/min limit
+      const env = { DB: db };
+      const request = new Request("https://example.com/api/metrics", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
+      });
+
+      const result = await checkRateLimit(request, env);
+
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(37); // 40 - 3
+      // D1 must be used (fail-closed path), not Cache API
+      expect(db.prepare).toHaveBeenCalled();
+      expect(mockCache.match).not.toHaveBeenCalled();
+    });
+
+    it("/api/metrics blocks the 41st request in the window from one IP", async () => {
+      const db = makeMockDB({ count: 41 }); // over the 40-req/min limit
+      const env = { DB: db };
+      const request = new Request("https://example.com/api/metrics", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
+      });
+
+      const result = await checkRateLimit(request, env);
+
+      expect(result.allowed).toBe(false);
+      expect(result.remaining).toBe(0);
+    });
+
+    it("/api/metrics fails closed when D1 throws (#482)", async () => {
+      const db = {
+        prepare: vi.fn().mockReturnValue({
+          bind: vi.fn().mockReturnValue({
+            run: vi.fn().mockRejectedValue(new Error("D1 unavailable")),
+            first: vi.fn().mockResolvedValue(null),
+          }),
+        }),
+      };
+      const env = { DB: db };
+      const request = new Request("https://example.com/api/metrics", {
+        headers: { "CF-Connecting-IP": "1.2.3.4" },
+      });
+
+      const result = await checkRateLimit(request, env);
+
+      expect(result.allowed).toBe(false); // must fail closed, not open
+    });
   });
 
   describe("IP bypass behaviour", () => {

--- a/functions/utils/rateLimit.js
+++ b/functions/utils/rateLimit.js
@@ -2,10 +2,12 @@
 //
 // Two strategies are used depending on endpoint sensitivity:
 //
-// 1. D1-backed (globally consistent) — used for FAIL_CLOSED_PATTERNS (auth, subscriptions).
-//    D1 is a globally-replicated SQLite database, so counters are shared across all
-//    Cloudflare PoPs. This prevents distributed brute-force attacks from bypassing
-//    limits by spreading requests across geographic regions.
+// 1. D1-backed (globally consistent) — used for FAIL_CLOSED_PATTERNS (auth, subscriptions,
+//    metrics). D1 is a globally-replicated SQLite database, so counters are shared across
+//    all Cloudflare PoPs. This prevents distributed brute-force attacks from bypassing
+//    limits by spreading requests across geographic regions. /api/metrics is included here
+//    not for credential protection but for write-amplification control: PoP-local counting
+//    would let 40 req/min scale to 40 × N-PoPs × up to 50 D1 upserts per request (#482).
 //
 // 2. Cache API (PoP-local) — used for non-sensitive public endpoints (events, schedule,
 //    feeds). PoP-local is acceptable here; the goal is DoS protection, not security
@@ -57,8 +59,10 @@ const SKIP_PATTERNS = [
 ];
 
 // Endpoints where a rate-limit failure blocks the request (fail closed).
-// These use D1 for globally-consistent counters.
-const FAIL_CLOSED_PATTERNS = ["/api/admin/auth/", "/api/auth/", "/api/subscriptions"];
+// These use D1 for globally-consistent counters. /api/metrics is here for
+// write-amplification control (up to 50 D1 upserts per request), not credential
+// protection — see file header and #482.
+const FAIL_CLOSED_PATTERNS = ["/api/admin/auth/", "/api/auth/", "/api/subscriptions", "/api/metrics"];
 
 function shouldFailClosed(pathname) {
   return (


### PR DESCRIPTION
## Summary

`/api/metrics` was rate-limited via `caches.default`, which is PoP-local and non-atomic — so the intended 40 req/min cap multiplied by however many Cloudflare PoPs an attacker sprayed, and each request can fan out to up to 50 D1 upserts (write amplification / quota-exhaustion risk). Adding `/api/metrics` to `FAIL_CLOSED_PATTERNS` routes it through the D1-backed globally-consistent counter, capping per-IP volume worldwide. One-line fix plus comments; the rate-limiter's upsert+SELECT→RETURNING optimization is deliberately split out as #492.

Closes #482

## What changed

| File | Change |
|------|--------|
| `functions/utils/rateLimit.js` | Add `"/api/metrics"` to `FAIL_CLOSED_PATTERNS`; header + inline comments explain it's for write-amplification control, not credential protection |
| `functions/utils/__tests__/rateLimit.test.js` | 3 new D1-path tests: metrics uses D1 (Cache untouched), 41st request blocked, D1 error fails closed |

## Security / correctness notes

Fail-closed is safe here: the metrics client is `navigator.sendBeacon` / `fetch().catch(() => {})` (fire-and-forget), so a 429 or fail-closed block is invisible to users — events are simply dropped, which is the documented best-effort contract. Loopback IPs still skip limiting (local dev unaffected) and a missing `env.DB` still falls back to the Cache API. Blocked requests still cost the limiter's own 1–2 D1 ops — same accepted tradeoff as the auth endpoints; the win is aggregate writes drop from ≤50/request to that fixed cost.

## Verification

- [x] Tests: TDD — 3 new tests failed pre-fix (Cache path: `remaining 39`, over-limit allowed), all 33 in file pass post-fix; full backend suite 68 files / 572 passed / 6 todo
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: N/A — frontend untouched
- [x] `validate:openapi`: N/A — spec unchanged (429 responses already documented behavior)
- [x] Manual smoke: Vera traced loopback-skip → fail-closed routing → D1-error block order in code and confirmed each; verified tests fail on revert

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)