### PR TITLE
feat(multiday): day-separated fan schedule display (#541)

### DIFF
--- a/frontend/src/admin/utils/dayOptions.js
+++ b/frontend/src/admin/utils/dayOptions.js
@@ -8,6 +8,7 @@
  * an event — they never re-derive which day a given performance belongs to;
  * that's an explicit admin choice, stored in performances.performance_date.
  */
+import { formatFestivalDate } from '../../utils/festivalDays'
 
 const parseDateParts = dateStr => {
   const [year, month, day] = dateStr.split('-').map(Number)
@@ -55,16 +56,6 @@ export const enumerateFestivalDays = (startDate, endDate) => {
   return days
 }
 
-const formatDayLabel = dateValue => {
-  const { year, month, day } = parseDateParts(dateValue)
-  const label = new Date(year, month - 1, day).toLocaleDateString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-  })
-  return label.replace(',', '')
-}
-
 /**
  * Builds <select> options for an event's festival days:
  * [{ value: 'YYYY-MM-DD', label: 'Day 1 (Sat Aug 2)' }, ...]
@@ -72,5 +63,5 @@ const formatDayLabel = dateValue => {
 export const buildDayOptions = (startDate, endDate) =>
   enumerateFestivalDays(startDate, endDate).map((value, index) => ({
     value,
-    label: `Day ${index + 1} (${formatDayLabel(value)})`,
+    label: `Day ${index + 1} (${formatFestivalDate(value, 'short')})`,
   }))

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -19,12 +19,14 @@ import {
   Trash2,
   Zap,
 } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { Fragment, useEffect, useMemo, useState } from 'react'
 import { HIGHLIGHTED_BANDS, getHighlightMessage } from '../config/highlights.jsx'
 import { copyToClipboard } from '../utils/clipboard'
+import { dayNumberByDate, isMultiDay } from '../utils/festivalDays'
 import { formatTimeRange } from '../utils/timeFormat'
 import BandCard from './BandCard'
 import LockInLineupPanel from './LockInLineupPanel'
+import { DayDivider } from './ui'
 import { walkMinutesBetween } from '../utils/walkTime'
 
 // Label a break between two sets at the same venue.
@@ -222,6 +224,15 @@ function MySchedule({
   const visibleBands = showPast ? sortedBands : sortedBands.filter(band => band.endMs > effectiveNow.getTime())
 
   const hiddenFinishedCount = sortedBands.length - visibleBands.length
+
+  // Day-divider support (#541): a flat time-sorted list, so day boundaries are
+  // detected by comparing each rendered band's `.date` to the previous one
+  // (see the render loop below). Numbering + the multi-day gate use the full
+  // `sortedBands` (not the `showPast`-filtered `visibleBands`) so a day's number
+  // never shifts when past sets are hidden — keeping it consistent with
+  // ScheduleView. Single-day schedules render zero dividers, byte-identical.
+  const dayNumberByDateMap = useMemo(() => dayNumberByDate(sortedBands), [sortedBands])
+  const multiDayEvent = useMemo(() => isMultiDay(sortedBands), [sortedBands])
 
   // Find first highlighted band ID (only show reminder for the first one)
   const firstHighlightedBandId = useMemo(() => {
@@ -561,6 +572,11 @@ function MySchedule({
           const hasOverlap = overlaps.some(c => c.band1 === band.id || c.band2 === band.id)
           const showDreReminder = band.id === firstHighlightedBandId
 
+          // Day-divider: render above this band when its festival day differs
+          // from the previously-rendered band's day (#541).
+          const previousDate = idx > 0 ? visibleBands[idx - 1].date : undefined
+          const showDayDivider = multiDayEvent && band.date !== previousDate
+
           // Walk + buffer from the previous set — the crawl's "can I make it?" math.
           let transition = null
           if (idx > 0) {
@@ -581,85 +597,90 @@ function MySchedule({
           }
 
           return (
-            <div key={band.id} className="relative mb-6">
-              {/* Walk / break transition from the previous set */}
-              {transition && (
-                <div className="flex flex-wrap items-center justify-center gap-1.5 py-3 text-xs">
-                  {transition.walkMin != null ? (
-                    <span className="inline-flex flex-wrap items-center justify-center gap-1.5 text-text-tertiary">
-                      <Footprints size={14} aria-hidden="true" />
-                      <span>
-                        ~{transition.walkMin} min walk to {transition.venue}
-                      </span>
-                      {transition.buffer != null && (
-                        <span className={transition.buffer < 3 ? 'font-semibold text-error-600' : 'text-text-tertiary'}>
-                          · {bufferLabel(transition.buffer)}
+            <Fragment key={band.id}>
+              {showDayDivider && <DayDivider date={band.date} dayNumber={dayNumberByDateMap.get(band.date)} />}
+              <div className="relative mb-6">
+                {/* Walk / break transition from the previous set */}
+                {transition && (
+                  <div className="flex flex-wrap items-center justify-center gap-1.5 py-3 text-xs">
+                    {transition.walkMin != null ? (
+                      <span className="inline-flex flex-wrap items-center justify-center gap-1.5 text-text-tertiary">
+                        <Footprints size={14} aria-hidden="true" />
+                        <span>
+                          ~{transition.walkMin} min walk to {transition.venue}
                         </span>
-                      )}
-                    </span>
-                  ) : (
-                    <span className="italic text-text-tertiary">{formatBreakLabel(transition.gapMinutes)}</span>
-                  )}
-                </div>
-              )}
-              {showDreReminder && (
-                <div className="text-center text-text-secondary text-xs italic pb-2 flex items-center justify-center gap-2">
-                  <Smile size={14} className="text-yellow-300" aria-hidden="true" />
-                  <span>{getHighlightMessage()}</span>
-                </div>
-              )}
-              <div className="space-y-2">
-                <div className={getTimeStatus(band).status === 'now' ? 'playing-now rounded-xl' : ''}>
-                  <BandCard
-                    band={band}
-                    isSelected={true}
-                    onToggle={onToggleBand}
-                    onRemove={onToggleBand}
-                    showVenue={true}
-                    clickable={false}
-                    eventSlug={eventSlug}
-                    currentTime={effectiveNow}
-                    warningType={hasConflict ? 'conflict' : hasOverlap ? 'overlap' : null}
-                    warningText={(() => {
-                      if (!hasConflict && !hasOverlap) return null
-                      const getNamesFrom = list => [
-                        ...new Set(
-                          list
-                            .filter(c => c.band1 === band.id || c.band2 === band.id)
-                            .map(c => {
-                              const otherId = c.band1 === band.id ? c.band2 : c.band1
-                              return bandNameById.get(otherId)
-                            })
-                            .filter(Boolean)
-                        ),
-                      ]
-                      const conflictNames = getNamesFrom(conflicts)
-                      const overlapNames = getNamesFrom(overlaps)
-                      const parts = []
-                      if (conflictNames.length > 0) parts.push(`Same time as ${conflictNames.join(', ')}`)
-                      if (overlapNames.length > 0) parts.push(`Overlaps with ${overlapNames.join(', ')}`)
-                      return parts.join(' · ')
-                    })()}
-                  />
-                </div>
-
-                {/* Countdown timer - appears BELOW the band card */}
-                {(() => {
-                  const timeStatus = getTimeStatus(band)
-                  return (
-                    <div
-                      className={`text-xs font-semibold px-3 py-1.5 rounded border ${timeStatus.color} flex items-center gap-2 leading-normal`}
-                    >
-                      {(() => {
-                        const StatusIcon = timeStatus.icon
-                        return <StatusIcon size={14} aria-hidden="true" />
+                        {transition.buffer != null && (
+                          <span
+                            className={transition.buffer < 3 ? 'font-semibold text-error-600' : 'text-text-tertiary'}
+                          >
+                            · {bufferLabel(transition.buffer)}
+                          </span>
+                        )}
+                      </span>
+                    ) : (
+                      <span className="italic text-text-tertiary">{formatBreakLabel(transition.gapMinutes)}</span>
+                    )}
+                  </div>
+                )}
+                {showDreReminder && (
+                  <div className="text-center text-text-secondary text-xs italic pb-2 flex items-center justify-center gap-2">
+                    <Smile size={14} className="text-yellow-300" aria-hidden="true" />
+                    <span>{getHighlightMessage()}</span>
+                  </div>
+                )}
+                <div className="space-y-2">
+                  <div className={getTimeStatus(band).status === 'now' ? 'playing-now rounded-xl' : ''}>
+                    <BandCard
+                      band={band}
+                      isSelected={true}
+                      onToggle={onToggleBand}
+                      onRemove={onToggleBand}
+                      showVenue={true}
+                      clickable={false}
+                      eventSlug={eventSlug}
+                      currentTime={effectiveNow}
+                      warningType={hasConflict ? 'conflict' : hasOverlap ? 'overlap' : null}
+                      warningText={(() => {
+                        if (!hasConflict && !hasOverlap) return null
+                        const getNamesFrom = list => [
+                          ...new Set(
+                            list
+                              .filter(c => c.band1 === band.id || c.band2 === band.id)
+                              .map(c => {
+                                const otherId = c.band1 === band.id ? c.band2 : c.band1
+                                return bandNameById.get(otherId)
+                              })
+                              .filter(Boolean)
+                          ),
+                        ]
+                        const conflictNames = getNamesFrom(conflicts)
+                        const overlapNames = getNamesFrom(overlaps)
+                        const parts = []
+                        if (conflictNames.length > 0) parts.push(`Same time as ${conflictNames.join(', ')}`)
+                        if (overlapNames.length > 0) parts.push(`Overlaps with ${overlapNames.join(', ')}`)
+                        return parts.join(' · ')
                       })()}
-                      <span>{timeStatus.text}</span>
-                    </div>
-                  )
-                })()}
+                    />
+                  </div>
+
+                  {/* Countdown timer - appears BELOW the band card */}
+                  {(() => {
+                    const timeStatus = getTimeStatus(band)
+                    return (
+                      <div
+                        className={`text-xs font-semibold px-3 py-1.5 rounded border ${timeStatus.color} flex items-center gap-2 leading-normal`}
+                      >
+                        {(() => {
+                          const StatusIcon = timeStatus.icon
+                          return <StatusIcon size={14} aria-hidden="true" />
+                        })()}
+                        <span>{timeStatus.text}</span>
+                      </div>
+                    )
+                  })()}
+                </div>
               </div>
-            </div>
+            </Fragment>
           )
         })}
       </div>

--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -1,9 +1,11 @@
 import { Check, Copy, Music } from 'lucide-react'
-import { memo, useMemo, useState } from 'react'
+import { Fragment, memo, useMemo, useState } from 'react'
 import { copyToClipboard } from '../utils/clipboard'
+import { dayNumberByDate, isMultiDay } from '../utils/festivalDays'
 import { formatTime, formatTimeRange } from '../utils/timeFormat'
 import { filterPerformancesByTime } from '../utils/timeFilter'
 import BandCard from './BandCard'
+import { DayDivider } from './ui'
 
 const UNSCHEDULED = Symbol('unscheduled')
 const UNSCHEDULED_FILTER_VALUE = '__unscheduled__'
@@ -60,6 +62,12 @@ function ScheduleView({
     const d = currentTime instanceof Date ? currentTime : new Date(currentTime)
     return d.getTime()
   }, [currentTime])
+
+  // Day-divider support (#541): numbering/gate derive from the full incoming
+  // `bands` set (not the filtered/split subsets below) so day numbers stay
+  // consistent across the Upcoming and Past sections and across filter changes.
+  const dayNumberByDateMap = useMemo(() => dayNumberByDate(bands), [bands])
+  const multiDayEvent = useMemo(() => isMultiDay(bands), [bands])
 
   const uniqueVenues = useMemo(() => [...new Set(bands.map(b => b.venue).filter(Boolean))].sort(), [bands])
   const hasUnscheduled = useMemo(() => bands.some(b => !b.venue), [bands])
@@ -490,31 +498,38 @@ function ScheduleView({
                 </h2>
                 <div className="flex-1 h-0.5 bg-bg-purple/30 ml-4"></div>
               </div>
-              {upcomingByTime.map(({ time, date, bands: timeBands }) => (
-                <div key={`${date ?? ''}-${time}`} className="relative ml-0 sm:ml-4">
-                  <div className="flex items-center mb-4">
-                    <h3 className="bg-bg-navy text-text-primary font-mono font-semibold text-base md:text-lg px-4 py-2 rounded-lg shadow">
-                      {time === 'TBD' ? 'Time To Be Announced' : formatTime(time)}
-                    </h3>
-                    <div className="flex-1 h-0.5 bg-bg-navy/20 ml-4"></div>
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 ml-0 sm:ml-4">
-                    {timeBands.map(band => (
-                      <BandCard
-                        key={band.id}
-                        band={band}
-                        isSelected={selectedBandsSet.has(band.id)}
-                        onToggle={onToggleBand}
-                        clickable={canToggleBands}
-                        showToggleButton={canToggleBands}
-                        eventSlug={eventSlug}
-                        showVenue={true}
-                        currentTime={currentTime}
-                      />
-                    ))}
-                  </div>
-                </div>
-              ))}
+              {upcomingByTime.map(({ time, date, bands: timeBands }, idx) => {
+                const previousDate = idx > 0 ? upcomingByTime[idx - 1].date : undefined
+                const showDayDivider = multiDayEvent && date !== previousDate
+                return (
+                  <Fragment key={`${date ?? ''}-${time}`}>
+                    {showDayDivider && <DayDivider date={date} dayNumber={dayNumberByDateMap.get(date)} />}
+                    <div className="relative ml-0 sm:ml-4">
+                      <div className="flex items-center mb-4">
+                        <h3 className="bg-bg-navy text-text-primary font-mono font-semibold text-base md:text-lg px-4 py-2 rounded-lg shadow">
+                          {time === 'TBD' ? 'Time To Be Announced' : formatTime(time)}
+                        </h3>
+                        <div className="flex-1 h-0.5 bg-bg-navy/20 ml-4"></div>
+                      </div>
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 ml-0 sm:ml-4">
+                        {timeBands.map(band => (
+                          <BandCard
+                            key={band.id}
+                            band={band}
+                            isSelected={selectedBandsSet.has(band.id)}
+                            onToggle={onToggleBand}
+                            clickable={canToggleBands}
+                            showToggleButton={canToggleBands}
+                            eventSlug={eventSlug}
+                            showVenue={true}
+                            currentTime={currentTime}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  </Fragment>
+                )
+              })}
             </div>
           )}
 
@@ -527,31 +542,38 @@ function ScheduleView({
                 </h2>
                 <div className="flex-1 h-0.5 bg-surface ml-4"></div>
               </div>
-              {pastByTime.map(({ time, date, bands: timeBands }) => (
-                <div key={`${date ?? ''}-${time}`} className="relative ml-0 sm:ml-4 opacity-60">
-                  <div className="flex items-center mb-4">
-                    <h3 className="bg-surface text-text-tertiary font-mono font-semibold text-base md:text-lg px-4 py-2 rounded-lg shadow">
-                      {time === 'TBD' ? 'Time To Be Announced' : formatTime(time)}
-                    </h3>
-                    <div className="flex-1 h-0.5 bg-surface ml-4"></div>
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 ml-0 sm:ml-4">
-                    {timeBands.map(band => (
-                      <BandCard
-                        key={band.id}
-                        band={band}
-                        isSelected={selectedBandsSet.has(band.id)}
-                        onToggle={onToggleBand}
-                        clickable={canToggleBands}
-                        showToggleButton={canToggleBands}
-                        eventSlug={eventSlug}
-                        showVenue={true}
-                        currentTime={currentTime}
-                      />
-                    ))}
-                  </div>
-                </div>
-              ))}
+              {pastByTime.map(({ time, date, bands: timeBands }, idx) => {
+                const previousDate = idx > 0 ? pastByTime[idx - 1].date : undefined
+                const showDayDivider = multiDayEvent && date !== previousDate
+                return (
+                  <Fragment key={`${date ?? ''}-${time}`}>
+                    {showDayDivider && <DayDivider date={date} dayNumber={dayNumberByDateMap.get(date)} />}
+                    <div className="relative ml-0 sm:ml-4 opacity-60">
+                      <div className="flex items-center mb-4">
+                        <h3 className="bg-surface text-text-tertiary font-mono font-semibold text-base md:text-lg px-4 py-2 rounded-lg shadow">
+                          {time === 'TBD' ? 'Time To Be Announced' : formatTime(time)}
+                        </h3>
+                        <div className="flex-1 h-0.5 bg-surface ml-4"></div>
+                      </div>
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 ml-0 sm:ml-4">
+                        {timeBands.map(band => (
+                          <BandCard
+                            key={band.id}
+                            band={band}
+                            isSelected={selectedBandsSet.has(band.id)}
+                            onToggle={onToggleBand}
+                            clickable={canToggleBands}
+                            showToggleButton={canToggleBands}
+                            eventSlug={eventSlug}
+                            showVenue={true}
+                            currentTime={currentTime}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  </Fragment>
+                )
+              })}
             </div>
           )}
         </div>

--- a/frontend/src/components/__tests__/ScheduleView.test.jsx
+++ b/frontend/src/components/__tests__/ScheduleView.test.jsx
@@ -270,6 +270,94 @@ describe('ScheduleView — P2: copy action respects visible filters', () => {
   })
 })
 
+describe('ScheduleView — #541: multi-day day dividers', () => {
+  it('renders no day dividers for a single-day lineup', () => {
+    const bands = [
+      makeBand({
+        id: '1',
+        name: 'Alpha',
+        date: '2024-06-01',
+        startTime: '21:00',
+        startMs: Date.parse('2024-06-01T21:00:00'),
+        endMs: Date.parse('2024-06-01T22:00:00'),
+      }),
+      makeBand({
+        id: '2',
+        name: 'Beta',
+        date: '2024-06-01',
+        startTime: '22:00',
+        startMs: Date.parse('2024-06-01T22:00:00'),
+        endMs: Date.parse('2024-06-01T23:00:00'),
+      }),
+    ]
+    renderView({ bands })
+
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument()
+    expect(screen.queryByText(/^Day 1/)).not.toBeInTheDocument()
+  })
+
+  it('renders one day-divider per festival day, in ascending order, for a multi-day lineup', () => {
+    const bands = [
+      makeBand({
+        id: '1',
+        name: 'Alpha',
+        date: '2024-06-01',
+        startTime: '21:00',
+        startMs: Date.parse('2024-06-01T21:00:00'),
+        endMs: Date.parse('2024-06-01T22:00:00'),
+      }),
+      makeBand({
+        id: '2',
+        name: 'Beta',
+        date: '2024-06-02',
+        startTime: '21:00',
+        startMs: Date.parse('2024-06-02T21:00:00'),
+        endMs: Date.parse('2024-06-02T22:00:00'),
+      }),
+    ]
+    renderView({ bands, currentTime: new Date('2024-05-31T12:00:00') })
+
+    const dividers = screen.getAllByRole('separator')
+    expect(dividers).toHaveLength(2)
+    expect(dividers[0]).toHaveTextContent('Day 1')
+    expect(dividers[0]).toHaveTextContent('Saturday, June 1')
+    expect(dividers[1]).toHaveTextContent('Day 2')
+    expect(dividers[1]).toHaveTextContent('Sunday, June 2')
+  })
+
+  it('renders a divider once per day even with multiple time slots on the same day', () => {
+    const bands = [
+      makeBand({
+        id: '1',
+        name: 'Alpha',
+        date: '2024-06-01',
+        startTime: '20:00',
+        startMs: Date.parse('2024-06-01T20:00:00'),
+        endMs: Date.parse('2024-06-01T21:00:00'),
+      }),
+      makeBand({
+        id: '2',
+        name: 'Beta',
+        date: '2024-06-01',
+        startTime: '21:30',
+        startMs: Date.parse('2024-06-01T21:30:00'),
+        endMs: Date.parse('2024-06-01T22:30:00'),
+      }),
+      makeBand({
+        id: '3',
+        name: 'Gamma',
+        date: '2024-06-02',
+        startTime: '20:00',
+        startMs: Date.parse('2024-06-02T20:00:00'),
+        endMs: Date.parse('2024-06-02T21:00:00'),
+      }),
+    ]
+    renderView({ bands, currentTime: new Date('2024-05-31T12:00:00') })
+
+    expect(screen.getAllByRole('separator')).toHaveLength(2)
+  })
+})
+
 describe('ScheduleView — P1: read-only schedule surfaces hide dead actions', () => {
   it('does not render schedule-building or past-toggle actions when handlers are absent', () => {
     const pastMs = NOW_MS - 2 * 60 * 60 * 1000

--- a/frontend/src/components/ui/DayDivider.jsx
+++ b/frontend/src/components/ui/DayDivider.jsx
@@ -1,0 +1,39 @@
+import { memo } from 'react'
+import PropTypes from 'prop-types'
+import { formatFestivalDate } from '../../utils/festivalDays'
+
+/**
+ * DayDivider - Design System v1.0
+ *
+ * Festival-day header shown between sets on different days of a multi-day
+ * event (#541): "DAY N · Saturday, August 2". Public / theme-following
+ * surface — semantic tokens only, never hardcoded white.
+ *
+ * Shared between ScheduleView and MySchedule so both fan-facing surfaces
+ * render identical day-divider styling.
+ *
+ * @example
+ * <DayDivider date="2026-08-02" dayNumber={1} />
+ */
+const DayDivider = memo(function DayDivider({ date, dayNumber, className = '' }) {
+  return (
+    <div
+      className={`flex items-center gap-3 pt-2 ${className}`.trim()}
+      role="separator"
+      aria-label={`Day ${dayNumber}`}
+    >
+      <span className="text-xs font-bold tracking-widest uppercase text-text-primary bg-surface border border-border px-3 py-1.5 rounded-full whitespace-nowrap">
+        Day {dayNumber} &middot; {formatFestivalDate(date, 'long')}
+      </span>
+      <div className="flex-1 h-px bg-border"></div>
+    </div>
+  )
+})
+
+DayDivider.propTypes = {
+  date: PropTypes.string.isRequired,
+  dayNumber: PropTypes.number,
+  className: PropTypes.string,
+}
+
+export default DayDivider

--- a/frontend/src/components/ui/index.js
+++ b/frontend/src/components/ui/index.js
@@ -16,6 +16,7 @@ export { default as Modal } from './Modal'
 export { default as Loading } from './Loading'
 export { default as Tooltip } from './Tooltip'
 export { default as ConfirmDialog } from './ConfirmDialog'
+export { default as DayDivider } from './DayDivider'
 export {
   BandCardSkeleton,
   BandCardSkeletonGrid,

--- a/frontend/src/test/MySchedule.test.jsx
+++ b/frontend/src/test/MySchedule.test.jsx
@@ -4,17 +4,20 @@ import { MemoryRouter } from 'react-router-dom'
 import '@testing-library/jest-dom'
 import MySchedule from '../components/MySchedule'
 
-const makeMs = timeStr => new Date(`2026-05-17T${timeStr}:00`).getTime()
+const makeMs = (timeStr, date = '2026-05-17') => new Date(`${date}T${timeStr}:00`).getTime()
 
-const makeBand = (id, name, venue, startTime, endTime) => ({
+const makeBand = (id, name, venue, startTime, endTime, date = '2026-05-17') => ({
   id: `event-test-perf-${id}`,
   name,
   venue,
-  date: '2026-05-17',
+  date,
   startTime,
   endTime,
-  startMs: makeMs(startTime),
-  endMs: makeMs(endTime) > makeMs(startTime) ? makeMs(endTime) : makeMs(endTime) + 24 * 60 * 60 * 1000,
+  startMs: makeMs(startTime, date),
+  endMs:
+    makeMs(endTime, date) > makeMs(startTime, date)
+      ? makeMs(endTime, date)
+      : makeMs(endTime, date) + 24 * 60 * 60 * 1000,
   genre: null,
   performance_id: id,
 })
@@ -149,5 +152,65 @@ describe('MySchedule — conflict vs overlap severity', () => {
     // Band C must show only an overlap warning, no conflict label
     expect(screen.getAllByText(/Overlaps with Band A, Band B/i).length).toBeGreaterThan(0)
     expect(screen.queryByText(/Same time as Band C/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('MySchedule — #541: multi-day day dividers', () => {
+  it('renders no day dividers for a single-day schedule', () => {
+    const bands = [
+      makeBand(1, 'Band Alpha', 'Stage A', '20:00', '20:30'),
+      makeBand(2, 'Band Beta', 'Stage B', '21:00', '21:30'),
+    ]
+    render(
+      <MemoryRouter>
+        <MySchedule {...defaultProps} bands={bands} />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument()
+  })
+
+  it('inserts a day-divider before Day 1 and again before the first Day 2 band, none for the second Day 1 band', () => {
+    const bands = [
+      makeBand(1, 'Band Alpha', 'Stage A', '20:00', '20:30', '2026-05-17'),
+      makeBand(2, 'Band Beta', 'Stage B', '21:00', '21:30', '2026-05-17'),
+      makeBand(3, 'Band Gamma', 'Stage A', '20:00', '20:30', '2026-05-18'),
+    ]
+    const { container } = render(
+      <MemoryRouter>
+        <MySchedule {...defaultProps} bands={bands} />
+      </MemoryRouter>
+    )
+
+    // One divider before the very first band (Day 1) and one before the first
+    // Day 2 band (Gamma); Band Beta (2nd Day 1 band) gets none since its date
+    // matches the previous rendered band's date.
+    const dividers = screen.getAllByRole('separator')
+    expect(dividers).toHaveLength(2)
+    expect(dividers[0]).toHaveTextContent('Day 1')
+    expect(dividers[1]).toHaveTextContent('Day 2')
+
+    // The Day 2 divider must appear before Band Gamma (the first Day 2 band) in DOM order.
+    const text = container.textContent
+    expect(text.indexOf('Day 2')).toBeLessThan(text.indexOf('Band Gamma'))
+  })
+
+  it('inserts a divider for each subsequent day change across a 3-day schedule', () => {
+    const bands = [
+      makeBand(1, 'Band Alpha', 'Stage A', '20:00', '20:30', '2026-05-17'),
+      makeBand(2, 'Band Beta', 'Stage A', '20:00', '20:30', '2026-05-18'),
+      makeBand(3, 'Band Gamma', 'Stage A', '20:00', '20:30', '2026-05-19'),
+    ]
+    render(
+      <MemoryRouter>
+        <MySchedule {...defaultProps} bands={bands} />
+      </MemoryRouter>
+    )
+
+    const dividers = screen.getAllByRole('separator')
+    expect(dividers).toHaveLength(3)
+    expect(dividers[0]).toHaveTextContent('Day 1')
+    expect(dividers[1]).toHaveTextContent('Day 2')
+    expect(dividers[2]).toHaveTextContent('Day 3')
   })
 })

--- a/frontend/src/utils/__tests__/festivalDays.test.js
+++ b/frontend/src/utils/__tests__/festivalDays.test.js
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { dayNumberByDate, formatFestivalDate, isMultiDay, orderedFestivalDays } from '../festivalDays'
+
+describe('formatFestivalDate', () => {
+  it('formats the short style as "Sun Aug 2" (no comma)', () => {
+    expect(formatFestivalDate('2026-08-02', 'short')).toBe('Sun Aug 2')
+  })
+
+  it('formats the long style as "Sunday, August 2"', () => {
+    expect(formatFestivalDate('2026-08-02', 'long')).toBe('Sunday, August 2')
+  })
+
+  it('defaults to the long style when no style is passed', () => {
+    expect(formatFestivalDate('2026-08-02')).toBe('Sunday, August 2')
+  })
+
+  it('does not drift a day near a month boundary (short style)', () => {
+    // July 31 2026 is a Friday; a UTC-parsing bug (`new Date('2026-07-31')`) would
+    // render as "Thu Jul 30" or "Fri Jul 31" depending on timezone offset direction —
+    // the local-timezone numeric constructor must keep this pinned to Jul 31.
+    expect(formatFestivalDate('2026-07-31', 'short')).toBe('Fri Jul 31')
+  })
+
+  it('does not drift a day near a month boundary (long style)', () => {
+    expect(formatFestivalDate('2026-08-01', 'long')).toBe('Saturday, August 1')
+  })
+
+  it('returns an empty string for a missing/empty date', () => {
+    expect(formatFestivalDate('')).toBe('')
+    expect(formatFestivalDate(null)).toBe('')
+    expect(formatFestivalDate(undefined)).toBe('')
+  })
+})
+
+describe('orderedFestivalDays', () => {
+  it('returns a single date for a single-day event', () => {
+    const items = [{ date: '2026-08-02' }, { date: '2026-08-02' }]
+    expect(orderedFestivalDays(items)).toEqual(['2026-08-02'])
+  })
+
+  it('returns distinct dates in ascending order for a 2-day event', () => {
+    const items = [{ date: '2026-08-03' }, { date: '2026-08-02' }, { date: '2026-08-02' }]
+    expect(orderedFestivalDays(items)).toEqual(['2026-08-02', '2026-08-03'])
+  })
+
+  it('returns distinct dates in ascending order for a 3-day event', () => {
+    const items = [{ date: '2026-08-04' }, { date: '2026-08-02' }, { date: '2026-08-03' }]
+    expect(orderedFestivalDays(items)).toEqual(['2026-08-02', '2026-08-03', '2026-08-04'])
+  })
+
+  it('ignores null/empty date values', () => {
+    const items = [{ date: null }, { date: '' }, { date: '2026-08-02' }, { date: undefined }]
+    expect(orderedFestivalDays(items)).toEqual(['2026-08-02'])
+  })
+
+  it('returns an empty array for empty/missing input', () => {
+    expect(orderedFestivalDays([])).toEqual([])
+    expect(orderedFestivalDays(null)).toEqual([])
+    expect(orderedFestivalDays(undefined)).toEqual([])
+  })
+})
+
+describe('dayNumberByDate', () => {
+  it('assigns Day 1 for a single-day event', () => {
+    const items = [{ date: '2026-08-02' }, { date: '2026-08-02' }]
+    const map = dayNumberByDate(items)
+    expect(map.get('2026-08-02')).toBe(1)
+    expect(map.size).toBe(1)
+  })
+
+  it('assigns 1..N in ascending date order for a multi-day event', () => {
+    const items = [{ date: '2026-08-03' }, { date: '2026-08-02' }, { date: '2026-08-04' }]
+    const map = dayNumberByDate(items)
+    expect(map.get('2026-08-02')).toBe(1)
+    expect(map.get('2026-08-03')).toBe(2)
+    expect(map.get('2026-08-04')).toBe(3)
+  })
+
+  it('excludes null/empty dates from the map', () => {
+    const items = [{ date: null }, { date: '2026-08-02' }, { date: '' }]
+    const map = dayNumberByDate(items)
+    expect(map.size).toBe(1)
+    expect(map.get('2026-08-02')).toBe(1)
+  })
+})
+
+describe('isMultiDay', () => {
+  it('is false for a single distinct date', () => {
+    expect(isMultiDay([{ date: '2026-08-02' }, { date: '2026-08-02' }])).toBe(false)
+  })
+
+  it('is false when all dates are null/empty (degenerate single-day case)', () => {
+    expect(isMultiDay([{ date: null }, { date: '' }])).toBe(false)
+  })
+
+  it('is true for a 2-day span', () => {
+    expect(isMultiDay([{ date: '2026-08-02' }, { date: '2026-08-03' }])).toBe(true)
+  })
+
+  it('is true for a 3-day span', () => {
+    expect(isMultiDay([{ date: '2026-08-02' }, { date: '2026-08-03' }, { date: '2026-08-04' }])).toBe(true)
+  })
+
+  it('is false for empty input', () => {
+    expect(isMultiDay([])).toBe(false)
+  })
+})

--- a/frontend/src/utils/festivalDays.js
+++ b/frontend/src/utils/festivalDays.js
@@ -1,0 +1,77 @@
+/**
+ * Shared festival-day helpers for multi-day events (#541).
+ *
+ * Both the admin day-selector (`frontend/src/admin/utils/dayOptions.js`) and
+ * fan-facing schedule surfaces (`ScheduleView`, `MySchedule`) need to label
+ * and order festival days consistently. This module is the single source of
+ * truth for that date handling so the two surfaces never drift.
+ *
+ * A "festival day" is `band.date` (a YYYY-MM-DD string) — the evening a
+ * performance belongs to, already offset for after-midnight sets by
+ * `prepareBands()` in `bandUtils.js`. These helpers never re-derive which
+ * day a performance belongs to; they only order/label the distinct days
+ * already present in the data.
+ */
+
+const parseDateParts = dateStr => {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  return { year, month, day }
+}
+
+/**
+ * Formats a YYYY-MM-DD string for display.
+ *
+ * `style: 'short'` -> "Sat Aug 2"
+ * `style: 'long'`  -> "Saturday, August 2"
+ *
+ * Uses the local-timezone numeric `new Date(year, month - 1, day)`
+ * constructor (parsed by splitting on `-`) — NEVER `new Date('YYYY-MM-DD')`,
+ * which parses a bare date string as UTC midnight and drifts a day in
+ * negative-offset timezones (documented repo invariant, see CLAUDE.md).
+ */
+export const formatFestivalDate = (dateValue, style = 'long') => {
+  if (!dateValue) return ''
+  const { year, month, day } = parseDateParts(dateValue)
+  const date = new Date(year, month - 1, day)
+
+  if (style === 'short') {
+    const label = date.toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    })
+    return label.replace(',', '')
+  }
+
+  return date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+/**
+ * Returns the distinct non-empty `.date` values present across `items`, in
+ * ascending order. Plain lexicographic string sort — YYYY-MM-DD strings sort
+ * chronologically as strings, so this never needs `new Date(...)` parsing.
+ */
+export const orderedFestivalDays = items => {
+  const dates = new Set()
+  ;(items ?? []).forEach(item => {
+    if (item?.date) dates.add(item.date)
+  })
+  return [...dates].sort()
+}
+
+/**
+ * Maps each distinct festival date to its 1-based day number (earliest = Day 1).
+ */
+export const dayNumberByDate = items => {
+  const days = orderedFestivalDays(items)
+  return new Map(days.map((date, index) => [date, index + 1]))
+}
+
+/**
+ * True when `items` span more than one distinct festival day.
+ */
+export const isMultiDay = items => orderedFestivalDays(items).length > 1


### PR DESCRIPTION
## Summary

The fan-facing payoff of the multiday epic (P1.5): `ScheduleView` and `MySchedule` now render a **day divider** — `Day N · Saturday, August 2` — per festival day of a multi-day event. Foundation-level, as scoped: clear day separation, not the polished sticky-tabs / `?day=N` experience (that's Phase 2). Single-day events render exactly as before.

Closes #541

## What changed

| File | Change |
|------|--------|
| `frontend/src/utils/festivalDays.js` (new) | Shared, UTC-safe festival-day helpers: `formatFestivalDate` (short/long), `orderedFestivalDays`, `dayNumberByDate`, `isMultiDay`. |
| `frontend/src/components/ui/DayDivider.jsx` (new) | Shared divider component (`role="separator"`), **semantic tokens only**. |
| `frontend/src/components/ScheduleView.jsx` | Day divider before each new `date` in the Upcoming/Past group loops; numbering off the full `bands` set. |
| `frontend/src/components/MySchedule.jsx` | Divider inserted into the flat list on `date` change; numbering + multi-day gate off the full `sortedBands`. |
| `frontend/src/admin/utils/dayOptions.js` | Refactored to reuse `formatFestivalDate` (removed the duplicated label formatter). Public API + tests unchanged. |

## Design notes

- **The #550 consolidation, done right:** rather than the speculative "canonical boundary util," this extracts the *actual* duplicated piece — day-label formatting — into `festivalDays.js`, now shared by admin (`Day N (Sat Aug 2)`) and fan (`Day N · Saturday, August 2`). Real reuse, real second consumer.
- **Numbering is stable + cross-surface consistent:** both surfaces derive `Day N` from the full band set, so hiding past sets never renumbers a day, and `MySchedule` and `ScheduleView` always agree.
- **Theme-safe:** these are public/theme-following surfaces — the divider uses `text-text-primary` / `bg-surface` / `border-border`, no hardcoded white (the recurring light-theme bug class).

## Security / correctness notes

None (presentational). Single-day (`date` uniform/NULL) → zero dividers, byte-identical. UTC-safe dates throughout (local numeric `Date` constructor + lexicographic string compare).

## Verification

- [x] Frontend tests: 371 pass (`npm test -- --run`, 42 files) — incl. new `festivalDays` + ScheduleView/MySchedule divider tests
- [x] ESLint 0 errors (2 pre-existing warnings), format clean, `npm run build` green
- [x] Existing `dayOptions.test.js` green after the refactor (external behavior unchanged)
- [ ] Manual smoke: single-day shows no divider; a 2-day event shows Day 1 / Day 2 headers in both the schedule and My Route

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
