### PR TITLE
feat(content): add About and Contact pages (#460, #461)

### DIFF
--- a/frontend/public/_routes.json
+++ b/frontend/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "include": ["/api/*", "/s/*", "/sitemap.xml", "/event/*", "/band/*", "/venue/*"],
-  "exclude": ["/", "/admin/*", "/privacy", "/terms", "/assets/*", "/favicon.ico", "/favicon.svg", "/favicon-*.png", "/apple-touch-icon.png", "/android-chrome-*.png", "/manifest.json", "/robots.txt", "/sw.js", "/offline.html"]
+  "exclude": ["/", "/admin/*", "/privacy", "/terms", "/about", "/contact", "/assets/*", "/favicon.ico", "/favicon.svg", "/favicon-*.png", "/apple-touch-icon.png", "/android-chrome-*.png", "/manifest.json", "/robots.txt", "/sw.js", "/offline.html"]
 }

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -15,6 +15,12 @@ function Footer() {
                 All Events
               </Link>
             )}
+            <Link to="/about" className="text-text-tertiary hover:text-accent-400 transition-colors">
+              About
+            </Link>
+            <Link to="/contact" className="text-text-tertiary hover:text-accent-400 transition-colors">
+              Contact
+            </Link>
             <Link to="/privacy" className="text-text-tertiary hover:text-accent-400 transition-colors">
               Privacy Policy
             </Link>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -11,6 +11,8 @@ import ResetPasswordPage from './pages/ResetPasswordPage.jsx'
 import ActivatePage from './pages/ActivatePage.jsx'
 import PrivacyPage from './pages/PrivacyPage.jsx'
 import TermsPage from './pages/TermsPage.jsx'
+import AboutPage from './pages/AboutPage.jsx'
+import ContactPage from './pages/ContactPage.jsx'
 import NotFoundPage from './pages/NotFoundPage.jsx'
 import ErrorBoundary from './components/ErrorBoundary.jsx'
 import { measurePageLoad } from './utils/performance'
@@ -88,6 +90,8 @@ ReactDOM.createRoot(document.getElementById('root')).render(
               <Route path="/activate" element={<ActivatePage />} />
               <Route path="/privacy" element={<PrivacyPage />} />
               <Route path="/terms" element={<TermsPage />} />
+              <Route path="/about" element={<AboutPage />} />
+              <Route path="/contact" element={<ContactPage />} />
 
               {/* Event recap: Lazy loaded */}
               <Route

--- a/frontend/src/pages/AboutPage.jsx
+++ b/frontend/src/pages/AboutPage.jsx
@@ -1,0 +1,109 @@
+import { useEffect } from 'react'
+import { Helmet } from 'react-helmet-async'
+import { Link } from 'react-router-dom'
+
+export default function AboutPage() {
+  // react-helmet-async does not reliably set document.title in React 19 — set it
+  // directly to match the <Helmet> title below. See BandProfilePage.jsx.
+  useEffect(() => {
+    document.title = 'About | SetTimes'
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple">
+      <Helmet>
+        <title>About | SetTimes</title>
+        <meta
+          name="description"
+          content="A free, community-run live-music schedule tool for Waterloo Region, Ontario. Plan your night across venues and discover local artists with SetTimes."
+        />
+        <link rel="canonical" href="https://settimes.ca/about" />
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'Organization',
+            name: 'SetTimes',
+            url: 'https://settimes.ca',
+            areaServed: 'Waterloo Region, Ontario',
+            email: 'hello@settimes.ca',
+          })}
+        </script>
+      </Helmet>
+
+      <main id="main-content" tabIndex={-1} className="container mx-auto px-4 max-w-2xl py-12">
+        <div className="mb-8">
+          <Link to="/" className="text-accent-400 hover:text-accent-500 text-sm transition-colors">
+            ← Back to SetTimes
+          </Link>
+        </div>
+
+        <h1 className="text-text-primary text-3xl font-bold mb-10">About SetTimes</h1>
+
+        <div className="space-y-8 text-text-secondary leading-relaxed">
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">What SetTimes is</h2>
+            <p>
+              SetTimes (settimes.ca) is a free, community-run live-music event-schedule tool for{' '}
+              <strong className="text-text-secondary">Waterloo Region, Ontario</strong>. We bring together lineups, set
+              times, and venue details from multiple stages into one place, so you don&apos;t have to piece together a
+              night out from a dozen Instagram posts.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Why we exist</h2>
+            <p>
+              Waterloo Region has a real live-music scene — but on a night with several venues running lineups at once,
+              it&apos;s easy to miss a band you&apos;d love or double-book yourself into two overlapping sets. SetTimes
+              exists to make it simple to plan your night across multiple venues and discover local artists you might
+              not have found otherwise.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">How it works — for fans</h2>
+            <p>
+              Browse the full lineup for an event, then build your own personal route by picking the bands you want to
+              catch — and share that route with friends. Follow your favourite bands to get an email alert when their
+              next set time is announced, so you never have to keep checking back.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">How it works — for organizers &amp; venues</h2>
+            <p>
+              If you&apos;re a venue, promoter, or organizer running a multi-venue event in Waterloo Region and want
+              your lineup listed on SetTimes, we&apos;d love to hear from you. Get in touch on our{' '}
+              <Link to="/contact" className="text-accent-400 hover:text-accent-500 transition-colors">
+                Contact page
+              </Link>
+              .
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">The flagship</h2>
+            <p>
+              Our flagship event is the Long Weekend Band Crawl, now in its 17th edition. Vol. 17 takes place{' '}
+              <strong className="text-text-secondary">August 2, 2026</strong>, with 22 bands across 6 venues on King St
+              N in Waterloo — Blue Room, Princess Cafe, Prohibition Warehouse, Revive Karaoke, Room 47, and Roost. Doors
+              at 6:30 PM, first sets at 6:45 PM. Ages 19+.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Community-run</h2>
+            <p>
+              SetTimes is built and maintained for Waterloo Region, not by a company. Questions, feedback, or want to
+              get involved? Email us at{' '}
+              <a href="mailto:hello@settimes.ca" className="text-accent-400 hover:text-accent-500 transition-colors">
+                hello@settimes.ca
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/ContactPage.jsx
+++ b/frontend/src/pages/ContactPage.jsx
@@ -1,0 +1,103 @@
+import { useEffect } from 'react'
+import { Helmet } from 'react-helmet-async'
+import { Link } from 'react-router-dom'
+
+export default function ContactPage() {
+  // react-helmet-async does not reliably set document.title in React 19 — set it
+  // directly to match the <Helmet> title below. See BandProfilePage.jsx.
+  useEffect(() => {
+    document.title = 'Contact | SetTimes'
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-linear-to-br from-bg-navy to-bg-purple">
+      <Helmet>
+        <title>Contact | SetTimes</title>
+        <meta
+          name="description"
+          content="Contact SetTimes — get your band or event listed, request a correction or takedown, or reach out for press and general inquiries."
+        />
+        <link rel="canonical" href="https://settimes.ca/contact" />
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'ContactPage',
+            name: 'Contact SetTimes',
+            url: 'https://settimes.ca/contact',
+          })}
+        </script>
+      </Helmet>
+
+      <main id="main-content" tabIndex={-1} className="container mx-auto px-4 max-w-2xl py-12">
+        <div className="mb-8">
+          <Link to="/" className="text-accent-400 hover:text-accent-500 text-sm transition-colors">
+            ← Back to SetTimes
+          </Link>
+        </div>
+
+        <h1 className="text-text-primary text-3xl font-bold mb-10">Contact</h1>
+
+        <div className="space-y-8 text-text-secondary leading-relaxed">
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Get in touch</h2>
+            <p>
+              The best way to reach SetTimes is by email:{' '}
+              <a href="mailto:hello@settimes.ca" className="text-accent-400 hover:text-accent-500 transition-colors">
+                hello@settimes.ca
+              </a>
+              . We&apos;re a small, community-run team based in Waterloo Region, and we read every message.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Get your band or event listed</h2>
+            <p>
+              Running a show, booking a lineup, or organizing a multi-venue event in Waterloo Region? We&apos;d love to
+              add you to SetTimes. Email us your event details — dates, venues, and lineup — and we&apos;ll get you set
+              up.
+            </p>
+            <p className="mt-3">
+              <a
+                href="mailto:hello@settimes.ca?subject=Get%20listed"
+                className="text-accent-400 hover:text-accent-500 transition-colors"
+              >
+                Email us to get listed →
+              </a>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Corrections &amp; takedowns</h2>
+            <p>
+              If something on SetTimes is inaccurate, out of date, or you believe it infringes your rights, let us know
+              and we&apos;ll review it promptly — correcting or removing content where appropriate (see our{' '}
+              <Link to="/terms" className="text-accent-400 hover:text-accent-500 transition-colors">
+                Terms of Service
+              </Link>
+              , §4).
+            </p>
+            <p className="mt-3">
+              <a
+                href="mailto:hello@settimes.ca?subject=Takedown%2Fcorrection"
+                className="text-accent-400 hover:text-accent-500 transition-colors"
+              >
+                Email a correction or takedown request →
+              </a>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Press &amp; general</h2>
+            <p>
+              For press inquiries, partnership ideas, or anything else, reach out at{' '}
+              <a href="mailto:hello@settimes.ca" className="text-accent-400 hover:text-accent-500 transition-colors">
+                hello@settimes.ca
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds two email-first public content pages — **About** (#460) and **Contact** (#461) — cloning the existing legal-page template. Both are trust + SEO wins ahead of Vol-17: the About page gives search engines local-relevance / E-E-A-T context, and the Contact page opens a real "get your band listed" inbound path (currently `hello@settimes.ca` is only surfaced on the legal pages).

Closes #460
Closes #461

## What changed

| File | Change |
|------|--------|
| `frontend/src/pages/AboutPage.jsx` | New. What SetTimes is / why it exists / how it works (fans + organizers) / the flagship (Vol.17) / community-run. `Organization` JSON-LD, canonical, Helmet + `document.title`. |
| `frontend/src/pages/ContactPage.jsx` | New. Email-first (no form — v2): get in touch, get listed, corrections & takedowns (→ Terms §4), press. `ContactPage` JSON-LD. |
| `frontend/src/main.jsx` | `/about` + `/contact` routes (static imports, matching `/privacy`/`/terms`). |
| `frontend/src/components/Footer.jsx` | About + Contact footer links (existing link styling). |
| `frontend/public/_routes.json` | `/about`, `/contact` added to the SPA `exclude` list. |

## Security / correctness notes

Pure frontend content — no backend, no form (a real contact form is deferred to v2: it would need a Functions endpoint + Turnstile + rate-limiting; `mailto:` suffices now). Theme tokens only (no hardcoded white — verified by grep). JSON-LD uses the same Helmet pattern as the existing BandProfilePage, so it's CSP-compatible. Both pages wrap content in `<main id="main-content">` so the global skip-link works (an a11y gap the older Privacy/Terms pages still have — tracked as a follow-up).

## Verification

- [x] Vera (code-reviewer) pass: no blockers; routing, footer, SEO, theming, content accuracy (Vol.17 canon exact) all verified; nits (skip-link landmark, "17th edition" phrasing) applied
- [x] Tests: 269 frontend pass; ESLint 0 errors; format clean; build green
- [x] Theme-token grep on both pages: empty
- [x] No Ottawa references; Waterloo Region throughout
- [ ] Manual smoke: routes resolve via SPA fallback (verified by build + route registration; live-click after deploy)

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
