### PR TITLE
feat(multiday): day-aware time model — grouping + conflict detection (#538)

### DIFF
--- a/frontend/src/admin/utils/__tests__/timeUtils.test.js
+++ b/frontend/src/admin/utils/__tests__/timeUtils.test.js
@@ -155,3 +155,55 @@ describe('detectConflicts — requires event_id on candidate', () => {
     expect(noIssues(detectConflicts(noEventId, [other]))).toBe(true)
   })
 })
+
+// ─── detectConflicts — festival-day scoping (#538) ──────────────────────────
+
+describe('detectConflicts — festival-day scoping (#538)', () => {
+  const dayBand = (id, start, end, performanceDate) => ({ ...band(id, start, end), performance_date: performanceDate })
+
+  it('does not conflict across different festival days even with identical clock times', () => {
+    const day1 = dayBand(1, '20:00', '23:00', '2026-08-02')
+    const day2 = dayBand(2, '20:00', '23:00', '2026-08-03')
+    expect(noIssues(detectConflicts(day1, [day1, day2]))).toBe(true)
+  })
+
+  it('does not conflict across different festival days for after-midnight sets', () => {
+    const day1Late = dayBand(1, '01:00', '02:00', '2026-08-02')
+    const day2Late = dayBand(2, '01:00', '02:00', '2026-08-03')
+    expect(noIssues(detectConflicts(day1Late, [day1Late, day2Late]))).toBe(true)
+  })
+
+  it('still flags a genuine overlap on the same festival day', () => {
+    const setA = dayBand(1, '20:00', '22:00', '2026-08-02')
+    const setB = dayBand(2, '21:00', '23:00', '2026-08-02')
+    const result = detectConflicts(setA, [setA, setB])
+    expect(result.overlaps).toEqual(['Band 2'])
+    expect(result.conflicts).toHaveLength(0)
+  })
+
+  it('still flags a genuine exact conflict on the same festival day', () => {
+    const setA = dayBand(1, '20:00', '22:00', '2026-08-02')
+    const setB = dayBand(2, '20:00', '22:00', '2026-08-02')
+    const result = detectConflicts(setA, [setA, setB])
+    expect(result.conflicts).toEqual(['Band 2'])
+    expect(result.overlaps).toHaveLength(0)
+  })
+
+  it('falls back to the supplied event date when performance_date is absent on one side', () => {
+    // `explicit` is pinned to Day 2; `implicit` has no performance_date, so it
+    // falls back to the eventDate argument (Day 1) — the two are on different
+    // festival days and must not conflict despite overlapping clock times.
+    const explicit = dayBand(1, '20:00', '22:00', '2026-08-03')
+    const implicit = band(2, '20:00', '22:00')
+    const result = detectConflicts(explicit, [explicit, implicit], '2026-08-02')
+    expect(noIssues(result)).toBe(true)
+  })
+
+  it('single-day invariant: with performance_date absent everywhere and no eventDate, behaves exactly as before', () => {
+    const setA = band(1, '20:00', '22:00')
+    const setB = band(2, '20:00', '22:00')
+    const result = detectConflicts(setA, [setA, setB])
+    expect(result.conflicts).toEqual(['Band 2'])
+    expect(result.overlaps).toHaveLength(0)
+  })
+})

--- a/frontend/src/admin/utils/timeUtils.js
+++ b/frontend/src/admin/utils/timeUtils.js
@@ -102,9 +102,25 @@ export const deriveDurationMinutes = (startTime, endTime) => {
 
 const intervalsOverlap = (intervalA, intervalB) => intervalA[0] < intervalB[1] && intervalB[0] < intervalA[1]
 
+// The festival day a performance belongs to: its own performance_date if set,
+// else the fallback event date supplied by the caller. Returns null when
+// neither is available, which — critically — makes the day-scope check below
+// a no-op (see detectConflicts).
+const resolveFestivalDay = (performance, eventDate) => performance?.performance_date || eventDate || null
+
 // Returns { overlaps: string[], conflicts: string[] }
 // conflicts = exact same start AND end time; overlaps = any other time intersection
-export const detectConflicts = (candidateBand, bands) => {
+//
+// `eventDate` is an optional fallback festival day (typically the event's own
+// `date`) used for performances whose `performance_date` is NULL — i.e. every
+// row today, since performance_date is a brand-new nullable column (#537).
+// Two performances scoped to different festival days can never conflict, no
+// matter how their clock times compare (a Day-1 8 PM set and a Day-2 8 PM set
+// are not the same slot). When neither side has day info (no performance_date
+// on either performance AND no eventDate passed — today's single-day call
+// sites), resolveFestivalDay returns null for both and the day-scope check
+// short-circuits, leaving behavior byte-identical to before #538.
+export const detectConflicts = (candidateBand, bands, eventDate = null) => {
   const empty = { overlaps: [], conflicts: [] }
   if (!candidateBand || !bands?.length) return empty
 
@@ -114,6 +130,8 @@ export const detectConflicts = (candidateBand, bands) => {
   const bandIntervals = buildTimeIntervals(startTime, endTime)
   if (!bandIntervals.length) return empty
 
+  const candidateDay = resolveFestivalDay(candidateBand, eventDate)
+
   const overlaps = []
   const conflicts = []
 
@@ -122,6 +140,9 @@ export const detectConflicts = (candidateBand, bands) => {
     if (id != null && other.id === id) continue
     if (!other.event_id || !other.venue_id) continue
     if (Number(other.event_id) !== Number(eventId) || Number(other.venue_id) !== Number(venueId)) continue
+
+    const otherDay = resolveFestivalDay(other, eventDate)
+    if (candidateDay && otherDay && candidateDay !== otherDay) continue
 
     const otherIntervals = buildTimeIntervals(other.start_time, other.end_time)
     if (!otherIntervals.some(b => bandIntervals.some(a => intervalsOverlap(a, b)))) continue

--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -8,17 +8,27 @@ import BandCard from './BandCard'
 const UNSCHEDULED = Symbol('unscheduled')
 const UNSCHEDULED_FILTER_VALUE = '__unscheduled__'
 
-function groupByTime(bands) {
+// Groups by (festival day, clock time) rather than bare clock time. `band.date`
+// is already the set's festival day (see AFTER_MIDNIGHT_THRESHOLD_HOUR /
+// prepareBands in bandUtils.js — after-midnight sets keep their *previous*
+// evening's date). Without the day component, two sets at the same clock time
+// on different festival days (e.g. both nights' 8 PM slot) would collapse into
+// one bucket (#538). In the single-day case `date` is constant across every
+// band, so the key degenerates to the old bare-time key and grouping is
+// byte-identical to before.
+export function groupByTime(bands) {
   const timeGroups = new Map()
   const grouped = []
   bands.forEach(band => {
     const slot = !band.startTime || band.startTime === 'TBD' ? 'TBD' : band.startTime
-    if (!timeGroups.has(slot)) {
-      const group = { time: slot, bands: [] }
-      timeGroups.set(slot, group)
+    const day = band.date ?? ''
+    const key = `${day}|${slot}`
+    if (!timeGroups.has(key)) {
+      const group = { time: slot, date: band.date, bands: [] }
+      timeGroups.set(key, group)
       grouped.push(group)
     }
-    timeGroups.get(slot).bands.push(band)
+    timeGroups.get(key).bands.push(band)
   })
   grouped.forEach(group => {
     group.bands.sort((a, b) => (a.venue ?? '').localeCompare(b.venue ?? ''))
@@ -480,8 +490,8 @@ function ScheduleView({
                 </h2>
                 <div className="flex-1 h-0.5 bg-bg-purple/30 ml-4"></div>
               </div>
-              {upcomingByTime.map(({ time, bands: timeBands }) => (
-                <div key={time} className="relative ml-0 sm:ml-4">
+              {upcomingByTime.map(({ time, date, bands: timeBands }) => (
+                <div key={`${date ?? ''}-${time}`} className="relative ml-0 sm:ml-4">
                   <div className="flex items-center mb-4">
                     <h3 className="bg-bg-navy text-text-primary font-mono font-semibold text-base md:text-lg px-4 py-2 rounded-lg shadow">
                       {time === 'TBD' ? 'Time To Be Announced' : formatTime(time)}
@@ -517,8 +527,8 @@ function ScheduleView({
                 </h2>
                 <div className="flex-1 h-0.5 bg-surface ml-4"></div>
               </div>
-              {pastByTime.map(({ time, bands: timeBands }) => (
-                <div key={time} className="relative ml-0 sm:ml-4 opacity-60">
+              {pastByTime.map(({ time, date, bands: timeBands }) => (
+                <div key={`${date ?? ''}-${time}`} className="relative ml-0 sm:ml-4 opacity-60">
                   <div className="flex items-center mb-4">
                     <h3 className="bg-surface text-text-tertiary font-mono font-semibold text-base md:text-lg px-4 py-2 rounded-lg shadow">
                       {time === 'TBD' ? 'Time To Be Announced' : formatTime(time)}

--- a/frontend/src/utils/__tests__/bandUtils.test.js
+++ b/frontend/src/utils/__tests__/bandUtils.test.js
@@ -139,3 +139,27 @@ describe('prepareBands — midnight-spanning real-world cases', () => {
     expect(bandA.endMs).toBeLessThan(bandB.startMs)
   })
 })
+
+describe('prepareBands — multi-day festival-day support (#538)', () => {
+  // prepareBands keys entirely off each band's own `date` field (its festival
+  // day), so it already generalizes to N days with NO code change — see the
+  // comment above prepareBands in bandUtils.js. This pins that: two sets with
+  // different `date`s sort correctly and land exactly one day apart, without
+  // any date-aware logic beyond what already existed.
+  it("sorts sets from different festival days using each set's own date, 24h apart", () => {
+    const bands = prepareBands([
+      makeBand('20:00', '23:00', '2026-08-03'), // Day 2 evening
+      makeBand('20:00', '23:00', '2026-08-02'), // Day 1 evening
+    ])
+    const sorted = [...bands].sort((a, b) => a.startMs - b.startMs)
+    expect(sorted[0].date).toBe('2026-08-02')
+    expect(sorted[1].date).toBe('2026-08-03')
+    expect(sorted[1].startMs - sorted[0].startMs).toBe(DAY_MS)
+  })
+
+  it("applies the after-midnight offset independently per set's own festival day", () => {
+    const [day1Late] = prepareBands([makeBand('01:00', '02:00', '2026-08-02')])
+    const [day2Late] = prepareBands([makeBand('01:00', '02:00', '2026-08-03')])
+    expect(day2Late.startMs - day1Late.startMs).toBe(DAY_MS)
+  })
+})

--- a/frontend/src/utils/__tests__/multidayTimeModel.test.js
+++ b/frontend/src/utils/__tests__/multidayTimeModel.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import { prepareBands } from '../bandUtils'
+import { groupByTime } from '../../components/ScheduleView'
+import { detectConflicts } from '../../admin/utils/timeUtils'
+
+// Collision fixture for #538 (highest-risk piece of the multi-day epic, #543).
+//
+// A 2-day event where BOTH nights have an 8 PM evening set AND a 1 AM
+// after-midnight set. Before this change:
+//   - groupByTime grouped by bare clock time, so the two 20:00 sets (and the
+//     two 01:00 sets) collapsed into one bucket despite being different
+//     festival days.
+//   - detectConflicts had no notion of "day" at all, so same-venue,
+//     same-clock-time sets on different festival days were flagged as exact
+//     conflicts (identical start_time/end_time).
+//
+// This file drives the real prepareBands / groupByTime / detectConflicts
+// functions directly against that fixture.
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const DAY1 = '2026-08-02'
+const DAY2 = '2026-08-03'
+
+const makeScheduleBand = (id, date, startTime, endTime, venue = 'Main Stage') => ({
+  id,
+  name: `Band ${id}`,
+  date,
+  startTime,
+  endTime,
+  venue,
+})
+
+// Day 1 (2026-08-02) 20:00 — evening set
+const day1Evening = makeScheduleBand('day1-evening', DAY1, '20:00', '23:00')
+// Day 1 (2026-08-02) 01:00 — after-midnight set of night 1 (stores Day 1's date)
+const day1Late = makeScheduleBand('day1-late', DAY1, '01:00', '02:00')
+// Day 2 (2026-08-03) 20:00 — evening set
+const day2Evening = makeScheduleBand('day2-evening', DAY2, '20:00', '23:00')
+// Day 2 (2026-08-03) 01:00 — after-midnight set of night 2 (stores Day 2's date)
+const day2Late = makeScheduleBand('day2-late', DAY2, '01:00', '02:00')
+
+describe('multi-day collision fixture (#538) — prepareBands', () => {
+  const prepared = prepareBands([day1Evening, day1Late, day2Evening, day2Late])
+  const byId = Object.fromEntries(prepared.map(b => [b.id, b]))
+
+  it('orders the four sort timestamps strictly: Day1-20:00 < Day1-01:00 < Day2-20:00 < Day2-01:00', () => {
+    expect(byId['day1-evening'].startMs).toBeLessThan(byId['day1-late'].startMs)
+    expect(byId['day1-late'].startMs).toBeLessThan(byId['day2-evening'].startMs)
+    expect(byId['day2-evening'].startMs).toBeLessThan(byId['day2-late'].startMs)
+  })
+
+  it('the two 20:00 sets are exactly 24h apart', () => {
+    expect(byId['day2-evening'].startMs - byId['day1-evening'].startMs).toBe(DAY_MS)
+  })
+
+  it('the two 01:00 after-midnight sets are exactly 24h apart', () => {
+    expect(byId['day2-late'].startMs - byId['day1-late'].startMs).toBe(DAY_MS)
+  })
+
+  it("each 01:00 set lands after its own night's evening set via the after-midnight offset", () => {
+    expect(byId['day1-late'].startMs).toBeGreaterThan(byId['day1-evening'].startMs)
+    expect(byId['day2-late'].startMs).toBeGreaterThan(byId['day2-evening'].startMs)
+  })
+})
+
+describe('multi-day collision fixture (#538) — groupByTime', () => {
+  const prepared = prepareBands([day1Evening, day1Late, day2Evening, day2Late])
+  const groups = groupByTime(prepared)
+
+  it('keeps the two 20:00 sets in SEPARATE groups (does not collapse same-clock-time, different-day sets)', () => {
+    const groupsAt2000 = groups.filter(g => g.time === '20:00')
+    expect(groupsAt2000).toHaveLength(2)
+    expect(groupsAt2000[0].bands).toHaveLength(1)
+    expect(groupsAt2000[1].bands).toHaveLength(1)
+    const ids = groupsAt2000.flatMap(g => g.bands.map(b => b.id))
+    expect(ids.sort()).toEqual(['day1-evening', 'day2-evening'])
+  })
+
+  it('keeps the two 01:00 after-midnight sets in SEPARATE groups', () => {
+    const groupsAt0100 = groups.filter(g => g.time === '01:00')
+    expect(groupsAt0100).toHaveLength(2)
+    expect(groupsAt0100[0].bands).toHaveLength(1)
+    expect(groupsAt0100[1].bands).toHaveLength(1)
+    const ids = groupsAt0100.flatMap(g => g.bands.map(b => b.id))
+    expect(ids.sort()).toEqual(['day1-late', 'day2-late'])
+  })
+
+  it('carries the festival day on each group so callers can build a unique key', () => {
+    const groupsAt2000 = groups.filter(g => g.time === '20:00')
+    expect(groupsAt2000.map(g => g.date).sort()).toEqual([DAY1, DAY2])
+  })
+})
+
+describe('multi-day collision fixture (#538) — detectConflicts', () => {
+  const EVENT_ID = 1
+  const VENUE_ID = 42
+  const perf = (id, date, start, end) => ({
+    id,
+    name: `Band ${id}`,
+    event_id: EVENT_ID,
+    venue_id: VENUE_ID,
+    start_time: start,
+    end_time: end,
+    performance_date: date,
+  })
+
+  const day1EveningPerf = perf(1, DAY1, '20:00', '23:00')
+  const day2EveningPerf = perf(2, DAY2, '20:00', '23:00')
+  const day1LatePerf = perf(3, DAY1, '01:00', '02:00')
+  const day2LatePerf = perf(4, DAY2, '01:00', '02:00')
+  const allPerfs = [day1EveningPerf, day2EveningPerf, day1LatePerf, day2LatePerf]
+
+  it('does NOT flag same-clock-time, same-venue sets on different festival days as a conflict', () => {
+    // Without day-scoping these are identical start_time/end_time -> would be
+    // classified as an exact "conflict", not merely an "overlap".
+    const result = detectConflicts(day1EveningPerf, allPerfs)
+    expect(result.conflicts).not.toContain('Band 2')
+    expect(result.overlaps).not.toContain('Band 2')
+  })
+
+  it('does NOT flag the two after-midnight sets (different festival days) as a conflict', () => {
+    const result = detectConflicts(day1LatePerf, allPerfs)
+    expect(result.conflicts).not.toContain('Band 4')
+    expect(result.overlaps).not.toContain('Band 4')
+  })
+
+  it('still flags a genuine SAME-day overlap as an overlap', () => {
+    const overlappingSameDay = perf(5, DAY1, '20:30', '21:30') // overlaps day1EveningPerf, same festival day
+    const result = detectConflicts(day1EveningPerf, [...allPerfs, overlappingSameDay])
+    expect(result.overlaps).toContain('Band 5')
+  })
+
+  it('still flags a genuine SAME-day exact conflict as a conflict', () => {
+    const exactSameDay = perf(6, DAY1, '20:00', '23:00') // identical times, same festival day
+    const result = detectConflicts(day1EveningPerf, [...allPerfs, exactSameDay])
+    expect(result.conflicts).toContain('Band 6')
+  })
+})
+
+describe('single-day invariant — byte-identical when every set shares one date (#538, #543)', () => {
+  it('groupByTime still collapses same-clock-time sets from a single-day event into ONE group', () => {
+    const bands = prepareBands([
+      makeScheduleBand('a', DAY1, '20:00', '23:00', 'Venue A'),
+      makeScheduleBand('b', DAY1, '20:00', '22:00', 'Venue B'),
+    ])
+    const groups = groupByTime(bands)
+    const groupsAt2000 = groups.filter(g => g.time === '20:00')
+    expect(groupsAt2000).toHaveLength(1)
+    expect(groupsAt2000[0].bands).toHaveLength(2)
+  })
+
+  it('detectConflicts still flags an identical-time match as a conflict when performance_date is absent everywhere', () => {
+    const perfA = { id: 1, name: 'A', event_id: 1, venue_id: 1, start_time: '20:00', end_time: '23:00' }
+    const perfB = { id: 2, name: 'B', event_id: 1, venue_id: 1, start_time: '20:00', end_time: '23:00' }
+    const result = detectConflicts(perfA, [perfA, perfB])
+    expect(result.conflicts).toEqual(['B'])
+    expect(result.overlaps).toHaveLength(0)
+  })
+
+  it('prepareBands is unaffected when every set shares one date (still applies the plain after-midnight offset)', () => {
+    const [band] = prepareBands([makeScheduleBand('x', DAY1, '01:00', '02:00')])
+    expect(band.startMs).toBe(Date.parse(`${DAY1}T01:00:00`) + DAY_MS)
+  })
+})

--- a/frontend/src/utils/bandUtils.js
+++ b/frontend/src/utils/bandUtils.js
@@ -7,6 +7,15 @@ const AFTER_MIDNIGHT_THRESHOLD_HOUR = 6
  * Enriches raw band data with precomputed startMs/endMs timestamps.
  * Handles after-midnight sets by detecting start times before AFTER_MIDNIGHT_THRESHOLD_HOUR
  * and offsetting them by one day so they sort correctly after evening performances.
+ *
+ * Multi-day support (#538): this already generalizes to N festival days with NO
+ * code change, because it keys entirely off each band's own `band.date` (its
+ * festival day) rather than a single shared event date. Two sets on different
+ * days simply parse to different base timestamps before the after-midnight
+ * offset is applied. Confirmed by the collision fixture in
+ * `__tests__/multidayTimeModel.test.js` and the regression test below. When
+ * every band shares one `date` (today's single-day events, and the NULL
+ * `performance_date` degenerate case), this is byte-identical to before.
  */
 export function prepareBands(list) {
   return list.map(band => {


### PR DESCRIPTION
## Summary

Adds the **day-aware time model** for multi-day events (P1.2 of the multiday epic), built on the nullable `performances.performance_date` column from #537/#544. Grouping and conflict-detection now reason about a performance's *festival day*, not just its clock time — so two sets at the same wall-clock time on different days no longer collapse together or false-flag as conflicts. Fully backward-compatible: for today's single-day events (and the NULL `performance_date` degenerate case) behavior is byte-identical to before.

Closes #538

## What changed

| File | Change |
|------|--------|
| `frontend/src/admin/utils/timeUtils.js` | `detectConflicts` gains an optional `eventDate` fallback; new `resolveFestivalDay` helper; performances on different festival days can't conflict. Short-circuits to prior behavior when no day info exists. |
| `frontend/src/components/ScheduleView.jsx` | `groupByTime` keys on `(festival day, clock time)` instead of bare time; group carries `date`; render keys updated to `${date}-${time}`. Now `export`ed for direct testing. |
| `frontend/src/utils/bandUtils.js` | Documented that `prepareBands` already generalizes to N days (keys off each band's own `date`); no behavior change. |
| `frontend/src/utils/__tests__/multidayTimeModel.test.js` | New integration test (164 lines) covering same-time-different-day grouping + conflict scoping. |
| `frontend/src/utils/__tests__/bandUtils.test.js`, `frontend/src/admin/utils/__tests__/timeUtils.test.js` | Regression + unit coverage for the day-aware paths. |

## Security / correctness notes

No auth/data-integrity surface. The **after-midnight invariant** (`AFTER_MIDNIGHT_THRESHOLD_HOUR = 6` in `bandUtils.js`) is preserved and explicitly relied upon — `band.date` already carries the correct *previous-evening* festival day for after-midnight sets, so day-keying composes with it rather than fighting it. Scope is deliberately the model layer only; visible day separators on the fan schedule are #541.

## Verification

- [x] Tests: 330 pass, 0 failures (`cd frontend && npm test -- --run`) — incl. 164 lines of new multiday tests
- [x] ESLint: 0 errors (`npm run lint`) — 2 pre-existing warnings in untouched admin files
- [x] Format check: clean (`npx prettier --check`)
- [x] Build: green (`npm run build`)
- [x] Rebased on current `main` and re-verified (tests + build) after the frontend dep bump
- [ ] Manual smoke: single-day schedule renders identically (grouping degenerates to bare-time key when `date` is constant)

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
