### PR TITLE
feat(footer): add @settimes.ca Instagram link and Organization sameAs

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -636,7 +636,12 @@ function App() {
             ? { address: { '@type': 'PostalAddress', addressLocality: eventData.city, addressCountry: 'CA' } }
             : { name: 'Canada', address: { '@type': 'PostalAddress', addressCountry: 'CA' } }),
         },
-        organizer: { '@type': 'Organization', name: 'SetTimes', url: 'https://settimes.ca' },
+        organizer: {
+          '@type': 'Organization',
+          name: 'SetTimes',
+          url: 'https://settimes.ca',
+          sameAs: ['https://www.instagram.com/settimes.ca'],
+        },
         ...(eventData.ticket_url && {
           offers: {
             '@type': 'Offer',

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -32,6 +32,18 @@ function Footer() {
             </Link>
           </div>
 
+          <div>
+            <a
+              href="https://www.instagram.com/settimes.ca"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent-400 hover:text-accent-500 transition-colors inline-flex items-center gap-1.5 text-sm font-medium"
+            >
+              <InstagramIcon size={16} />
+              <span>@settimes.ca</span>
+            </a>
+          </div>
+
           <p className="text-text-tertiary text-xs">Times are subject to change - late starts happen!</p>
 
           <p className="text-text-tertiary text-xs">


### PR DESCRIPTION
## Summary

The platform's Instagram account (**@settimes.ca**) launched today; this surfaces it on the main site. The footer gets a brand Instagram link (same `InstagramIcon` pattern as the existing site credit), and the MusicEvent JSON-LD's `organizer` gains `sameAs` pointing at the account so search engines associate the profile with the site entity.

Related: #564 (brand identity kit).

Closes: none — direct request.

## What changed

| File | Change |
|------|--------|
| `frontend/src/components/Footer.jsx` | New centered footer line linking to instagram.com/settimes.ca (icon + @handle, accent tokens, `noopener noreferrer`) |
| `frontend/src/App.jsx` | `organizer` in the MusicEvent JSON-LD now includes `sameAs: ['https://www.instagram.com/settimes.ca']` |

## Security / correctness notes

External link uses `target="_blank"` with `rel="noopener noreferrer"`, matching the existing footer credit link. Static URL, no user input involved. JSON-LD change adds a static string to an already-static object. Theme-safe: semantic `text-accent-*` tokens only, renders on all four themes.

## Verification

- [x] Tests: 390 pass, 0 failures (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors (`npm run lint` — 2 pre-existing warnings in untouched admin files)
- [x] Format check: clean (`cd frontend && npm run format:check`)
- [x] Build: green (`npm run build --prefix frontend`)
- [ ] `validate:openapi`: no drift (if `docs/api-spec.yaml` changed) — N/A, not changed
- [x] Manual smoke: served the production build (`vite preview`) and verified via Playwright that the footer renders the `@settimes.ca` link pointing at instagram.com/settimes.ca; console errors are only the expected `/api/*` 502s under preview (no backend)

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)