### PR TITLE
chore(api): replace SELECT * with explicit column lists in public band endpoints

### DIFF
--- a/functions/api/bands/[name].js
+++ b/functions/api/bands/[name].js
@@ -56,11 +56,14 @@ export async function onRequestGet(context) {
     }
 
     // Resolve band profile first (v2 schema)
+    // #484: explicit column list so future band_profiles columns don't
+    // silently join the public payload.
     let bandProfile = null;
     if (bandId) {
       bandProfile = await DB.prepare(
         `
-        SELECT * FROM band_profiles WHERE id = ? LIMIT 1
+        SELECT id, name, origin, origin_city, origin_region, social_links
+        FROM band_profiles WHERE id = ? LIMIT 1
       `,
       )
         .bind(bandId)
@@ -69,7 +72,8 @@ export async function onRequestGet(context) {
       const normalized = normalizeBandName(searchName);
       bandProfile = await DB.prepare(
         `
-        SELECT * FROM band_profiles
+        SELECT id, name, origin, origin_city, origin_region, social_links
+        FROM band_profiles
         WHERE name_normalized = ?
            OR LOWER(TRIM(name)) = LOWER(?)
         LIMIT 1

--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -57,11 +57,15 @@ export async function onRequestGet(context) {
     }
 
     // Resolve band profile first (v2 schema)
+    // #484: explicit column list so future band_profiles columns don't
+    // silently join the public payload.
     let bandProfile = null;
     if (bandId) {
       bandProfile = await DB.prepare(
         `
-        SELECT * FROM band_profiles WHERE id = ? LIMIT 1
+        SELECT id, name, origin, origin_city, origin_region, social_links,
+               photo_url, photo_alt_text, description, genre
+        FROM band_profiles WHERE id = ? LIMIT 1
       `,
       )
         .bind(bandId)
@@ -70,7 +74,9 @@ export async function onRequestGet(context) {
       const normalized = normalizeBandName(searchName);
       bandProfile = await DB.prepare(
         `
-        SELECT * FROM band_profiles
+        SELECT id, name, origin, origin_city, origin_region, social_links,
+               photo_url, photo_alt_text, description, genre
+        FROM band_profiles
         WHERE name_normalized = ?
            OR LOWER(TRIM(name)) = LOWER(?)
         LIMIT 1


### PR DESCRIPTION
## Summary

The two public band endpoints fetched `band_profiles` rows with `SELECT *`. Nothing leaks today — the response builders pick fields explicitly — but any future column (`contact_email`, internal flags, …) would silently join the fetched row object, one `Object.assign` or debug log away from the public payload. Each of the four query sites now selects exactly the columns its handler actually reads, derived by tracing every row access (not copied from the issue's hint list).

Closes #484

## What changed

| File | Change |
|------|--------|
| `functions/api/bands/[name].js` | Both sites (by-id, by-name): `SELECT id, name, origin, origin_city, origin_region, social_links` — the response reads only id/name/social_links plus `formatOrigin()`'s three origin fields |
| `functions/api/bands/stats/[name].js` | Both sites: the same base set plus `photo_url, photo_alt_text, description, genre`, which the richer stats response reads directly |

## Security / correctness notes

- Defence-in-depth only — no data currently leaks. The lists differ between the two files because their responses genuinely differ; sharing one list would have re-widened the profile endpoint.
- `name_normalized` (in the issue's hint) is deliberately not selected: it's a WHERE-clause input, never read off the fetched row.
- Verified no spread (`...bandProfile`) usage in either file, so the traced property accesses are exhaustive.
- Schema cross-checked against `database/setup-complete.sql` and migrations 0001/0013/0020/0042 — no drift.

## Verification

- [x] Tests: 615 pass, 0 failures (`npm test` in a node:22 Linux container — better-sqlite3 can't load on Apple Silicon); response shape unchanged, existing #483 scheme tests included
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: N/A — backend-only change, no `frontend/src` files touched
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged (response shapes identical)
- [x] Manual smoke: N/A — column-list narrowing with byte-identical responses, pinned by the existing endpoint test suites

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
