### PR TITLE
feat(seo): link the orphaned recap pages + band→event links; recaps in sitemap (#555)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -723,6 +723,14 @@ function App() {
             <div>
               <span className="font-semibold text-text-primary">This event has concluded.</span> You&apos;re viewing the
               archived lineup for reference.
+              {eventData?.slug && (
+                <>
+                  {' '}
+                  <Link to={`/events/${eventData.slug}/recap`} className="text-accent-400 hover:underline">
+                    View the recap →
+                  </Link>
+                </>
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -653,6 +653,19 @@ function EventCard({
             >
               {isPast || event.status === 'archived' ? 'View Lineup' : 'Plan Your Night'}
             </Button>
+            {/* Past editions get a recap link — the recap page was previously
+                unreachable except by URL (#555). */}
+            {(isPast || event.status === 'archived') && event.slug && (
+              <Button
+                as={Link}
+                to={`/events/${event.slug}/recap`}
+                variant="secondary"
+                size="md"
+                className="w-full sm:w-auto sm:min-w-[160px]"
+              >
+                Recap
+              </Button>
+            )}
             {ticketHref !== '#' && (
               <Button
                 as="a"

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -91,3 +91,53 @@ describe('EventTimeline', () => {
     })
   })
 })
+
+// Recap links on past editions (#555): the recap page was previously
+// unreachable except by typing the URL.
+describe('EventTimeline recap links', () => {
+  const baseEvent = {
+    venues: [],
+    bands: [],
+    band_count: 0,
+    venue_count: 0,
+    ticket_url: null,
+    is_published: true,
+    status: 'published',
+  }
+
+  beforeEach(() => {
+    const timelineData = {
+      now: [],
+      upcoming: [{ ...baseEvent, id: 1, name: 'Upcoming Fest', slug: 'upcoming-fest', date: '2099-05-10' }],
+      past: [{ ...baseEvent, id: 2, name: 'Past Fest', slug: 'past-fest', date: '2020-05-10' }],
+    }
+    global.fetch = vi.fn(url => {
+      if (url.startsWith('/api/events/timeline')) {
+        return Promise.resolve(jsonResponse(timelineData))
+      }
+      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('past event cards link to the recap; upcoming cards do not', async () => {
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Upcoming Fest')).toBeInTheDocument()
+
+    // Past events sit behind the "Show History" toggle
+    fireEvent.click(screen.getByRole('button', { name: /show history/i }))
+    expect(await screen.findByText('Past Fest')).toBeInTheDocument()
+
+    const recapLinks = screen.getAllByRole('link', { name: 'Recap' })
+    expect(recapLinks).toHaveLength(1)
+    expect(recapLinks[0]).toHaveAttribute('href', '/events/past-fest/recap')
+  })
+})

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -782,7 +782,18 @@ export default function BandProfilePage() {
                     <Card key={idx} variant="outline" hoverable className="p-4">
                       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                         <div className="flex-1">
-                          <h3 className="text-xl font-semibold text-accent-500 mb-2">{performance.event_name}</h3>
+                          <h3 className="text-xl font-semibold text-accent-500 mb-2">
+                            {performance.event_slug ? (
+                              <Link
+                                to={`/event/${performance.event_slug}`}
+                                className="transition-colors hover:text-accent-400 hover:underline"
+                              >
+                                {performance.event_name}
+                              </Link>
+                            ) : (
+                              performance.event_name
+                            )}
+                          </h3>
                           <div className="flex flex-wrap gap-3 text-sm text-text-secondary">
                             {performance.event_date && (
                               <span className="flex items-center gap-2">
@@ -861,7 +872,18 @@ export default function BandProfilePage() {
                       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                         <div className="flex-1">
                           <div className="flex items-center gap-2 mb-2 flex-wrap">
-                            <h3 className="text-xl font-semibold text-accent-500">{performance.event_name}</h3>
+                            <h3 className="text-xl font-semibold text-accent-500">
+                              {performance.event_slug ? (
+                                <Link
+                                  to={`/event/${performance.event_slug}`}
+                                  className="transition-colors hover:text-accent-400 hover:underline"
+                                >
+                                  {performance.event_name}
+                                </Link>
+                              ) : (
+                                performance.event_name
+                              )}
+                            </h3>
                             {performance.event_status === 'archived' && (
                               <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-text-primary/10 text-text-tertiary border border-text-primary/10">
                                 <Archive size={12} aria-hidden="true" />

--- a/functions/__tests__/sitemap.test.js
+++ b/functions/__tests__/sitemap.test.js
@@ -1,0 +1,53 @@
+/**
+ * Dynamic sitemap tests (#555) — recap URLs for past editions.
+ *
+ * The recap page (/events/:slug/recap) is content-rich but was reachable only
+ * by typing the URL. The sitemap now lists it for every PAST published event;
+ * future events must not get a recap entry (the recap doesn't exist yet), and
+ * unpublished events must not appear at all.
+ */
+import { describe, expect, test } from "vitest";
+import { onRequestGet } from "../sitemap.xml.js";
+import { createTestEnv, insertEvent } from "../api/test-utils.js";
+
+async function fetchSitemap(env) {
+  env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+  const res = await onRequestGet({ env });
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+function publish(rawDb, eventId) {
+  rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(eventId);
+}
+
+describe("GET /sitemap.xml — recap entries (#555)", () => {
+  test("past published event gets both an /event/ and a recap URL", async () => {
+    const { env, rawDb } = createTestEnv();
+    const past = insertEvent(rawDb, { name: "Past Fest", slug: "past-fest", date: "2020-01-01" });
+    publish(rawDb, past.id);
+
+    const xml = await fetchSitemap(env);
+    expect(xml).toContain("<loc>https://settimes.ca/event/past-fest</loc>");
+    expect(xml).toContain("<loc>https://settimes.ca/events/past-fest/recap</loc>");
+  });
+
+  test("future published event gets an /event/ URL but NO recap URL", async () => {
+    const { env, rawDb } = createTestEnv();
+    const future = insertEvent(rawDb, { name: "Future Fest", slug: "future-fest", date: "2099-01-01" });
+    publish(rawDb, future.id);
+
+    const xml = await fetchSitemap(env);
+    expect(xml).toContain("<loc>https://settimes.ca/event/future-fest</loc>");
+    expect(xml).not.toContain("/events/future-fest/recap");
+  });
+
+  test("unpublished past event appears nowhere", async () => {
+    const { env, rawDb } = createTestEnv();
+    insertEvent(rawDb, { name: "Draft Fest", slug: "draft-fest", date: "2020-01-01" });
+    // deliberately not published
+
+    const xml = await fetchSitemap(env);
+    expect(xml).not.toContain("draft-fest");
+  });
+});

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -74,6 +74,10 @@ export async function onRequestGet(context) {
   </url>`,
     ];
 
+    // YYYY-MM-DD lexicographic comparison — never new Date('YYYY-MM-DD'),
+    // which UTC-parses and drifts a day (documented repo invariant).
+    const today = new Date().toISOString().split("T")[0];
+
     for (const event of events) {
       rows.push(`  <url>
     <loc>https://settimes.ca/event/${event.slug}</loc>
@@ -81,6 +85,17 @@ export async function onRequestGet(context) {
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>`);
+      // Past editions also get their recap page (#555) — a content-rich page
+      // that was previously reachable only by typing the URL. Recaps only
+      // exist once the event has happened, so future events are excluded.
+      if (event.date < today) {
+        rows.push(`  <url>
+    <loc>https://settimes.ca/events/${event.slug}/recap</loc>
+    <lastmod>${event.date}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>`);
+      }
     }
 
     for (const band of bands) {


### PR DESCRIPTION
## Summary

The event recap page (`/events/:slug/recap`) — a content-rich page linking bands and venues — was **orphaned**: zero inbound links anywhere in the app and absent from the sitemap. Fans couldn't find it; crawlers couldn't either. This PR wires it into the navigation graph and closes the one missing internal-link edge (band→event).

Closes #555

## What changed

| File | Change |
|------|--------|
| `frontend/src/App.jsx` | Archived-event banner ("This event has concluded…") now links "View the recap →". |
| `frontend/src/components/EventTimeline.jsx` | Past/archived event cards get a secondary **Recap** button beside "View Lineup". Now/upcoming cards unchanged. |
| `frontend/src/pages/BandProfilePage.jsx` | Performance-history event names link to `/event/:slug` (both upcoming + past sites; venue links already existed). Plain text when no slug. |
| `functions/sitemap.xml.js` | Past published events also emit `/events/:slug/recap` (lexicographic `YYYY-MM-DD` compare — never `new Date('YYYY-MM-DD')`; future events excluded since their recap doesn't exist yet). |
| `functions/__tests__/sitemap.test.js` (new) | Past → both URLs; future → `/event/` only; unpublished → neither. |
| `frontend/src/components/__tests__/EventTimeline.test.jsx` | Past card renders the Recap link (behind Show History); upcoming does not. |

## Scope decision

**No separate `/archive` page** — the homepage timeline already lists the full crawl history (#364); a new page would duplicate it. Noted here so the issue's "archive pages" ask has an explicit answer: recaps + the timeline *are* the archive, now mutually linked and indexable.

## Security / correctness notes

None — links + sitemap entries only. All touched surfaces are public/theme-following → semantic tokens (`text-accent-400`, `secondary` Button variant), no hardcoded white. UTC-safe date comparison in the sitemap.

## Verification

- [x] Backend: 666 pass, 6 todo (`npm test`, 72 files) — incl. 3 new sitemap tests; ESLint 0 errors; format clean
- [x] Frontend: 390 pass incl. new recap-link test; **coverage 62.8% lines, no threshold errors** (`npm test -- --run --coverage`); ESLint 0 errors; format clean; build green
- [ ] Manual smoke: archived event shows the recap link; homepage history cards show Recap; band page event names navigate

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)