### PR TITLE
a11y(pages): add #main-content landmark to Privacy and Terms pages (#527)

### DIFF
--- a/frontend/src/pages/PrivacyPage.jsx
+++ b/frontend/src/pages/PrivacyPage.jsx
@@ -18,7 +18,7 @@ export default function PrivacyPage() {
         <link rel="canonical" href="https://settimes.ca/privacy" />
       </Helmet>
 
-      <div className="container mx-auto px-4 max-w-2xl py-12 legal-document">
+      <main id="main-content" tabIndex={-1} className="container mx-auto px-4 max-w-2xl py-12 legal-document">
         <div className="no-print mb-8 flex items-center justify-between gap-3">
           <Link to="/" className="text-accent-400 hover:text-accent-500 text-sm transition-colors">
             ← Back to SetTimes
@@ -213,7 +213,7 @@ export default function PrivacyPage() {
             </p>
           </section>
         </div>
-      </div>
+      </main>
     </div>
   )
 }

--- a/frontend/src/pages/TermsPage.jsx
+++ b/frontend/src/pages/TermsPage.jsx
@@ -21,7 +21,7 @@ export default function TermsPage() {
         <link rel="canonical" href="https://settimes.ca/terms" />
       </Helmet>
 
-      <div className="container mx-auto px-4 max-w-2xl py-12 legal-document">
+      <main id="main-content" tabIndex={-1} className="container mx-auto px-4 max-w-2xl py-12 legal-document">
         <div className="no-print mb-8 flex items-center justify-between gap-3">
           <Link to="/" className="text-accent-400 hover:text-accent-500 text-sm transition-colors">
             ← Back to SetTimes
@@ -238,7 +238,7 @@ export default function TermsPage() {
             </p>
           </section>
         </div>
-      </div>
+      </main>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Wraps the content container in `<main id="main-content" tabIndex={-1}>` on the Privacy and Terms pages, so the global skip link (which targets `#main-content`) actually resolves — it was a no-op on these two pages — and the pages expose a `<main>` landmark. Matches About/Contact and the rest of the app.

Closes #527

## What changed
`frontend/src/pages/PrivacyPage.jsx` and `TermsPage.jsx`: the content-container `<div>` → `<main id="main-content" tabIndex={-1}>` (same classes). Nothing else touched.

## Security / correctness notes
None — a11y-only markup change on existing public pages. No text, classes, or logic changed.

## Verification
- [x] ESLint 0 errors; build green; 272 frontend tests pass
- [x] `<main>`/`</main>` balanced in both files

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)