### PR TITLE
fix(themes): make status colours readable on the light themes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -598,7 +598,7 @@ function App() {
     return (
       <div className="min-h-screen flex items-center justify-center px-4">
         <div className="max-w-md text-center">
-          <div className="text-red-400 mb-4" aria-hidden="true">
+          <div className="text-error-400 mb-4" aria-hidden="true">
             <CircleAlert size={64} />
           </div>
           <h2 className="text-text-primary text-2xl font-bold mb-2">Oops! Something went wrong</h2>

--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -142,8 +142,8 @@ function BandCard({
                   ? 'bg-yellow-900/80 text-yellow-100'
                   : 'bg-red-900/70 text-red-100'
                 : warningType === 'overlap'
-                  ? 'bg-yellow-500/30 text-yellow-200'
-                  : 'bg-red-500/30 text-red-200'
+                  ? 'bg-warning-500/25 text-text-primary'
+                  : 'bg-error-500/25 text-text-primary'
             }`}
           >
             {warningType === 'overlap' ? (

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -43,7 +43,7 @@ class ErrorBoundary extends Component {
       // Default error UI
       return (
         <div className="min-h-screen bg-bg-navy flex items-center justify-center px-4">
-          <div className="max-w-lg w-full bg-bg-purple rounded-xl border-2 border-red-500/30 p-8 text-center">
+          <div className="max-w-lg w-full bg-bg-purple rounded-xl border-2 border-error-500/30 p-8 text-center">
             <div className="text-6xl mb-4">⚠️</div>
             <h1 className="text-3xl font-bold text-text-primary mb-4">{this.props.title || 'Something went wrong'}</h1>
             <p className="text-text-secondary mb-6">
@@ -57,7 +57,7 @@ class ErrorBoundary extends Component {
                   Error Details (Dev Only)
                 </summary>
                 <div className="bg-bg-navy p-4 rounded text-sm text-text-secondary overflow-auto max-h-60">
-                  <p className="font-mono text-red-400 mb-2">{this.state.error.toString()}</p>
+                  <p className="font-mono text-error-400 mb-2">{this.state.error.toString()}</p>
                   {this.state.errorInfo && (
                     <pre className="text-xs whitespace-pre-wrap">{this.state.errorInfo.componentStack}</pre>
                   )}

--- a/frontend/src/components/LockInLineupPanel.jsx
+++ b/frontend/src/components/LockInLineupPanel.jsx
@@ -137,7 +137,7 @@ export default function LockInLineupPanel({ performanceIds, bandCount }) {
         </div>
 
         {followStatus === 'success' ? (
-          <p className="inline-flex items-start gap-1.5 text-sm text-success-500 sm:max-w-xs">
+          <p className="inline-flex items-start gap-1.5 text-sm text-success-400 sm:max-w-xs">
             <Check size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
             Check your email to confirm — one click locks in all {n} {n === 1 ? 'band' : 'bands'}.
           </p>
@@ -171,7 +171,7 @@ export default function LockInLineupPanel({ performanceIds, bandCount }) {
       </div>
 
       {followStatus === 'error' && (
-        <p className="mt-2 text-xs text-error-500" role="alert">
+        <p className="mt-2 text-xs text-error-400" role="alert">
           {followError}
         </p>
       )}

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -533,7 +533,7 @@ function MySchedule({
       {/* Contextual reminder */}
       {reminder && (
         <div className="max-w-5xl mx-auto">
-          <div className="text-xs text-green-300 bg-green-900/20 px-4 py-2 rounded border border-green-500/30 text-center flex items-center justify-center gap-2 leading-normal">
+          <div className="text-xs text-text-primary bg-success-500/15 px-4 py-2 rounded border border-success-500/40 text-center flex items-center justify-center gap-2 leading-normal">
             {(() => {
               const ReminderIcon = reminder.icon
               return <ReminderIcon size={14} aria-hidden="true" />
@@ -624,7 +624,7 @@ function MySchedule({
                 )}
                 {showDreReminder && (
                   <div className="text-center text-text-secondary text-xs italic pb-2 flex items-center justify-center gap-2">
-                    <Smile size={14} className="text-yellow-300" aria-hidden="true" />
+                    <Smile size={14} className="text-warning-400" aria-hidden="true" />
                     <span>{getHighlightMessage()}</span>
                   </div>
                 )}

--- a/frontend/src/components/PasswordStrength.jsx
+++ b/frontend/src/components/PasswordStrength.jsx
@@ -14,9 +14,9 @@ const buildChecks = password => {
 
 const getStrength = checks => {
   const score = checks.filter(check => check.ok).length
-  if (score <= 2) return { label: 'Weak', color: 'bg-red-500', score }
-  if (score <= 4) return { label: 'Medium', color: 'bg-yellow-500', score }
-  return { label: 'Strong', color: 'bg-green-500', score }
+  if (score <= 2) return { label: 'Weak', color: 'bg-error-500', score }
+  if (score <= 4) return { label: 'Medium', color: 'bg-warning-500', score }
+  return { label: 'Strong', color: 'bg-success-500', score }
 }
 
 export default function PasswordStrength({ password }) {
@@ -42,7 +42,7 @@ export default function PasswordStrength({ password }) {
       <div className="grid gap-1 text-xs text-text-secondary sm:grid-cols-2">
         {checks.map(check => (
           <div key={check.label} className="flex items-center gap-2">
-            <span className={`inline-block h-2 w-2 rounded-full ${check.ok ? 'bg-green-400' : 'bg-surface'}`} />
+            <span className={`inline-block h-2 w-2 rounded-full ${check.ok ? 'bg-success-400' : 'bg-surface'}`} />
             <span className={check.ok ? 'text-text-primary' : ''}>{check.label}</span>
           </div>
         ))}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -280,6 +280,24 @@
   --shadow-xl: 0 25px 50px -12px rgb(0 0 0 / 0.15);
   --shadow-glow-primary: 0 0 20px rgba(190, 18, 60, 0.22);
   --shadow-glow-accent: 0 0 20px rgba(194, 65, 12, 0.24);
+
+  /* Status ramps re-tuned for light surfaces, mirroring the accent-ramp
+     philosophy above: -400 (text/icon usage) goes DARK so it clears 4.5:1 on
+     the paper backgrounds; -500 (solid fills / translucent chip tints) darkens
+     one grade so white button text stays readable; -600 stays the darkest
+     hover step. The dark themes keep the @theme defaults. */
+  --color-success-400: #15803d;
+  --color-success-500: #16a34a;
+  --color-success-600: #166534;
+  --color-warning-400: #b45309;
+  --color-warning-500: #d97706;
+  --color-warning-600: #92400e;
+  --color-error-400: #b91c1c;
+  --color-error-500: #dc2626;
+  --color-error-600: #991b1b;
+  --color-info-400: #1d4ed8;
+  --color-info-500: #2563eb;
+  --color-info-600: #1e40af;
 }
 
 /* silver-lining — light cool */
@@ -333,6 +351,22 @@
   --shadow-xl: 0 25px 50px -12px rgb(0 0 0 / 0.15);
   --shadow-glow-primary: 0 0 20px rgba(100, 116, 139, 0.2);
   --shadow-glow-accent: 0 0 20px rgba(59, 130, 246, 0.2);
+
+  /* Status ramps re-tuned for light surfaces — same values as daybreak (status
+     colours carry no warm/cool identity); see the daybreak block for the
+     -400/-500/-600 usage rationale. */
+  --color-success-400: #15803d;
+  --color-success-500: #16a34a;
+  --color-success-600: #166534;
+  --color-warning-400: #b45309;
+  --color-warning-500: #d97706;
+  --color-warning-600: #92400e;
+  --color-error-400: #b91c1c;
+  --color-error-500: #dc2626;
+  --color-error-600: #991b1b;
+  --color-info-400: #1d4ed8;
+  --color-info-500: #2563eb;
+  --color-info-600: #1e40af;
 }
 
 /*

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -716,7 +716,7 @@ export default function BandProfilePage() {
               <p className="text-xs text-text-secondary">Get notified when they join a new lineup.</p>
             </div>
             {followStatus === 'success' ? (
-              <p className="inline-flex items-start gap-1.5 text-sm text-green-400 sm:max-w-sm">
+              <p className="inline-flex items-start gap-1.5 text-sm text-success-400 sm:max-w-sm">
                 <Check size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
                 Almost there — check your email to confirm your follow of {profile.name}.
               </p>
@@ -747,7 +747,7 @@ export default function BandProfilePage() {
               </form>
             )}
           </div>
-          {followStatus === 'error' && <p className="mt-2 text-xs text-red-400">{followError}</p>}
+          {followStatus === 'error' && <p className="mt-2 text-xs text-error-400">{followError}</p>}
         </div>
 
         {/* Stats/Facts (left) + Shows (right). When a band has no stats, the shows

--- a/frontend/src/pages/ResetPasswordPage.jsx
+++ b/frontend/src/pages/ResetPasswordPage.jsx
@@ -195,7 +195,7 @@ export default function ResetPasswordPage() {
           {message && (
             <div
               className={`p-4 rounded-lg ${
-                status === 'error' ? 'bg-red-500/20 text-red-200' : 'bg-green-500/20 text-green-200'
+                status === 'error' ? 'bg-error-500/20 text-text-primary' : 'bg-success-500/20 text-text-primary'
               }`}
             >
               {message}

--- a/frontend/src/pages/SubscribePage.jsx
+++ b/frontend/src/pages/SubscribePage.jsx
@@ -245,7 +245,7 @@ export default function SubscribePage() {
             {message && (
               <div
                 className={`p-4 rounded-lg ${
-                  status === 'success' ? 'bg-green-500/20 text-green-200' : 'bg-red-500/20 text-red-200'
+                  status === 'success' ? 'bg-success-500/20 text-text-primary' : 'bg-error-500/20 text-text-primary'
                 }`}
               >
                 {message}

--- a/frontend/src/utils/liveLabel.js
+++ b/frontend/src/utils/liveLabel.js
@@ -18,7 +18,7 @@ const LABELS = {
   archive: { label: 'Archive', classes: 'bg-surface text-text-secondary border-border' },
   recap: { label: 'Recap', classes: 'bg-info-500/15 text-info-400 border-info-500/30' },
   live: { label: 'Live Tonight', classes: 'bg-accent-500/15 text-accent-400 border-accent-500/30' },
-  upcoming: { label: 'Upcoming', classes: 'bg-blue-500/15 text-blue-300 border-blue-500/30' },
+  upcoming: { label: 'Upcoming', classes: 'bg-info-500/15 text-info-400 border-info-500/30' },
 }
 
 const toMs = value => (value instanceof Date ? value : new Date(value)).getTime()


### PR DESCRIPTION
## Summary

The two light themes (daybreak, silver-lining) were flagged as unusable in practice (see screenshots from mobile testing on the My Route page — an invisible green tip banner, washed-out Upcoming badge). Root cause is two-layered: the light themes **never overrode the status colour ramps** (so even token-correct components rendered success/warning/error/info at ~2:1 contrast on cream), and several fan surfaces still used dark-first Tailwind palette literals (`text-green-300 bg-green-900/20`) that are outright invisible on light backgrounds.

This finishes the light-theme contrast sweep (PR2 of the effort that shipped the primitives).

Closes: none — direct report from Dre (2026-07-09).

## What changed

| File | Change |
|------|--------|
| `frontend/src/index.css` | AA-tuned status ramp overrides in both light theme blocks, mirroring the existing accent-ramp philosophy (-400 text step goes dark on light surfaces) |
| `frontend/src/utils/liveLabel.js` | `upcoming` badge: blue literals → info tokens (matching its recap/live/archive siblings) |
| `frontend/src/components/MySchedule.jsx` | Reminder banner green literals → success tokens + `text-text-primary`; Smile icon yellow → warning token |
| `frontend/src/components/BandCard.jsx` | Warning/conflict chips (non-amber branch only) → warning/error tokens; the on-amber branch sits on a fixed orange gradient and is untouched |
| `frontend/src/pages/SubscribePage.jsx`, `ResetPasswordPage.jsx` | Status messages → `bg-<status>-500/20 text-text-primary` per CLAUDE.md convention |
| `frontend/src/pages/BandProfilePage.jsx`, `components/LockInLineupPanel.jsx` | Follow status text → `-400` text steps (LockIn was using `-500` fill steps as text — pre-PR review catch) |
| `frontend/src/components/PasswordStrength.jsx`, `ErrorBoundary.jsx`, `App.jsx` | Remaining red/yellow/green literals → tokens |

Intentional fixed colours untouched: social brand buttons, photo scrims, theme swatch dots, admin (dark-pinned), highlights easter egg.

## Security / correctness notes

None — class names and CSS custom property values only. Dark themes are pixel-identical for the CSS layer (they keep the `@theme` defaults); the literal→token conversions on dark render within the same visual family per the CLAUDE.md status-colour convention.

## Verification

- [x] Tests: 390 pass, 0 failures (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors (2 pre-existing warnings in untouched admin files)
- [x] Format check: clean
- [x] Build: green (`npm run build --prefix frontend`)
- [ ] `validate:openapi`: N/A — not changed
- [x] Manual smoke: rendered a harness page against the **built** CSS with the exact class combos under all three themes side-by-side — every status element reads clearly on daybreak/silver-lining, midnight-ember control unchanged
- [x] Pre-PR review (code-reviewer agent): 1 finding (LockInLineupPanel `-500`-as-text), fixed; noted CI gap — axe contrast specs never render under the light themes (follow-up candidate)

---
Built by Theo · Reviewed by Vera · 🤖 [Claude Code](https://claude.ai/claude-code)