### PR TITLE
docs(content): make the About flagship section evergreen

### DIFF
--- a/frontend/src/pages/AboutPage.jsx
+++ b/frontend/src/pages/AboutPage.jsx
@@ -82,12 +82,18 @@ export default function AboutPage() {
           </section>
 
           <section>
-            <h2 className="text-text-primary text-lg font-semibold mb-3">The flagship</h2>
+            <h2 className="text-text-primary text-lg font-semibold mb-3">Where we started</h2>
             <p>
-              Our flagship event is the Long Weekend Band Crawl, now in its 17th edition. Vol. 17 takes place{' '}
-              <strong className="text-text-secondary">August 2, 2026</strong>, with 22 bands across 6 venues on King St
-              N in Waterloo — Blue Room, Princess Cafe, Prohibition Warehouse, Revive Karaoke, Room 47, and Roost. Doors
-              at 6:30 PM, first sets at 6:45 PM. Ages 19+.
+              SetTimes was originally built to power the{' '}
+              <strong className="text-text-secondary">Long Weekend Band Crawl</strong> — a one-night, multi-venue
+              live-music event in Waterloo Region where bands play back-to-back across a cluster of nearby venues. That
+              crawl is still our flagship, and it&apos;s what shaped everything here: plan a route across venues, catch
+              the sets you want, and don&apos;t miss a band. For the current edition&apos;s date and full lineup, head
+              to the{' '}
+              <Link to="/" className="text-accent-400 hover:text-accent-500 transition-colors">
+                schedule
+              </Link>
+              .
             </p>
           </section>
 


### PR DESCRIPTION
## Summary

Makes the About page's flagship section **evergreen**. The previous paragraph hardcoded the volume (Vol. 17), date (Aug 2 2026), band count (22), the six venue names, and doors/show times — all of which change every edition and would need manual updates multiple times a year. It's rewritten as an origin story that doesn't go stale, and points to the live schedule for current-edition details instead of duplicating them.

Requested by the owner.

## What changed

`frontend/src/pages/AboutPage.jsx` — the "The flagship" section (now "Where we started"):
- **Before:** "…now in its 17th edition. Vol. 17 takes place August 2, 2026, with 22 bands across 6 venues on King St N… Blue Room, Princess Cafe, … Doors at 6:30 PM…"
- **After:** "SetTimes was originally built to power the Long Weekend Band Crawl — a one-night, multi-venue live-music event in Waterloo Region… That crawl is still our flagship… For the current edition's date and full lineup, head to the [schedule](/)."

Single source of truth for edition details stays the event pages; the About prose no longer duplicates (and can no longer contradict) them.

## Security / correctness notes

None — copy-only change on an existing public page. Theme tokens unchanged (no hardcoded white); `<main>` landmark and SEO/JSON-LD untouched.

## Verification

- [x] ESLint 0 errors; build green; theme-token grep clean
- [ ] Tests: no test asserts this copy; render tests unaffected
- [x] Reads correctly on all themes (semantic tokens only)

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
