### PR TITLE
fix(email): announcement digest linked /events/:slug which 404s

### DIFF
--- a/functions/api/admin/bands/__tests__/announce-digest.test.js
+++ b/functions/api/admin/bands/__tests__/announce-digest.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils.js";
 import { flushAnnounceDigest } from "../../../../utils/announceDigest.js";
+import { getPublicBaseUrl } from "../../../../utils/publicUrl.js";
 
 vi.mock("../../../../utils/email.js", () => ({
   sendEmail: vi.fn(() => Promise.resolve({ delivered: true })),
@@ -41,8 +42,19 @@ describe("flushAnnounceDigest", () => {
     expect(stats.sent).toBe(1);
     expect(stats.failed).toBe(0);
     expect(sendEmail).toHaveBeenCalledOnce();
-    const [, { subject }] = sendEmail.mock.calls[0];
+    const [, { subject, text, html }] = sendEmail.mock.calls[0];
     expect(subject).toBe("The Band just joined the lineup for Fest!");
+
+    // Regression: the "View the schedule" link must point at the singular
+    // /event/:slug route (frontend/src/main.jsx), not the plural /events/
+    // route (which only exists for /events/:slug/recap and 404s otherwise).
+    const publicUrl = getPublicBaseUrl(env);
+    const correctEventUrl = `${publicUrl}/event/fest-single`;
+    const wrongEventUrl = `${publicUrl}/events/fest-single`;
+    expect(text).toContain(correctEventUrl);
+    expect(html).toContain(correctEventUrl);
+    expect(text).not.toContain(wrongEventUrl);
+    expect(html).not.toContain(wrongEventUrl);
 
     // Queue entry consumed
     const remaining = rawDb.prepare("SELECT * FROM band_announce_queue").all();
@@ -97,8 +109,17 @@ describe("flushAnnounceDigest", () => {
     // One email for the fan, not two
     expect(stats.sent).toBe(1);
     expect(sendEmail).toHaveBeenCalledOnce();
-    const [, { subject }] = sendEmail.mock.calls[0];
+    const [, { subject, text, html }] = sendEmail.mock.calls[0];
     expect(subject).toBe("2 bands you follow are playing Crawl!");
+
+    // Regression: digest emails must also use the singular /event/:slug route.
+    const publicUrl = getPublicBaseUrl(env);
+    const correctEventUrl = `${publicUrl}/event/crawl-digest`;
+    const wrongEventUrl = `${publicUrl}/events/crawl-digest`;
+    expect(text).toContain(correctEventUrl);
+    expect(html).toContain(correctEventUrl);
+    expect(text).not.toContain(wrongEventUrl);
+    expect(html).not.toContain(wrongEventUrl);
 
     // Both queue entries consumed, both notification rows written
     expect(rawDb.prepare("SELECT * FROM band_announce_queue").all()).toHaveLength(0);

--- a/functions/utils/announceDigest.js
+++ b/functions/utils/announceDigest.js
@@ -51,7 +51,7 @@ export async function flushAnnounceDigest(env, DB) {
 
   for (const items of groups.values()) {
     const { email, event_name, event_slug } = items[0];
-    const eventUrl = `${publicUrl}/events/${event_slug}`;
+    const eventUrl = `${publicUrl}/event/${event_slug}`;
 
     // Claim each (performance_id, band_follow_id) atomically before sending.
     // INSERT OR IGNORE: changes=0 means already claimed by a concurrent flush


### PR DESCRIPTION
## Summary

The "View the schedule" link in band-announcement digest emails pointed at `/events/${slug}` (plural), but the fan event page is `/event/:slug` (singular) — every digest email linked to the 404 page. Latent today (zero verified followers in production) but would bite on the first real flush. Found while publishing BLR3.

Closes #562

## What changed

| File | Change |
|------|--------|
| `functions/utils/announceDigest.js` | `/events/` → `/event/` in the digest email URL |
| `functions/api/admin/bands/__tests__/announce-digest.test.js` | Regression assertions on the sent email text/html: exact correct URL present, plural form absent (full-URL match avoids the `/event`⊂`/events` substring trap) |

Audited every other fan-facing URL builder in `functions/` (bandFollowNotify, emailTemplates, follow/subscribe/verify endpoints) — announceDigest was the only offender; the plural `/events/:slug/recap` links elsewhere are correct routes.

## Security / correctness notes

None — static URL path in email content.

## Verification

- [x] Tests: backend 671 pass / 6 todo (73 files), including 8 in the digest suite
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: N/A — backend only
- [ ] `validate:openapi`: N/A — not changed
- [x] Manual smoke: route confirmed against `frontend/src/main.jsx` route table (`/event/:slug` renders the event page; verified live earlier at settimes.ca/event/blr3)

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)