### PR TITLE
seo: site-wide Organization/WebSite JSON-LD + list content pages in sitemap

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,30 @@
     <meta name="twitter:title" content="SetTimes – Live Music Events & Show Schedules" />
     <meta name="twitter:description" content="Discover upcoming live music events and build your personalized show schedule." />
 
+    <!-- Site-wide structured data (JSON-LD data blocks — not executable, so no CSP hash needed).
+         Lives in the SPA shell so every route carries Organization + WebSite; SSR routes
+         (event/band/venue) add their own MusicEvent/MusicGroup/MusicVenue on top. -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "SetTimes",
+        "url": "https://settimes.ca",
+        "logo": "https://settimes.ca/apple-touch-icon.png",
+        "email": "hello@settimes.ca",
+        "areaServed": "Waterloo Region, Ontario",
+        "description": "A free, community-run live-music event-schedule tool for Waterloo Region, Ontario."
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "SetTimes",
+        "url": "https://settimes.ca"
+      }
+    </script>
+
     <!-- Favicon: ICO first for Safari desktop fallback, then SVG for modern browsers, then PNGs -->
     <link rel="icon" href="/favicon.ico" sizes="32x32 16x16" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -47,6 +47,31 @@ export async function onRequestGet(context) {
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>`,
+      `  <url>
+    <loc>https://settimes.ca/about</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>`,
+      `  <url>
+    <loc>https://settimes.ca/contact</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>`,
+      `  <url>
+    <loc>https://settimes.ca/stats</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.4</priority>
+  </url>`,
+      `  <url>
+    <loc>https://settimes.ca/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>`,
+      `  <url>
+    <loc>https://settimes.ca/terms</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>`,
     ];
 
     for (const event of events) {


### PR DESCRIPTION
## Summary
Proactive SEO/discoverability pass on the public surface ahead of Vol-17 (local discovery is how fans find the event). An audit found the detail pages are well-covered (MusicEvent+offers, MusicGroup, MusicVenue+GeoCoordinates, BreadcrumbList — all SSR-injected), but two real gaps: the homepage/SPA shell had **no structured data at all**, and the new content pages weren't in the sitemap.

## What changed

| File | Change |
|------|--------|
| `frontend/index.html` | Adds **Organization** + **WebSite** JSON-LD. Placed in the SPA shell so it's site-wide — every route carries it, and the SSR routes (event/band/venue) stack their specific-entity schema on top (Google's recommended Organization + entity pattern). |
| `functions/sitemap.xml.js` | Adds `/about`, `/contact`, `/stats` (+ `/privacy`, `/terms` at low priority) to the sitemap. About was built as an SEO/E-E-A-T surface (#460) but wasn't crawlable. |

**Deliberately not fabricated:** no `SearchAction`/sitelinks-searchbox (there's no search endpoint to point it at), no `Organization.sameAs` (the only social link in the repo is a band's Instagram, not a verified SetTimes account). Better to omit than assert something false to Google.

## Security / correctness notes
- JSON-LD is a **non-executable data block**, so it is not governed by `script-src` and needs no CSP hash — consistent with the SSR pages, which already inject these blocks in production. The hash-protected theme-flash script is untouched (verified its line is intact and the built `dist/index.html` still contains it).
- Both JSON-LD blocks validated as parseable JSON; built `dist/index.html` confirmed to contain Organization + WebSite.

## Verification
- [x] JSON-LD parses valid (Organization, WebSite); present in built `dist/index.html`
- [x] Sitemap emits the 5 new URLs
- [x] Backend lint 0 errors; frontend build green; format clean
- [x] Theme-flash CSP hash unaffected (script unchanged)
- [ ] Post-deploy: validate with Google Rich Results Test on the live homepage

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)