### PR TITLE
fix(live): keep event 'Live' through after-midnight sets, not until midnight (#558)

### DIFF
--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -1,6 +1,6 @@
 import { CalendarDays, ChevronDown, Clock, Route, Warehouse } from 'lucide-react'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
-import { getEventState } from '../utils/eventLifecycle'
+import { getLifecycleLabel } from '../utils/liveLabel'
 import GhostEasterEgg from './GhostEasterEgg'
 import TimeFilter from './TimeFilter'
 
@@ -21,33 +21,6 @@ function formatCurrentTime(value) {
     hour: 'numeric',
     minute: '2-digit',
   })
-}
-
-function isSameLocalDay(eventDate, currentTime) {
-  if (!eventDate) return false
-  const current = currentTime instanceof Date ? currentTime : new Date(currentTime)
-  const year = current.getFullYear()
-  const month = String(current.getMonth() + 1).padStart(2, '0')
-  const day = String(current.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}` === eventDate
-}
-
-function getLifecycleLabel(eventDate, currentTime) {
-  const state = getEventState(eventDate, currentTime)
-
-  if (state === 'archived') {
-    return { label: 'Archive', classes: 'bg-surface text-text-secondary border-border' }
-  }
-
-  if (state === 'recently_completed') {
-    return { label: 'Recap', classes: 'bg-info-500/15 text-info-400 border-info-500/30' }
-  }
-
-  if (isSameLocalDay(eventDate, currentTime)) {
-    return { label: 'Live Tonight', classes: 'bg-accent-500/15 text-accent-400 border-accent-500/30' }
-  }
-
-  return { label: 'Upcoming', classes: 'bg-blue-500/15 text-blue-300 border-blue-500/30' }
 }
 
 function LiveContextBar({
@@ -73,7 +46,10 @@ function LiveContextBar({
     return venueOptions.length
   }, [eventData?.venue_info, venueOptions.length])
 
-  const lifecycle = useMemo(() => getLifecycleLabel(eventData?.date, currentTime), [currentTime, eventData?.date])
+  const lifecycle = useMemo(
+    () => getLifecycleLabel(eventData?.date, currentTime, bands),
+    [bands, currentTime, eventData?.date]
+  )
   const [isFiltersOpen, setIsFiltersOpen] = useState(true)
   const [showGhost, setShowGhost] = useState(false)
   const tapCountRef = useRef(0)

--- a/frontend/src/utils/__tests__/liveLabel.test.js
+++ b/frontend/src/utils/__tests__/liveLabel.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { getLifecycleLabel, isSameLocalDay } from '../liveLabel'
+
+// Local-time epoch ms (month is 1-based here for readability). Mirrors how
+// prepareBands parses `${date}T${time}` — local, no offset.
+const at = (y, mo, d, h, mi = 0) => new Date(y, mo - 1, d, h, mi).getTime()
+const band = (startMs, endMs) => ({ startMs, endMs })
+
+const labelOf = (...args) => getLifecycleLabel(...args).label
+
+describe('getLifecycleLabel — after-midnight sets (#558)', () => {
+  // Evening set 20:00–21:00 on Aug 2, plus a 1 AM set that prepareBands has
+  // offset to Aug 3 01:00–02:00 (it belongs to Aug 2's festival day).
+  const bands = [band(at(2026, 8, 2, 20), at(2026, 8, 2, 21)), band(at(2026, 8, 3, 1), at(2026, 8, 3, 2))]
+
+  it('stays "Live Tonight" at 1:30 AM while the after-midnight set is playing', () => {
+    // The bug: the old date-based logic flipped to "Recap" at midnight here.
+    expect(labelOf('2026-08-02', new Date(2026, 7, 3, 1, 30), bands)).toBe('Live Tonight')
+  })
+
+  it('flips to "Recap" only after the last set actually ends', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 3, 2, 30), bands)).toBe('Recap')
+  })
+
+  it('archives 48h after the real last-set end, not after midnight', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 3, 1, 30), bands)).toBe('Live Tonight') // still live
+    expect(labelOf('2026-08-02', new Date(2026, 7, 5, 3, 0), bands)).toBe('Archive') // >48h past 02:00
+    expect(labelOf('2026-08-02', new Date(2026, 7, 5, 1, 0), bands)).toBe('Recap') // <48h past
+  })
+})
+
+describe('getLifecycleLabel — single-day (no after-midnight) is byte-identical', () => {
+  // Last set ends 23:00, before the 23:59:59 day boundary → liveEnd = day end.
+  const bands = [band(at(2026, 8, 2, 20), at(2026, 8, 2, 21)), band(at(2026, 8, 2, 22), at(2026, 8, 2, 23))]
+
+  it('is Live during the event day', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 22, 30), bands)).toBe('Live Tonight')
+  })
+
+  it('stays Live between the last set and midnight (unchanged from before)', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 23, 30), bands)).toBe('Live Tonight')
+  })
+
+  it('flips to Recap at midnight (unchanged from before)', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 3, 0, 30), bands)).toBe('Recap')
+  })
+})
+
+describe('getLifecycleLabel — no set times entered yet (date-based fallback)', () => {
+  const noTimes = [band(0, 0), band(0, 0)] // prepareBands sets 0 for untimed bands
+
+  it('is Live on the event day even with no times', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 15, 0), noTimes)).toBe('Live Tonight')
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 15, 0), [])).toBe('Live Tonight')
+  })
+
+  it('is Upcoming before the event day', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 1, 12, 0), noTimes)).toBe('Upcoming')
+  })
+
+  it('is Recap within 48h after, Archive beyond', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 3, 12, 0), noTimes)).toBe('Recap')
+    expect(labelOf('2026-08-02', new Date(2026, 7, 6, 12, 0), noTimes)).toBe('Archive')
+  })
+
+  it('defaults to Upcoming with neither date nor times', () => {
+    expect(labelOf(null, new Date(2026, 7, 2, 15, 0), [])).toBe('Upcoming')
+  })
+})
+
+describe('isSameLocalDay', () => {
+  it('matches the event calendar day', () => {
+    expect(isSameLocalDay('2026-08-02', new Date(2026, 7, 2, 23, 0))).toBe(true)
+  })
+  it('is false after midnight (next calendar day)', () => {
+    expect(isSameLocalDay('2026-08-02', new Date(2026, 7, 3, 1, 0))).toBe(false)
+  })
+  it('is false with no eventDate', () => {
+    expect(isSameLocalDay(null, new Date())).toBe(false)
+  })
+})

--- a/frontend/src/utils/liveLabel.js
+++ b/frontend/src/utils/liveLabel.js
@@ -1,0 +1,87 @@
+/**
+ * Fan-facing event lifecycle label (the badge in LiveContextBar).
+ *
+ * Schedule-aware: the event stays "Live Tonight" until whichever is later —
+ * the event day's local end, or the actual last set's end (which prepareBands
+ * has already offset correctly for after-midnight sets). This fixes the badge
+ * flipping to "Recap" at calendar midnight while 1 AM sets are still playing
+ * (#558), while staying byte-identical for events with no after-midnight sets.
+ *
+ * Deliberately independent of the admin edit-protection lifecycle
+ * (`getEventState` in `eventLifecycle.js`) — coupling the two is what caused
+ * #558. This is display only; that is data-mutation protection.
+ */
+
+const GRACE_PERIOD_MS = 48 * 60 * 60 * 1000
+
+const LABELS = {
+  archive: { label: 'Archive', classes: 'bg-surface text-text-secondary border-border' },
+  recap: { label: 'Recap', classes: 'bg-info-500/15 text-info-400 border-info-500/30' },
+  live: { label: 'Live Tonight', classes: 'bg-accent-500/15 text-accent-400 border-accent-500/30' },
+  upcoming: { label: 'Upcoming', classes: 'bg-blue-500/15 text-blue-300 border-blue-500/30' },
+}
+
+const toMs = value => (value instanceof Date ? value : new Date(value)).getTime()
+
+/**
+ * True when `currentTime` falls on the same local calendar day as the
+ * YYYY-MM-DD `eventDate`. Local components on purpose — the badge is for the
+ * viewer's own clock.
+ */
+export function isSameLocalDay(eventDate, currentTime) {
+  if (!eventDate) return false
+  const current = currentTime instanceof Date ? currentTime : new Date(currentTime)
+  const year = current.getFullYear()
+  const month = String(current.getMonth() + 1).padStart(2, '0')
+  const day = String(current.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}` === eventDate
+}
+
+/**
+ * Real start/end of the crawl from prepared bands. `prepareBands` sets
+ * `endMs`/`startMs` to 0 for bands with no/invalid times, so we ignore those.
+ * Fields are null when no band has a real time yet (e.g. before the schedule's
+ * set times are entered).
+ */
+function scheduleWindow(bands) {
+  let firstStart = Infinity
+  let lastEnd = 0
+  for (const band of bands ?? []) {
+    if (band?.endMs > 0 && band.endMs > lastEnd) lastEnd = band.endMs
+    if (band?.startMs > 0 && band.startMs < firstStart) firstStart = band.startMs
+  }
+  return { firstStart: firstStart === Infinity ? null : firstStart, lastEnd: lastEnd > 0 ? lastEnd : null }
+}
+
+/**
+ * @param {string} eventDate - YYYY-MM-DD
+ * @param {Date|number} currentTime
+ * @param {Array<{startMs:number,endMs:number}>} bands - prepared bands (prepareBands)
+ * @returns {{label:string, classes:string}}
+ */
+export function getLifecycleLabel(eventDate, currentTime, bands = []) {
+  const { firstStart, lastEnd } = scheduleWindow(bands)
+
+  // Baseline: the event day's local end (23:59:59), matching the prior
+  // date-based behavior. `new Date('YYYY-MM-DDT23:59:59')` parses as LOCAL time
+  // (no offset) — same as the old getEventState path, so single-day events are
+  // byte-identical.
+  const baselineEnd = eventDate ? new Date(eventDate + 'T23:59:59').getTime() : 0
+  // Live through whichever is later — the day's end, or the real last set. Only
+  // after-midnight sets push this past midnight; everything else is unchanged.
+  const liveEnd = Math.max(baselineEnd, lastEnd ?? 0)
+
+  // Neither a date nor any set times → nothing to reason about.
+  if (liveEnd <= 0) return LABELS.upcoming
+
+  const now = toMs(currentTime)
+  if (now >= liveEnd + GRACE_PERIOD_MS) return LABELS.archive
+  if (now >= liveEnd) return LABELS.recap
+  // Before the crawl ends: "Live" on the event's local day, or once the first
+  // set has started — the latter keeps it Live through the after-midnight
+  // window, when the local calendar day has rolled over but the crawl is on.
+  if (isSameLocalDay(eventDate, currentTime) || (firstStart != null && now >= firstStart)) {
+    return LABELS.live
+  }
+  return LABELS.upcoming
+}


### PR DESCRIPTION
## Summary

The fan-facing live badge (`LiveContextBar`) flipped to **"Recap" at calendar midnight** while after-midnight sets were still playing — a 1 AM set belongs to that evening's festival day (`AFTER_MIDNIGHT_THRESHOLD_HOUR = 6`), so at 1 AM the badge said the crawl was over while `ComingUp` (which uses `prepareBands`, correctly offset) showed that same band **"Now Playing."** Contradictory UI on the most important night.

Root cause: the fan label reused the admin `getEventState`, which assumes the event ends at `date + 23:59:59`.

Closes #558 (found during the #554 day-of readiness audit; split out because it's unblocked by the missing timetables).

## What changed

| File | Change |
|------|--------|
| `frontend/src/utils/liveLabel.js` (new) | Extracted, schedule-aware `getLifecycleLabel` (+ `isSameLocalDay`). Liveness ends at **`max(event-day end, last set's real endMs)`** — only after-midnight sets push it past midnight. Deliberately decoupled from the admin `getEventState`. |
| `frontend/src/components/LiveContextBar.jsx` | Import the util; pass the (already `prepareBands`-prepared) `bands` to it; drop the now-unused `getEventState` import + inline functions. |
| `frontend/src/utils/__tests__/liveLabel.test.js` (new) | 13 tests. |

## Security / correctness notes

Display-only; the admin edit-protection lifecycle (`getEventState`, 48h grace) is untouched — coupling the two was the bug. **Single-day and no-set-times events are byte-identical** (proven by tests: Live through the day, Recap at midnight, correct fallback when times aren't entered yet — Vol-17's current state). Dates parsed local (`YYYY-MM-DDT23:59:59`), matching prior behavior.

## Verification

- [x] Frontend: 384 pass (`npm test -- --run`, 43 files) — incl. 13 new; after-midnight stays Live at 1:30 AM, Recap only after the real last set, single-day byte-identical
- [x] ESLint 0 errors (2 pre-existing warnings), format clean, `npm run build` green
- [ ] Manual smoke: with a real multi-set schedule, badge stays "Live Tonight" past midnight until the last set ends

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)