### PR TITLE
fix(events): classify event days by Toronto-local date, not UTC

### DIFF
--- a/frontend/src/admin/EventFormModal.jsx
+++ b/frontend/src/admin/EventFormModal.jsx
@@ -290,8 +290,10 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
 
   if (!isOpen) return null
 
-  // Get today's date in YYYY-MM-DD format for min attribute
-  const today = new Date().toISOString().split('T')[0]
+  // Today's date (device-local, YYYY-MM-DD) for the min attribute.
+  // Not toISOString(): that is the UTC day, which flips to tomorrow at 8 PM
+  // Eastern and blocks the admin from picking today's date in the evening.
+  const today = new Date().toLocaleDateString('en-CA')
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -651,7 +651,7 @@ function EventCard({
                 }
               }}
             >
-              {isPast || event.status === 'archived' ? 'View Lineup' : 'Plan Your Night'}
+              {isPast || event.status === 'archived' ? 'View Lineup' : 'Build Your Schedule'}
             </Button>
             {/* Past editions get a recap link — the recap page was previously
                 unreachable except by URL (#555). */}

--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -1,6 +1,7 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
 import { normalizeBandName } from "../../../utils/bandName.js";
 import { safeReflectSocialLinks } from "../../../utils/validation.js";
+import { eventLocalToday } from "../../../utils/eventDay.js";
 
 /**
  * Public API: Get band profile with rich stats
@@ -129,7 +130,7 @@ export async function onRequestGet(context) {
     const allPerformances = performances.results || [];
 
     // Calculate statistics
-    const today = new Date().toISOString().split("T")[0];
+    const today = eventLocalToday();
 
     // Separate upcoming and past performances
     // Archived events always go to past regardless of date

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -8,6 +8,7 @@
 import { describe, it, test, expect, beforeEach, vi } from "vitest";
 import { onRequestGet as timelineHandler } from "../timeline.js";
 import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
+import { eventLocalToday } from "../../../utils/eventDay.js";
 
 // Returns the mock result set for a query string, keyed off the distinctive
 // WHERE clause for each period (now / upcoming / past). The "now" and "past"
@@ -595,7 +596,7 @@ describe("Timeline real-DB — reveal_mode JOIN gate (SQL exercise)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
 
-    const today = new Date().toISOString().split("T")[0];
+    const today = eventLocalToday();
 
     const event = insertEvent(rawDb, {
       name: "Embargo Event",
@@ -679,7 +680,7 @@ describe("Timeline real-DB — NULL venue_id must not inflate venue_count (#479)
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
 
-    const today = new Date().toISOString().split("T")[0];
+    const today = eventLocalToday();
 
     const event = insertEvent(rawDb, {
       name: "No Venue Event",
@@ -720,7 +721,7 @@ describe("Timeline real-DB — derived band url is scheme-validated (#483)", () 
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
 
-    const today = new Date().toISOString().split("T")[0];
+    const today = eventLocalToday();
 
     const event = insertEvent(rawDb, {
       name: "Scheme Test Event",
@@ -756,7 +757,7 @@ describe("Timeline real-DB — derived band url is scheme-validated (#483)", () 
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
 
-    const today = new Date().toISOString().split("T")[0];
+    const today = eventLocalToday();
 
     const event = insertEvent(rawDb, {
       name: "Scheme Fallback Event",
@@ -802,7 +803,7 @@ describe("Timeline real-DB — event ticket_url is scheme-validated (#504)", () 
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
 
-    const today = new Date().toISOString().split("T")[0];
+    const today = eventLocalToday();
 
     const event = insertEvent(rawDb, {
       name: "Unsafe Ticket Event",
@@ -831,7 +832,7 @@ describe("Timeline real-DB — event ticket_url is scheme-validated (#504)", () 
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
 
-    const today = new Date().toISOString().split("T")[0];
+    const today = eventLocalToday();
 
     const event = insertEvent(rawDb, {
       name: "Safe Ticket Event",

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -1,5 +1,6 @@
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { normalizeHttpUrl } from "../../utils/validation.js";
+import { eventLocalToday } from "../../utils/eventDay.js";
 
 /**
  * Public API: Get events timeline (now, upcoming, past)
@@ -48,7 +49,7 @@ export async function onRequestGet(context) {
       past: [],
     };
 
-    const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+    const today = eventLocalToday(); // YYYY-MM-DD, events' local (Toronto) day — not UTC
 
     // Helper function to group bands by event (processes results from JOIN query)
     function groupEventData(rows) {

--- a/functions/api/venues/[id].js
+++ b/functions/api/venues/[id].js
@@ -6,6 +6,7 @@
 
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { validateId } from "../../utils/validation.js";
+import { eventLocalToday } from "../../utils/eventDay.js";
 
 function json(body, status = 200, extraHeaders = {}) {
   return new Response(JSON.stringify(body), {
@@ -71,7 +72,7 @@ export async function onRequestGet(context) {
       .all();
 
     const all = perfs.results || [];
-    const today = new Date().toISOString().split("T")[0];
+    const today = eventLocalToday();
     const isPast = (p) => p.event_date < today || p.event_status === "archived";
 
     const mapPerf = (p) => ({

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -3,6 +3,7 @@
  * Includes all published events and band profiles with at least one published performance.
  */
 import { getPublicDataGateResponse } from "./utils/publicGate.js";
+import { eventLocalToday } from "./utils/eventDay.js";
 
 export async function onRequestGet(context) {
   const { env } = context;
@@ -76,7 +77,7 @@ export async function onRequestGet(context) {
 
     // YYYY-MM-DD lexicographic comparison — never new Date('YYYY-MM-DD'),
     // which UTC-parses and drifts a day (documented repo invariant).
-    const today = new Date().toISOString().split("T")[0];
+    const today = eventLocalToday();
 
     for (const event of events) {
       rows.push(`  <url>

--- a/functions/utils/__tests__/eventDay.test.js
+++ b/functions/utils/__tests__/eventDay.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { eventLocalToday } from "../eventDay.js";
+
+describe("eventLocalToday", () => {
+  it("returns YYYY-MM-DD", () => {
+    expect(eventLocalToday()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("stays on the Toronto day when UTC has already rolled over (the BLR3 bug)", () => {
+    // 2026-07-10T01:00:00Z is 9:00 PM EDT on July 9 — toISOString() says
+    // "2026-07-10" here, which marked events "Happening Now" the evening
+    // before. The Toronto day is still July 9.
+    expect(eventLocalToday(new Date("2026-07-10T01:00:00Z"))).toBe("2026-07-09");
+  });
+
+  it("rolls to the next Toronto day at local midnight, not UTC midnight", () => {
+    // 04:00Z on July 10 is exactly midnight EDT — the first instant of the
+    // Toronto July 10.
+    expect(eventLocalToday(new Date("2026-07-10T04:00:00Z"))).toBe("2026-07-10");
+    expect(eventLocalToday(new Date("2026-07-10T03:59:59Z"))).toBe("2026-07-09");
+  });
+
+  it("handles EST (winter, UTC-5) as well as EDT", () => {
+    // 04:30Z on Jan 10 is 11:30 PM EST on Jan 9.
+    expect(eventLocalToday(new Date("2026-01-10T04:30:00Z"))).toBe("2026-01-09");
+    expect(eventLocalToday(new Date("2026-01-10T05:00:00Z"))).toBe("2026-01-10");
+  });
+
+  it("agrees with the UTC day in the Toronto afternoon", () => {
+    expect(eventLocalToday(new Date("2026-07-10T18:00:00Z"))).toBe("2026-07-10");
+  });
+});

--- a/functions/utils/eventDay.js
+++ b/functions/utils/eventDay.js
@@ -1,0 +1,28 @@
+// "Today" for event-day classification, anchored to the events' local timezone.
+//
+// The platform's events are Ontario-local (Waterloo Region and southern
+// Ontario), so the calendar day that decides whether an event is happening
+// now / upcoming / past must be the REGION'S local day — never the UTC day.
+// `new Date().toISOString().slice(0, 10)` flips to tomorrow at 8:00 PM
+// Eastern (EDT), which marked events "Happening Now" the evening before
+// (Bad Livin' Roadshow 3, 2026-07-09) and moved a band's in-progress show
+// into "past shows" mid-set.
+//
+// `en-CA` formats as YYYY-MM-DD, so the result stays safe for the repo's
+// lexicographic date comparisons (documented invariant: never
+// `new Date('YYYY-MM-DD')`).
+
+const TORONTO_DAY = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "America/Toronto",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+/**
+ * @param {Date} [now] - injectable for tests; defaults to the current instant
+ * @returns {string} the current calendar date in America/Toronto, YYYY-MM-DD
+ */
+export function eventLocalToday(now = new Date()) {
+  return TORONTO_DAY.format(now);
+}


### PR DESCRIPTION
## Summary

Dre spotted BLR3 showing as "Happening Now" on the homepage on July 9 — the event starts July 10. Root cause: `new Date().toISOString().split('T')[0]` computes the **UTC** day, which flips to tomorrow at 8:00 PM Eastern. Every surface using that pattern for event-day classification went wrong every evening: the homepage promoted events a night early, band pages moved an in-progress show into "past shows" mid-set, venue lineups aged a day early, and the admin event form's min-date blocked picking today's date after 8 PM.

New helper `eventLocalToday()` anchors "today" to America/Toronto — the region every event lives in — formatted `YYYY-MM-DD` (en-CA) so the repo's lexicographic date-comparison invariant holds. `metrics.js` deliberately keeps UTC day-bucketing (analytics aggregation, not event classification).

Bonus copy fix while in `EventTimeline`: **"Plan Your Night" → "Build Your Schedule"** — BLR3's Saturday starts at noon, so "night" was misleading (also reported by Dre).

Closes: none — direct report (2026-07-09, eve of BLR3).

## What changed

| File | Change |
|------|--------|
| `functions/utils/eventDay.js` (new) | `eventLocalToday()` — Toronto-local YYYY-MM-DD, injectable clock for tests |
| `functions/utils/__tests__/eventDay.test.js` (new) | Pins the 8 PM EDT boundary, local-midnight rollover, EST winter case |
| `functions/api/events/timeline.js` | now/upcoming/past classification uses the helper |
| `functions/api/bands/stats/[name].js`, `functions/api/venues/[id].js` | upcoming/past split uses the helper |
| `functions/sitemap.xml.js` | same, for consistency |
| `functions/api/events/__tests__/timeline.test.js` | seeds "today" via the helper (6 spots) — **the suite itself was failing after 8 PM Eastern**, which is the bug demonstrating itself |
| `frontend/src/admin/EventFormModal.jsx` | min-date via device-local `toLocaleDateString('en-CA')` |
| `frontend/src/components/EventTimeline.jsx` | button copy |

## Security / correctness notes

None. Timezone anchoring is display/classification only; no auth or storage semantics change. Workers runtime has full ICU, so `Intl.DateTimeFormat` with `timeZone: 'America/Toronto'` handles EDT/EST transitions (covered by tests).

## Verification

- [x] Tests: backend 671 pass / 6 todo (73 files — includes the 6 previously failing timeline tests, now green); frontend 390 pass
- [x] ESLint: 0 errors (backend + frontend)
- [x] Format check: clean (both)
- [x] Build: green (`npm run build --prefix frontend`)
- [ ] `validate:openapi`: N/A — not changed
- [x] Manual smoke: it is currently past 8 PM Eastern — before the fix, the timeline suite failed 6 tests because UTC had rolled to July 10; after, all pass and the unit tests pin the exact boundary instants

---
Built by Theo & Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)