### PR TITLE
fix(frontend): retry transient public GET failures once; distinct timeline 500 body (#508)

### DIFF
--- a/frontend/src/utils/__tests__/publicApi.test.js
+++ b/frontend/src/utils/__tests__/publicApi.test.js
@@ -56,4 +56,102 @@ describe('fetchPublicJson', () => {
     await expect(fetchPublicJson('/api/bands/stats/22')).resolves.toEqual({ id: 22, name: '$wamp A$$' })
     expect(fetchMock).toHaveBeenCalledWith('/api/bands/stats/22', {})
   })
+
+  describe('transient failure retry', () => {
+    const RETRY_DELAY_MS = 600
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('retries once and succeeds when a GET request first returns a 5xx', async () => {
+      const fetchMock = global.fetch
+      fetchMock
+        .mockResolvedValueOnce(
+          new globalThis.Response(JSON.stringify({ error: 'Database error', message: 'nope' }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+        .mockResolvedValueOnce(
+          new globalThis.Response(JSON.stringify({ now: [], upcoming: [], past: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+
+      const promise = fetchPublicJson('/api/events/timeline')
+      const expectation = expect(promise).resolves.toEqual({ now: [], upcoming: [], past: [] })
+      await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS)
+
+      await expectation
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries once and succeeds when a GET request first throws a network error', async () => {
+      const fetchMock = global.fetch
+      fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch')).mockResolvedValueOnce(
+        new globalThis.Response(JSON.stringify({ id: 22 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+
+      const promise = fetchPublicJson('/api/events/timeline')
+      const expectation = expect(promise).resolves.toEqual({ id: 22 })
+      await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS)
+
+      await expectation
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not retry a 4xx response', async () => {
+      const fetchMock = global.fetch
+      fetchMock.mockResolvedValueOnce(
+        new globalThis.Response(JSON.stringify({ error: 'Not found' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+
+      await expect(fetchPublicJson('/api/events/timeline')).rejects.toMatchObject({ status: 404 })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not retry a non-GET request even on a 5xx response', async () => {
+      const fetchMock = global.fetch
+      fetchMock.mockResolvedValueOnce(
+        new globalThis.Response(JSON.stringify({ error: 'Database error', message: 'boom' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+
+      await expect(fetchPublicJson('/api/events/timeline', { method: 'POST' })).rejects.toMatchObject({
+        status: 500,
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('propagates the error when both attempts return a 5xx', async () => {
+      const fetchMock = global.fetch
+      fetchMock.mockResolvedValue(
+        new globalThis.Response(JSON.stringify({ error: 'Database error', message: 'still down' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+
+      const promise = fetchPublicJson('/api/events/timeline')
+      const expectation = expect(promise).rejects.toMatchObject({ status: 500, message: 'still down' })
+      await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS)
+
+      await expectation
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/frontend/src/utils/publicApi.js
+++ b/frontend/src/utils/publicApi.js
@@ -30,7 +30,46 @@ export async function parsePublicApiResponse(response, fallbackMessage = 'API re
   return data
 }
 
+const RETRY_DELAY_MS = 600
+const MAX_ATTEMPTS = 2
+
+function isRetryableRequest(options) {
+  const method = (options.method || 'GET').toUpperCase()
+  return method === 'GET'
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+// Retries a single time on transient failures (network error or 5xx) for GET
+// reads only — never for mutating requests, where a retry could double the
+// side effect. This exists to ride out brief upstream blips (e.g. a
+// transient D1 5xx) without blanking the page on one bad response.
 export async function fetchPublicJson(url, options = {}, fallbackMessage = 'API request failed') {
-  const response = await fetch(url, options)
-  return parsePublicApiResponse(response, fallbackMessage)
+  const canRetry = isRetryableRequest(options)
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const isFinalAttempt = attempt === MAX_ATTEMPTS
+    let response
+
+    try {
+      response = await fetch(url, options)
+    } catch (networkError) {
+      if (canRetry && !isFinalAttempt) {
+        await delay(RETRY_DELAY_MS)
+        continue
+      }
+      throw networkError
+    }
+
+    if (canRetry && !isFinalAttempt && response.status >= 500) {
+      await delay(RETRY_DELAY_MS)
+      continue
+    }
+
+    return parsePublicApiResponse(response, fallbackMessage)
+  }
+
+  return undefined
 }

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -247,7 +247,8 @@ describe("Timeline API - Optimized JOIN Queries", () => {
 
       const data = await response.json();
       expect(data).toHaveProperty("error");
-      expect(data.error).toBe("Failed to fetch events timeline");
+      expect(data.error).toBe("Database error");
+      expect(data.message).toBe("Events are temporarily unavailable. Please try again.");
     });
 
     it("should handle empty results", async () => {

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -319,7 +319,8 @@ export async function onRequestGet(context) {
 
     return new Response(
       JSON.stringify({
-        error: "Failed to fetch events timeline",
+        error: "Database error",
+        message: "Events are temporarily unavailable. Please try again.",
       }),
       {
         status: 500,


### PR DESCRIPTION
## Summary

During today's Cloudflare D1 degradation, single transient 5xx responses from `/api/events/timeline` blanked the public homepage ("Failed to load events") — confirmed live by monitoring (multiple 500s within minutes, self-clearing). `fetchPublicJson` now retries GET reads **once** (600 ms) on network errors or 5xx, which rides out isolated blips invisibly. The timeline's catch-all 500 body also no longer duplicates the frontend's fallback string byte-for-byte, so server 500s and network-level failures are distinguishable from a screenshot (this ambiguity slowed today's incident diagnosis).

Addresses the first two checkboxes of #508 (log-retention decision remains open).

Closes #508

## What changed

| File | Change |
|------|--------|
| `frontend/src/utils/publicApi.js` | `fetchPublicJson`: max 2 attempts, 600 ms apart, retrying only when the request is a GET **and** the first attempt threw or returned ≥ 500. Never retries 4xx or mutating requests (no doubled side effects). The retried 5xx response is not body-parsed (no double read). `parsePublicApiResponse` untouched. |
| `frontend/src/utils/__tests__/publicApi.test.js` | Five new cases: 500→200 retry succeeds; network-throw→200 succeeds; 404 does not retry (single fetch call); POST 500 does not retry; two 500s propagate the error. Fake timers per file convention. |
| `functions/api/events/timeline.js` | Catch-all 500 body → `{ error: "Database error", message: "Events are temporarily unavailable. Please try again." }` (the prevailing two-key shape across public endpoints). |
| `functions/api/events/__tests__/timeline.test.js` | 500-body assertion updated to the new shape. |

## Security / correctness notes

Retry is limited to idempotent GETs — mutating verbs keep exactly one attempt. No consumer keys off the old error strings (repo-wide grep: the only exact-string test was updated; `isPublishGateError` checks `status === 503`, not text).

## Verification

- [x] Tests: frontend 269 pass (incl. 5 new retry cases), backend 626 pass in node:22 container
- [x] ESLint: 0 errors (frontend + backend)
- [x] Format check: clean (frontend + backend)
- [x] Build: green (`npm run build`)
- [ ] `validate:openapi`: N/A — error-body key shape isn't enumerated in the spec's generic Error schema
- [x] Manual smoke: retry behavior pinned by unit tests; live 500 recurrence is being monitored in production and this deploys the mitigation

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
