### PR TITLE
ci: skip heavy CI on docs-only PRs; run E2E suites on PRs to dev (#478 items 7+8)

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -27,6 +27,13 @@ jobs:
     name: Test and build
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # dorny/paths-filter detects PR changes via the GitHub REST API, which needs
+    # pull-requests: read (the workflow default of contents-only leaves it at
+    # none). contents: read is repeated because a job-level permissions block
+    # replaces — not extends — the inherited top-level one.
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -33,6 +33,37 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Required status check: this job must always report (never be skipped by
+      # trigger-level paths-ignore, or a docs-only PR would be stuck on "Expected
+      # — waiting for status" forever). Instead, docs-only PRs run this step,
+      # find no code changes, and every heavy step below short-circuits via
+      # `if:`, so the job still completes (green) in seconds.
+      #
+      # An explicit allowlist of code roots is used instead of negating
+      # `docs/**`, because `docs/api-spec.yaml` (the OpenAPI contract validated
+      # below) lives under docs/ and must NOT be treated as docs-only.
+      - name: Detect non-documentation changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        with:
+          filters: |
+            code:
+              - 'frontend/**'
+              - 'functions/**'
+              - 'migrations/**'
+              - 'database/**'
+              - 'scripts/**'
+              - 'e2e/**'
+              - '.github/**'
+              - 'docs/api-spec.yaml'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'wrangler.toml'
+              - 'vitest.config.js'
+              - 'eslint.config.js'
+              - '.npmrc'
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -43,27 +74,34 @@ jobs:
             frontend/package-lock.json
 
       - name: Install root dependencies
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         run: npm ci
 
       - name: Validate OpenAPI spec
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         run: npm run validate:openapi
 
       - name: Install frontend dependencies
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         working-directory: frontend
         run: npm ci
 
       - name: Run backend tests
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         run: npm run test
 
       - name: Run frontend linting
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         working-directory: frontend
         run: npm run lint
 
       - name: Run frontend tests
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         working-directory: frontend
         run: npm run test
 
       - name: Build frontend
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         working-directory: frontend
         env:
           # Public Turnstile site key — Vite inlines VITE_* into the client bundle
@@ -77,6 +115,7 @@ jobs:
         run: npm run build
 
       - name: Upload frontend build artifact
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-dist

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,14 @@ name: CodeQL
 on:
   push:
     branches: [main, dev]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
   pull_request:
     branches: [main, dev]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
   schedule:
     - cron: "0 6 * * 1"
 

--- a/.github/workflows/e2e-a11y-visual.yml
+++ b/.github/workflows/e2e-a11y-visual.yml
@@ -2,7 +2,7 @@ name: E2E A11y + Visual
 
 on:
     pull_request:
-        branches: [main]
+        branches: [main, dev]
         paths:
             - 'e2e/accessibility/**'
             - 'e2e/visual-regression.spec.js'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,7 +4,7 @@ on:
     push:
         branches: [main, dev]
     pull_request:
-        branches: [main]
+        branches: [main, dev]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,6 +3,14 @@ name: Quality Checks
 on:
   pull_request:
     branches: [main, dev]
+    # Skip docs-only PRs — but docs/api-spec.yaml is the OpenAPI contract this
+    # workflow's "OpenAPI Validation" job exists to check, so re-include it.
+    # (paths patterns evaluate in order; the last matching pattern decides.)
+    paths:
+      - "**"
+      - "!docs/**"
+      - "!**.md"
+      - "docs/api-spec.yaml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Items **#7 and #8** of the #451 CI audit tracked in #478. Docs-only PRs stop paying for the full CI matrix, and the E2E suites now run on PRs targeting `dev`. The design is shaped by one constraint: **"Test and build" is a required status check**, so it can never be skipped at the trigger level (a skipped required check strands the PR on "Expected — waiting for status" forever). Instead it self-gates: a `paths-filter` step classifies the PR, and heavy steps short-circuit on docs-only changes while the job still reports success in seconds.

Part of #478 (items 7+8; item 9, the coverage gate, comes separately — it needs a baseline measurement to set honest thresholds).

## What changed

| File | Change |
|------|--------|
| `.github/workflows/cloudflare-pages.yml` | `Test and build` gains a `Detect non-documentation changes` paths-filter step (PR events only); every heavy step gated by `github.event_name != 'pull_request' \|\| code == 'true'` — pushes and dispatch keep byte-identical behavior. The `code` filter is an explicit **allowlist** of code roots, deliberately including `docs/api-spec.yaml` (the OpenAPI contract lives under `docs/` but is validated by this very job). |
| `.github/workflows/quality.yml` | Trigger-level docs skip via ordered `paths` negations — with `docs/api-spec.yaml` re-included, since this workflow's "OpenAPI Validation" job exists precisely for spec changes. |
| `.github/workflows/codeql.yml` | `paths-ignore: docs/**, **.md` on push + PR (non-required check; CodeQL has nothing to analyze in Markdown). Weekly cron unaffected. |
| `.github/workflows/e2e-tests.yml`, `e2e-a11y-visual.yml` | `on.pull_request.branches: [main]` → `[main, dev]`. |

## Security / correctness notes

- **Deploy pipeline unreachable from this change:** `should_deploy` is always `'false'` for `pull_request` events, and on pushes every gated step's condition is unconditionally true — the `ci` job behaves byte-for-byte as before and still produces the `frontend-dist` artifact deploys need.
- **Why an allowlist, not `!docs/**` negation:** a denylist would classify a `docs/api-spec.yaml`-only edit as docs-only and skip the exact validation built to catch spec drift. Config files that alter job behavior (`vitest.config.js`, `eslint.config.js`, `.npmrc`, lockfiles, `wrangler.toml`) are on the list for the same reason.
- Full five-scenario logic table (docs-only PR / code PR / push / dev PR / dispatch, per workflow) was derived from the committed YAML during review — required check reports in every scenario.

## Verification

- [x] `actionlint` (dockerized): zero new findings (3 pre-existing SC2086 infos in untouched zap-baseline.yml)
- [x] YAML parse: all five touched files clean
- [x] This PR is itself the `.github/**` case: it must run the FULL matrix (`.github/**` is on the code allowlist) — green checks here prove the gating doesn't misfire on CI changes
- [ ] Tests / ESLint / build: N/A — workflow YAML only
- [ ] Docs-only behavior: verify on the next docs PR (#513 is queued) — expected: Test and build green in seconds, quality/codeql absent

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
