### PR TITLE
perf(rateLimit): collapse checkRateLimitD1 upsert+SELECT into one RETURNING statement

### DIFF
--- a/functions/utils/__tests__/rateLimit.test.js
+++ b/functions/utils/__tests__/rateLimit.test.js
@@ -11,14 +11,15 @@ global.caches = {
   default: mockCache,
 };
 
-// Mock D1 database (used for fail-closed endpoints: /api/auth/*, /api/subscriptions)
+// Mock D1 database (used for fail-closed endpoints: /api/auth/*, /api/subscriptions).
+// checkRateLimitD1 issues a single INSERT ... ON CONFLICT ... RETURNING statement
+// (#492), so the mock only needs to satisfy .bind(...).first().
 function makeMockDB({ count = 1, window_start = null } = {}) {
   const now = Math.floor(Date.now() / 1000);
   const row = { count, window_start: window_start ?? now };
   return {
     prepare: vi.fn().mockReturnValue({
       bind: vi.fn().mockReturnValue({
-        run: vi.fn().mockResolvedValue({}),
         first: vi.fn().mockResolvedValue(row),
       }),
     }),
@@ -171,8 +172,7 @@ describe("Rate Limiting", () => {
       const db = {
         prepare: vi.fn().mockReturnValue({
           bind: vi.fn().mockReturnValue({
-            run: vi.fn().mockRejectedValue(new Error("D1 error")),
-            first: vi.fn().mockResolvedValue(null),
+            first: vi.fn().mockRejectedValue(new Error("D1 error")),
           }),
         }),
       };
@@ -219,8 +219,7 @@ describe("Rate Limiting", () => {
       const db = {
         prepare: vi.fn().mockReturnValue({
           bind: vi.fn().mockReturnValue({
-            run: vi.fn().mockRejectedValue(new Error("D1 unavailable")),
-            first: vi.fn().mockResolvedValue(null),
+            first: vi.fn().mockRejectedValue(new Error("D1 unavailable")),
           }),
         }),
       };
@@ -280,8 +279,7 @@ describe("Rate Limiting", () => {
       const db = {
         prepare: vi.fn().mockReturnValue({
           bind: vi.fn().mockReturnValue({
-            run: vi.fn().mockRejectedValue(new Error("D1 unavailable")),
-            first: vi.fn().mockResolvedValue(null),
+            first: vi.fn().mockRejectedValue(new Error("D1 unavailable")),
           }),
         }),
       };
@@ -408,8 +406,7 @@ describe("Rate Limiting", () => {
       const db = {
         prepare: vi.fn().mockReturnValue({
           bind: vi.fn().mockReturnValue({
-            run: vi.fn().mockRejectedValue(new Error("D1 error")),
-            first: vi.fn().mockResolvedValue(null),
+            first: vi.fn().mockRejectedValue(new Error("D1 error")),
           }),
         }),
       };
@@ -446,7 +443,6 @@ describe("Rate Limiting", () => {
           preparedCalls.push(sql);
           return {
             bind: vi.fn().mockReturnValue({
-              run: vi.fn().mockResolvedValue({}),
               first: vi.fn().mockResolvedValue({
                 count: 1,
                 window_start: Math.floor(Date.now() / 1000),
@@ -470,15 +466,15 @@ describe("Rate Limiting", () => {
         env,
       );
 
-      // Each call results in two D1 statements (upsert + select), so 4 total
-      expect(db.prepare).toHaveBeenCalledTimes(4);
+      // Each call issues a single RETURNING upsert statement (#492), so 2 total
+      expect(db.prepare).toHaveBeenCalledTimes(2);
 
-      // Extract the bind arguments from the key upsert calls to confirm distinct keys
+      // Extract the bind arguments from the upsert calls to confirm distinct keys
       const bindCalls = db.prepare.mock.results.map((r) => r.value.bind.mock.calls[0]).filter(Boolean);
 
       // The first positional arg to bind is the key — should differ for /follow vs /unfollow
       const keys = bindCalls.map((args) => args[0]);
-      // At least two distinct keys across the four bind calls
+      // Both calls must use distinct keys
       const uniqueKeys = [...new Set(keys)];
       expect(uniqueKeys.length).toBeGreaterThanOrEqual(2);
     });

--- a/functions/utils/rateLimit.js
+++ b/functions/utils/rateLimit.js
@@ -129,9 +129,11 @@ async function checkRateLimitD1(DB, ip, pathname, config) {
   const key = getRateLimitKey(ip, pathname);
 
   try {
-    // Atomically upsert: insert on first request, or increment/reset on subsequent ones.
+    // Single round trip: the upsert and the post-write read are combined via RETURNING,
+    // instead of a separate .run() + SELECT .first(). This halves D1 cost on the hot
+    // fail-closed path (auth, subscriptions, band follows, /api/metrics — #492).
     // The CASE expression resets the window when it has expired.
-    await DB.prepare(
+    const row = await DB.prepare(
       `
       INSERT INTO rate_limits (key, count, window_start, updated_at)
       VALUES (?1, 1, ?2, ?2)
@@ -139,13 +141,14 @@ async function checkRateLimitD1(DB, ip, pathname, config) {
         count = CASE WHEN (?2 - window_start) >= ?3 THEN 1 ELSE count + 1 END,
         window_start = CASE WHEN (?2 - window_start) >= ?3 THEN ?2 ELSE window_start END,
         updated_at = ?2
+      RETURNING count, window_start
     `,
     )
       .bind(key, now, config.window)
-      .run();
+      .first();
 
-    const row = await DB.prepare("SELECT count, window_start FROM rate_limits WHERE key = ?").bind(key).first();
-
+    // A RETURNING upsert always yields a row; these fallbacks guard shim/driver
+    // differences and cost nothing.
     const count = row?.count ?? 1;
     const windowStart = row?.window_start ?? now;
     const remaining = Math.max(0, config.requests - count);


### PR DESCRIPTION
## Summary

`checkRateLimitD1` issued two D1 round-trips per request — an atomic upsert followed by a `SELECT count, window_start` — on every fail-closed endpoint (auth, subscriptions, band follows, and high-volume `/api/metrics` since #494). This collapses them into a single `INSERT … ON CONFLICT … RETURNING count, window_start` executed via `.first()`, halving D1 cost on the hot fail-closed path. Split out of #482 by design so the security change stayed one line.

Closes #492

## What changed

| File | Change |
|------|--------|
| `functions/utils/rateLimit.js` | `RETURNING count, window_start` added to the upsert; the follow-up SELECT removed; `.run()` → `.first()`. The CASE window-reset semantics are byte-identical; the defensive `row?.count ?? 1` fallbacks and the fail-closed catch are unchanged |
| `functions/utils/__tests__/rateLimit.test.js` | Mocks updated to the single-call `.bind(...).first()` shape; the fail-closed tests now inject the D1 error on `.first()` (previously `.run()`, which no longer exists); the depth-5-key test's prepare-count assertion updated 4 → 2 |

## Security / correctness notes

- Fail-closed behavior is unchanged: any D1 error still returns `allowed: false`. The four fail-closed tests (sensitive endpoint, admin login, `/api/metrics`, band follow) all still exercise that path.
- D1 supports `RETURNING` on upserts and `.first()` on writing statements; the window-reset CASE logic was not touched.
- Coverage note: the rate-limit suite fully mocks `DB.prepare`, so the SQL text is not executed against a real driver in unit tests (true before this change as well). Production behavior is exercised by the e2e suite's live wrangler/D1 path.

## Verification

- [x] Tests: 615 pass, 0 failures (`npm test` in a node:22 Linux container — better-sqlite3 can't load on Apple Silicon)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: N/A — backend-only change, no `frontend/src` files touched
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged (no response-shape change)
- [x] Manual smoke: N/A — behavior-preserving perf change; response shape and headers identical, verified by the unchanged assertions in the rate-limit suite

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
