### PR TITLE
security(admin): sanitize social_links at the event-duplication write path (#499)

### DIFF
--- a/functions/api/admin/events/[id]/duplicate.js
+++ b/functions/api/admin/events/[id]/duplicate.js
@@ -83,7 +83,7 @@ export async function onRequestPost(context) {
         originalEvent.city || null,
         originalEvent.ticket_url || null,
         originalEvent.venue_info || null,
-        originalEvent.social_links || null,
+        safeReflectSocialLinksString(originalEvent.social_links || null, ["instagram", "x", "tiktok"]),
         originalEvent.theme_colors || null,
         currentUser.userId,
       )
@@ -93,12 +93,12 @@ export async function onRequestPost(context) {
       throw new Error("events INSERT returned null");
     }
 
-    // Read-path sanitize (#493): social_links is copied verbatim from the
-    // source event (INSERT ... originalEvent.social_links), so it may carry
-    // a pre-#483 (or otherwise legacy) value. Sanitize what's reflected back
-    // here; every other admin read path is sanitized too, so the stored
-    // duplicate is never echoed unsanitized regardless of which one serves
-    // a later request.
+    // Read-path sanitize (#493): the INSERT above already stores a sanitized
+    // copy of social_links (#499), so this row can no longer carry a stale
+    // pre-#483 value. This reflection sanitize stays anyway for consistency
+    // with every other admin read path (each RETURNING * / SELECT * echo is
+    // sanitized independently), so a future write path that skips
+    // sanitization still can't leak an unsafe value through this response.
     newEvent.social_links = safeReflectSocialLinksString(newEvent.social_links, ["instagram", "x", "tiktok"]);
 
     // Copy performances. If the copy fails, compensate by deleting the new event

--- a/functions/api/admin/events/__tests__/events.test.js
+++ b/functions/api/admin/events/__tests__/events.test.js
@@ -443,6 +443,57 @@ describe("Event API - handler integration", () => {
     expect(data.bands_copied).toBeGreaterThanOrEqual(2);
   });
 
+  it("duplicate endpoint sanitizes a legacy javascript: social_links value at the write path (#499)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    // Original event, with a malicious social_links value seeded directly via
+    // SQL (bypassing write-path validation) to simulate a pre-#483 legacy row
+    // that never went through sanitizeEventSocialLinks.
+    const original = insertEvent(rawDb, { name: "Legacy Source", slug: "legacy-source" });
+    rawDb.prepare("UPDATE events SET social_links = ? WHERE id = ?").run(
+      // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #499 write-path guard
+      JSON.stringify({ instagram: "javascript:alert(1)", website: "javascript:alert(1)", x: "someHandle" }),
+      original.id,
+    );
+
+    const body = {
+      name: "Copy of Legacy Source",
+      date: "2026-01-01",
+      slug: "legacy-source-copy",
+    };
+    const request = new Request(`https://example.test/api/admin/events/${original.id}/duplicate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-role": "editor",
+      },
+      body: JSON.stringify(body),
+    });
+
+    const res = await duplicateHandler.onRequestPost({
+      request,
+      env,
+      params: { id: String(original.id) },
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+
+    // Response echo is sanitized (defense-in-depth, unchanged behaviour).
+    // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #499 write-path guard
+    expect(data.event.social_links).not.toContain("javascript:");
+
+    // The core assertion: the row actually stored in the DB is sanitized too,
+    // not just the response. Query it directly rather than trusting the echo.
+    const stored = rawDb.prepare("SELECT social_links FROM events WHERE id = ?").get(data.event.id);
+    // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #499 write-path guard
+    expect(stored.social_links).not.toContain("javascript:");
+    const storedParsed = JSON.parse(stored.social_links);
+    expect(storedParsed.instagram).toBeNull();
+    expect(storedParsed.website).toBeNull();
+    expect(storedParsed.x).toBe("someHandle");
+  });
+
   it("delete endpoint requires admin and deletes event", async () => {
     const rawDb = createTestDB();
     const env = { DB: createDBEnv(rawDb) };


### PR DESCRIPTION
## Summary

Event duplication copied `originalEvent.social_links` verbatim into the new row, so a pre-#483 legacy value (e.g. a `javascript:` scheme) seeded before write-path validation existed would be perpetuated into freshly created rows. The INSERT now routes the value through `safeReflectSocialLinksString(…, ["instagram", "x", "tiktok"])`, so duplicated events start clean. Not an exposure — every read path already sanitizes (#483 public, #493 admin) — this is data-hygiene hardening at the last unsanitized write.

Closes #499

## What changed

| File | Change |
|------|--------|
| `functions/api/admin/events/[id]/duplicate.js` | INSERT binds a sanitized copy of `social_links` instead of the raw column. Read-path reflection sanitize stays (defense-in-depth); its comment rewritten to match the new reality. |
| `functions/api/admin/events/__tests__/events.test.js` | New regression test: seeds a `javascript:` value via direct SQL (simulating legacy data), duplicates, and asserts the **stored row** (direct `SELECT`, not the response echo) is sanitized — unsafe keys nulled, benign `x` handle survives. |

## Security / correctness notes

- Sanitizer semantics: `javascript:` values are **nulled, not dropped** (handle fields reject any colon via `safeReflectHandleOrUrl`; URL fields reject non-http(s) via `normalizeHttpUrl`). Allowlist `["instagram", "x", "tiktok"]` matches the existing read-path calls for events.
- Malformed legacy JSON now stores as `{}` instead of propagating garbage (`safeReflectSocialLinks` catches parse failures) — strict improvement, no throw path added.
- Reviewing the remaining verbatim-copied fields surfaced a same-class gap for `ticket_url` (validated on write, unsanitized on public reads, copied verbatim here) — filed as #504 with a production scan confirming zero current exposure.

## Verification

- [x] Tests: 626 pass, 0 failures (`npm test` in node:22 container; includes the new #499 regression test)
- [x] ESLint: 0 errors (`npm run lint`; `no-script-url` fixture literals carry justified disables matching the existing convention)
- [x] Format check: clean (`npm run format:check`)
- [ ] Build: N/A — no frontend changes
- [ ] `validate:openapi`: N/A — response shapes unchanged
- [x] Manual smoke: N/A — covered by the handler-integration test asserting the stored DB row directly

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
