### PR TITLE
security(ci): gitleaks-ignore the OWASP-doc example key (false positive)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -9,3 +9,9 @@
 # docs/API_DOCUMENTATION.md contains a placeholder curl example with a fictional
 # session_token value — not a real credential.
 05735d9da9763dd7d509dd75605844da7c787e3d:docs/API_DOCUMENTATION.md:curl-auth-header:150
+
+# .github/instructions/security-and-owasp.instructions.md line 412 is a security
+# guidance "// BAD" example — const API_KEY = 'hardcoded-example-key-never-do-this'
+# (literally that placeholder string, not a real key). The stripe-access-token
+# rule matches its shape. The scheduled full-history scan flags it; suppress it.
+d309339626793c926544a15d8a3932882e1b5b16:.github/instructions/security-and-owasp.instructions.md:stripe-access-token:412


### PR DESCRIPTION
## Summary
The scheduled full-history secret scan ([run 28775417974](https://github.com/BreakableHoodie/settimesdotca/actions/runs/28775417974)) failed on `main` with one gitleaks finding — a **false positive**.

`.github/instructions/security-and-owasp.instructions.md:412` is a security-guidance "// BAD" example:
```
const API_KEY = 'hardcoded-example-key-never-do-this'; // placeholder, not a real key
```
Not a real key — but gitleaks' `stripe-access-token` rule matches its shape. PR-time scans only see the diff, so it slipped in on 2026-07-02; the scheduled scan checks full history and catches it.

## What changed
Adds the finding's fingerprint to `.gitleaksignore`, matching the two existing doc-example entries there. History can't be edited without a rewrite, so fingerprint-suppression is the established pattern for these.

## Security / correctness notes
Verified the flagged value is the literal placeholder string `hardcoded-example-key-never-do-this` in an anti-pattern teaching example — not a credential. No real secret is or was exposed.

## Verification
- [x] Confirmed the source line is an illustrative example, not a real key
- [x] Fingerprint matches the scan output exactly
- [ ] Scheduled secret scan green on next run (or re-run after merge)

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)