### PR TITLE
docs: refresh ROADMAP to reflect delivered work; file remaining gaps

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Canonical active roadmap for SetTimes.ca. Use this file for handoffs between Claude, OpenCode, and humans.
 
-Last updated: 2026-06-19
+Last updated: 2026-07-07
 
 ## Mission
 
@@ -10,10 +10,10 @@ Build SetTimes.ca into the best multi-venue and multi-artist event platform for 
 
 ## Fixed Context
 
-- Region: Waterloo Region only, with current focus on Kitchener-Waterloo.
+- Region: Waterloo Region only, with current focus on Kitchener-Waterloo. No non-Waterloo references in new code/docs.
 - Brand: SetTimes.ca. Do not rebrand.
-- Event: Long Weekend Band Crawl Vol. 17, August 2, 2026.
-- Venues: Blue Room, Princess Cafe, Prohibition Warehouse, Revive Karaoke, Room 47, Roost.
+- Event: Long Weekend Band Crawl Vol. 17, August 2, 2026 (single day, ~4 weeks out).
+- Venues: Blue Room (Inside Revive Karaoke), Princess Cafe, Prohibition Warehouse, Revive Karaoke, Room 47, Roost — all King St N, Waterloo.
 - Lineup: 22 bands, doors 6:30 PM, show 6:45 PM, ages 19+.
 - Priority balance: fan-facing experience and admin tooling are both critical.
 - SEO: event pages, band pages, local discovery, and structured data matter.
@@ -22,116 +22,84 @@ Build SetTimes.ca into the best multi-venue and multi-artist event platform for 
 
 ## Operating Rules
 
-- Never merge with failed CI.
-- Read review comments carefully, including line-level PR comments.
-- Reply to review comments when addressed.
-- Add or update tests for behavior changes where testable.
-- Keep changes small and focused. Avoid mixing roadmap/docs, dependency work, and feature work in one PR.
-- Avoid direct writes to localStorage schedule keys; use `frontend/src/utils/scheduleStorage.js`.
-- Preserve after-midnight sorting behavior from `frontend/src/utils/bandUtils.js`.
+- Never merge with failed CI. Vera (code-reviewer) is the primary review gate; reply to and resolve review threads.
+- Add or update tests for behavior changes where testable. Keep changes small and focused.
+- Track remaining/deferred work as GitHub issues (`gh issue create`); reference from PRs (`Closes #N`).
+- Avoid direct writes to localStorage schedule keys; use `frontend/src/utils/scheduleStorage.js` (YYYY-MM-DD lexicographic compare, never `new Date('YYYY-MM-DD')`).
+- Preserve after-midnight sorting from `frontend/src/utils/bandUtils.js` (`AFTER_MIDNIGHT_THRESHOLD_HOUR = 6`, never remove/lower).
+- Multi-day: single-day events stay byte-identical (NULL `performance_date`); never show a "Day 1" label on single-day events (gate on `isMultiDay`).
 
-## Immediate Merge Queue
+## Status Summary (2026-07-07)
 
-1. Merge roster formatting follow-up if still open.
-   - Purpose: keep `main` format-clean after the follower count roster change.
-   - Verify: all CI green.
+**The platform is largely feature-complete for Vol. 17.** The June–July sprint (140+ commits) delivered nearly every P0/P1 across all tracks, plus surfaces the old roadmap never listed. The issue backlog is effectively clear; remaining work is polish, pre-event hardening, and forward-looking (multi-day Phase 2, future editions). See "Next Up" for the live backlog.
 
-2. Merge frontend dependency remediation if still open.
-   - Purpose: clear current frontend dependency alerts.
-   - Verify: `npm audit --audit-level=low` passes in `frontend/` and CI is green.
+### Shipped since 2026-06-19 (highlights)
 
-3. Merge announcement resend/backfill work if still open.
-   - Purpose: per-follower announcement delivery tracking and resend recovery.
-   - Verify: backfill migration, resend race fix, backend tests, and CI green.
+- **Public experience:** event lifecycle states (Upcoming/Live/Recap via `eventLifecycle.js` + `LiveContextBar`); live companion (`ComingUp`, `EventTimeline`, "Next Move"); My Route with walk-time + buffer itinerary; ForkCard conflict chooser; genre-led discovery wall; full crawl history on landing; PWA network-first + offline schedule.
+- **New pages:** About, Contact, public Stats (privacy-safe aggregates), Event Recap, artist directory + search, venue directory + detail, Terms/Privacy (+ one-click PDF).
+- **SEO:** SSR meta + JSON-LD on band/event/venue pages, site-wide Organization/WebSite JSON-LD, sitemap content pages, per-page meta/titles, Waterloo-consistent language.
+- **Multi-day epic (Phase 1, #543):** per-set `performance_date`, day-aware grouping/conflicts, per-set-date APIs + `COALESCE(end_date,date)` windows, admin day selector, day-separated fan display. Invisible to single-day events.
+- **Admin:** bulk import/delete, reveal-mode embargo, per-follower announcement tracking + resend, batch follow / "Lock in your lineup", digest emails, venueless-performance edit fix.
+- **Themes:** light-theme WCAG-AA sweep across public surfaces; semantic tokens.
+- **Perf/reliability/security:** lazy-loaded admin + non-primary routes, batched D1 reads, service-worker cache, schema-drift guard (generated `setup-complete.sql`), CSP/Turnstile hardening, rate-limit + body-size + social-link/ticket-url validation, observability for silent metrics/email failures.
+- **Infra/docs:** MkDocs docs site at docs.settimes.ca; consolidated docs index; ICS feed correctness (America/Toronto).
 
-## Track A: Vol. 17 Public Experience
+## Track A: Vol. 17 Public Experience — largely delivered
 
-Goal: make the public event page useful before, during, and after the crawl.
-
-P0:
-
-- Redesign event page into lifecycle states: preview, live, recap, archive.
-- Build a mobile-first live schedule with Now Playing, Starting Soon, and My Next Set.
-- Rename and refine My Schedule into My Route.
-- Improve save/remove actions and overlap warnings.
-- Preserve offline-readable schedule and saved route state.
-
-P1:
-
-- Add venue-lane schedule view.
-- Add walking-time hints between King Street venues.
-- Add map-aware next-stop suggestions.
-- Improve post-event archive and recap modules.
-
-## Track B: Visual Identity And Themes
-
-Goal: deliver a fresh Vol. 17 identity while preserving readable, fast UI.
-
-Done:
-
-- Theme foundation with four palettes via `data-theme`.
-- LocalStorage persistence and FOUC prevention script.
-- Dynamic `theme-color` metadata.
-- Visible public header theme toggle.
+Done: lifecycle states, mobile live schedule (Now Playing / Coming Up / My Next), My Route rename + walk-time itinerary, save/remove + overlap warnings (ForkCard), offline/PWA, venue-lane view, King St venue strip, post-event recap page.
 
 Next:
+- **Vol-17 day-of readiness pass** — end-to-end verify + harden the live experience for Aug 2 (lifecycle transitions at real times, live clock/timezone, offline resilience, mobile in a loud low-light venue). Highest pre-event value. *(#554)*
+- Map-aware next-stop suggestions — deferred/optional: low ROI for a 6-venue single-street crawl already covered by `VenueStrip` + walk-times.
 
-- Ensure all admin and public surfaces use semantic theme tokens.
-- Tune mobile contrast for low-light event conditions.
+## Track B: Visual Identity And Themes — delivered
 
-## Track C: Band And Event SEO
+Done: four-palette `data-theme` foundation, FOUC script, dynamic `theme-color`, header toggle, light-theme WCAG-AA sweep across public surfaces, semantic tokens (admin dark-pinned by design).
 
-Goal: make SetTimes.ca discoverable for local artists, venues, and event searches.
+Next: opportunistic contrast tuning as new surfaces land; keep the semantic-token discipline on every new public component.
 
-P0:
+## Track C: Band And Event SEO — P0 delivered
 
-- Improve band profile metadata and structured data.
-- Improve event page structured data.
-- Ensure Waterloo Region language is consistent.
-- Remove or avoid non-Waterloo references in new docs/code.
-
-P1:
-
-- Add better archive pages for recurring events.
-- Add stronger internal links between bands, venues, events, and recaps.
-
-## Track D: Admin Tooling
-
-Goal: make event setup and live operations reliable and fast for organizers.
-
-Done or in flight:
-
-- Bulk band import.
-- Bulk band delete fixes.
-- Per-band verified follower counts in roster.
-- Per-follower announcement tracking with resend recovery.
+Done: SSR structured data + local signals on band/event/venue pages, site-wide Organization/WebSite JSON-LD, sitemap, per-page meta, Waterloo-consistent language.
 
 Next:
+- Stronger internal linking between bands, venues, events, and recaps, plus archive pages for recurring editions. *(#555)*
 
-- Improve roster mobile view and sorting quality.
-- Improve lineup management for reveal-mode events.
-- Surface follower engagement where it helps announcement planning.
-- Keep viewer/editor/admin RBAC boundaries explicit on every mutating endpoint.
+## Track D: Admin Tooling — core delivered
 
-## Track E: Performance And Reliability
+Done: bulk import/delete, per-band verified follower counts, per-follower announcement tracking + resend, reveal-mode embargo, RBAC on every mutating endpoint, roster sorting.
 
-Goal: keep the site fast on mobile and safe to operate under event load.
+Next:
+- Surface follower engagement where it helps announcement planning. *(#556)*
+- Roster mobile-view polish; reveal-mode lineup management refinements.
 
-P0:
+## Track E: Performance And Reliability — delivered / continuous
 
-- Code-split `AdminApp` to reduce the large admin chunk.
-- Keep build warnings visible and actionable.
-- Re-run ZAP baseline after CSP/header changes.
-- Keep dependency alerts at zero where practical.
+Done: admin + route code-splitting, batched D1 reads, service-worker caching, schema-drift guard, observability for metrics/email failures, ZAP baseline documented.
 
-P1:
+Continuous: keep build warnings actionable and dependency alerts near zero (Dependabot); re-run ZAP after CSP/header changes.
 
-- Review caching and offline behavior for the schedule.
-- Improve observability around metrics ingestion and email delivery failures.
+## Track F: Multi-day / Multi-event Platform (new)
+
+Phase 1 foundation delivered (#543 closed). Forward-looking:
+- **Phase 2 polish (#542):** day tabs, `?day=N` deep-links, per-day SEO/ICS/hours.
+- **#551:** day-scope bulk conflict detection.
+- **#550 (deferred):** unify the 6 AM festival-day boundary into one util — only when a second consumer (server-side derivation for import/backfill) exists.
+
+## Next Up (live backlog — see GitHub issues)
+
+The tracker is the source of truth. As of 2026-07-07 the actionable queue is short and mostly forward-looking:
+
+1. **#554** — Vol-17 day-of readiness / live-experience hardening (top pre-event value, p1).
+2. **#555** — internal linking + recurring-event archive (Track C P1).
+3. **#556** — follower-engagement surfacing for announcement planning (Track D).
+4. Multi-day Phase 2 (#542), bulk conflict day-scoping (#551) — forward-looking.
+
+Parked (do not resurface unprompted): #466 (Vol-17 venue data — organizer's task), #510 (multi-day scoping — superseded by delivered #543).
 
 ## Reference Docs
 
 - `CLAUDE.md`: assistant context, invariants, stack, and safety rules.
-- `docs/SETTIMES_V2_UX_BRIEF.md`: UX direction and product experience details.
-- `docs/TESTING.md`: testing strategy and known test categories.
+- `docs/INDEX.md`: documentation index.
 - `docs/DATABASE.md`: schema and database implementation notes.
+- `docs/TESTING.md`: testing strategy and known test categories.


### PR DESCRIPTION
## Summary

The canonical roadmap was frozen at **2026-06-19** and had gone badly stale — it predated ~140 commits, including the entire multi-day epic (#543), the About/Contact/Stats/Recap pages, artist + venue directories, legal pages, the docs site, and most Track A–E P0/P1 items (several listed as "to-do" were already shipped). This rewrites it against reality so it's a trustworthy handoff doc again.

## What changed

- Updated `Last updated` → 2026-07-07; dropped the fully-done "Immediate Merge Queue".
- Added a **Status Summary** + "Shipped since 2026-06-19" highlights.
- Rewrote every track to **Done / Next** against the actual codebase (verified via git history + page/route audit).
- Added **Track F: Multi-day / Multi-event Platform** (Phase 1 delivered; Phase 2 #542 forward-looking).
- Linked the three genuine remaining gaps I filed: **#554** (Vol-17 day-of readiness — top pre-event value, p1), **#555** (internal linking + recurring-event archive), **#556** (follower-engagement surfacing).
- Refreshed Operating Rules + Reference Docs (multi-day invariants, single-day-no-"Day 1", `docs/INDEX.md`).

## Security / correctness notes

None — documentation only.

## Verification

- [x] Docs-only change; no code paths touched
- [x] Cross-checked "Done" claims against git history (2026-06-19→07-07) and the actual page/component surface
- [ ] Skim-review the tone/accuracy of each track

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)