### PR TITLE
security(admin): sanitize social_links on admin read paths via safeReflectSocialLinks

### DIFF
--- a/functions/api/admin/bands.js
+++ b/functions/api/admin/bands.js
@@ -6,6 +6,8 @@ import { checkPermission } from "./_middleware.js";
 import {
   FIELD_LIMITS,
   isValidEmail,
+  safeReflectSocialLinks,
+  safeReflectSocialLinksString,
   sanitizeBandSocialLinks,
   sanitizeOptionalHttpUrl,
   sanitizeString,
@@ -25,15 +27,16 @@ async function getEventStatus(DB, eventId) {
 // Helper to unpack social links
 function unpackSocialLinks(band) {
   if (!band) return null;
-  let social = {};
-  try {
-    social = JSON.parse(band.social_links || "{}");
-  } catch (_e) {
-    social = {};
-  }
+  // Read-path sanitize (#493): `band.social_links` may be a pre-#483 (or
+  // otherwise legacy) DB value that was never routed through
+  // sanitizeBandSocialLinks on write. Never reflect it verbatim.
+  const social = safeReflectSocialLinks(band.social_links || "{}");
   const origin = [band.origin_city, band.origin_region].filter(Boolean).join(", ") || band.origin || "";
   return {
     ...band,
+    // Preserve the raw string/null shape — RosterTab.jsx JSON.parses this
+    // field directly — while sanitizing its contents.
+    social_links: safeReflectSocialLinksString(band.social_links),
     origin,
     url: social.website || "",
     instagram: social.instagram || "",

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -6,6 +6,7 @@ import { checkPermission, auditLog } from "../_middleware.js";
 import {
   FIELD_LIMITS,
   isValidEmail,
+  safeReflectSocialLinks,
   sanitizeBandSocialLinks,
   sanitizeOptionalHttpUrl,
   sanitizeString,
@@ -573,13 +574,15 @@ export async function onRequestPut(context) {
       };
     }
 
-    // Unpack social links for response compatibility
-    let social = {};
-    try {
-      social = JSON.parse(result.social_links || "{}");
-    } catch (_e) {
-      /* ignore malformed JSON — social stays {} */
-    }
+    // Unpack social links for response compatibility. Read-path sanitize
+    // (#493): `result.social_links` may reflect a pre-#483 (or otherwise
+    // untouched) DB value even when this request didn't itself update
+    // social_links — never echo it back verbatim.
+    const social = safeReflectSocialLinks(result.social_links || "{}");
+    // Preserve the raw string/null shape of `social_links` in the response —
+    // the admin frontend (RosterTab.jsx / LineupTab.jsx) JSON.parses this
+    // field directly.
+    result.social_links = result.social_links == null ? result.social_links : JSON.stringify(social);
     result.url = social.website || "";
     result.origin = [result.origin_city, result.origin_region].filter(Boolean).join(", ") || result.origin || "";
 

--- a/functions/api/admin/bands/__tests__/bands.test.js
+++ b/functions/api/admin/bands/__tests__/bands.test.js
@@ -1419,3 +1419,74 @@ describe("Admin bands API - Bulk POST onRequestPost full flow (T6)", () => {
     expect(data.skipped.length).toBe(1);
   });
 });
+
+describe("Admin bands API - social_links read-path sanitization (#493)", () => {
+  it("GET /api/admin/bands nulls out a javascript: scheme while keeping a legitimate handle and URL", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "SchemeListEvent", slug: "scheme-list-event" });
+    const venue = insertVenue(rawDb, { name: "Scheme List Venue" });
+    insertBand(rawDb, {
+      name: "Scheme List Band",
+      event_id: ev.id,
+      venue_id: venue.id,
+      social_links: JSON.stringify({
+        // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #493 admin read-path guard
+        website: "javascript:alert(1)",
+        instagram: "the_band",
+        bandcamp: "https://theband.bandcamp.com",
+      }),
+    });
+
+    const request = new Request(`https://example.test/api/admin/bands?event_id=${ev.id}`, { headers });
+    const res = await bandsHandler.onRequestGet({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    const band = data.bands.find((b) => b.name === "Scheme List Band");
+    expect(band).toBeDefined();
+
+    // Unpacked per-platform fields sanitized.
+    expect(band.url).toBe("");
+    expect(band.instagram).toBe("the_band");
+    expect(band.bandcamp).toBe("https://theband.bandcamp.com/");
+
+    // The raw `social_links` string RosterTab.jsx parses is sanitized too,
+    // and stays a JSON string (response shape unchanged).
+    expect(typeof band.social_links).toBe("string");
+    const parsed = JSON.parse(band.social_links);
+    expect(parsed.website).toBeNull();
+    expect(parsed.instagram).toBe("the_band");
+    expect(parsed.bandcamp).toBe("https://theband.bandcamp.com/");
+  });
+
+  it("PUT /api/admin/bands/{id} response nulls out a javascript: scheme in social_links untouched by the request", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev = insertEvent(rawDb, { name: "SchemePutEvent", slug: "scheme-put-event" });
+    const venue = insertVenue(rawDb, { name: "Scheme Put Venue" });
+    const band = insertBand(rawDb, {
+      name: "Scheme Put Band",
+      event_id: ev.id,
+      venue_id: venue.id,
+      social_links: JSON.stringify({
+        // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #493 admin read-path guard
+        website: "javascript:alert(1)",
+        instagram: "legit_handle",
+      }),
+    });
+
+    // Update an unrelated field (genre) — the request never touches social_links.
+    const request = new Request(`https://example.test/api/admin/bands/${band.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ genre: "Punk" }),
+    });
+    const res = await bandIdHandler.onRequestPut({ request, env, data: { user: { role: "editor" } } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.band.url).toBe("");
+    expect(typeof data.band.social_links).toBe("string");
+    const parsed = JSON.parse(data.band.social_links);
+    expect(parsed.website).toBeNull();
+    expect(parsed.instagram).toBe("legit_handle");
+  });
+});

--- a/functions/api/admin/bands/__tests__/stats.test.js
+++ b/functions/api/admin/bands/__tests__/stats.test.js
@@ -619,11 +619,49 @@ describe("GET /api/admin/bands/stats/:name", () => {
         description: "A great band",
         genre: "Rock",
         origin: "Seattle, WA",
+        // Read-path sanitized (#493): the website URL is re-normalized via
+        // safeReflectSocialLinksString, which adds the trailing slash `new
+        // URL(...).toString()` produces for a bare origin.
         social_links: JSON.stringify({
-          website: "https://example.com",
+          website: "https://example.com/",
           instagram: "@band",
         }),
       });
+    });
+
+    it("nulls out a javascript: scheme in social_links but keeps a legitimate handle (#493)", async () => {
+      // Arrange
+      const event = insertEvent(db, {
+        name: "Scheme Stats Event",
+        slug: "scheme-stats-event",
+        date: "2025-06-01",
+      });
+      const venue = insertVenue(db, { name: "Scheme Stats Venue" });
+      insertBandWithProfile(db, {
+        name: "Scheme Stats Band",
+        event_id: event.id,
+        venue_id: venue.id,
+        start_time: "20:00",
+        end_time: "21:00",
+        social_links: JSON.stringify({
+          // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #493 admin read-path guard
+          website: "javascript:alert(1)",
+          instagram: "legit_handle",
+        }),
+      });
+
+      // Act
+      const request = new Request("https://example.test/api/admin/bands/stats/Scheme%20Stats%20Band", {
+        headers: { "x-test-role": "viewer" },
+      });
+      const response = await onRequestGet({ request, env });
+
+      // Assert
+      const data = await response.json();
+      expect(typeof data.profile.social_links).toBe("string");
+      const parsed = JSON.parse(data.profile.social_links);
+      expect(parsed.website).toBeNull();
+      expect(parsed.instagram).toBe("legit_handle");
     });
   });
 

--- a/functions/api/admin/bands/stats/[name].js
+++ b/functions/api/admin/bands/stats/[name].js
@@ -2,6 +2,7 @@
 // GET /api/admin/bands/stats/{name} - Get performance history and stats for a band
 
 import { checkPermission } from "../../_middleware.js";
+import { safeReflectSocialLinksString } from "../../../../utils/validation.js";
 
 function formatOrigin(profile) {
   if (!profile) return null;
@@ -119,7 +120,9 @@ export async function onRequestGet(context) {
       description: latestEntry.description,
       genre: latestEntry.genre,
       origin: formatOrigin(latestEntry),
-      social_links: latestEntry.social_links,
+      // Read-path sanitize (#493): may be a pre-#483 (or otherwise legacy)
+      // value never routed through sanitizeBandSocialLinks on write.
+      social_links: safeReflectSocialLinksString(latestEntry.social_links),
     };
 
     return new Response(

--- a/functions/api/admin/events.js
+++ b/functions/api/admin/events.js
@@ -7,6 +7,7 @@ import {
   validateEntity,
   VALIDATION_SCHEMAS,
   validationErrorResponse,
+  safeReflectSocialLinksString,
   sanitizeEventSocialLinks,
   sanitizeVenueInfo,
 } from "../../utils/validation.js";
@@ -59,9 +60,17 @@ export async function onRequestGet(context) {
       .bind(...queryParams)
       .all();
 
+    // Read-path sanitize (#493): `e.*` pulls in the raw social_links column,
+    // which may hold a pre-#483 (or otherwise legacy) value never routed
+    // through sanitizeEventSocialLinks on write.
+    const events = (result.results || []).map((event) => ({
+      ...event,
+      social_links: safeReflectSocialLinksString(event.social_links, ["instagram", "x", "tiktok"]),
+    }));
+
     return new Response(
       JSON.stringify({
-        events: result.results || [],
+        events,
       }),
       {
         status: 200,

--- a/functions/api/admin/events/[id].js
+++ b/functions/api/admin/events/[id].js
@@ -8,6 +8,7 @@ import { checkPermission, auditLog } from "../_middleware.js";
 import {
   FIELD_LIMITS,
   isValidURL,
+  safeReflectSocialLinksString,
   sanitizeEventSocialLinks,
   sanitizeString,
   sanitizeVenueInfo,
@@ -385,6 +386,11 @@ export async function onRequestPatch(context) {
       .bind(...params)
       .first();
 
+    // Read-path sanitize (#493): RETURNING * echoes the full row, so
+    // social_links may reflect a pre-#483 (or otherwise legacy) value even
+    // when this request didn't touch social_links itself.
+    result.social_links = safeReflectSocialLinksString(result.social_links, ["instagram", "x", "tiktok"]);
+
     // Audit log
     await auditLog(
       env,
@@ -493,6 +499,9 @@ export async function onRequestPut(context) {
       )
         .bind(newStatus, nextStatus, currentUser.userId, eventId)
         .first();
+
+      // Read-path sanitize (#493): see the PATCH handler above.
+      result.social_links = safeReflectSocialLinksString(result.social_links, ["instagram", "x", "tiktok"]);
 
       // Audit log
       await auditLog(

--- a/functions/api/admin/events/[id]/archive.js
+++ b/functions/api/admin/events/[id]/archive.js
@@ -3,6 +3,7 @@
 
 import { checkPermission, auditLog } from "../../_middleware.js";
 import { getClientIP } from "../../../../utils/request.js";
+import { safeReflectSocialLinksString } from "../../../../utils/validation.js";
 
 // Helper to extract event ID from path
 function getEventId(request) {
@@ -82,6 +83,10 @@ export async function onRequestPost(context) {
     )
       .bind(currentUser.userId, eventId)
       .first();
+
+    // Read-path sanitize (#493): RETURNING * echoes the full row, so
+    // social_links may reflect a pre-#483 (or otherwise legacy) value.
+    result.social_links = safeReflectSocialLinksString(result.social_links, ["instagram", "x", "tiktok"]);
 
     // Audit log
     await auditLog(

--- a/functions/api/admin/events/[id]/duplicate.js
+++ b/functions/api/admin/events/[id]/duplicate.js
@@ -10,7 +10,7 @@
 
 import { checkPermission, auditLog } from "../../_middleware.js";
 import { getClientIP } from "../../../../utils/request.js";
-import { validateId } from "../../../../utils/validation.js";
+import { safeReflectSocialLinksString, validateId } from "../../../../utils/validation.js";
 
 function json(body, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -92,6 +92,14 @@ export async function onRequestPost(context) {
     if (!newEvent) {
       throw new Error("events INSERT returned null");
     }
+
+    // Read-path sanitize (#493): social_links is copied verbatim from the
+    // source event (INSERT ... originalEvent.social_links), so it may carry
+    // a pre-#483 (or otherwise legacy) value. Sanitize what's reflected back
+    // here; every other admin read path is sanitized too, so the stored
+    // duplicate is never echoed unsanitized regardless of which one serves
+    // a later request.
+    newEvent.social_links = safeReflectSocialLinksString(newEvent.social_links, ["instagram", "x", "tiktok"]);
 
     // Copy performances. If the copy fails, compensate by deleting the new event
     // so we never leave an empty orphan draft behind (D1 has no BEGIN/COMMIT).

--- a/functions/api/admin/events/[id]/edit.js
+++ b/functions/api/admin/events/[id]/edit.js
@@ -5,7 +5,7 @@
 
 import { checkPermission, auditLog } from "../../_middleware.js";
 import { getClientIP } from "../../../../utils/request.js";
-import { validateId } from "../../../../utils/validation.js";
+import { safeReflectSocialLinksString, validateId } from "../../../../utils/validation.js";
 
 export async function onRequestPut(context) {
   const { request, env, params } = context;
@@ -103,6 +103,11 @@ export async function onRequestPut(context) {
     )
       .bind(name, date, slug, ticket_url || null, eventId)
       .first();
+
+    // Read-path sanitize (#493): RETURNING * echoes the full row, so
+    // social_links may reflect a pre-#483 (or otherwise legacy) value even
+    // though this endpoint doesn't touch that column itself.
+    result.social_links = safeReflectSocialLinksString(result.social_links, ["instagram", "x", "tiktok"]);
 
     await auditLog(
       env,

--- a/functions/api/admin/events/[id]/publish.js
+++ b/functions/api/admin/events/[id]/publish.js
@@ -3,6 +3,7 @@
 
 import { checkPermission, auditLog } from "../../_middleware.js";
 import { getClientIP } from "../../../../utils/request.js";
+import { safeReflectSocialLinksString } from "../../../../utils/validation.js";
 
 // Helper to extract event ID from path
 function getEventId(request) {
@@ -114,6 +115,10 @@ export async function onRequestPost(context) {
     )
       .bind(newStatus, publish ? 1 : 0, currentUser.userId, eventId)
       .first();
+
+    // Read-path sanitize (#493): RETURNING * echoes the full row, so
+    // social_links may reflect a pre-#483 (or otherwise legacy) value.
+    result.social_links = safeReflectSocialLinksString(result.social_links, ["instagram", "x", "tiktok"]);
 
     // Audit log
     await auditLog(

--- a/functions/api/admin/events/__tests__/events.test.js
+++ b/functions/api/admin/events/__tests__/events.test.js
@@ -127,6 +127,66 @@ describe("Event API - handler integration", () => {
     expect(data.event.name).toBe("New Name");
   });
 
+  it("onRequestPatch response sanitizes a javascript: scheme in social_links untouched by the request (#493)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const ev = insertEvent(rawDb, { name: "Scheme Event", slug: "scheme-event" });
+    rawDb.prepare("UPDATE events SET social_links = ? WHERE id = ?").run(
+      JSON.stringify({
+        // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #493 admin read-path guard
+        instagram: "javascript:alert(1)",
+        x: "legit_handle",
+        website: "https://example.com",
+      }),
+      ev.id,
+    );
+
+    // Update an unrelated field (city) — the request never touches social_links.
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ city: "Kitchener" }),
+    });
+
+    const res = await eventIdHandler.onRequestPatch({ request, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(typeof data.event.social_links).toBe("string");
+    const parsed = JSON.parse(data.event.social_links);
+    expect(parsed.instagram).toBeNull();
+    expect(parsed.x).toBe("legit_handle");
+    expect(parsed.website).toBe("https://example.com/");
+  });
+
+  it("GET /api/admin/events sanitizes a javascript: scheme in social_links across the list", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const ev = insertEvent(rawDb, { name: "Scheme List Event", slug: "scheme-list-event" });
+    rawDb.prepare("UPDATE events SET social_links = ? WHERE id = ?").run(
+      JSON.stringify({
+        // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #493 admin read-path guard
+        tiktok: "javascript:alert(1)",
+        instagram: "legit_handle",
+      }),
+      ev.id,
+    );
+
+    const request = new Request("https://example.test/api/admin/events", {
+      headers: { "x-test-role": "viewer" },
+    });
+    const res = await eventsHandler.onRequestGet({ request, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    const found = data.events.find((e) => e.id === ev.id);
+    expect(found).toBeDefined();
+    expect(typeof found.social_links).toBe("string");
+    const parsed = JSON.parse(found.social_links);
+    expect(parsed.tiktok).toBeNull();
+    expect(parsed.instagram).toBe("legit_handle");
+  });
+
   it("publish endpoint requires >=1 band and publishes event", async () => {
     const rawDb = createTestDB();
     const env = { DB: createDBEnv(rawDb) };

--- a/functions/utils/__tests__/validation.test.js
+++ b/functions/utils/__tests__/validation.test.js
@@ -13,6 +13,7 @@ import {
   VALIDATION_SCHEMAS,
   safeReflectHandleOrUrl,
   safeReflectSocialLinks,
+  safeReflectSocialLinksString,
   sanitizeBandSocialLinks,
 } from "../validation.js";
 
@@ -311,6 +312,44 @@ describe("safeReflectSocialLinks (#483)", () => {
     ]);
     expect(result.x).toBeNull();
     expect(result.tiktok).toBe("the_band");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #493 — admin read endpoints reflect `social_links` as a raw JSON string
+// (the admin frontend parses it client-side), not a parsed object like the
+// public endpoints #483 fixed. safeReflectSocialLinksString wraps
+// safeReflectSocialLinks so those endpoints can sanitize without changing
+// that string response shape.
+// ---------------------------------------------------------------------------
+describe("safeReflectSocialLinksString (#493)", () => {
+  it("nulls out a javascript: scheme in a URL field but keeps a plain handle, re-serialized as a string", () => {
+    // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #493 admin read-path guard
+    const jsonString = JSON.stringify({ website: "javascript:alert(1)", instagram: "the_band" });
+    expect(safeReflectSocialLinksString(jsonString)).toBe(JSON.stringify({ website: null, instagram: "the_band" }));
+  });
+
+  it("passes through a valid https URL, re-normalized, as a string", () => {
+    expect(safeReflectSocialLinksString(JSON.stringify({ website: "https://example.com" }))).toBe(
+      JSON.stringify({ website: "https://example.com/" }),
+    );
+  });
+
+  it("respects a custom handleFields list (event social_links: instagram/x/tiktok)", () => {
+    // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #493 admin read-path guard
+    const jsonString = JSON.stringify({ x: "javascript:alert(1)", tiktok: "the_band" });
+    expect(safeReflectSocialLinksString(jsonString, ["instagram", "x", "tiktok"])).toBe(
+      JSON.stringify({ x: null, tiktok: "the_band" }),
+    );
+  });
+
+  it("returns '{}' for malformed JSON", () => {
+    expect(safeReflectSocialLinksString("not json")).toBe("{}");
+  });
+
+  it("passes null and undefined through unchanged, rather than coercing to '{}'", () => {
+    expect(safeReflectSocialLinksString(null)).toBeNull();
+    expect(safeReflectSocialLinksString(undefined)).toBeUndefined();
   });
 });
 

--- a/functions/utils/validation.js
+++ b/functions/utils/validation.js
@@ -407,6 +407,29 @@ export function safeReflectSocialLinks(jsonString, handleFields = ["instagram"])
   return sanitized;
 }
 
+/**
+ * String-in/string-out wrapper around `safeReflectSocialLinks`, for admin
+ * read endpoints (#493) that reflect `social_links` as a raw JSON string —
+ * the admin frontend (RosterTab.jsx, EventFormModal.jsx, LineupTab.jsx,
+ * admin/utils/pickerFormData.js) parses that string itself, so the response
+ * shape must stay a string rather than switching to a parsed object.
+ *
+ * A `null`/`undefined` column value (no social links set) is passed through
+ * unchanged rather than coerced to `"{}"`, so callers that never had a
+ * `social_links` value don't see one appear in the response.
+ *
+ * @param {string|null|undefined} jsonString - Raw `social_links` column value
+ * @param {string[]} handleFields - Keys that hold handles rather than URLs
+ * @returns {string|null|undefined} Sanitized JSON string, or the original
+ *   nullish value
+ */
+export function safeReflectSocialLinksString(jsonString, handleFields = ["instagram"]) {
+  if (jsonString === null || jsonString === undefined) {
+    return jsonString;
+  }
+  return JSON.stringify(safeReflectSocialLinks(jsonString, handleFields));
+}
+
 export function sanitizeOptionalHttpUrl(value, maxLength = FIELD_LIMITS.url.max, label = "URL") {
   const text = sanitizeOptionalText(value, maxLength, label);
   if (!text) {


### PR DESCRIPTION
## Summary

Follow-up to #483 (merged as #497): the public read paths sanitize `social_links` before reflecting it, but admin read endpoints still echoed the raw DB value — including every event-mutation endpoint, whose `RETURNING *` echoes the full row even when the request never touched `social_links`. This applies the shared `safeReflectSocialLinks` helper across all admin read reflections, adding a `safeReflectSocialLinksString` wrapper for the sites that reflect `social_links` as a raw JSON string, because the admin frontend (`RosterTab.jsx`, `LineupTab.jsx`, `EventFormModal.jsx`, `pickerFormData.js`) parses that string itself — **no response shapes change**.

Closes #493

## What changed

| File | Change |
|------|--------|
| `functions/utils/validation.js` | New `safeReflectSocialLinksString(jsonString, handleFields)` — string-in/string-out wrapper; passes `null`/`undefined` through unchanged so absent values don't materialize as `"{}"` |
| `functions/api/admin/bands.js` | `unpackSocialLinks()` (GET list) sanitizes; `social_links` re-serialized to preserve the string shape |
| `functions/api/admin/bands/[id].js` | PUT response echo sanitized (reuses the parsed object already needed for `result.url`) |
| `functions/api/admin/bands/stats/[name].js` | The issue's cited site — raw field now sanitized |
| `functions/api/admin/events.js` | GET list (`e.*` pulls the raw column) — each row sanitized |
| `functions/api/admin/events/[id].js` | PATCH and publish-toggle PUT `RETURNING *` echoes sanitized |
| `functions/api/admin/events/[id]/{archive,publish,edit,duplicate}.js` | Each `RETURNING *` echo sanitized (none of these touch the column themselves, so the echoed value can be legacy) |
| 4 test files | Per the issue's "Done when": seed `javascript:alert(1)` via direct SQL, assert the admin read nulls it while legit handles/URLs survive — covering bands list, band PUT, band stats, events list, and event PATCH; plus direct unit tests for the new helper |

## Security / correctness notes

- Handle fields match the #483 public-path precedent: bands → `["instagram"]`, events → `["instagram", "x", "tiktok"]` (same as `schedule.js`).
- Write paths deliberately untouched: `sanitizeBandSocialLinks`/`sanitizeEventSocialLinks` call sites and the band PATCH merge logic are already correct territory; sanitizing the merge would silently alter stored data.
- `duplicate.js` still copies the raw value into the new row — filed as #499 (data hygiene, not exposure: every read path now sanitizes, public and admin).
- Every sanitized `RETURNING *` echo sits behind an existence 404 guard, so the new property assignments can't hit a null row.
- Sites verified clean and left alone: `wizard.js` (freshly-inserted row, column provably null), `bulk-preview.js` and performance selects (no `social_links` column), the band POST response (echoes the client's own validated body, not a DB read).
- `docs/api-spec.yaml` already declares these fields `oneOf: string | GenericRecord` — shapes unchanged, no spec drift.

## Verification

- [x] Tests: 625 pass, 0 failures (`npm test` in a node:22 Linux container — better-sqlite3 can't load on Apple Silicon)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: N/A — backend-only change, no `frontend/src` files touched
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged (shapes preserved by design)
- [x] Manual smoke: admin read surfaces exercised end-to-end in endpoint tests with hostile fixtures seeded via direct SQL; response shapes pinned by the existing admin-suite assertions

---
Built by Sonny · Reviewed by Theo & Vera · 🤖 [Claude Code](https://claude.ai/claude-code)
