### PR TITLE
feat(multiday): schedule API per-set date + multi-day current-event window (#539)

### DIFF
--- a/functions/api/__tests__/schedule-reveal.test.js
+++ b/functions/api/__tests__/schedule-reveal.test.js
@@ -87,3 +87,107 @@ describe("GET /api/schedule - ticket_url sanitization (#504)", () => {
     expect(data.event.ticket_url).toBe("https://tickets.example.com/vol6");
   });
 });
+
+describe("GET /api/schedule - multi-day per-set date (#539)", () => {
+  it("returns each performance's own performance_date, not the event's start date", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const ev = insertEvent(rawDb, { name: "Multi-Day Fest", slug: "multi-day-fest", date: "2026-08-01" });
+    rawDb.prepare("UPDATE events SET is_published=1, end_date=? WHERE id=?").run("2026-08-02", ev.id);
+    const venue = insertVenue(rawDb, { name: "Main Stage" });
+
+    const day1Band = insertBand(rawDb, {
+      name: "Day One Band",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-08-01", day1Band.id);
+
+    const day2Band = insertBand(rawDb, {
+      name: "Day Two Band",
+      event_id: ev.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-08-02", day2Band.id);
+
+    const req = new Request("https://example.test/api/schedule?event=multi-day-fest");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    const day1 = data.bands.find((b) => b.name === "Day One Band");
+    const day2 = data.bands.find((b) => b.name === "Day Two Band");
+    expect(day1.date).toBe("2026-08-01");
+    expect(day2.date).toBe("2026-08-02");
+    // Event metadata still carries the start date — proving day 2's set date
+    // comes from its own performance_date, not from the event-wide date.
+    expect(data.event.date).toBe("2026-08-01");
+  });
+
+  it("a performance with NULL performance_date inherits event.date (single-day unchanged)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const ev = insertEvent(rawDb, { name: "Single Day Show", slug: "single-day-show", date: "2026-08-01" });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    const venue = insertVenue(rawDb, { name: "Solo Venue" });
+    insertBand(rawDb, { name: "Only Band", event_id: ev.id, venue_id: venue.id });
+    // performance_date is left NULL (the column's default) here.
+
+    const req = new Request("https://example.test/api/schedule?event=single-day-show");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.bands[0].date).toBe("2026-08-01");
+    expect(data.bands[0].date).toBe(data.event.date);
+  });
+});
+
+describe("GET /api/schedule - current-event window (#539)", () => {
+  it("keeps a multi-day event current when date is yesterday but end_date is today", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const todayStr = today.toISOString().split("T")[0];
+    const yesterdayStr = yesterday.toISOString().split("T")[0];
+
+    const ev = insertEvent(rawDb, { name: "Two Day Crawl", slug: "two-day-crawl", date: yesterdayStr });
+    rawDb.prepare("UPDATE events SET is_published=1, end_date=? WHERE id=?").run(todayStr, ev.id);
+    const venue = insertVenue(rawDb, { name: "Some Venue" });
+    insertBand(rawDb, { name: "Some Band", event_id: ev.id, venue_id: venue.id });
+
+    const req = new Request("https://example.test/api/schedule?event=current");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    // Before the COALESCE(end_date, date) fix this event would have already
+    // vanished from "current" on day 2 (its `date` alone is yesterday).
+    expect(data.event.slug).toBe("two-day-crawl");
+  });
+
+  it("still excludes a single-day event that ended in the past", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // Use 2 days ago (not 1) so this stays unambiguously outside the existing
+    // -6 hour grace window regardless of what time of day the suite runs.
+    const twoDaysAgo = new Date();
+    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+    const twoDaysAgoStr = twoDaysAgo.toISOString().split("T")[0];
+
+    const ev = insertEvent(rawDb, { name: "Old Single Day Show", slug: "old-single-day-show", date: twoDaysAgoStr });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+
+    const req = new Request("https://example.test/api/schedule?event=current");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    // No published event qualifies as current/upcoming — 404, same as before
+    // the fix (single-day past-event exclusion is unchanged).
+    expect(res.status).toBe(404);
+  });
+});

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -10,9 +10,11 @@ import { onRequestGet as timelineHandler } from "../timeline.js";
 import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
 
 // Returns the mock result set for a query string, keyed off the distinctive
-// WHERE clause for each period (now / upcoming / past).
+// WHERE clause for each period (now / upcoming / past). The "now" and "past"
+// clauses use COALESCE(end_date, date) (#539) so a multi-day event stays
+// "now" through its end_date instead of sliding into "past" a day early.
 const resultForQuery = (query) => {
-  if (query.includes("e.date = ?")) {
+  if (query.includes("e.date <= ?")) {
     // "Now" events query
     return {
       results: [
@@ -55,7 +57,7 @@ const resultForQuery = (query) => {
   } else if (query.includes("e.date > ?")) {
     // "Upcoming" events query
     return { results: [] };
-  } else if (query.includes("e.date < ?")) {
+  } else if (query.includes("COALESCE(e.end_date, e.date) < ?")) {
     // "Past" events query
     return {
       results: [

--- a/functions/api/events/public.js
+++ b/functions/api/events/public.js
@@ -32,7 +32,7 @@ export async function onRequestGet(context) {
         e.description,
         e.city,
         e.ticket_url,
-        CASE WHEN e.date >= date('now', '-6 hours') THEN 1 ELSE 0 END as is_upcoming,
+        CASE WHEN COALESCE(e.end_date, e.date) >= date('now', '-6 hours') THEN 1 ELSE 0 END as is_upcoming,
         COUNT(DISTINCT p.band_profile_id) as band_count,
         COUNT(DISTINCT p.venue_id) as venue_count
       FROM events e
@@ -61,9 +61,11 @@ export async function onRequestGet(context) {
 
     // Filter by upcoming (future events only)
     // Use -6 hours offset to account for ET timezone (UTC-5/UTC-4)
-    // This prevents events from disappearing while still ongoing
+    // This prevents events from disappearing while still ongoing.
+    // COALESCE(end_date, date): a multi-day event stays "upcoming" through its
+    // end_date instead of dropping off the morning after it starts (#539).
     if (upcoming) {
-      query += ` AND e.date >= date('now', '-6 hours')`;
+      query += ` AND COALESCE(e.end_date, e.date) >= date('now', '-6 hours')`;
     }
 
     query += `

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -143,7 +143,11 @@ export async function onRequestGet(context) {
     const statements = [];
     const slots = {};
 
-    // "Now" events (happening today) - single JOIN query
+    // "Now" events (happening today) - single JOIN query.
+    // e.date <= today AND COALESCE(end_date, date) >= today: today falls within
+    // the event's [date, end_date] span, so a multi-day event stays "now" on
+    // day 2+ instead of sliding into "past" (#539). NULL end_date collapses
+    // this to the original `e.date = today` for single-day events.
     if (includeNow) {
       slots.now = statements.length;
       statements.push(
@@ -179,10 +183,11 @@ export async function onRequestGet(context) {
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
         WHERE e.is_published = 1
-        AND e.date = ?
+        AND e.date <= ?
+        AND COALESCE(e.end_date, e.date) >= ?
         ORDER BY e.date DESC, p.start_time, v.name
       `,
-        ).bind(today),
+        ).bind(today, today),
       );
     }
 
@@ -240,7 +245,10 @@ export async function onRequestGet(context) {
       );
     }
 
-    // "Past" events (historical) - single JOIN query
+    // "Past" events (historical) - single JOIN query.
+    // COALESCE(end_date, date) < today: a multi-day event isn't "past" until
+    // its end_date has elapsed, so it doesn't slip out of "now" a day early
+    // (#539). NULL end_date collapses this to the original `e.date < today`.
     if (includePast) {
       slots.past = statements.length;
       statements.push(
@@ -277,12 +285,12 @@ export async function onRequestGet(context) {
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
         WHERE (
-          (e.is_published = 1 AND e.date < ?)
+          (e.is_published = 1 AND COALESCE(e.end_date, e.date) < ?)
           OR e.status = 'archived'
         )
         AND e.id IN (
           SELECT id FROM events
-          WHERE (is_published = 1 AND date < ?) OR status = 'archived'
+          WHERE (is_published = 1 AND COALESCE(end_date, date) < ?) OR status = 'archived'
           ORDER BY date DESC
           LIMIT ?
         )

--- a/functions/api/feeds/ical.js
+++ b/functions/api/feeds/ical.js
@@ -49,7 +49,7 @@ export async function onRequestGet(context) {
       LEFT JOIN band_profiles bp ON p.band_profile_id = bp.id
       LEFT JOIN venues v ON v.id = p.venue_id
       WHERE e.is_published = 1
-      AND e.date >= date('now')
+      AND COALESCE(e.end_date, e.date) >= date('now')
     `;
 
     const params = [];

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -30,7 +30,7 @@ export async function onRequestGet(context) {
         SELECT id, name, date, end_date, city, slug, status, ticket_url, theme_colors, venue_info, social_links, reveal_mode
         FROM events
         WHERE is_published = 1
-          AND date >= date('now', '-6 hours')
+          AND COALESCE(end_date, date) >= date('now', '-6 hours')
         ORDER BY date ASC
         LIMIT 1
       `,
@@ -74,6 +74,7 @@ export async function onRequestGet(context) {
         b.name,
         p.start_time as startTime,
         p.end_time as endTime,
+        p.performance_date as performanceDate,
         b.social_links,
         b.photo_url,
         v.name as venue,
@@ -136,7 +137,10 @@ export async function onRequestGet(context) {
         venue: band.venue ?? null,
         venue_lat: typeof band.venue_lat === "number" ? band.venue_lat : null,
         venue_lng: typeof band.venue_lng === "number" ? band.venue_lng : null,
-        date: event.date,
+        // Per-set festival day: a performance carries its own performance_date
+        // when the event spans multiple days (epic #543); NULL inherits the
+        // event's single date, keeping single-day events byte-identical.
+        date: band.performanceDate || event.date,
         startTime: extractTime(band.startTime),
         endTime: extractTime(band.endTime),
         url: primaryUrl,

--- a/functions/api/subscriptions/__tests__/mocks/d1.js
+++ b/functions/api/subscriptions/__tests__/mocks/d1.js
@@ -226,6 +226,7 @@ export class MockD1Database {
         name: event.name,
         slug: event.slug || `event-${event.id}`,
         date: event.date,
+        end_date: event.end_date ?? null,
         description: event.description,
         city: event.city,
         ticket_url: event.ticket_url,
@@ -258,9 +259,17 @@ export class MockD1Database {
       });
     }
 
-    if (queryLower.includes("where date >= date('now')") || queryLower.includes("e.date >= date('now'")) {
+    // Mirrors the COALESCE(end_date, date) >= date('now', ...) window (#539):
+    // a multi-day event stays "upcoming"/current through its end_date rather
+    // than dropping off the day after it starts. NULL end_date falls back to
+    // date, so single-day behavior is unchanged.
+    if (
+      queryLower.includes("where date >= date('now')") ||
+      queryLower.includes("e.date >= date('now'") ||
+      queryLower.includes("coalesce(e.end_date, e.date) >= date('now'")
+    ) {
       const today = new Date().toISOString().split("T")[0];
-      results = results.filter((e) => e.date >= today);
+      results = results.filter((e) => (e.end_date || e.date) >= today);
     }
 
     // Sort
@@ -311,9 +320,13 @@ export class MockD1Database {
 
       if (!event || !band) continue;
 
-      // Check future events only
+      // Check future events only. Mirrors the production
+      // COALESCE(e.end_date, e.date) >= date('now') window (#539): a
+      // multi-day event stays in the feed through its end_date instead of
+      // dropping out the day after it starts. NULL end_date falls back to
+      // date, so single-day behavior is unchanged.
       const today = new Date().toISOString().split("T")[0];
-      if (event.date < today) continue;
+      if ((event.end_date || event.date) < today) continue;
 
       // Apply city filter
       if (cityFilter && event.city?.toLowerCase() !== cityFilter.toLowerCase()) {

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -171,7 +171,8 @@ export function createTestDB() {
       created_at TEXT DEFAULT (datetime('now')),
       updated_at TEXT DEFAULT (datetime('now')),
       is_announced INTEGER NOT NULL DEFAULT 1,
-      band_follow_notified INTEGER NOT NULL DEFAULT 0
+      band_follow_notified INTEGER NOT NULL DEFAULT 0,
+      performance_date TEXT
     );
 
     CREATE TABLE schedule_builds (


### PR DESCRIPTION
## Summary

Wires the multi-day time model (P1.3) through the **read APIs**, on top of the `performances.performance_date` (#537) and `events.end_date` (0038) columns. Two things: (1) the public schedule now returns each performance's *own* festival day, and (2) fixes a pre-existing bug where a multi-day event drops out of "current/upcoming/now/feed" the morning after it starts, before it has actually ended.

Closes #539

## What changed

| File | Change |
|------|--------|
| `functions/api/schedule.js` | SELECT `p.performance_date`; response `date` = `performance_date || event.date`. Current-event lookup widened to `COALESCE(end_date, date) >= date('now','-6 hours')`. |
| `functions/api/events/public.js` | `is_upcoming` flag + upcoming filter use `COALESCE(e.end_date, e.date)`. |
| `functions/api/events/timeline.js` | "Now" bucket = `e.date <= today AND COALESCE(end_date,date) >= today`; "Past" = `COALESCE(end_date,date) < today`. |
| `functions/api/feeds/ical.js` | Feed-inclusion window uses `COALESCE(e.end_date, e.date)`. |
| `functions/api/test-utils.js` | Test-DB `performances` schema gains `performance_date`. |
| `functions/api/**/__tests__/*`, subscription `mocks/d1.js` | New multi-day coverage; mocks mirror the COALESCE window. |

## Security / correctness notes

No auth/data surface. **Backward compatibility is structural:** every window is `COALESCE(end_date, date)` and the per-set date is `performance_date || event.date` — for single-day events (`end_date`/`performance_date` NULL) both collapse to the prior expression exactly. Guaranteed by keeping all existing tests green plus explicit single-day regression cases. **Festival-day semantics** (6 AM boundary; `performance_date` = calendar date of the festival day) are consumed by the already-merged #538 grouping — this PR only supplies the per-set date; it does not re-derive it.

## Verification

- [x] Tests: 646 pass, 6 todo, 0 failures (`npm test`, 71 files) — incl. new per-set-date + multi-day-window cases
- [x] ESLint: 0 errors (`npm run lint`, ESLint 10.6.0)
- [x] Format check: clean (`npm run format:check`)
- [x] Rebased on current `main` and re-verified (lint + full suite) after the ESLint-10 / dep bumps
- [ ] Manual smoke: single-day schedule + timeline + iCal unchanged; 2-day event stays "current" on day-2 morning

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
