### PR TITLE
docs: freshness pass — Vol-17 stamps and ADR-0004 Lucia note (#418)

### DIFF
--- a/docs/ADMIN_HANDBOOK.md
+++ b/docs/ADMIN_HANDBOOK.md
@@ -680,7 +680,7 @@ wrangler d1 execute settimes-production-db --command="EXPLAIN QUERY PLAN <your_q
 
 ```javascript
 // In functions/api/_middleware.js
-console.log('[DEBUG]', { user, action, details });
+console.log("[DEBUG]", { user, action, details });
 ```
 
 **View Debug Logs:**
@@ -780,7 +780,7 @@ ENVIRONMENT = "development"
 ---
 
 **Version**: 1.0
-**Last Updated**: November 2025
+**Last Updated**: 2026-07-04
 **For**: SetTimes.ca Platform
 
 ---

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -53,10 +53,10 @@ Before you start, make sure you have:
 **Example:**
 
 ```text
-Event Name: Long Weekend Band Crawl Vol. 16
-Date: May 16, 2026
-Slug: lwbc16
-Description: Annual music crawl featuring 20+ bands across downtown
+Event Name: Long Weekend Band Crawl Vol. 17
+Date: August 2, 2026
+Slug: lwbc17
+Description: Annual music crawl featuring 22 bands across 6 venues in downtown Waterloo
 ```
 
 3. Click **"Next"** to continue
@@ -68,7 +68,7 @@ Description: Annual music crawl featuring 20+ bands across downtown
 For each performance location:
 
 1. Enter the **venue name**
-   - Example: "The Analog Cafe"
+   - Example: "Blue Room"
 2. Enter the **address** (optional but recommended)
    - Example: "123 Main Street, City, Province"
 3. Click **"Add Venue"**
@@ -79,9 +79,9 @@ For each performance location:
 
 **Example Venues:**
 
-- The Analog Cafe - 123 Main St
-- Black Cat Tavern - 456 Queen St
-- Velvet Underground - 789 King St
+- Blue Room - 28 King St N, Waterloo
+- Princess Cafe - 46 King St N, Waterloo
+- Room 47 - 47 King St N, Waterloo
 
 ---
 
@@ -106,17 +106,17 @@ Repeat for all bands
 
 ```
 Band: The Sunset Trio
-Venue: The Analog Cafe
+Venue: Blue Room
 Start: 7:00 PM
 End: 8:00 PM
 
 Band: Electric Dreams
-Venue: The Analog Cafe
+Venue: Blue Room
 Start: 8:30 PM
 End: 9:30 PM
 
 Band: Northern Lights
-Venue: Black Cat Tavern
+Venue: Princess Cafe
 Start: 7:00 PM
 End: 8:00 PM
 ```
@@ -383,7 +383,7 @@ Events tab → Find event → Edit → Uncheck "Published" → Save
 ---
 
 **Version:** 1.0
-**Last Updated:** November 2025
+**Last Updated:** 2026-07-04
 **For:** SetTimes Platform (settimes.ca)
 
 ---

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -667,7 +667,7 @@ SetTimes uses industry-standard security:
 - **CSRF protection** on all state-changing requests
 - **Role-based access control** (only editors/admins can modify data)
 - **Audit logging** tracks all important actions
-- **Regular security audits** (latest: November 2025 - Rating A)
+- **Regular security audits** — see `docs/code-review/` for the review history
 
 ### Best Practices
 
@@ -722,7 +722,7 @@ A: Database export tools are available to administrators. Contact support for as
 ---
 
 **Version:** 2.0
-**Last Updated:** November 2025
+**Last Updated:** 2026-07-04
 **For:** SetTimes Platform (settimes.ca)
 
 ---

--- a/docs/adr/0004-sqlite-datetime-format.md
+++ b/docs/adr/0004-sqlite-datetime-format.md
@@ -12,6 +12,11 @@ superseded_by: ""
 
 Accepted
 
+_Superseded context: Lucia was removed entirely in PR #290. The `lucia_sessions` table name is
+retained for historical/compatibility reasons but is now managed by the direct D1 session manager
+in `functions/utils/auth.js`, not by Lucia. The INTEGER Unix-epoch `expires_at` invariant described
+below still holds exactly as written._
+
 ## Context
 
 SetTimes uses Cloudflare D1 as its primary database. D1 is SQLite-compatible, and SQLite TEXT comparisons are strictly lexicographic — they compare strings character-by-character using ASCII values.
@@ -21,7 +26,7 @@ Two incompatible datetime string formats are in play:
 - **D1 native format**: `datetime('now')` returns `YYYY-MM-DD HH:MM:SS` (space separator, no timezone suffix).
 - **JavaScript native format**: `new Date().toISOString()` returns `YYYY-MM-DDThh:mm:ssZ` (T separator, Z suffix).
 
-The ASCII value of `T` (84) is greater than the ASCII value of space (32). This means that at any given instant, the T-separated ISO 8601 representation of a datetime sorts lexicographically *higher* than the equivalent space-separated SQLite representation of the same instant:
+The ASCII value of `T` (84) is greater than the ASCII value of space (32). This means that at any given instant, the T-separated ISO 8601 representation of a datetime sorts lexicographically _higher_ than the equivalent space-separated SQLite representation of the same instant:
 
 ```
 "2026-05-14 12:00:00"  <  "2026-05-14T12:00:00Z"
@@ -38,7 +43,7 @@ A secondary complexity exists with the `lucia_sessions` table, which stores `exp
 All datetime values written to D1 TEXT columns must be normalized to space-separated SQLite format before storage using the pattern:
 
 ```js
-new Date(Date.now() + ms).toISOString().replace("T", " ").slice(0, 19)
+new Date(Date.now() + ms).toISOString().replace("T", " ").slice(0, 19);
 ```
 
 A reusable helper `toSqliteDateTime(date)` is defined in `functions/utils/authAttempts.js` (line 55). New code that stores datetimes in D1 TEXT columns must use `toSqliteDateTime()` or the equivalent inline pattern. ISO 8601 strings from JavaScript must never be stored directly in D1 TEXT columns.


### PR DESCRIPTION
## Summary

Documentation freshness pass from the 2026-06-26 review. Two clearly-scoped parts (the third — labeling `docs/code-review/` — was **dropped**: that directory is deliberately gitignored as "Confidential local data", so per owner decision it stays fully untracked, no README, `.gitignore` unchanged).

Closes #418

## What changed

| File | Change |
|------|--------|
| `docs/QUICK_START.md` | Vol. 16 → **Vol. 17 / Aug 2 2026**; fictional venues → real King St N canon (Blue Room, Princess Cafe, Room 47, real addresses from `migrations/0044`); slug `lwbc16`→`lwbc17`; footer stamp → 2026-07-04. Every `Vol. 16` / `May 16` / `November 2025` occurrence swept, not just the cited lines. |
| `docs/ADMIN_HANDBOOK.md`, `docs/USER_GUIDE.md` | "November 2025" stamps → 2026-07-04; the hard-coded "latest audit: November 2025 - Rating A" claim replaced with a neutral pointer to the review history (no invented rating). |
| `docs/adr/0004-sqlite-datetime-format.md` | Added an italicized *Superseded context:* note after Status — Lucia removed in #290, `lucia_sessions` name retained/now managed by the direct D1 session manager, INTEGER Unix-epoch invariant unchanged. ADR body untouched (historical record). |

## Security / correctness notes

None — docs only. Note: `.gitignore` is deliberately **not** touched; the confidential `code-review/` archive remains fully untracked (I verified a would-be un-ignore exposed only a README, but the owner opted to keep the directory entirely confidential).

## Verification

- [x] `npx prettier --check` on all 4 changed files: clean
- [x] Grep sweep: no `Vol. 16` / `May 16` / `November 2025` left in the touched files
- [ ] Tests/lint/build: N/A — Markdown only
- [x] Docs-only PR: exercises the #517 gate (Test-and-build fast, quality/codeql skipped)

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
