### PR TITLE
fix(ci): regenerate setup-complete.sql from migrations and add schema-drift guard (#506)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -113,6 +113,29 @@ jobs:
       - name: Lint backend
         run: npm run lint
 
+  schema-drift:
+    name: Schema Drift Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Check setup-complete.sql matches migrations
+        run: node scripts/check-schema-drift.mjs
+
   accessibility-tests:
     name: Accessibility Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Invoke these without being asked — don't wait for the user to request them:
 | After writing or modifying error handling (`catch` blocks, `.catch()`, `try/finally`) in `functions/` | Invoke `pr-review-toolkit:silent-failure-hunter` agent |
 | Before declaring any multi-file feature complete | Invoke `pr-review-toolkit:code-reviewer` agent |
 | After editing `frontend/src/` public pages (outside `admin/`) | Scan for `text-white`/`bg-white` theme violations before finishing |
-| After editing `migrations/` or `setup-complete.sql` | Verify `setup-complete.sql` stays in sync (it seeds CI; drift causes 500s) |
+| After adding/editing anything in `migrations/` | Run `node scripts/regenerate-setup-complete.mjs` then `node scripts/check-schema-drift.mjs` — `setup-complete.sql`'s schema section is generated, never hand-edit it (CI enforces via quality.yml) |
 | When SEO-relevant pages change (band pages, event pages, venue pages) | Check structured data and `document.title` assignments |
 
 The `hooks` in `.claude/settings.local.json` automate the mechanical parts (prettier, ESLint, pre-PR gate). The triggers above require judgment — apply them proactively.

--- a/database/seed-test-data.sql
+++ b/database/seed-test-data.sql
@@ -1,35 +1,39 @@
--- Test Data: Full Year of Events, Venues, and Bands
+-- Test Data: Events, Venues, Band Profiles, and Performances
 -- Run with: npx wrangler d1 execute DB --local --file=database/seed-test-data.sql
+--
+-- Note: the legacy v1 `bands` table (and its ~150 fixture rows) was removed in
+-- #506 — no API reads it (the public timeline reads band_profiles +
+-- performances), and production has no such table.
 
 -- ============================================
 -- VENUES (20 venues across different cities)
 -- ============================================
 
-INSERT OR REPLACE INTO venues (id, name, address, city, capacity, website) VALUES
+INSERT OR REPLACE INTO venues (id, name, address, city, website) VALUES
 -- Waterloo Region venues
-(1, 'Waterloo Music Hall', '75 King St N', 'Waterloo', 800, 'https://waterloohall.ca'),
-(2, 'The Kitchener Arms', '22 Queen St S', 'Kitchener', 300, 'https://kitchenerarms.ca'),
-(3, 'Cambridge Folk Club', '16 Main St', 'Cambridge', 150, 'https://cambridgefolkclub.ca'),
-(4, 'The Iron Horse', '48 King St W', 'Kitchener', 600, 'https://ironhorse.ca'),
-(5, 'Stage 86', '86 Erb St W', 'Waterloo', 400, 'https://stage86.ca'),
+(1, 'Waterloo Music Hall', '75 King St N', 'Waterloo', 'https://waterloohall.ca'),
+(2, 'The Kitchener Arms', '22 Queen St S', 'Kitchener', 'https://kitchenerarms.ca'),
+(3, 'Cambridge Folk Club', '16 Main St', 'Cambridge', 'https://cambridgefolkclub.ca'),
+(4, 'The Iron Horse', '48 King St W', 'Kitchener', 'https://ironhorse.ca'),
+(5, 'Stage 86', '86 Erb St W', 'Waterloo', 'https://stage86.ca'),
 -- Toronto venues
-(6, 'Lee''s Palace', '529 Bloor St W', 'Toronto', 550, 'https://leespalace.com'),
-(7, 'The Horseshoe Tavern', '370 Queen St W', 'Toronto', 400, 'https://horseshoetavern.com'),
-(8, 'Velvet Underground', '508 Queen St W', 'Toronto', 300, 'https://thevelvet.ca'),
-(9, 'The Phoenix Concert Theatre', '410 Sherbourne St', 'Toronto', 1350, 'https://thephoenixconcerttheatre.com'),
-(10, 'The Drake Hotel', '1150 Queen St W', 'Toronto', 200, 'https://thedrake.ca'),
+(6, 'Lee''s Palace', '529 Bloor St W', 'Toronto', 'https://leespalace.com'),
+(7, 'The Horseshoe Tavern', '370 Queen St W', 'Toronto', 'https://horseshoetavern.com'),
+(8, 'Velvet Underground', '508 Queen St W', 'Toronto', 'https://thevelvet.ca'),
+(9, 'The Phoenix Concert Theatre', '410 Sherbourne St', 'Toronto', 'https://thephoenixconcerttheatre.com'),
+(10, 'The Drake Hotel', '1150 Queen St W', 'Toronto', 'https://thedrake.ca'),
 -- Montreal venues
-(11, 'Casa del Popolo', '4873 St Laurent Blvd', 'Montreal', 150, 'https://casadelpopolo.com'),
-(12, 'Bar Le Ritz PDB', '179 Jean-Talon W', 'Montreal', 200, 'https://barleritzpdb.com'),
-(13, 'L''Astral', '305 Ste-Catherine St W', 'Montreal', 500, 'https://sallelastral.com'),
-(14, 'Foufounes Électriques', '87 Ste-Catherine St E', 'Montreal', 400, 'https://foufritz.com'),
-(15, 'Le National', '1220 Ste-Catherine St E', 'Montreal', 900, 'https://lenational.ca'),
+(11, 'Casa del Popolo', '4873 St Laurent Blvd', 'Montreal', 'https://casadelpopolo.com'),
+(12, 'Bar Le Ritz PDB', '179 Jean-Talon W', 'Montreal', 'https://barleritzpdb.com'),
+(13, 'L''Astral', '305 Ste-Catherine St W', 'Montreal', 'https://sallelastral.com'),
+(14, 'Foufounes Électriques', '87 Ste-Catherine St E', 'Montreal', 'https://foufritz.com'),
+(15, 'Le National', '1220 Ste-Catherine St E', 'Montreal', 'https://lenational.ca'),
 -- Other cities
-(16, 'Call the Office', '216 York St', 'London', 300, 'https://calltheoffice.com'),
-(17, 'This Ain''t Hollywood', '345 James St N', 'Hamilton', 250, 'https://thisainthollywood.ca'),
-(18, 'The Mansion', '506 Princess St', 'Kingston', 400, 'https://themansionkingston.com'),
-(19, 'Maxwell''s Concerts', '35 University Ave E', 'Waterloo', 350, 'https://maxwellswaterloo.ca'),
-(20, 'Rum Runners', '178 Dundas St', 'London', 500, 'https://rumrunners.com');
+(16, 'Call the Office', '216 York St', 'London', 'https://calltheoffice.com'),
+(17, 'This Ain''t Hollywood', '345 James St N', 'Hamilton', 'https://thisainthollywood.ca'),
+(18, 'The Mansion', '506 Princess St', 'Kingston', 'https://themansionkingston.com'),
+(19, 'Maxwell''s Concerts', '35 University Ave E', 'Waterloo', 'https://maxwellswaterloo.ca'),
+(20, 'Rum Runners', '178 Dundas St', 'London', 'https://rumrunners.com');
 
 -- ============================================
 -- EVENTS (12 monthly events + special events)
@@ -47,7 +51,7 @@ INSERT OR REPLACE INTO events (id, name, date, slug, is_published, status, descr
 (8, 'August Heat Wave', '2024-08-10', 'august-heat-2024', 1, 'published', 'The hottest bands for the hottest month. Dance music, hip-hop, and R&B showcase.', 'Montreal', NULL),
 (9, 'Labour Day Loud', '2024-09-02', 'labour-day-2024', 1, 'published', 'Send off summer with a bang. Two days of punk, hardcore, and metal.', 'Hamilton', NULL),
 (10, 'Autumn Acoustics', '2024-10-12', 'autumn-acoustics-2024', 1, 'published', 'Intimate acoustic performances as leaves change color. Folk, singer-songwriter, and jazz.', 'Kingston', NULL),
-(11, 'Halloween Havoc', '2024-10-31', 'halloween-havoc-2024', 1, 'published', 'Costumes encouraged! Dark wave, goth, and spooky sounds all night long.', 'Toronto', NULL),
+(11, 'Halloween Havoc 2024', '2024-10-31', 'halloween-havoc-2024', 1, 'published', 'Costumes encouraged! Dark wave, goth, and spooky sounds all night long.', 'Toronto', NULL),
 
 -- Current/Upcoming events
 (12, 'November Noise Fest', '2024-11-16', 'november-noise-2024', 1, 'published', 'Experimental, noise, and avant-garde music festival. Push your sonic boundaries.', 'Montreal', 'https://ticketscene.ca/november-noise'),
@@ -69,230 +73,15 @@ INSERT OR REPLACE INTO events (id, name, date, slug, is_published, status, descr
 (26, 'November Noise 2025', '2025-11-15', 'november-noise-2025', 1, 'published', 'Experimental music festival. Noise, drone, ambient, and beyond.', 'Montreal', 'https://ticketscene.ca/noise-2025'),
 (27, 'Holiday Hootenanny 2025', '2025-12-13', 'holiday-hootenanny-2025', 1, 'published', 'Annual holiday celebration with community favorites.', 'Waterloo', 'https://ticketscene.ca/holiday-2025');
 
--- ============================================
--- BANDS (150+ bands across all events)
--- ============================================
-
--- Winter Warm-Up 2024 (Event 1) - Past
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(1, 1, 1, 'The Frozen Hearts', '19:00', '19:45', 'Indie Rock', 'Waterloo', 'Local indie favorites bringing warmth to winter nights'),
-(2, 1, 1, 'Snowblind', '20:00', '20:45', 'Shoegaze', 'Toronto', 'Dreamy shoegaze perfect for cold evenings'),
-(3, 1, 1, 'Arctic Monkeys Tribute', '21:00', '22:00', 'Indie Rock', 'Montreal', 'Faithful tribute to the Sheffield legends'),
-(4, 1, 2, 'The Mittens', '20:00', '20:45', 'Folk Punk', 'Waterloo', 'Rowdy folk punk with a Canadian twist'),
-(5, 1, 2, 'Frostbite', '21:00', '21:45', 'Hardcore', 'Hamilton', 'Blistering hardcore from the Hammer'),
-(6, 1, 3, 'Cabin Fever', '21:30', '22:15', 'Garage Rock', 'Kingston', 'Raw garage rock for the winter blues');
-
--- Frost Fest 2024 (Event 2) - Past
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(7, 2, 1, 'Northern Lights', '19:00', '19:45', 'Electronic', 'Waterloo', 'Ambient electronic inspired by aurora borealis'),
-(8, 2, 1, 'The Ice Fishers', '20:00', '20:45', 'Folk', 'Waterloo', 'Traditional folk with modern sensibilities'),
-(9, 2, 1, 'Blizzard Warning', '21:00', '22:00', 'Post-Rock', 'Toronto', 'Epic instrumental post-rock soundscapes'),
-(10, 2, 2, 'Hypothermia', '20:00', '20:45', 'Metal', 'Montreal', 'Cold, calculated metal assault'),
-(11, 2, 2, 'Skating Rink', '21:00', '21:45', 'Synth Pop', 'Waterloo', 'Retro synth pop with modern edge'),
-(12, 2, 3, 'Snow Day', '21:30', '22:15', 'Pop Punk', 'Toronto', 'Nostalgic pop punk about winter memories');
-
--- Spring Thaw 2024 (Event 3) - Past
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(13, 3, 6, 'Melting Point', '19:00', '19:45', 'Indie Pop', 'Toronto', 'Bright indie pop for sunny days ahead'),
-(14, 3, 6, 'The Puddles', '20:00', '20:45', 'Garage Rock', 'Hamilton', 'Splashy garage rock from the Hammer'),
-(15, 3, 6, 'First Bloom', '21:00', '22:00', 'Dream Pop', 'Montreal', 'Ethereal dream pop like spring flowers'),
-(16, 3, 7, 'Mud Season', '20:00', '20:45', 'Alt Country', 'Kingston', 'Gritty alternative country'),
-(17, 3, 7, 'April Showers', '21:00', '21:45', 'Emo', 'Toronto', 'Emotional rock for rainy afternoons'),
-(18, 3, 8, 'The Robins', '21:30', '22:15', 'Folk Rock', 'Waterloo', 'Cheerful folk rock heralding spring');
-
--- Canada Day 2024 (Event 7) - Past
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(19, 7, 1, 'True North', '12:00', '12:45', 'Rock', 'Waterloo', 'Canadian rock anthems for Canada Day'),
-(20, 7, 1, 'Maple Leaf Rag', '13:00', '13:45', 'Jazz', 'Toronto', 'Swinging jazz with Canadian flair'),
-(21, 7, 1, 'The Canadians', '14:00', '14:45', 'Pop Rock', 'Vancouver', 'Catchy pop rock celebrating home'),
-(22, 7, 1, 'Northern Soul', '15:00', '15:45', 'Soul', 'Montreal', 'Canadian soul and R&B'),
-(23, 7, 1, 'Grand River Funk', '16:00', '16:45', 'Funk', 'Waterloo', 'Funky grooves from the Grand'),
-(24, 7, 1, 'Confederation', '17:00', '18:00', 'Prog Rock', 'Toronto', 'Epic prog rock about Canadian history'),
-(25, 7, 2, 'Beaver Tales', '19:00', '19:45', 'Folk Punk', 'Waterloo', 'Raucous folk punk'),
-(26, 7, 2, 'The Loons', '20:00', '20:45', 'Indie Rock', 'Muskoka', 'Cottage country indie rock'),
-(27, 7, 2, 'Mounties', '21:00', '22:00', 'Alt Rock', 'Calgary', 'Hard-driving alternative rock'),
-(28, 7, 3, 'Poutine', '20:00', '20:45', 'Punk', 'Montreal', 'Messy, delicious punk rock'),
-(29, 7, 3, 'Timbits', '21:00', '21:45', 'Pop Punk', 'Waterloo', 'Sweet pop punk treats'),
-(30, 7, 4, 'The Hockey Fighters', '22:00', '23:00', 'Hardcore', 'Toronto', 'Hard-hitting hardcore');
-
--- Halloween Havoc 2024 (Event 11) - Past
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(31, 11, 6, 'Graveyard Shift', '20:00', '20:45', 'Goth Rock', 'Toronto', 'Classic goth rock revivalists'),
-(32, 11, 6, 'The Specters', '21:00', '21:45', 'Post-Punk', 'Montreal', 'Haunting post-punk atmospherics'),
-(33, 11, 6, 'Witch House', '22:00', '23:00', 'Dark Electronic', 'Toronto', 'Spooky electronic soundscapes'),
-(34, 11, 7, 'Skeleton Crew', '20:00', '20:45', 'Death Rock', 'Hamilton', 'Bone-rattling death rock'),
-(35, 11, 7, 'The Haunted', '21:00', '21:45', 'Doom Metal', 'Waterloo', 'Crushing doom for All Hallows Eve'),
-(36, 11, 8, 'Vampire Weekend Tribute', '22:00', '23:00', 'Indie Pop', 'Toronto', 'Celebrating the band, not the holiday');
-
--- Holiday Hootenanny 2024 (Event 13) - Current/Near Future
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(37, 13, 1, 'The Carolers', '19:00', '19:45', 'Folk', 'Waterloo', 'Traditional holiday folk songs with a twist'),
-(38, 13, 1, 'Jingle Punks', '20:00', '20:45', 'Punk', 'Toronto', 'Punk rock holiday classics'),
-(39, 13, 1, 'Silent Night Owl', '21:00', '22:00', 'Indie Rock', 'Montreal', 'Mellow indie rock for the season'),
-(40, 13, 2, 'Nutcracker Suite', '20:00', '20:45', 'Electronic', 'Waterloo', 'Electronic reinterpretations of classics'),
-(41, 13, 2, 'Figgy Pudding', '21:00', '21:45', 'Garage Rock', 'Kingston', 'Messy, fun garage rock'),
-(42, 13, 3, 'The Grinches', '21:30', '22:15', 'Hardcore', 'Hamilton', 'Anti-holiday hardcore anthems');
-
--- Winter Warm-Up 2025 (Event 15)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(43, 15, 1, 'Polar Vortex', '19:00', '19:45', 'Noise Rock', 'Waterloo', 'Swirling noise rock chaos'),
-(44, 15, 1, 'The Snowsqualls', '20:00', '20:45', 'Indie Rock', 'Toronto', 'Blustery indie rock anthems'),
-(45, 15, 1, 'Hibernation Station', '21:00', '22:00', 'Slowcore', 'Montreal', 'Slow, dreamy winter soundscapes'),
-(46, 15, 2, 'Ice Storm', '20:00', '20:45', 'Metal', 'Waterloo', 'Cold, crushing metal'),
-(47, 15, 2, 'The Parkas', '21:00', '21:45', 'Post-Punk', 'Hamilton', 'Bundled-up post-punk'),
-(48, 15, 3, 'Hot Cocoa', '21:30', '22:15', 'Indie Pop', 'Kingston', 'Warm, sweet indie pop'),
-(49, 15, 4, 'Snowmobile', '22:00', '23:00', 'Electronic', 'Toronto', 'High-speed electronic music'),
-(50, 15, 5, 'The Toques', '20:00', '20:45', 'Folk Punk', 'Waterloo', 'Knit-cap wearing folk punks');
-
--- Frost Fest 2025 (Event 16)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(51, 16, 1, 'Crystal Palace', '19:00', '19:45', 'Synth Pop', 'Waterloo', 'Icy synth pop perfection'),
-(52, 16, 1, 'The Flurries', '20:00', '20:45', 'Dream Pop', 'Toronto', 'Soft, swirling dream pop'),
-(53, 16, 1, 'Permafrost', '21:00', '22:00', 'Post-Metal', 'Montreal', 'Frozen, heavy post-metal'),
-(54, 16, 2, 'Ski Lodge', '20:00', '20:45', 'Indie Folk', 'Waterloo', 'Cozy cabin folk music'),
-(55, 16, 2, 'Black Ice', '21:00', '21:45', 'Punk', 'Hamilton', 'Dangerous, slick punk'),
-(56, 16, 3, 'The Snowbirds', '21:30', '22:15', 'Country', 'Calgary', 'Canadian country from out west'),
-(57, 16, 4, 'Ice Rink DJs', '22:00', '01:00', 'House', 'Toronto', 'Late night dance party'),
-(58, 16, 5, 'Maple Syrup', '20:00', '20:45', 'Funk', 'Montreal', 'Sweet, sticky funk grooves');
-
--- Tulip Tunes 2025 (Event 19)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(59, 19, 1, 'The Petals', '14:00', '14:45', 'Indie Pop', 'Waterloo', 'Bright, colorful indie pop'),
-(60, 19, 1, 'Garden Party', '15:00', '15:45', 'Jazz', 'Toronto', 'Sophisticated garden party jazz'),
-(61, 19, 1, 'Photosynthesis', '16:00', '16:45', 'Psych Rock', 'Montreal', 'Sun-soaked psychedelic rock'),
-(62, 19, 1, 'The Pollinators', '17:00', '17:45', 'Folk Rock', 'Waterloo', 'Buzzworthy folk rock'),
-(63, 19, 1, 'Dutch Masters', '18:00', '19:00', 'Progressive Rock', 'Amsterdam', 'Visiting Dutch prog rock masters'),
-(64, 19, 2, 'Greenhouse Effect', '19:00', '19:45', 'Electronic', 'Vancouver', 'Ambient electronic ecosystems'),
-(65, 19, 2, 'The Butterflies', '20:00', '20:45', 'Dream Pop', 'Toronto', 'Delicate, floating dream pop'),
-(66, 19, 2, 'Compost Heap', '21:00', '21:45', 'Noise Rock', 'Hamilton', 'Decomposing noise rock chaos'),
-(67, 19, 3, 'Dandelion Wine', '20:00', '20:45', 'Folk', 'Waterloo', 'Homemade folk music'),
-(68, 19, 3, 'The Sprouts', '21:00', '21:45', 'Pop Punk', 'Kingston', 'Fresh pop punk energy');
-
--- Summer Solstice 2025 (Event 20)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(69, 20, 6, 'High Noon', '12:00', '12:45', 'Country Rock', 'Calgary', 'Blazing country rock'),
-(70, 20, 6, 'Sun Stroke', '13:00', '13:45', 'Funk', 'Toronto', 'Hot, sweaty funk grooves'),
-(71, 20, 6, 'Solar Flare', '14:00', '14:45', 'Psych Rock', 'Austin', 'Texas psych rock heat wave'),
-(72, 20, 6, 'The Sundials', '15:00', '15:45', 'Indie Rock', 'Toronto', 'Timeless indie rock'),
-(73, 20, 6, 'Heatwave', '16:00', '16:45', 'Disco', 'Montreal', 'Retro disco revival'),
-(74, 20, 6, 'Summer Camp', '17:00', '17:45', 'Pop Punk', 'Waterloo', 'Nostalgic summer pop punk'),
-(75, 20, 6, 'The Longest Day', '18:00', '19:00', 'Post-Rock', 'Toronto', 'Epic instrumental journey'),
-(76, 20, 7, 'Bonfire', '19:00', '19:45', 'Folk Punk', 'Hamilton', 'Campfire folk punk'),
-(77, 20, 7, 'Night Swim', '20:00', '20:45', 'Synth Pop', 'Vancouver', 'Cool synth pop relief'),
-(78, 20, 7, 'Midnight Sun', '21:00', '22:00', 'Shoegaze', 'Montreal', 'Bright, endless shoegaze'),
-(79, 20, 8, 'The Fireflies', '22:00', '22:45', 'Dream Pop', 'Toronto', 'Glowing dream pop'),
-(80, 20, 8, 'After Dark', '23:00', '00:00', 'Electronic', 'Berlin', 'German electronic headliner');
-
--- Canada Day 2025 (Event 21)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(81, 21, 1, 'O Canada', '12:00', '12:45', 'Folk', 'Waterloo', 'Patriotic folk anthems'),
-(82, 21, 1, 'Red & White', '13:00', '13:45', 'Pop Rock', 'Toronto', 'Celebratory pop rock'),
-(83, 21, 1, 'The Territories', '14:00', '14:45', 'Indie Rock', 'Yellowknife', 'Northern indie rock'),
-(84, 21, 1, 'Dominion', '15:00', '15:45', 'Metal', 'Vancouver', 'Heavy Canadian metal'),
-(85, 21, 1, 'Heritage Minute', '16:00', '16:45', 'Post-Punk', 'Winnipeg', 'Prairie post-punk'),
-(86, 21, 1, 'The Voyageurs', '17:00', '18:00', 'Folk Rock', 'Montreal', 'Historical folk rock journey'),
-(87, 21, 2, 'Centennial', '19:00', '19:45', 'Jazz', 'Toronto', 'Canadian jazz standards'),
-(88, 21, 2, 'Coast to Coast', '20:00', '20:45', 'Alt Rock', 'Halifax', 'East coast alternative rock'),
-(89, 21, 2, 'Arctic Circle', '21:00', '22:00', 'Electronic', 'Iqaluit', 'Northern electronic sounds'),
-(90, 21, 3, 'Confederation Bridge', '20:00', '20:45', 'Punk', 'Charlottetown', 'Maritime punk'),
-(91, 21, 3, 'The Maple Leafs', '21:00', '21:45', 'Ska', 'Toronto', 'Upstroke ska celebration'),
-(92, 21, 4, 'Fireworks', '22:00', '23:30', 'Electronic', 'Montreal', 'Explosive electronic finale');
-
--- August Heat Wave 2025 (Event 22)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(93, 22, 11, 'Les Chaleurs', '19:00', '19:45', 'Indie Rock', 'Montreal', 'Montreal indie rock heat'),
-(94, 22, 11, 'Canicule', '20:00', '20:45', 'Electronic', 'Paris', 'French electronic visitors'),
-(95, 22, 11, 'Tropique', '21:00', '22:00', 'World Music', 'Montreal', 'Tropical world fusion'),
-(96, 22, 12, 'The Humid Ones', '20:00', '20:45', 'Soul', 'Detroit', 'Sweaty Detroit soul'),
-(97, 22, 12, 'AC/DC Tribute', '21:00', '22:00', 'Hard Rock', 'Toronto', 'High voltage tribute'),
-(98, 22, 13, 'Summer Thunder', '20:00', '20:45', 'Metal', 'Montreal', 'Stormy metal assault'),
-(99, 22, 13, 'Hot Flash', '21:00', '21:45', 'Punk', 'Waterloo', 'Fast, sweaty punk'),
-(100, 22, 13, 'The BBQ Boys', '22:00', '23:00', 'Country', 'Nashville', 'Smoky country rock'),
-(101, 22, 14, 'Patio Weather', '22:00', '23:30', 'House', 'Ibiza', 'Late night house party');
-
--- Halloween Havoc 2025 (Event 25)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(102, 25, 6, 'The Undead', '20:00', '20:45', 'Punk', 'Toronto', 'Zombie punk chaos'),
-(103, 25, 6, 'Crypt Keeper', '21:00', '21:45', 'Death Metal', 'Montreal', 'Tales from the crypt'),
-(104, 25, 6, 'Full Moon', '22:00', '22:45', 'Goth Rock', 'London UK', 'British goth legends'),
-(105, 25, 6, 'The Witching Hour', '23:00', '00:00', 'Dark Wave', 'Toronto', 'Midnight dark wave'),
-(106, 25, 7, 'Jack O Lantern', '20:00', '20:45', 'Garage Rock', 'Hamilton', 'Carved-up garage rock'),
-(107, 25, 7, 'Monster Mash-Up', '21:00', '21:45', 'Mashup DJ', 'Waterloo', 'Halloween mashup party'),
-(108, 25, 7, 'The Creatures', '22:00', '23:00', 'Post-Punk', 'Vancouver', 'Creepy post-punk'),
-(109, 25, 8, 'Nightmare', '22:00', '22:45', 'Industrial', 'Toronto', 'Industrial horror soundtrack'),
-(110, 25, 8, 'The Black Cats', '23:00', '00:00', 'Rockabilly', 'Memphis', 'Spooky rockabilly'),
-(111, 25, 9, 'Dawn of the Dead', '00:00', '01:00', 'Hardcore', 'Montreal', 'Zombie hardcore til dawn');
-
--- Autumn Acoustics 2025 (Event 24)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(112, 24, 18, 'Falling Leaves', '19:00', '19:45', 'Folk', 'Kingston', 'Gentle autumn folk'),
-(113, 24, 18, 'The Harvest', '20:00', '20:45', 'Bluegrass', 'Kentucky', 'American bluegrass'),
-(114, 24, 18, 'October Rust', '21:00', '22:00', 'Acoustic Rock', 'Toronto', 'Rustic acoustic rock'),
-(115, 24, 18, 'The Sweaters', '20:00', '20:45', 'Indie Folk', 'Montreal', 'Cozy indie folk'),
-(116, 24, 18, 'Cider House', '21:00', '21:45', 'Jazz', 'Waterloo', 'Warm jazz for cool nights'),
-(117, 24, 18, 'Bonfire Stories', '22:00', '23:00', 'Singer-Songwriter', 'Halifax', 'Maritime storytelling');
-
--- November Noise 2025 (Event 26)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(118, 26, 11, 'Static Void', '19:00', '19:45', 'Noise', 'Montreal', 'Pure noise assault'),
-(119, 26, 11, 'The Drones', '20:00', '20:45', 'Drone', 'Toronto', 'Meditative drone music'),
-(120, 26, 11, 'Frequency Shift', '21:00', '22:00', 'Experimental', 'Berlin', 'German experimental electronics'),
-(121, 26, 12, 'Tape Hiss', '20:00', '20:45', 'Lo-Fi', 'Waterloo', 'Degraded lo-fi aesthetics'),
-(122, 26, 12, 'The Oscillators', '21:00', '21:45', 'Modular Synth', 'Vancouver', 'Modular synth exploration'),
-(123, 26, 13, 'White Noise', '20:00', '20:45', 'Harsh Noise', 'Tokyo', 'Japanese harsh noise'),
-(124, 26, 13, 'Feedback Loop', '21:00', '21:45', 'Noise Rock', 'Chicago', 'Chicago noise rock'),
-(125, 26, 13, 'The Minimalists', '22:00', '23:00', 'Minimal', 'New York', 'NYC minimal composition');
-
--- Holiday Hootenanny 2025 (Event 27)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(126, 27, 1, 'Yuletide', '19:00', '19:45', 'Folk', 'Waterloo', 'Traditional holiday folk'),
-(127, 27, 1, 'The Ornaments', '20:00', '20:45', 'Indie Pop', 'Toronto', 'Decorative indie pop'),
-(128, 27, 1, 'Sugarplum', '21:00', '22:00', 'Electronic', 'Montreal', 'Sweet electronic dreams'),
-(129, 27, 2, 'Coal Mine', '20:00', '20:45', 'Blues', 'Chicago', 'Naughty list blues'),
-(130, 27, 2, 'The Elves', '21:00', '21:45', 'Pop Punk', 'Waterloo', 'Tiny pop punk energy'),
-(131, 27, 3, 'Krampus', '21:30', '22:15', 'Metal', 'Vienna', 'Austrian holiday metal'),
-(132, 27, 4, 'Midnight Clear', '22:00', '23:00', 'Jazz', 'New Orleans', 'New Orleans holiday jazz'),
-(133, 27, 5, 'The Gift', '20:00', '20:45', 'Singer-Songwriter', 'Waterloo', 'Heartfelt holiday songs');
-
--- Add more bands to April Amplified 2025 (Event 18) for variety
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(134, 18, 11, 'Amplifier', '19:00', '19:45', 'Stoner Rock', 'Montreal', 'Heavy stoner grooves'),
-(135, 18, 11, 'The Decibels', '20:00', '20:45', 'Punk', 'Waterloo', 'Loud, fast punk'),
-(136, 18, 11, 'Maximum Volume', '21:00', '22:00', 'Metal', 'Toronto', 'Cranked-up metal'),
-(137, 18, 12, 'Distortion Pedal', '20:00', '20:45', 'Noise Rock', 'Hamilton', 'Fuzzy noise rock'),
-(138, 18, 12, 'The Amps', '21:00', '21:45', 'Hardcore', 'Montreal', 'Full-stack hardcore'),
-(139, 18, 13, 'Feedback', '20:00', '20:45', 'Shoegaze', 'Toronto', 'Wall of sound shoegaze'),
-(140, 18, 13, 'The Stacks', '21:00', '21:45', 'Post-Metal', 'Vancouver', 'Towering post-metal'),
-(141, 18, 13, 'Speaker Blow', '22:00', '23:00', 'Industrial', 'Chicago', 'Industrial assault'),
-(142, 18, 14, 'The Wattage', '22:00', '23:30', 'Electronic', 'Berlin', 'Powered electronic');
-
--- Labour Day Loud 2025 (Event 23)
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(143, 23, 17, 'Working Class', '14:00', '14:45', 'Punk', 'Hamilton', 'Blue collar punk'),
-(144, 23, 17, 'The Unions', '15:00', '15:45', 'Hardcore', 'Detroit', 'Motor city hardcore'),
-(145, 23, 17, 'Labour Force', '16:00', '16:45', 'Metal', 'Pittsburgh', 'Steel city metal'),
-(146, 23, 17, 'Nine to Five', '17:00', '17:45', 'Post-Punk', 'Toronto', 'Office drone post-punk'),
-(147, 23, 17, 'Overtime', '18:00', '19:00', 'Noise Rock', 'Chicago', 'Extended noise rock'),
-(148, 23, 17, 'The Grinders', '19:00', '19:45', 'Sludge', 'New Orleans', 'Heavy sludge metal'),
-(149, 23, 17, 'Punch Clock', '20:00', '20:45', 'Punk', 'Waterloo', 'Time-keeping punk'),
-(150, 23, 17, 'End of Shift', '21:00', '22:00', 'Hardcore', 'Montreal', 'Closing time hardcore');
-
 -- Future Test Event (always in the future for E2E tests)
 -- Uses date('now', '+14 days') so it always falls in the timeline's 30-day upcoming window
 INSERT OR REPLACE INTO events (id, name, date, slug, is_published, status, description, city, ticket_url) VALUES
 (28, 'Future Fest E2E', date('now', '+14 days'), 'future-fest-e2e', 1, 'published', 'An annual celebration of live music. Multi-venue festival featuring local and touring acts across Waterloo Region venues.', 'Waterloo', 'https://ticketscene.ca/future-fest-e2e');
 
--- Future Fest E2E (Event 28) - Bands for E2E test coverage
-INSERT OR REPLACE INTO bands (id, event_id, venue_id, name, start_time, end_time, genre, origin, description) VALUES
-(151, 28, 1, 'The Time Travellers', '19:00', '19:45', 'Indie Rock', 'Waterloo', 'Indie rock from the future'),
-(152, 28, 1, 'Future Sound', '20:00', '20:45', 'Electronic', 'Toronto', 'Electronic music ahead of its time'),
-(153, 28, 2, 'The Prophets', '21:00', '22:00', 'Post-Rock', 'Montreal', 'Instrumental post-rock soundscapes'),
-(154, 28, 2, 'Tomorrow''s Echo', '22:00', '23:00', 'Dream Pop', 'Waterloo', 'Dreamy sounds from the future');
-
 -- ============================================
 -- BAND PROFILES + PERFORMANCES for Future Fest E2E (Event 28)
--- The public timeline API reads band_profiles + performances, not the bands table.
--- Without these, every event card expands with 0 venues and 0 performers, making
+-- The public timeline API reads band_profiles + performances. Without these,
+-- every event card expands with 0 venues and 0 performers, making
 -- venue/performer heading assertions impossible in E2E tests.
 -- ============================================
 
@@ -309,5 +98,5 @@ INSERT OR REPLACE INTO performances (id, event_id, band_profile_id, venue_id, st
 (4, 28, 4, 2, '22:00', '23:00');
 
 -- Update sqlite_sequence if needed
-DELETE FROM sqlite_sequence WHERE name IN ('venues', 'events', 'bands', 'band_profiles', 'performances');
-INSERT INTO sqlite_sequence (name, seq) VALUES ('venues', 20), ('events', 28), ('bands', 154), ('band_profiles', 4), ('performances', 4);
+DELETE FROM sqlite_sequence WHERE name IN ('venues', 'events', 'band_profiles', 'performances');
+INSERT INTO sqlite_sequence (name, seq) VALUES ('venues', 20), ('events', 28), ('band_profiles', 4), ('performances', 4);

--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -1,229 +1,285 @@
 -- Complete Local Development Database Setup
--- Run this to initialize all tables needed for local development
 -- Usage: sqlite3 <database-file> < database/setup-complete.sql
+--
+-- GENERATED FILE — do not hand-edit the schema section.
+-- Regenerate with:  node scripts/regenerate-setup-complete.mjs
+-- Verified in CI by: node scripts/check-schema-drift.mjs (quality.yml)
+--
+-- Schema below is the exact cumulative result of migrations/0001..N replayed
+-- in order (#506). To change the schema, add a migration and regenerate.
+-- The SEED DATA section at the bottom is carried forward as-is.
 
 -- ============================================
--- CORE TABLES
+-- SCHEMA (generated from migrations/)
 -- ============================================
 
--- Events table
 CREATE TABLE IF NOT EXISTS events (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  name TEXT NOT NULL,
-  date TEXT NOT NULL,
-  end_date TEXT,
-  slug TEXT NOT NULL UNIQUE,
-  is_published INTEGER NOT NULL DEFAULT 0,
-  status TEXT DEFAULT 'draft',
-  archived_at TEXT,
-  description TEXT,
-  city TEXT,
-  ticket_url TEXT,
-  venue_info TEXT,
-  social_links TEXT,
-  theme_colors TEXT,
-  reveal_mode INTEGER NOT NULL DEFAULT 0,
-  created_by_user_id INTEGER,
-  updated_by_user_id INTEGER,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at TEXT DEFAULT (datetime('now'))
-);
+  name TEXT NOT NULL,                    -- e.g., "Summer Music Festival 2025"
+  date TEXT NOT NULL,                    -- Event date in YYYY-MM-DD format
+  slug TEXT NOT NULL UNIQUE,             -- URL-friendly identifier, e.g., "vol-5"
+  is_published INTEGER NOT NULL DEFAULT 0, -- 0 = draft, 1 = published (visible to public)
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+, created_by_user_id INTEGER REFERENCES users(id), updated_by_user_id INTEGER REFERENCES users(id), updated_at TEXT DEFAULT (datetime('now')), status TEXT DEFAULT 'draft', archived_at TEXT, ticket_url TEXT, theme_colors TEXT, venue_info TEXT, social_links TEXT, city TEXT, description TEXT, reveal_mode INTEGER NOT NULL DEFAULT 0, end_date TEXT);
 
--- Venues table
 CREATE TABLE IF NOT EXISTS venues (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  name TEXT NOT NULL UNIQUE,
-  address TEXT,
-  address_line1 TEXT,
-  address_line2 TEXT,
-  city TEXT,
-  region TEXT,
-  postal_code TEXT,
-  country TEXT,
-  capacity INTEGER,
-  website TEXT,
-  instagram TEXT,
-  facebook TEXT,
-  phone TEXT,
-  contact_email TEXT,
-  latitude REAL,
-  longitude REAL,
-  created_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
+  name TEXT NOT NULL UNIQUE,             -- Venue name, e.g., "Room 47"
+  address TEXT                           -- Optional venue address
+, created_by_user_id INTEGER REFERENCES users(id), updated_by_user_id INTEGER REFERENCES users(id), updated_at TEXT DEFAULT (datetime('now')), website TEXT, instagram TEXT, facebook TEXT, created_at TEXT DEFAULT (datetime('now')), address_line1 TEXT, address_line2 TEXT, region TEXT, postal_code TEXT, country TEXT, phone TEXT, contact_email TEXT, city TEXT, latitude REAL, longitude REAL);
 
--- Bands table (with event_id for direct event association)
-CREATE TABLE IF NOT EXISTS bands (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  event_id INTEGER,
-  venue_id INTEGER,
-  name TEXT NOT NULL,
-  start_time TEXT,
-  end_time TEXT,
-  url TEXT,
-  photo_url TEXT,
-  description TEXT,
-  genre TEXT,
-  origin TEXT,
-  social_links TEXT,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE SET NULL,
-  FOREIGN KEY (venue_id) REFERENCES venues(id) ON DELETE SET NULL
-);
-
--- Performances table (current schema plus legacy compatibility columns)
-CREATE TABLE IF NOT EXISTS performances (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  event_id INTEGER NOT NULL,
-  band_profile_id INTEGER NOT NULL,
-  venue_id INTEGER,
-  start_time TEXT,
-  end_time TEXT,
-  notes TEXT,
-  band_id INTEGER,
-  band_name TEXT,
-  stage TEXT,
-  is_announced INTEGER NOT NULL DEFAULT 1,
-  band_follow_notified INTEGER NOT NULL DEFAULT 0,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  created_by_user_id INTEGER,
-  updated_by_user_id INTEGER,
-  updated_at TEXT DEFAULT (datetime('now')),
-  FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
-  FOREIGN KEY (band_profile_id) REFERENCES band_profiles(id) ON DELETE RESTRICT,
-  FOREIGN KEY (band_id) REFERENCES bands(id) ON DELETE SET NULL,
-  FOREIGN KEY (venue_id) REFERENCES venues(id) ON DELETE SET NULL,
-  FOREIGN KEY (created_by_user_id) REFERENCES users(id),
-  FOREIGN KEY (updated_by_user_id) REFERENCES users(id)
-);
-
--- Band profiles (current schema plus legacy compatibility columns)
 CREATE TABLE IF NOT EXISTS band_profiles (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  name TEXT NOT NULL,
-  name_normalized TEXT NOT NULL UNIQUE,
-  description TEXT,
-  genre TEXT,
-  origin TEXT,
-  origin_city TEXT,
-  origin_region TEXT,
-  contact_email TEXT,
-  is_active INTEGER NOT NULL DEFAULT 1,
-  social_links TEXT,
-  photo_url TEXT,
-  photo_alt_text TEXT,
-  url TEXT,
-  band_name TEXT,
-  bio TEXT,
-  genres TEXT,
-  hometown TEXT,
-  formed_year INTEGER,
-  website TEXT,
-  total_views INTEGER DEFAULT 0,
-  total_social_clicks INTEGER DEFAULT 0,
-  popularity_score REAL DEFAULT 0,
+  name TEXT NOT NULL,                    -- Display name (preserves artistic capitalization)
+  name_normalized TEXT NOT NULL UNIQUE,  -- Lowercase + trimmed for duplicate detection
+  description TEXT,                      -- Band bio/description (markdown supported)
+  photo_url TEXT,                        -- Hero image URL (uploaded or external)
+  genre TEXT,                            -- Genre tags (comma-separated for MVP)
+  social_links TEXT,                     -- JSON: {"bandcamp": "url", "instagram": "@handle", ...}
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at TEXT DEFAULT (datetime('now'))
-);
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+, created_by_user_id INTEGER REFERENCES users(id), origin TEXT, origin_city TEXT, origin_region TEXT, contact_email TEXT, is_active INTEGER NOT NULL DEFAULT 1, total_views INTEGER DEFAULT 0, total_social_clicks INTEGER DEFAULT 0, popularity_score REAL DEFAULT 0, photo_alt_text TEXT);
 
--- Artist daily stats (privacy-first, aggregated)
-CREATE TABLE IF NOT EXISTS artist_daily_stats (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  band_profile_id INTEGER NOT NULL,
-  date TEXT NOT NULL,
-  page_views INTEGER DEFAULT 0,
-  social_clicks INTEGER DEFAULT 0,
-  created_at TEXT DEFAULT (datetime('now')),
-  UNIQUE(band_profile_id, date),
-  FOREIGN KEY (band_profile_id) REFERENCES band_profiles(id) ON DELETE CASCADE
-);
+CREATE INDEX IF NOT EXISTS idx_events_published ON events(is_published);
 
-CREATE INDEX IF NOT EXISTS idx_artist_stats_date ON artist_daily_stats(date);
-CREATE INDEX IF NOT EXISTS idx_artist_stats_band ON artist_daily_stats(band_profile_id);
+CREATE INDEX IF NOT EXISTS idx_events_slug ON events(slug);
 
--- Page views (aggregated daily by path)
-CREATE TABLE IF NOT EXISTS page_views_daily (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  page TEXT NOT NULL,
-  date TEXT NOT NULL,
-  views INTEGER DEFAULT 0,
-  UNIQUE(page, date)
-);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_band_profiles_normalized ON band_profiles(name_normalized);
 
-CREATE INDEX IF NOT EXISTS idx_page_views_date ON page_views_daily(date);
+CREATE INDEX IF NOT EXISTS idx_band_profiles_genre ON band_profiles(genre);
 
--- ============================================
--- AUTH TABLES
--- ============================================
+CREATE INDEX IF NOT EXISTS idx_band_profiles_name ON band_profiles(name);
 
--- Users table
+CREATE TRIGGER IF NOT EXISTS update_band_profile_timestamp
+AFTER UPDATE ON band_profiles
+BEGIN
+  UPDATE band_profiles SET updated_at = datetime('now') WHERE id = NEW.id;
+END;
+
 CREATE TABLE IF NOT EXISTS users (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   email TEXT UNIQUE NOT NULL,
   password_hash TEXT NOT NULL,
-  role TEXT NOT NULL DEFAULT 'editor',
-  name TEXT,
-  first_name TEXT,
-  last_name TEXT,
-  is_active INTEGER NOT NULL DEFAULT 1,
-  activation_token TEXT,
-  activation_token_expires_at TEXT,
-  activated_at TEXT,
-  totp_secret TEXT,
-  totp_enabled INTEGER DEFAULT 0,
-  webauthn_enabled INTEGER DEFAULT 0,
-  email_otp_enabled INTEGER DEFAULT 0,
-  backup_codes TEXT,
-  require_2fa INTEGER DEFAULT 1,
-  deactivated_at TEXT,
-  deactivated_by INTEGER REFERENCES users(id),
+  role TEXT NOT NULL DEFAULT 'editor', -- 'admin' or 'editor'
+  name TEXT,                            -- Optional display name
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  last_login TEXT,
-  updated_at TEXT DEFAULT (datetime('now'))
-);
+  last_login TEXT
+, totp_secret TEXT, totp_enabled INTEGER DEFAULT 0, webauthn_enabled INTEGER DEFAULT 0, email_otp_enabled INTEGER DEFAULT 0, backup_codes TEXT, require_2fa INTEGER DEFAULT 1, is_active INTEGER DEFAULT 1, deactivated_at TEXT, deactivated_by INTEGER REFERENCES users(id), updated_at TEXT DEFAULT (datetime('now')), first_name TEXT, last_name TEXT, activation_token TEXT, activation_token_expires_at TEXT, activated_at TEXT);
 
--- Sessions table
-CREATE TABLE IF NOT EXISTS sessions (
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
+
+CREATE TABLE IF NOT EXISTS webauthn_credentials (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_token TEXT UNIQUE NOT NULL,
-  user_id INTEGER NOT NULL,
-  ip_address TEXT,
-  user_agent TEXT,
-  remember_me INTEGER DEFAULT 0,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  last_activity_at TEXT NOT NULL DEFAULT (datetime('now')),
-  expires_at TEXT NOT NULL,
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
-
--- Lucia sessions table
-CREATE TABLE IF NOT EXISTS lucia_sessions (
-  id TEXT PRIMARY KEY,
   user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  expires_at INTEGER NOT NULL,
-  ip_address TEXT,
-  user_agent TEXT,
-  remember_me INTEGER DEFAULT 0,
+  credential_id TEXT NOT NULL UNIQUE,     -- Base64 encoded credential ID
+  public_key TEXT NOT NULL,               -- Base64 encoded public key
+  counter INTEGER NOT NULL DEFAULT 0,     -- Signature counter for replay protection
+  device_name TEXT,                       -- User-friendly name (e.g., "iPhone 15", "YubiKey")
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  last_activity_at TEXT NOT NULL DEFAULT (datetime('now'))
+  last_used_at TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_lucia_sessions_user_id ON lucia_sessions(user_id);
-CREATE INDEX IF NOT EXISTS idx_lucia_sessions_expires_at ON lucia_sessions(expires_at);
+CREATE INDEX IF NOT EXISTS idx_webauthn_user_id ON webauthn_credentials(user_id);
 
--- Auth attempts (for rate limiting)
-CREATE TABLE IF NOT EXISTS auth_attempts (
+CREATE INDEX IF NOT EXISTS idx_webauthn_credential_id ON webauthn_credentials(credential_id);
+
+CREATE TABLE IF NOT EXISTS email_otp_codes (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id INTEGER,
-  email TEXT,
-  ip_address TEXT NOT NULL,
-  user_agent TEXT,
-  attempt_type TEXT NOT NULL,
-  success INTEGER NOT NULL,
-  failure_reason TEXT,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  code_hash TEXT NOT NULL,                -- Hash of the 6-digit code
+  expires_at TEXT NOT NULL,               -- Codes expire after 10 minutes
+  verified INTEGER DEFAULT 0,             -- 1 if code was used successfully
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
--- MFA challenges (for TOTP verification flow)
+CREATE INDEX IF NOT EXISTS idx_email_otp_user_id ON email_otp_codes(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_email_otp_expires ON email_otp_codes(expires_at);
+
+CREATE TABLE IF NOT EXISTS auth_attempts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  email TEXT,                             -- Store email even if user doesn't exist
+  ip_address TEXT,
+  user_agent TEXT,
+  attempt_type TEXT NOT NULL,             -- 'login', 'totp', 'webauthn', 'email_otp'
+  success INTEGER NOT NULL,               -- 1 for success, 0 for failure
+  failure_reason TEXT,                    -- Why it failed
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_attempts_user ON auth_attempts(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_auth_attempts_email ON auth_attempts(email);
+
+CREATE INDEX IF NOT EXISTS idx_auth_attempts_ip ON auth_attempts(ip_address);
+
+CREATE INDEX IF NOT EXISTS idx_auth_attempts_created ON auth_attempts(created_at);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_token TEXT UNIQUE NOT NULL,     -- UUID session token
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  ip_address TEXT,
+  user_agent TEXT,
+  remember_me INTEGER DEFAULT 0,          -- Long-lived session if 1
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  last_activity_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT NOT NULL                -- Session expiry time
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_expires ON sessions(expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_token ON sessions(session_token);
+
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,              -- UUID token for reset link
+  created_by INTEGER NOT NULL REFERENCES users(id), -- Admin who initiated reset
+  expires_at TEXT NOT NULL,                -- Tokens expire after 24 hours
+  used INTEGER DEFAULT 0,                  -- 1 if token was used
+  used_at TEXT,                           -- When token was used
+  ip_address TEXT,                        -- IP that used the token
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+, reason TEXT);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_user_id ON password_reset_tokens(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_token ON password_reset_tokens(token);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_expires ON password_reset_tokens(expires_at);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER,
+  action TEXT NOT NULL,                    -- e.g., 'user.created', 'event.updated', 'band.deleted'
+  resource_type TEXT,                      -- e.g., 'user', 'event', 'band', 'venue'
+  resource_id INTEGER,                     -- ID of the affected resource
+  details TEXT,                            -- JSON string with additional context
+  ip_address TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_user ON audit_log(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_created ON audit_log(created_at);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_resource ON audit_log(resource_type, resource_id);
+
+CREATE TRIGGER IF NOT EXISTS update_events_timestamp
+AFTER UPDATE ON events
+BEGIN
+  UPDATE events SET updated_at = datetime('now') WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS update_venues_timestamp
+AFTER UPDATE ON venues
+BEGIN
+  UPDATE venues SET updated_at = datetime('now') WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS update_users_timestamp
+AFTER UPDATE ON users
+BEGIN
+  UPDATE users SET updated_at = datetime('now') WHERE id = NEW.id;
+END;
+
+CREATE INDEX IF NOT EXISTS idx_events_status ON events(status);
+
+CREATE INDEX IF NOT EXISTS idx_events_archived ON events(archived_at);
+
+CREATE TABLE IF NOT EXISTS email_subscriptions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT NOT NULL,
+  city TEXT NOT NULL,                    -- "portland", "seattle", "all"
+  genre TEXT NOT NULL,                   -- "punk", "indie", "all"
+  frequency TEXT NOT NULL DEFAULT 'weekly', -- "daily", "weekly", "monthly"
+  verified BOOLEAN NOT NULL DEFAULT 0,   -- Email verified via confirmation link
+  verification_token TEXT UNIQUE,        -- Token for email verification
+  unsubscribe_token TEXT UNIQUE NOT NULL, -- Token for unsubscribe link
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  last_email_sent TEXT, consent_ip TEXT, consent_method TEXT NOT NULL DEFAULT 'web_form',                  -- When was last email sent
+
+  UNIQUE(email, city, genre)             -- Prevent duplicate subscriptions
+);
+
+CREATE TABLE IF NOT EXISTS subscription_verifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  subscription_id INTEGER NOT NULL,
+  verified_at TEXT NOT NULL DEFAULT (datetime('now')),                       -- For spam prevention
+
+  FOREIGN KEY (subscription_id) REFERENCES email_subscriptions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS subscription_unsubscribes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  subscription_id INTEGER NOT NULL,
+  unsubscribed_at TEXT NOT NULL DEFAULT (datetime('now')),
+  reason TEXT,                           -- Optional feedback
+
+  FOREIGN KEY (subscription_id) REFERENCES email_subscriptions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_email ON email_subscriptions(email);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_city_genre ON email_subscriptions(city, genre);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_verified ON email_subscriptions(verified);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_verification_token ON email_subscriptions(verification_token);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_unsubscribe_token ON email_subscriptions(unsubscribe_token);
+
+CREATE TABLE IF NOT EXISTS schedule_builds (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id INTEGER NOT NULL,
+  performance_id INTEGER NOT NULL,
+  user_session TEXT NOT NULL,              -- Session identifier (no PII)
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+
+  FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
+  FOREIGN KEY (performance_id) REFERENCES performances(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_builds_event ON schedule_builds(event_id);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_builds_session ON schedule_builds(user_session);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_builds_created ON schedule_builds(created_at);
+
+CREATE TABLE IF NOT EXISTS invite_codes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  code TEXT NOT NULL UNIQUE,              -- Random invite code (UUID)
+  email TEXT,                             -- Optional: restrict to specific email
+  role TEXT NOT NULL DEFAULT 'editor',    -- Role for new account (viewer, editor, admin)
+  created_by_user_id INTEGER,             -- Admin who created the invite
+  used_by_user_id INTEGER,                -- User who used the invite (NULL if unused)
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  used_at TEXT,                           -- When the invite was used
+  expires_at TEXT NOT NULL,               -- Expiration timestamp
+  is_active INTEGER NOT NULL DEFAULT 1,   -- 0 = disabled, 1 = active
+
+  FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (used_by_user_id) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_invite_codes_code ON invite_codes(code);
+
+CREATE INDEX IF NOT EXISTS idx_invite_codes_active ON invite_codes(is_active, expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_invite_codes_email ON invite_codes(email);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_schedule_builds_unique
+  ON schedule_builds(event_id, performance_id, user_session);
+
 CREATE TABLE IF NOT EXISTS mfa_challenges (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   token TEXT NOT NULL UNIQUE,
@@ -236,80 +292,59 @@ CREATE TABLE IF NOT EXISTS mfa_challenges (
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_mfa_challenges_token ON mfa_challenges(token);
 CREATE INDEX IF NOT EXISTS idx_mfa_challenges_user_id ON mfa_challenges(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_mfa_challenges_token ON mfa_challenges(token);
+
 CREATE INDEX IF NOT EXISTS idx_mfa_challenges_expires_at ON mfa_challenges(expires_at);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_mfa_challenges_active_user
-  ON mfa_challenges(user_id)
-  WHERE used = 0;
 
--- Invite codes
-CREATE TABLE IF NOT EXISTS invite_codes (
+CREATE INDEX IF NOT EXISTS idx_users_activation_token ON users(activation_token);
+
+CREATE TABLE IF NOT EXISTS artist_daily_stats (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  code TEXT NOT NULL UNIQUE,
-  email TEXT,
-  role TEXT NOT NULL DEFAULT 'editor',
-  created_by_user_id INTEGER,
-  used_by_user_id INTEGER,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  used_at TEXT,
-  expires_at TEXT NOT NULL,
-  is_active INTEGER NOT NULL DEFAULT 1,
-  FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE SET NULL,
-  FOREIGN KEY (used_by_user_id) REFERENCES users(id) ON DELETE SET NULL
+  band_profile_id INTEGER NOT NULL,
+  date TEXT NOT NULL,
+  page_views INTEGER DEFAULT 0,
+  social_clicks INTEGER DEFAULT 0,
+  created_at TEXT DEFAULT (datetime('now')),
+  UNIQUE(band_profile_id, date),
+  FOREIGN KEY (band_profile_id) REFERENCES band_profiles(id) ON DELETE CASCADE
 );
 
--- ============================================
--- 2FA TABLES
--- ============================================
+CREATE INDEX IF NOT EXISTS idx_artist_stats_date ON artist_daily_stats(date);
 
-CREATE TABLE IF NOT EXISTS webauthn_credentials (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id INTEGER NOT NULL,
-  credential_id TEXT UNIQUE NOT NULL,
-  public_key TEXT NOT NULL,
-  counter INTEGER NOT NULL DEFAULT 0,
-  device_name TEXT,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  last_used_at TEXT,
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
+CREATE INDEX IF NOT EXISTS idx_artist_stats_band ON artist_daily_stats(band_profile_id);
 
-CREATE TABLE IF NOT EXISTS email_otp_codes (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id INTEGER NOT NULL,
-  code TEXT NOT NULL,
-  expires_at TEXT NOT NULL,
-  used INTEGER NOT NULL DEFAULT 0,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS password_reset_tokens (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id INTEGER NOT NULL,
-  token TEXT UNIQUE NOT NULL,
-  created_by INTEGER NOT NULL,
-  expires_at TEXT NOT NULL,
-  used INTEGER NOT NULL DEFAULT 0,
-  used_at TEXT,
+CREATE TABLE IF NOT EXISTS lucia_sessions (
+  id TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  expires_at INTEGER NOT NULL,
   ip_address TEXT,
-  reason TEXT,
+  user_agent TEXT,
+  remember_me INTEGER DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-  FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+  last_activity_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
--- ============================================
--- TRUSTED DEVICES (Remember this device for MFA)
--- ============================================
+CREATE INDEX IF NOT EXISTS idx_lucia_sessions_user_id ON lucia_sessions(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_lucia_sessions_expires_at ON lucia_sessions(expires_at);
+
+CREATE TABLE IF NOT EXISTS rate_limits (
+  key TEXT PRIMARY KEY,
+  count INTEGER NOT NULL DEFAULT 0,
+  window_start INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limits_updated_at ON rate_limits (updated_at);
 
 CREATE TABLE IF NOT EXISTS trusted_devices (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   user_id INTEGER NOT NULL,
   token TEXT UNIQUE NOT NULL,
-  device_fingerprint TEXT,           -- Hash of IP + User-Agent for validation
-  ua_hash TEXT,                      -- Hash of User-Agent alone for independent validation
+  device_fingerprint TEXT,
+  ua_hash TEXT,
   ip_address TEXT,
   user_agent TEXT,
   expires_at TEXT NOT NULL,
@@ -319,42 +354,50 @@ CREATE TABLE IF NOT EXISTS trusted_devices (
 );
 
 CREATE INDEX IF NOT EXISTS idx_trusted_devices_user ON trusted_devices(user_id);
+
 CREATE INDEX IF NOT EXISTS idx_trusted_devices_token ON trusted_devices(token);
+
 CREATE INDEX IF NOT EXISTS idx_trusted_devices_expires ON trusted_devices(expires_at);
 
--- ============================================
--- AUDIT & SECURITY TABLES
--- ============================================
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mfa_challenges_active_user
+  ON mfa_challenges(user_id)
+  WHERE used = 0;
 
-CREATE TABLE IF NOT EXISTS audit_log (
+CREATE TABLE IF NOT EXISTS "performances" (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id INTEGER,
-  action TEXT NOT NULL,
-  resource_type TEXT,
-  resource_id INTEGER,
-  details TEXT,
-  ip_address TEXT,
-  created_at TEXT DEFAULT (datetime('now')),
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+  event_id INTEGER NOT NULL,
+  band_profile_id INTEGER NOT NULL,
+  venue_id INTEGER,
+  start_time TEXT,
+  end_time TEXT,
+  notes TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  created_by_user_id INTEGER,
+  updated_by_user_id INTEGER,
+  updated_at TEXT DEFAULT (datetime('now')), is_announced INTEGER NOT NULL DEFAULT 1, band_follow_notified INTEGER NOT NULL DEFAULT 0,
+  FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
+  FOREIGN KEY (band_profile_id) REFERENCES band_profiles(id) ON DELETE RESTRICT,
+  FOREIGN KEY (venue_id) REFERENCES venues(id) ON DELETE SET NULL,
+  FOREIGN KEY (created_by_user_id) REFERENCES users(id),
+  FOREIGN KEY (updated_by_user_id) REFERENCES users(id)
 );
 
-CREATE TABLE IF NOT EXISTS auth_audit (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  timestamp TEXT NOT NULL DEFAULT (datetime('now')),
-  action TEXT NOT NULL,
-  success INTEGER NOT NULL,
-  ip_address TEXT NOT NULL,
-  user_agent TEXT,
-  details TEXT
-);
+CREATE INDEX IF NOT EXISTS idx_performances_event ON performances(event_id);
 
-CREATE TABLE IF NOT EXISTS rate_limit (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  ip_address TEXT NOT NULL UNIQUE,
-  failed_attempts INTEGER NOT NULL DEFAULT 0,
-  lockout_until TEXT,
-  last_attempt TEXT NOT NULL DEFAULT (datetime('now'))
-);
+CREATE INDEX IF NOT EXISTS idx_performances_band ON performances(band_profile_id);
+
+CREATE INDEX IF NOT EXISTS idx_performances_venue ON performances(venue_id);
+
+CREATE INDEX IF NOT EXISTS idx_performances_event_time ON performances(event_id, start_time);
+
+CREATE TRIGGER IF NOT EXISTS update_performances_timestamp
+AFTER UPDATE ON performances
+BEGIN
+  UPDATE performances SET updated_at = datetime('now') WHERE id = NEW.id;
+END;
+
+CREATE INDEX IF NOT EXISTS idx_performances_announced
+  ON performances(event_id, is_announced);
 
 CREATE TABLE IF NOT EXISTS band_follows (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -363,15 +406,40 @@ CREATE TABLE IF NOT EXISTS band_follows (
   verified INTEGER NOT NULL DEFAULT 0,
   verification_token TEXT UNIQUE,
   unsubscribe_token TEXT UNIQUE NOT NULL,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  consent_ip TEXT,
-  consent_method TEXT NOT NULL DEFAULT 'web_form',
-  batch_token TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')), consent_ip TEXT, consent_method TEXT NOT NULL DEFAULT 'web_form', batch_token TEXT,
   UNIQUE(email, band_profile_id)
 );
+
 CREATE INDEX IF NOT EXISTS idx_band_follows_band ON band_follows(band_profile_id);
+
 CREATE INDEX IF NOT EXISTS idx_band_follows_email ON band_follows(email);
-CREATE INDEX IF NOT EXISTS idx_band_follows_batch_token ON band_follows(batch_token);
+
+CREATE INDEX IF NOT EXISTS idx_events_published_date ON events (is_published, date);
+
+CREATE TABLE IF NOT EXISTS share_links (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug            TEXT    NOT NULL UNIQUE,
+  event_id        INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  event_slug      TEXT    NOT NULL,
+  performance_ids TEXT    NOT NULL,
+  band_names      TEXT    NOT NULL,
+  created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+  expires_at      TEXT    NOT NULL
+, view_count INTEGER NOT NULL DEFAULT 0);
+
+CREATE INDEX IF NOT EXISTS idx_share_links_slug ON share_links(slug);
+
+CREATE INDEX IF NOT EXISTS idx_share_links_expires_at ON share_links(expires_at);
+
+CREATE TABLE IF NOT EXISTS page_views_daily (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  page TEXT NOT NULL,
+  date TEXT NOT NULL,
+  views INTEGER DEFAULT 0,
+  UNIQUE(page, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_page_views_date ON page_views_daily(date);
 
 CREATE TABLE IF NOT EXISTS band_follow_notifications (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -380,7 +448,9 @@ CREATE TABLE IF NOT EXISTS band_follow_notifications (
   notified_at TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(performance_id, band_follow_id)
 );
-CREATE INDEX IF NOT EXISTS idx_band_follow_notifications_performance ON band_follow_notifications(performance_id);
+
+CREATE INDEX IF NOT EXISTS idx_band_follow_notifications_performance
+  ON band_follow_notifications(performance_id);
 
 CREATE TABLE IF NOT EXISTS band_announce_queue (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -394,58 +464,26 @@ CREATE TABLE IF NOT EXISTS band_announce_queue (
   queued_at TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(band_follow_id, performance_id)
 );
+
 CREATE INDEX IF NOT EXISTS idx_band_announce_queue_event ON band_announce_queue(event_id);
+
 CREATE INDEX IF NOT EXISTS idx_band_announce_queue_follow ON band_announce_queue(band_follow_id);
 
--- ============================================
--- INDEXES
--- ============================================
+CREATE INDEX IF NOT EXISTS idx_band_follows_batch_token ON band_follows(batch_token);
 
-CREATE INDEX IF NOT EXISTS idx_events_published ON events(is_published);
-CREATE INDEX IF NOT EXISTS idx_events_slug ON events(slug);
-CREATE INDEX IF NOT EXISTS idx_events_status ON events(status);
-CREATE INDEX IF NOT EXISTS idx_bands_event ON bands(event_id);
-CREATE INDEX IF NOT EXISTS idx_bands_venue ON bands(venue_id);
-CREATE INDEX IF NOT EXISTS idx_performances_event ON performances(event_id);
-CREATE INDEX IF NOT EXISTS idx_performances_band ON performances(band_profile_id);
-CREATE INDEX IF NOT EXISTS idx_performances_venue ON performances(venue_id);
-CREATE INDEX IF NOT EXISTS idx_performances_event_time ON performances(event_id, start_time);
-CREATE INDEX IF NOT EXISTS idx_band_profiles_name ON band_profiles(name);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_band_profiles_normalized ON band_profiles(name_normalized);
-CREATE INDEX IF NOT EXISTS idx_band_profiles_genre ON band_profiles(genre);
-CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
-CREATE INDEX IF NOT EXISTS idx_users_activation_token ON users(activation_token);
-CREATE INDEX IF NOT EXISTS idx_sessions_token ON sessions(session_token);
-CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id);
-CREATE INDEX IF NOT EXISTS idx_auth_attempts_email ON auth_attempts(email);
-CREATE INDEX IF NOT EXISTS idx_auth_attempts_ip ON auth_attempts(ip_address);
+CREATE TABLE IF NOT EXISTS auth_audit (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+  action TEXT NOT NULL,
+  success INTEGER NOT NULL,
+  ip_address TEXT NOT NULL,
+  user_agent TEXT,
+  details TEXT
+);
+
 CREATE INDEX IF NOT EXISTS idx_auth_audit_timestamp ON auth_audit(timestamp);
+
 CREATE INDEX IF NOT EXISTS idx_auth_audit_ip ON auth_audit(ip_address);
-CREATE INDEX IF NOT EXISTS idx_rate_limit_ip ON rate_limit(ip_address);
-
--- Globally-consistent fixed-window rate limit counters (D1-backed, for auth/subscription endpoints)
-CREATE TABLE IF NOT EXISTS rate_limits (
-  key TEXT PRIMARY KEY,
-  count INTEGER NOT NULL DEFAULT 0,
-  window_start INTEGER NOT NULL,
-  updated_at INTEGER NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_rate_limits_updated_at ON rate_limits (updated_at);
-
--- Schedule share link snapshots (server-side /s/[slug] sharing)
-CREATE TABLE IF NOT EXISTS share_links (
-  id              INTEGER PRIMARY KEY AUTOINCREMENT,
-  slug            TEXT    NOT NULL UNIQUE,
-  event_id        INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
-  event_slug      TEXT    NOT NULL,
-  performance_ids TEXT    NOT NULL,
-  band_names      TEXT    NOT NULL,
-  created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
-  expires_at      TEXT    NOT NULL,
-  view_count      INTEGER NOT NULL DEFAULT 0
-);
-CREATE INDEX IF NOT EXISTS idx_share_links_slug ON share_links(slug);
-CREATE INDEX IF NOT EXISTS idx_share_links_expires_at ON share_links(expires_at);
 
 -- ============================================
 -- TEST ACCOUNTS (passwords set by scripts/setup-local-db.sh)

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -2,18 +2,18 @@
 
 **Type:** Cloudflare D1 (SQLite-compatible)
 
-This document is derived directly from `database/setup-complete.sql` — every
-table, column, and foreign key below reflects that file, except the four
-tables in "Subscriptions & schedule builds", which exist only in `migrations/`
-(see "Known schema drift"). When the schema changes, update
-`database/setup-complete.sql` and this document together (see `migrations/`
-history at the bottom for how schema changes are made).
+This document describes the schema produced by replaying `migrations/` in
+order — which, since #506, is exactly what `database/setup-complete.sql`
+contains: its schema section is **generated** by
+`scripts/regenerate-setup-complete.mjs` and CI verifies the two never diverge
+(`scripts/check-schema-drift.mjs` in `quality.yml`). To change the schema,
+add a migration, regenerate the bootstrap, and update this document together.
 
 ## Overview
 
 Schema is managed two ways:
 
-- **`migrations/0001…0048_*.sql`** — numbered, sequential migrations. These are
+- **`migrations/NNNN_*.sql`** — numbered, sequential migrations. These are
   applied to the production D1 database automatically on deploy by the
   "Apply remote D1 migrations" step in `.github/workflows/cloudflare-pages.yml`
   (`wrangler d1 migrations apply <db> --remote`). Do not apply them manually.
@@ -202,31 +202,15 @@ schedule-first entry flows.
 
 ### Legacy / compatibility
 
-#### `bands`
+#### `bands` and `rate_limit` (removed from the bootstrap, #506)
 
-A pre-band-profile-era table (event-scoped band + performance in one row).
-Still created by `setup-complete.sql` and still referenced by
-`performances.band_id`/`band_name` as compatibility columns, but no current
-endpoint under `functions/api/` reads from or writes to `bands` itself — all
-band/performance data flows through `band_profiles` + `performances`.
-
-| Column         | Type    | Notes                                          |
-| -------------- | ------- | ---------------------------------------------- |
-| `id`           | INTEGER | PK, autoincrement                              |
-| `event_id`     | INTEGER | Nullable, FK → `events(id)` ON DELETE SET NULL |
-| `venue_id`     | INTEGER | Nullable, FK → `venues(id)` ON DELETE SET NULL |
-| `name`         | TEXT    | NOT NULL                                       |
-| `start_time`   | TEXT    | Nullable                                       |
-| `end_time`     | TEXT    | Nullable                                       |
-| `url`          | TEXT    | Nullable                                       |
-| `photo_url`    | TEXT    | Nullable                                       |
-| `description`  | TEXT    | Nullable                                       |
-| `genre`        | TEXT    | Nullable                                       |
-| `origin`       | TEXT    | Nullable                                       |
-| `social_links` | TEXT    | Nullable (JSON)                                |
-| `created_at`   | TEXT    | NOT NULL, DEFAULT `datetime('now')`            |
-
-Indexes: `idx_bands_event(event_id)`, `idx_bands_venue(venue_id)`.
+Two pre-v2 tables (`bands`: event-scoped band+performance rows, superseded by
+`band_profiles` + `performances`; `rate_limit`: one-row-per-IP limiter,
+superseded by `rate_limits` in migration 0028) existed **only** in the
+hand-maintained bootstrap — no migration creates them, production does not
+have them, and no code reads or writes them. They were removed from
+`database/setup-complete.sql` when it was regenerated from the migrations
+replay (#506).
 
 #### `sessions`
 
@@ -248,22 +232,6 @@ goes entirely through `lucia_sessions` (see below and
 | `expires_at`       | TEXT    | NOT NULL                                     |
 
 Indexes: `idx_sessions_token(session_token)`, `idx_sessions_user(user_id)`.
-
-#### `rate_limit`
-
-A pre-sliding-window rate-limit table (one row per IP). Superseded by
-`rate_limits` (migration 0028); no current endpoint reads from or writes to
-`rate_limit`.
-
-| Column            | Type    | Notes                               |
-| ----------------- | ------- | ----------------------------------- |
-| `id`              | INTEGER | PK, autoincrement                   |
-| `ip_address`      | TEXT    | NOT NULL, UNIQUE                    |
-| `failed_attempts` | INTEGER | NOT NULL, DEFAULT 0                 |
-| `lockout_until`   | TEXT    | Nullable                            |
-| `last_attempt`    | TEXT    | NOT NULL, DEFAULT `datetime('now')` |
-
-Index: `idx_rate_limit_ip(ip_address)`.
 
 ### Fan engagement
 
@@ -350,7 +318,7 @@ Indexes: `idx_share_links_slug(slug)`, `idx_share_links_expires_at(expires_at)`.
 Per `CLAUDE.md`, `share_links` — not telemetry events — is the source of truth
 for share create/view counts.
 
-### Subscriptions & schedule builds (migrations-only — see #506)
+### Subscriptions & schedule builds
 
 These four tables are live and queried (`functions/api/subscriptions/*`,
 `functions/api/schedule/build.js`, `functions/api/admin/events/[id]/metrics.js`,
@@ -802,10 +770,8 @@ DELETE FROM events WHERE id = ?;
 ```
 
 **Event metrics batch** (`functions/api/admin/events/[id]/metrics.js`) — reads
-`schedule_builds` (documented under "Subscriptions & schedule builds" above;
-created by migrations only, not by `database/setup-complete.sql` — see "Known
-schema drift" below) alongside `performances` and `band_profiles` in one
-`DB.batch()`:
+`schedule_builds` (documented under "Subscriptions & schedule builds" above)
+alongside `performances` and `band_profiles` in one `DB.batch()`:
 
 ```sql
 SELECT COUNT(*) as total_schedule_builds,
@@ -814,16 +780,18 @@ SELECT COUNT(*) as total_schedule_builds,
 FROM schedule_builds WHERE event_id = ?;
 ```
 
-## Known schema drift
+## Schema drift protection
 
-`database/setup-complete.sql` currently lags `migrations/` in two ways —
-four live tables (`email_subscriptions`, `subscription_verifications`,
-`subscription_unsubscribes`, `schedule_builds`; documented in the
-"Subscriptions & schedule builds" subsection above, since they exist only in
-migrations) and all `updated_at` triggers exist only in migrations. Tracked
-with full detail and a fix plan in
-[issue #506](https://github.com/BreakableHoodie/settimesdotca/issues/506);
-the bootstrap file should gain those tables and triggers when it closes.
+Historical drift between `database/setup-complete.sql` and `migrations/`
+(whole tables, columns, foreign keys, indexes, and triggers — see
+[issue #506](https://github.com/BreakableHoodie/settimesdotca/issues/506))
+was eliminated by regenerating the bootstrap from the migrations replay.
+Two scripts keep it that way:
+
+- `node scripts/regenerate-setup-complete.mjs` — rewrites the bootstrap's
+  schema section from `migrations/` (run after adding any migration).
+- `node scripts/check-schema-drift.mjs` — structurally compares the two and
+  fails on any divergence; runs in CI (`quality.yml`, Schema Drift Check).
 
 ## Further reading
 

--- a/migrations/0049_drop_theme_settings.sql
+++ b/migrations/0049_drop_theme_settings.sql
@@ -1,0 +1,13 @@
+-- Migration: 0049_drop_theme_settings
+-- Description: Drop the unused theme_settings table.
+--   Created in 0008 for a single global primary/secondary/accent/text color
+--   scheme, since superseded by the 4-theme CSS custom-property system
+--   (frontend/src/index.css, data-theme on <html>, persisted in localStorage).
+--   No code path in functions/ or frontend/ reads or writes this table — it
+--   was fully replaced, never migrated. The single stale production row's
+--   values are preserved in issue #506's comments for the record.
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+DROP TABLE IF EXISTS theme_settings;

--- a/migrations/0050_restore_auth_audit.sql
+++ b/migrations/0050_restore_auth_audit.sql
@@ -1,0 +1,28 @@
+-- Migration: 0050_restore_auth_audit
+-- Description: Restore auth_audit to the migration history.
+--   Migration 0001 created auth_audit; 0002 dropped it during the single-org
+--   simplification, and no later migration recreated it — yet the table exists
+--   in production (recreated out-of-band) and is written by live code
+--   (functions/api/auth/reset-password-complete.js) and pruned by the retention
+--   job (functions/api/admin/maintenance/retention.js). This migration makes the
+--   migration history produce the table again so a from-scratch replay matches
+--   production and database/setup-complete.sql (see #506).
+--
+--   No-op on production for the table itself (IF NOT EXISTS); the two indexes
+--   from 0001 are (re)created — production currently lacks them.
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+CREATE TABLE IF NOT EXISTS auth_audit (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+  action TEXT NOT NULL,
+  success INTEGER NOT NULL,
+  ip_address TEXT NOT NULL,
+  user_agent TEXT,
+  details TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_audit_timestamp ON auth_audit(timestamp);
+CREATE INDEX IF NOT EXISTS idx_auth_audit_ip ON auth_audit(ip_address);

--- a/scripts/check-schema-drift.mjs
+++ b/scripts/check-schema-drift.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+// scripts/check-schema-drift.mjs
+//
+// Structurally compares database/setup-complete.sql (the bootstrap script that
+// seeds every CI/E2E database) against the cumulative effect of migrations/*.sql
+// applied in numeric order (what production actually has, via
+// `wrangler d1 migrations apply <db> --remote`). The two must describe the same
+// schema, or CI/E2E databases silently diverge from production and mutations
+// against tables/columns/triggers that only exist in one of the two 500 in
+// exactly the environment nobody is watching.
+//
+// Compares STRUCTURE, not raw SQL text — a textual diff false-positives on things
+// like `IF NOT EXISTS`, comment differences, or whitespace/formatting that don't
+// change the resulting schema. See issue #506.
+//
+// Usage: node scripts/check-schema-drift.mjs
+
+import Database from "better-sqlite3";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.join(__dirname, "..");
+
+// ============================================================================
+// ALLOWLIST — accepted divergences between setup-complete.sql and migrations/.
+// Empty by default: as of #506, the two describe the same schema exactly.
+//
+// Add an entry here only for a deliberate, permanent divergence (e.g. a table
+// that is intentionally migrations-only and never bootstrapped). Every entry
+// must reference the issue that decided it's intentional — this is a
+// documented exception list, not a place to silence real drift. If a table
+// only differs temporarily (a migration hasn't landed on this branch yet,
+// etc.), fix the source of drift instead of allowlisting it.
+// ============================================================================
+const ALLOWLIST = new Set([
+  // (none — see #506)
+]);
+
+const SYSTEM_TABLE_PATTERNS = [/^sqlite_/i, /^d1_migrations$/i, /^_cf_/i];
+
+function isSystemTable(name) {
+  return SYSTEM_TABLE_PATTERNS.some((re) => re.test(name));
+}
+
+// ----------------------------------------------------------------------------
+// DB construction
+// ----------------------------------------------------------------------------
+
+function buildFromSetupComplete() {
+  const db = new Database(":memory:");
+  const sql = readFileSync(path.join(rootDir, "database/setup-complete.sql"), "utf8");
+  db.exec(sql);
+  return db;
+}
+
+export function buildFromMigrations() {
+  const db = new Database(":memory:");
+  const migrationsDir = path.join(rootDir, "migrations");
+  const files = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort(); // zero-padded NNNN_ prefixes sort numerically as strings
+
+  for (const file of files) {
+    const sql = readFileSync(path.join(migrationsDir, file), "utf8");
+    applyMigration(db, sql, file);
+  }
+  return db;
+}
+
+function applyMigration(db, sql, filename) {
+  try {
+    db.exec(sql);
+    return;
+  } catch (wholeFileError) {
+    // Some migrations mix PRAGMA/DDL/DML in ways a single exec() call can choke
+    // on. Fall back to executing each top-level statement individually (still
+    // whole-file semantics — just statement-by-statement instead of one call).
+    try {
+      for (const statement of splitStatements(sql)) {
+        if (!statement.trim()) continue;
+        try {
+          db.exec(statement);
+        } catch (statementError) {
+          if (isHarmlessDuplicateColumn(statement, statementError)) {
+            // Pre-existing quirk, not something this script should "fix": a few
+            // migrations backfill columns onto tables for production databases
+            // that predated a *later* migration's CREATE TABLE already
+            // including that column (e.g. 0016 backfills password_reset_tokens
+            // columns that 0003's CREATE TABLE IF NOT EXISTS already defines).
+            // In production, migrations are only ever applied incrementally on
+            // top of the existing DB (never replayed from empty), so this path
+            // never actually fires there — it only surfaces here because we
+            // replay 0001..N from scratch to reconstruct the cumulative schema.
+            // Either way the column ends up present, so treat as satisfied.
+            console.warn(`  (${filename}) skipping redundant ADD COLUMN — already present: ${statement.trim()}`);
+            continue;
+          }
+          throw statementError;
+        }
+      }
+    } catch (fallbackError) {
+      throw new Error(
+        `Failed to apply migration ${filename}:\n  whole-file error: ${wholeFileError.message}\n  fallback error: ${fallbackError.message}`,
+      );
+    }
+  }
+}
+
+function isHarmlessDuplicateColumn(statement, error) {
+  // Strip line comments first — a statement chunk from splitStatements() often
+  // carries a leading `-- comment` line, which would otherwise defeat the
+  // anchored ALTER TABLE check below.
+  const withoutComments = statement.replace(/--[^\n]*/g, "").trim();
+  return /^ALTER\s+TABLE\s+\S+\s+ADD\s+COLUMN/i.test(withoutComments) && /duplicate column name/i.test(error.message);
+}
+
+// Splits a SQL file into top-level statements, treating `CREATE TRIGGER ... END;`
+// blocks as a single atomic statement (they contain their own internal `;`s that
+// must not be split on). Not a general SQL parser — sufficient for this repo's
+// migration files.
+function splitStatements(sql) {
+  const triggerBlocks = [];
+  const placeholder = (i) => `__TRIGGER_BLOCK_${i}__`;
+
+  const withPlaceholders = sql.replace(/CREATE\s+TRIGGER[\s\S]*?\bEND\s*;/gi, (match) => {
+    const idx = triggerBlocks.length;
+    triggerBlocks.push(match);
+    return `${placeholder(idx)};`;
+  });
+
+  return withPlaceholders
+    .split(";")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((stmt) => {
+      const m = stmt.match(/^__TRIGGER_BLOCK_(\d+)__$/);
+      return m ? triggerBlocks[Number(m[1])] : `${stmt};`;
+    });
+}
+
+// ----------------------------------------------------------------------------
+// Introspection
+// ----------------------------------------------------------------------------
+
+function getUserTables(db) {
+  return db
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
+    .all()
+    .map((r) => r.name)
+    .filter((n) => !isSystemTable(n));
+}
+
+function getColumns(db, table) {
+  return db.pragma(`table_info("${table}")`).map(({ name, type, notnull, dflt_value, pk }) => ({
+    name,
+    type: normalizeText(type),
+    notnull,
+    dflt_value: normalizeText(dflt_value),
+    pk,
+  }));
+}
+
+function getForeignKeys(db, table) {
+  return db
+    .pragma(`foreign_key_list("${table}")`)
+    .map(({ table: refTable, from, to, on_update, on_delete, match }) => ({
+      refTable,
+      from,
+      to,
+      on_update,
+      on_delete,
+      match,
+    }))
+    .sort((a, b) => (a.from + a.refTable).localeCompare(b.from + b.refTable));
+}
+
+function getIndexes(db, table) {
+  return db
+    .pragma(`index_list("${table}")`)
+    .filter((idx) => !idx.name.startsWith("sqlite_autoindex_"))
+    .map((idx) => ({
+      name: idx.name,
+      unique: !!idx.unique,
+      columns: db.pragma(`index_info("${idx.name}")`).map((c) => c.name),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function getTriggerNames(db, table) {
+  return db
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ? ORDER BY name`)
+    .all(table)
+    .map((r) => r.name);
+}
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : value;
+}
+
+// ----------------------------------------------------------------------------
+// Diffing
+// ----------------------------------------------------------------------------
+
+function diffColumns(colsA, colsB) {
+  const messages = [];
+  const mapA = new Map(colsA.map((c) => [c.name, c]));
+  const mapB = new Map(colsB.map((c) => [c.name, c]));
+
+  for (const name of mapB.keys()) {
+    if (!mapA.has(name)) messages.push(`column '${name}' missing from setup-complete.sql`);
+  }
+  for (const name of mapA.keys()) {
+    if (!mapB.has(name)) messages.push(`column '${name}' present in setup-complete.sql but not produced by migrations`);
+  }
+  for (const [name, colB] of mapB) {
+    const colA = mapA.get(name);
+    if (!colA) continue;
+    for (const field of ["type", "notnull", "dflt_value", "pk"]) {
+      if (colA[field] !== colB[field]) {
+        messages.push(
+          `column '${name}' ${field} mismatch: setup-complete=${JSON.stringify(colA[field])} vs migrations=${JSON.stringify(colB[field])}`,
+        );
+      }
+    }
+  }
+  return messages;
+}
+
+function diffJson(label, a, b) {
+  const normA = JSON.stringify(a);
+  const normB = JSON.stringify(b);
+  if (normA === normB) return null;
+  return `${label} differ:\n      setup-complete: ${normA}\n      migrations:     ${normB}`;
+}
+
+function diffTable(dbA, dbB, table) {
+  const messages = [];
+
+  messages.push(...diffColumns(getColumns(dbA, table), getColumns(dbB, table)));
+
+  const fkMsg = diffJson("foreign keys", getForeignKeys(dbA, table), getForeignKeys(dbB, table));
+  if (fkMsg) messages.push(fkMsg);
+
+  const idxMsg = diffJson("indexes", getIndexes(dbA, table), getIndexes(dbB, table));
+  if (idxMsg) messages.push(idxMsg);
+
+  const trigMsg = diffJson("triggers", getTriggerNames(dbA, table), getTriggerNames(dbB, table));
+  if (trigMsg) messages.push(trigMsg);
+
+  return messages;
+}
+
+// ----------------------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------------------
+
+function main() {
+  console.log("Building DB A from database/setup-complete.sql...");
+  const dbA = buildFromSetupComplete();
+
+  console.log("Building DB B from migrations/*.sql applied in order...");
+  const dbB = buildFromMigrations();
+
+  const tablesA = new Set(getUserTables(dbA));
+  const tablesB = new Set(getUserTables(dbB));
+  const allTables = [...new Set([...tablesA, ...tablesB])].sort();
+
+  const failures = [];
+  const allowlisted = [];
+
+  for (const table of allTables) {
+    if (ALLOWLIST.has(table)) {
+      allowlisted.push(table);
+      continue;
+    }
+
+    const inA = tablesA.has(table);
+    const inB = tablesB.has(table);
+    let messages;
+
+    if (!inA && inB) {
+      messages = ["table missing from setup-complete.sql (present in migrations)"];
+    } else if (inA && !inB) {
+      messages = ["table present in setup-complete.sql but not produced by migrations"];
+    } else {
+      messages = diffTable(dbA, dbB, table);
+    }
+
+    if (messages.length) failures.push({ table, messages });
+  }
+
+  dbA.close();
+  dbB.close();
+
+  if (failures.length) {
+    console.error("\nSchema drift detected between database/setup-complete.sql and migrations/:\n");
+    for (const { table, messages } of failures) {
+      console.error(`  ${table}:`);
+      for (const m of messages) console.error(`    - ${m}`);
+    }
+    console.error(
+      `\n${failures.length} table(s) diverged (checked ${allTables.length - allowlisted.length} of ${allTables.length}; allowlisted: ${allowlisted.join(", ") || "none"}).`,
+    );
+    console.error(
+      "Fix database/setup-complete.sql to match migrations/, or add a justified entry to the ALLOWLIST at the top of this script referencing an issue.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\nOK: database/setup-complete.sql matches migrations/ for ${allTables.length - allowlisted.length} table(s) (allowlisted: ${allowlisted.join(", ") || "none"}).`,
+  );
+}
+
+// Run the check only when executed directly — scripts/regenerate-setup-complete.mjs
+// imports buildFromMigrations() from this module and must not trigger a check.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/regenerate-setup-complete.mjs
+++ b/scripts/regenerate-setup-complete.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Regenerates database/setup-complete.sql from the cumulative migrations replay.
+//
+// database/setup-complete.sql bootstraps every CI/E2E database in one shot and
+// MUST be schema-identical to applying migrations/0001..N in order (#506 —
+// years of hand-maintenance had drifted it from production on whole tables,
+// columns, foreign keys, indexes, and triggers). This script makes syncing
+// mechanical instead of manual:
+//
+//   1. Replays every migrations/*.sql into an in-memory SQLite DB
+//      (via buildFromMigrations from scripts/check-schema-drift.mjs).
+//   2. Dumps the resulting schema objects in creation order (FK-safe),
+//      normalized to IF NOT EXISTS form.
+//   3. Carries the SEED DATA section forward verbatim from the current
+//      database/setup-complete.sql (seed rows are data, not schema — the
+//      drift guard deliberately ignores them).
+//
+// Workflow after any schema change:
+//   node scripts/regenerate-setup-complete.mjs   # rewrite the bootstrap
+//   node scripts/check-schema-drift.mjs          # verify (also runs in CI)
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildFromMigrations } from "./check-schema-drift.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.join(__dirname, "..");
+const targetPath = path.join(rootDir, "database/setup-complete.sql");
+
+const SYSTEM_TABLE_PATTERNS = [/^sqlite_/i, /^d1_migrations$/i, /^_cf_/i];
+
+function isSystemObject(row) {
+  return SYSTEM_TABLE_PATTERNS.some((re) => re.test(row.tbl_name || row.name));
+}
+
+// sqlite_master stores each object's original CREATE text; normalize to the
+// idempotent form the bootstrap file uses throughout.
+function toIfNotExists(sql) {
+  return sql.replace(
+    /^CREATE\s+(TABLE|(?:UNIQUE\s+)?INDEX|TRIGGER)\s+(?!IF\s+NOT\s+EXISTS)/i,
+    "CREATE $1 IF NOT EXISTS ",
+  );
+}
+
+function extractSeedSection(currentFile) {
+  const match = currentFile.match(/^-- =+\n-- TEST ACCOUNTS[\s\S]*$/m);
+  if (!match) {
+    throw new Error(
+      "Could not locate the '-- TEST ACCOUNTS' banner in database/setup-complete.sql — refusing to regenerate without carrying the seed rows forward.",
+    );
+  }
+  return match[0].trimEnd() + "\n";
+}
+
+function main() {
+  const currentFile = readFileSync(targetPath, "utf8");
+  const seedSection = extractSeedSection(currentFile);
+
+  console.log("Replaying migrations/*.sql...");
+  const db = buildFromMigrations();
+
+  const objects = db
+    .prepare(
+      `SELECT type, name, tbl_name, sql FROM sqlite_master
+       WHERE sql IS NOT NULL AND type IN ('table', 'index', 'trigger')
+       ORDER BY rowid`,
+    )
+    .all()
+    .filter((row) => !isSystemObject(row));
+  db.close();
+
+  const header = `-- Complete Local Development Database Setup
+-- Usage: sqlite3 <database-file> < database/setup-complete.sql
+--
+-- GENERATED FILE — do not hand-edit the schema section.
+-- Regenerate with:  node scripts/regenerate-setup-complete.mjs
+-- Verified in CI by: node scripts/check-schema-drift.mjs (quality.yml)
+--
+-- Schema below is the exact cumulative result of migrations/0001..N replayed
+-- in order (#506). To change the schema, add a migration and regenerate.
+-- The SEED DATA section at the bottom is carried forward as-is.
+
+-- ============================================
+-- SCHEMA (generated from migrations/)
+-- ============================================
+`;
+
+  const body = objects.map((row) => toIfNotExists(row.sql.trim()) + ";").join("\n\n");
+
+  writeFileSync(targetPath, `${header}\n${body}\n\n${seedSection}`);
+  console.log(
+    `Wrote ${path.relative(rootDir, targetPath)}: ${objects.filter((o) => o.type === "table").length} tables, ` +
+      `${objects.filter((o) => o.type === "index").length} indexes, ` +
+      `${objects.filter((o) => o.type === "trigger").length} triggers (+ seed section carried forward).`,
+  );
+}
+
+main();

--- a/scripts/validate-db-schema.js
+++ b/scripts/validate-db-schema.js
@@ -63,7 +63,13 @@ function hasCreateTable(sql, table) {
 }
 
 function hasColumn(sql, table, column) {
-  const tablePattern = new RegExp(`CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${table}\\s*\\((.*?)\\)\\s*;`, "is");
+  // Table names may be quoted in generated SQL (sqlite_master preserves the
+  // original CREATE text, and migration 0032's recreated `"performances"`
+  // carries its quotes into the regenerated setup-complete.sql).
+  const tablePattern = new RegExp(
+    `CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?"?${table}"?\\s*\\((.*?)\\)\\s*;`,
+    "is",
+  );
   const tableMatch = sql.match(tablePattern);
   if (!tableMatch) return false;
 

--- a/scripts/validate-db-schema.js
+++ b/scripts/validate-db-schema.js
@@ -10,7 +10,6 @@ const FILE_RULES = [
     tables: [
       "events",
       "venues",
-      "bands",
       "performances",
       "band_profiles",
       "artist_daily_stats",


### PR DESCRIPTION
## Summary

`database/setup-complete.sql` (which bootstraps every CI/E2E database) had drifted from the migrations replay — i.e., from **production** — far beyond the four tables #506 originally cited. The structural comparator built for this PR found whole tables existing on only one side, column-level divergence (`band_profiles` carrying seven phantom columns; `email_otp_codes` with plaintext `code` instead of the real `code_hash`), and missing FKs, indexes, and every `updated_at` trigger. Rather than hand-patch dozens of diffs, the bootstrap's schema section is now **generated** from the migrations replay, and CI enforces equivalence so this drift class cannot recur silently.

Verified against production directly: prod matches the migrations replay (spot-checked `band_profiles`, `email_otp_codes` via read-only D1 query), modulo the two deltas this PR's migrations resolve.

Closes #506

## What changed

| File | Change |
|------|--------|
| `scripts/check-schema-drift.mjs` | **New** guard: builds one DB from the bootstrap, one from `migrations/*.sql` replayed in order, and structurally diffs columns/FKs/indexes/triggers per table (text-normalization-proof). Empty allowlist. Exit 1 on divergence. |
| `scripts/regenerate-setup-complete.mjs` | **New**: rewrites the bootstrap's schema section from the replay (creation order, `IF NOT EXISTS` forms); seed rows carried forward verbatim (kept out of the script so fixture hashes aren't duplicated for secret scanners). |
| `database/setup-complete.sql` | Regenerated. Gains the 4 live subscription/schedule tables + all `updated_at` triggers + missing FKs/indexes/columns; loses phantom tables (`bands`, `rate_limit`) and phantom columns. Now a generated file — header says so. |
| `migrations/0049_drop_theme_settings.sql` | Drops the abandoned `theme_settings` table (boss-approved; the single stale row's values are preserved in #506 comments). |
| `migrations/0050_restore_auth_audit.sql` | Restores `auth_audit` to the migration history — 0002 dropped it, production recreated it out-of-band, and live code writes it (`reset-password-complete.js`) and prunes it (`retention.js`). No-op on prod except restoring its two indexes. |
| `.github/workflows/quality.yml` | New `Schema Drift Check` job running the guard. |
| `database/seed-test-data.sql` | Reconciled to the real schema (legacy `bands` fixtures and phantom `venues.capacity` removed). |
| `scripts/validate-db-schema.js` | `bands` removed from the expected-table list. |
| `docs/DATABASE.md`, `CLAUDE.md` | Updated to the generate-then-verify workflow; dead-table sections replaced with a removal note. (Table sections that inherited old phantom shapes are tracked separately in #513.) |

## Security / correctness notes

- CI/E2E databases now match production schema — previously E2E exercised a DB where e.g. `email_otp_codes` stored a plaintext `code` column that doesn't exist in prod.
- Migration 0049 is destructive by design and boss-approved (data preserved in the issue record). 0050 is `IF NOT EXISTS` — safe on prod.
- Guard mutation-tested: passes on the regenerated file; fails (exit 1) when a table is renamed out of the bootstrap; the diff path is proven by the original drift run (20+ table report).

## Verification

- [x] Tests: 626 pass in node:22 container (unit tests use their own inline schema and are unaffected)
- [x] Guard: `OK … matches migrations/ for 27 table(s) (allowlisted: none)` after regeneration; exit 1 under mutation
- [x] Seed validation: `setup-complete.sql` + `seed-test-data.sql` apply cleanly to a fresh DB (20 venues / 28 events / 3 users)
- [x] ESLint: 0 errors; format check clean
- [x] `actionlint`: no new findings (3 pre-existing SC2086 infos in untouched zap-baseline.yml)
- [x] E2E runs on this PR via the `schema`/`database/**` trigger filter — green checks here mean the app boots and passes against the corrected schema
- [ ] `validate:openapi`: N/A — no API shape changes

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
