### PR TITLE
ci: extract e2e-env composite action; fail on server-start timeout (#478 items 4+5)

### DIFF
--- a/.github/actions/e2e-env/action.yml
+++ b/.github/actions/e2e-env/action.yml
@@ -1,0 +1,120 @@
+name: E2E environment
+description: Installs dependencies, builds the frontend, initializes local D1, and starts wrangler pages dev on :8788.
+
+inputs:
+    e2e-admin-password:
+        description: Admin password to seed for E2E login
+        required: false
+        default: ''
+    e2e-admin-email:
+        description: Admin email to seed
+        required: false
+        default: ''
+
+runs:
+    using: composite
+    steps:
+        - name: Setup Node
+          uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+          with:
+              node-version: 22
+              cache: npm
+              cache-dependency-path: |
+                  package-lock.json
+                  frontend/package-lock.json
+
+        - name: Install dependencies
+          shell: bash
+          run: npm ci
+
+        - name: Install frontend dependencies
+          shell: bash
+          working-directory: frontend
+          run: npm ci
+
+        - name: Cache Playwright browsers
+          id: playwright-cache
+          uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+          with:
+              path: ~/.cache/ms-playwright
+              key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+              restore-keys: |
+                  playwright-${{ runner.os }}-
+
+        - name: Install Playwright browsers
+          shell: bash
+          env:
+              CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
+          run: |
+              if [ "$CACHE_HIT" = "true" ]; then
+                  npx playwright install-deps chromium
+                  npx playwright install chromium
+              else
+                  npx playwright install chromium --with-deps
+              fi
+
+        - name: Build frontend
+          shell: bash
+          working-directory: frontend
+          run: npm run build
+
+        - name: Initialize D1 database with schema
+          shell: bash
+          env:
+              E2E_ADMIN_PASSWORD: ${{ inputs.e2e-admin-password }}
+              E2E_ADMIN_EMAIL: ${{ inputs.e2e-admin-email }}
+          run: |
+              printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\nENVIRONMENT="development"\n' > .dev.vars
+
+              echo "Initializing D1 database with schema..."
+              ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/setup-complete.sql
+
+              echo "Seeding test data (venues, events, bands)..."
+              ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/seed-test-data.sql
+
+              if [ -n "$E2E_ADMIN_PASSWORD" ] && [ -n "$E2E_ADMIN_EMAIL" ]; then
+                  echo "Creating E2E admin user..."
+                  SEED_SQL=$(node scripts/seed-e2e-admin.mjs --email "$E2E_ADMIN_EMAIL" --password "$E2E_ADMIN_PASSWORD")
+                  ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="$SEED_SQL"
+                  echo "✓ E2E admin user created: $E2E_ADMIN_EMAIL"
+              else
+                  echo "⚠ E2E credentials not set, using default test accounts"
+              fi
+
+              echo "Database users:"
+              ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="SELECT id, email, role FROM users;"
+
+              echo "✓ Database initialization complete"
+
+        - name: Start Pages Functions server
+          shell: bash
+          run: |
+              ./frontend/node_modules/.bin/wrangler pages dev frontend/dist --port 8788 --persist-to .wrangler/state > /tmp/wrangler.log 2>&1 &
+              WRANGLER_PID=$!
+
+              echo "Waiting for server to start..."
+              i=1
+              while [ $i -le 90 ]; do
+                  if ! kill -0 $WRANGLER_PID 2>/dev/null; then
+                      echo "✗ Wrangler process exited unexpectedly"
+                      echo "Wrangler logs:"
+                      cat /tmp/wrangler.log
+                      exit 1
+                  fi
+                  if curl -s http://localhost:8788/ > /dev/null 2>&1; then
+                      echo "✓ Server is ready on port 8788!"
+                      exit 0
+                  fi
+                  if [ $((i % 20)) -eq 0 ]; then
+                      echo "--- Wrangler log (iteration $i) ---"
+                      tail -20 /tmp/wrangler.log 2>/dev/null
+                      echo "---"
+                  fi
+                  echo "Waiting for server... ($i/90)"
+                  sleep 2
+                  i=$((i + 1))
+              done
+              echo "✗ Server failed to start after 180 seconds"
+              echo "Wrangler logs:"
+              cat /tmp/wrangler.log
+              exit 1

--- a/.github/workflows/e2e-a11y-visual.yml
+++ b/.github/workflows/e2e-a11y-visual.yml
@@ -7,6 +7,8 @@ on:
             - 'e2e/accessibility/**'
             - 'e2e/visual-regression.spec.js'
             - 'frontend/**'
+            - '.github/actions/e2e-env/**'
+            - '.github/workflows/e2e-a11y-visual.yml'
     schedule:
         - cron: '0 7 * * 1'
 
@@ -32,104 +34,11 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Setup Node
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+            - name: E2E environment
+              uses: ./.github/actions/e2e-env
               with:
-                  node-version: 22
-                  cache: npm
-                  cache-dependency-path: |
-                      package-lock.json
-                      frontend/package-lock.json
-
-            - name: Install dependencies
-              run: npm ci
-
-            - name: Install frontend dependencies
-              working-directory: frontend
-              run: npm ci
-
-            - name: Cache Playwright browsers
-              id: playwright-cache
-              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-              with:
-                  path: ~/.cache/ms-playwright
-                  key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-                  restore-keys: |
-                      playwright-${{ runner.os }}-
-
-            - name: Install Playwright browsers
-              run: |
-                  if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
-                      npx playwright install-deps chromium
-                      npx playwright install chromium
-                  else
-                      npx playwright install chromium --with-deps
-                  fi
-
-            - name: Build frontend
-              working-directory: frontend
-              run: npm run build
-
-            - name: Initialize D1 database with schema
-              env:
-                  E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD  }}
-                  E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL  }}
-              run: |
-                  printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\nENVIRONMENT="development"\n' > .dev.vars
-
-                  echo "Initializing D1 database with schema..."
-                  ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/setup-complete.sql
-
-                  echo "Seeding test data (venues, events, bands)..."
-                  ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/seed-test-data.sql
-
-                  if [ -n "$E2E_ADMIN_PASSWORD" ] && [ -n "$E2E_ADMIN_EMAIL" ]; then
-                      echo "Creating E2E admin user..."
-                      SEED_SQL=$(node scripts/seed-e2e-admin.mjs --email "$E2E_ADMIN_EMAIL" --password "$E2E_ADMIN_PASSWORD")
-                      ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="$SEED_SQL"
-                      echo "✓ E2E admin user created: $E2E_ADMIN_EMAIL"
-                  else
-                      echo "⚠ E2E credentials not set, using default test accounts"
-                  fi
-
-                  echo "Database users:"
-                  ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="SELECT id, email, role FROM users;"
-
-                  echo "✓ Database initialization complete"
-
-            - name: Start Pages Functions server
-              timeout-minutes: 5
-              run: |
-                  ./frontend/node_modules/.bin/wrangler pages dev frontend/dist --port 8788 --persist-to .wrangler/state > /tmp/wrangler.log 2>&1 &
-                  WRANGLER_PID=$!
-                  echo "WRANGLER_PID=$WRANGLER_PID" >> $GITHUB_ENV
-
-                  echo "Waiting for server to start..."
-                  i=1
-                  while [ $i -le 90 ]; do
-                      if ! kill -0 $WRANGLER_PID 2>/dev/null; then
-                          echo "✗ Wrangler process exited unexpectedly"
-                          echo "Wrangler logs:"
-                          cat /tmp/wrangler.log
-                          exit 1
-                      fi
-                      if curl -s http://localhost:8788/ > /dev/null 2>&1; then
-                          echo "✓ Server is ready on port 8788!"
-                          exit 0
-                      fi
-                      if [ $((i % 20)) -eq 0 ]; then
-                          echo "--- Wrangler log (iteration $i) ---"
-                          tail -20 /tmp/wrangler.log 2>/dev/null
-                          echo "---"
-                      fi
-                      echo "Waiting for server... ($i/90)"
-                      sleep 2
-                      i=$((i + 1))
-                  done
-                  echo "✗ Server failed to start after 180 seconds"
-                  echo "Wrangler logs:"
-                  cat /tmp/wrangler.log
-                  exit 1
+                  e2e-admin-password: ${{ secrets.E2E_ADMIN_PASSWORD }}
+                  e2e-admin-email: ${{ secrets.E2E_ADMIN_EMAIL }}
 
             - name: Check linux snapshots exist
               env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,15 +27,6 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Setup Node
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-              with:
-                  node-version: 22
-                  cache: npm
-                  cache-dependency-path: |
-                      package-lock.json
-                      frontend/package-lock.json
-
             - name: Run affected tests (fast-path)
               id: affected
               uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
@@ -47,106 +38,19 @@ jobs:
                       schema: |
                           migrations/**
                           database/**
+                      ci: |
+                          .github/actions/e2e-env/**
+                          .github/workflows/e2e-tests.yml
 
-            - name: Install dependencies
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
-              run: npm ci
-
-            - name: Install frontend dependencies
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
-              working-directory: frontend
-              run: npm ci
-
-            - name: Cache Playwright browsers
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
-              id: playwright-cache
-              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+            - name: E2E environment
+              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true' || steps.affected.outputs['ci'] == 'true'
+              uses: ./.github/actions/e2e-env
               with:
-                  path: ~/.cache/ms-playwright
-                  key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-                  restore-keys: |
-                      playwright-${{ runner.os }}-
-
-            - name: Install Playwright browsers
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
-              run: |
-                  if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
-                      npx playwright install-deps chromium
-                      npx playwright install chromium
-                  else
-                      npx playwright install chromium --with-deps
-                  fi
-
-            - name: Build frontend
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
-              working-directory: frontend
-              run: npm run build
-
-            - name: Initialize D1 database with schema
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
-              env:
-                  E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
-                  E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
-              run: |
-                  printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\nENVIRONMENT="development"\n' > .dev.vars
-
-                  echo "Initializing D1 database with schema..."
-                  ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/setup-complete.sql
-
-                  echo "Seeding test data (venues, events, bands)..."
-                  ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/seed-test-data.sql
-
-                  if [ -n "$E2E_ADMIN_PASSWORD" ] && [ -n "$E2E_ADMIN_EMAIL" ]; then
-                      echo "Creating E2E admin user..."
-                      SEED_SQL=$(node scripts/seed-e2e-admin.mjs --email "$E2E_ADMIN_EMAIL" --password "$E2E_ADMIN_PASSWORD")
-                      ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="$SEED_SQL"
-                      echo "✓ E2E admin user created: $E2E_ADMIN_EMAIL"
-                  else
-                      echo "⚠ E2E credentials not set, using default test accounts"
-                  fi
-
-                  echo "Database users:"
-                  ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="SELECT id, email, role FROM users;"
-
-                  echo "✓ Database initialization complete"
-
-            - name: Start Pages Functions server
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
-              timeout-minutes: 5
-              run: |
-                  ./frontend/node_modules/.bin/wrangler pages dev frontend/dist --port 8788 --persist-to .wrangler/state > /tmp/wrangler.log 2>&1 &
-                  WRANGLER_PID=$!
-                  echo "WRANGLER_PID=$WRANGLER_PID" >> $GITHUB_ENV
-
-                  echo "Waiting for server to start..."
-                  i=1
-                  while [ $i -le 90 ]; do
-                      if ! kill -0 $WRANGLER_PID 2>/dev/null; then
-                          echo "✗ Wrangler process exited unexpectedly"
-                          echo "Wrangler logs:"
-                          cat /tmp/wrangler.log
-                          exit 1
-                      fi
-                      if curl -s http://localhost:8788/ > /dev/null 2>&1; then
-                          echo "✓ Server is ready on port 8788!"
-                          exit 0
-                      fi
-                      if [ $((i % 20)) -eq 0 ]; then
-                          echo "--- Wrangler log (iteration $i) ---"
-                          tail -20 /tmp/wrangler.log 2>/dev/null
-                          echo "---"
-                      fi
-                      echo "Waiting for server... ($i/90)"
-                      sleep 2
-                      i=$((i + 1))
-                  done
-                  echo "✗ Server failed to start after 180 seconds"
-                  echo "Wrangler logs:"
-                  cat /tmp/wrangler.log
-                  exit 1
+                  e2e-admin-password: ${{ secrets.E2E_ADMIN_PASSWORD }}
+                  e2e-admin-email: ${{ secrets.E2E_ADMIN_EMAIL }}
 
             - name: Run Playwright tests
-              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true'
+              if: github.event_name == 'push' || steps.affected.outputs['frontend'] == 'true' || steps.affected.outputs['e2e'] == 'true' || steps.affected.outputs['functions'] == 'true' || steps.affected.outputs['schema'] == 'true' || steps.affected.outputs['ci'] == 'true'
               env:
                   ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
                   ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}

--- a/.github/workflows/update-visual-snapshots.yml
+++ b/.github/workflows/update-visual-snapshots.yml
@@ -27,87 +27,16 @@ jobs:
                   ref: ${{ inputs.branch || github.ref_name }}
                   fetch-depth: 1
 
-            - name: Setup Node
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+            - name: E2E environment
+              uses: ./.github/actions/e2e-env
               with:
-                  node-version: 22
-                  cache: npm
-                  cache-dependency-path: |
-                      package-lock.json
-                      frontend/package-lock.json
-
-            - name: Install dependencies
-              run: npm ci
-
-            - name: Install frontend dependencies
-              working-directory: frontend
-              run: npm ci
-
-            - name: Cache Playwright browsers
-              id: playwright-cache
-              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-              with:
-                  path: ~/.cache/ms-playwright
-                  key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-                  restore-keys: |
-                      playwright-${{ runner.os }}-
-
-            - name: Install Playwright browsers
-              env:
-                  CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
-              run: |
-                  if [ "$CACHE_HIT" = "true" ]; then
-                      npx playwright install-deps chromium
-                      npx playwright install chromium
-                  else
-                      npx playwright install chromium --with-deps
-                  fi
-
-            - name: Build frontend
-              working-directory: frontend
-              run: npm run build
-
-            - name: Initialize D1 database with schema
-              env:
-                  E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD  }}
-                  E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL  }}
-              run: |
-                  printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\nENVIRONMENT="development"\n' > .dev.vars
-
-                  ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/setup-complete.sql
-                  ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/seed-test-data.sql
-
-                  if [ -n "$E2E_ADMIN_PASSWORD" ] && [ -n "$E2E_ADMIN_EMAIL" ]; then
-                      SEED_SQL=$(node scripts/seed-e2e-admin.mjs --email "$E2E_ADMIN_EMAIL" --password "$E2E_ADMIN_PASSWORD")
-                      ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="$SEED_SQL"
-                  fi
-
-            - name: Start Pages Functions server
-              timeout-minutes: 5
-              run: |
-                  ./frontend/node_modules/.bin/wrangler pages dev frontend/dist --port 8788 --persist-to .wrangler/state > /tmp/wrangler.log 2>&1 &
-                  WRANGLER_PID=$!
-                  echo "WRANGLER_PID=$WRANGLER_PID" >> $GITHUB_ENV
-
-                  i=1
-                  while [ $i -le 90 ]; do
-                      if ! kill -0 $WRANGLER_PID 2>/dev/null; then
-                          echo "✗ Wrangler process exited unexpectedly"
-                          cat /tmp/wrangler.log
-                          exit 1
-                      fi
-                      if curl -s http://localhost:8788/ > /dev/null 2>&1; then
-                          echo "✓ Server is ready"
-                          break
-                      fi
-                      sleep 2
-                      i=$((i + 1))
-                  done
+                  e2e-admin-password: ${{ secrets.E2E_ADMIN_PASSWORD }}
+                  e2e-admin-email: ${{ secrets.E2E_ADMIN_EMAIL }}
 
             - name: Regenerate visual snapshots
               env:
-                  ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD  }}
-                  ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL  }}
+                  ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
+                  ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
               run: npx playwright test e2e/visual-regression.spec.js --update-snapshots
 
             - name: Commit updated snapshots


### PR DESCRIPTION
## Summary

Extracts the ~80-line E2E environment block (Node setup → `npm ci` ×2 → Playwright cache/install → frontend build → local D1 init → `wrangler pages dev` start) that was duplicated near-byte-identically across `e2e-tests.yml`, `e2e-a11y-visual.yml`, and `update-visual-snapshots.yml` into a composite action, `.github/actions/e2e-env`. This is items **#4 and #5** of the #451 CI audit tracked in #478. Item #5 is a real bug fix: the snapshot workflow's server-wait loop had no `exit 1` on timeout — it silently fell through and ran Playwright against a dead server; the composite's loop (taken from `e2e-tests.yml`) always fails loudly with the wrangler log dumped.

Part of #478 (items #4 + #5; #7/#8/#9 remain).

## What changed

| File | Change |
|------|--------|
| `.github/actions/e2e-env/action.yml` | **New** composite action: setup-node, root+frontend `npm ci`, Playwright browser cache+install, frontend build, D1 init (schema + seed + optional admin via inputs), server start with fail-loud wait loop. Same pinned action SHAs. |
| `.github/workflows/e2e-tests.yml` | Setup block → one composite call; the 8× repeated fast-path `if:` collapses to 2. New `ci` paths-filter (`.github/actions/e2e-env/**` + the workflow itself) added to the run condition so E2E-env changes exercise the suite. |
| `.github/workflows/e2e-a11y-visual.yml` | Setup block → composite call. `on.pull_request.paths` gains the action dir + the workflow itself. |
| `.github/workflows/update-visual-snapshots.yml` | Setup block → composite call. Its quiet wait loop (the one missing `exit 1`) is replaced by the composite's fail-loud verbose loop. |

Deliberate details:

- **Secrets flow through action inputs** (`e2e-admin-password`/`e2e-admin-email`) — composite actions can't read `secrets.*` implicitly; values remain masked in logs.
- **`timeout-minutes` dropped from the server-start step** — unsupported on composite-action steps. The loop self-bounds at ~180 s and the job-level 35-minute timeout still applies.
- **Cache-hit conditional uses the `CACHE_HIT` env pattern** (from `update-visual-snapshots.yml`) instead of interpolating `${{ }}` inside the script — the safer of the two pre-existing variants.
- In `e2e-tests.yml`, Setup Node moves under the fast-path condition (inside the composite). Nothing outside the composite needs Node: paths-filter doesn't, and the test step shares the same condition. The `always()` report upload already tolerated skipped runs.

## Security / correctness notes

No secret-handling changes beyond routing through action inputs (still runner-masked). The `ci` filter means `.github`-only PRs touching the action now run the full E2E suite — previously the job passed trivially without exercising anything, which would have masked breakage of exactly this refactor.

## Verification

- [x] `actionlint` (dockerized): zero findings on the four changed files (3 pre-existing SC2086 warnings in untouched `zap-baseline.yml` only)
- [x] YAML parse: all four files parse cleanly
- [x] **Self-verifying by design:** the new trigger paths make both `e2e` and `e2e-a11y-visual` run on this PR against the composite — green checks here mean the extraction works end-to-end
- [x] `update-visual-snapshots` exercised via `workflow_dispatch` on this branch (its trigger can't fire from a PR) — run link posted in comments when complete
- [ ] Tests: N/A — no application code changed
- [ ] ESLint / format / build: N/A — workflow YAML only

---
Built by Sonny · Reviewed by Vera · 🤖 [Claude Code](https://claude.ai/claude-code)
