### PR TITLE
fix(feeds): correct ICS timezone to America/Toronto; settimes.ca identity (#509)

### DIFF
--- a/functions/api/feeds/__tests__/ical.test.js
+++ b/functions/api/feeds/__tests__/ical.test.js
@@ -81,8 +81,26 @@ describe("GET /api/feeds/ical", () => {
 
     expect(response.status).toBe(200);
     expect(icalData).toContain("VERSION:2.0");
-    expect(icalData).toContain("PRODID:-//Concert Schedule//EN");
+    expect(icalData).toContain("PRODID:-//SetTimes//settimes.ca//EN");
     expect(icalData).toContain("CALSCALE:GREGORIAN");
+  });
+
+  it("should declare America/Toronto as the calendar timezone (Waterloo Region, not America/Los_Angeles)", async () => {
+    const event = createMockEvent();
+    const venue = createMockVenue();
+    const band = createMockBand();
+
+    seedMockData(mockDB, [event], [venue], [band]);
+
+    const request = new Request("http://localhost/api/feeds/ical");
+    const context = { request, env: mockEnv };
+
+    const response = await onRequestGet(context);
+    const icalData = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(icalData).toContain("X-WR-TIMEZONE:America/Toronto");
+    expect(icalData).not.toContain("America/Los_Angeles");
   });
 
   it("should format each event with VEVENT block including DTSTART, DTEND, SUMMARY", async () => {
@@ -209,9 +227,9 @@ describe("GET /api/feeds/ical", () => {
     expect(icalData).toContain("SUMMARY:Band One");
     expect(icalData).toContain("SUMMARY:Band Two");
 
-    // UIDs should be unique (using performance IDs)
-    expect(icalData).toContain(`UID:performance-1-${dateStr}@concertschedule.app`);
-    expect(icalData).toContain(`UID:performance-2-${dateStr}@concertschedule.app`);
+    // UIDs should be unique (using performance IDs) and use the settimes.ca domain
+    expect(icalData).toContain(`UID:performance-1-${dateStr}@settimes.ca`);
+    expect(icalData).toContain(`UID:performance-2-${dateStr}@settimes.ca`);
 
     // Count VEVENT blocks - should be 2
     const vevents = icalData.split("BEGIN:VEVENT").length - 1;

--- a/functions/api/feeds/ical.js
+++ b/functions/api/feeds/ical.js
@@ -1,5 +1,5 @@
 // iCal feed generation
-// Format: https://portland.ics?genre=indie
+// GET /api/feeds/ical?city=…&genre=…
 // Compatible with Google Calendar, Apple Calendar, Outlook
 
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
@@ -92,9 +92,9 @@ function generateICal(bands, city, genre) {
   const ical = [
     "BEGIN:VCALENDAR",
     "VERSION:2.0",
-    "PRODID:-//Concert Schedule//EN",
+    "PRODID:-//SetTimes//settimes.ca//EN",
     `X-WR-CALNAME:${escapeIcal(`${city} ${genre} Shows`)}`,
-    "X-WR-TIMEZONE:America/Los_Angeles",
+    "X-WR-TIMEZONE:America/Toronto",
     "CALSCALE:GREGORIAN",
     "METHOD:PUBLISH",
   ];
@@ -112,7 +112,7 @@ function generateICal(bands, city, genre) {
     const dtend = `${eventDate.replace(/-/g, "")}T${endTime.replace(/:/g, "")}00`;
 
     // Generate unique ID using performance ID to ensure uniqueness per band
-    const uid = `performance-${band.performance_id}-${eventDate}@concertschedule.app`;
+    const uid = `performance-${band.performance_id}-${eventDate}@settimes.ca`;
 
     // Location
     const location = band.venue_name ? `${band.venue_name}${band.address ? ", " + band.address : ""}` : "TBD";


### PR DESCRIPTION
## Summary

The ICS calendar feed carried three leftovers from a previous project: `X-WR-TIMEZONE:America/Los_Angeles`, VEVENT UIDs on `@concertschedule.app`, and `PRODID:-//Concert Schedule//EN`. Since DTSTART/DTEND are emitted as floating local times, clients that honor the calendar-level timezone (Google Calendar does) interpret a Waterloo 8 PM set as Pacific — shifting it to 11 PM for Eastern subscribers. Found during the multi-day festival scoping study (#510).

Closes #509

## What changed

| File | Change |
|------|--------|
| `functions/api/feeds/ical.js` | `X-WR-TIMEZONE` → `America/Toronto`; UID domain → `@settimes.ca`; `PRODID` → `-//SetTimes//settimes.ca//EN`; stale `portland.ics` example comment replaced with the real route. |
| `functions/api/feeds/__tests__/ical.test.js` | Assertions updated to the new UID/PRODID values; new test pins `America/Toronto` present and `America/Los_Angeles` absent. |

Deliberately NOT changed: the floating-time (no TZID/VTIMEZONE) emission style — correct for a single-region product once the calendar zone is right.

## Security / correctness notes

None security-wise. **UID change causes a one-time re-add** (duplicate-then-replace) for any existing subscribed calendars rather than an in-place update — accepted churn; UIDs should live on our domain. Repo-wide grep confirms no other `concertschedule`/`Concert Schedule` remnants.

## Verification

- [x] Tests: 627 pass in node:22 container (ical.test.js 11/11 incl. the new timezone pin)
- [x] ESLint: 0 errors
- [x] Format check: clean
- [ ] Build / `validate:openapi`: N/A — backend feed only, no API shape change
- [x] Manual smoke: N/A — feed output fully pinned by unit tests

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
