### PR TITLE
feat(turnstile): defer the widget until the visitor engages with the form

### DIFF
--- a/frontend/src/components/LockInLineupPanel.jsx
+++ b/frontend/src/components/LockInLineupPanel.jsx
@@ -1,5 +1,5 @@
 import { Bell, Check } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTurnstile } from '../hooks/useTurnstile'
 
 /**
@@ -31,6 +31,15 @@ export default function LockInLineupPanel({ performanceIds, bandCount }) {
     reset: resetTurnstile,
   } = useTurnstile(followEngaged)
   const hasPerformances = Array.isArray(performanceIds) && performanceIds.length > 0
+
+  // If the route empties (fan removes every band), the form — and the Turnstile
+  // widget's container — unmounts while this component instance survives.
+  // Reset engagement so the next focus re-activates a fresh widget.
+  useEffect(() => {
+    if (!hasPerformances) {
+      setFollowEngaged(false)
+    }
+  }, [hasPerformances])
 
   // Early return after hooks (React rules of hooks: no conditional hook calls)
   if (!hasPerformances) return null

--- a/frontend/src/components/LockInLineupPanel.jsx
+++ b/frontend/src/components/LockInLineupPanel.jsx
@@ -1,7 +1,6 @@
 import { Bell, Check } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
-
-const TURNSTILE_SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+import { useState } from 'react'
+import { useTurnstile } from '../hooks/useTurnstile'
 
 /**
  * LockInLineupPanel — Batch follow CTA for "My Route" and shared-route import.
@@ -20,62 +19,18 @@ export default function LockInLineupPanel({ performanceIds, bandCount }) {
   const [followEmail, setFollowEmail] = useState('')
   const [followStatus, setFollowStatus] = useState('idle') // 'idle' | 'loading' | 'success' | 'error'
   const [followError, setFollowError] = useState('')
-  const turnstileContainerRef = useRef(null)
-  const turnstileWidgetIdRef = useRef(null)
-  const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY || ''
-  const turnstileEnabled = Boolean(turnstileSiteKey)
-  const [turnstileToken, setTurnstileToken] = useState('')
+  // Turnstile stays dormant until the visitor engages with the email field.
+  // Engagement is only possible when the form is mounted, which also covers
+  // the old hasPerformances gating (the component returns null without any
+  // performances, so the field can never be focused).
+  const [followEngaged, setFollowEngaged] = useState(false)
+  const {
+    enabled: turnstileEnabled,
+    token: turnstileToken,
+    containerRef: turnstileContainerRef,
+    reset: resetTurnstile,
+  } = useTurnstile(followEngaged)
   const hasPerformances = Array.isArray(performanceIds) && performanceIds.length > 0
-
-  // Mirror the Turnstile setup from BandProfilePage — explicit render, interaction-only
-  // appearance (invisible unless a human challenge fires), cleanup on unmount/re-run.
-  // Gate on hasPerformances so we don't try to render into a null container ref when
-  // the component returns null early.
-  useEffect(() => {
-    if (!turnstileEnabled || !hasPerformances) return undefined
-
-    let cancelled = false
-    let scriptElement = document.querySelector('script[data-turnstile-script="true"]')
-
-    const renderTurnstile = () => {
-      if (cancelled || !window.turnstile || !turnstileContainerRef.current) return
-      if (turnstileWidgetIdRef.current !== null) return
-
-      turnstileWidgetIdRef.current = window.turnstile.render(turnstileContainerRef.current, {
-        sitekey: turnstileSiteKey,
-        appearance: 'interaction-only',
-        callback: token => setTurnstileToken(token),
-        'expired-callback': () => setTurnstileToken(''),
-        'error-callback': () => setTurnstileToken(''),
-      })
-    }
-
-    if (scriptElement) {
-      if (window.turnstile) {
-        renderTurnstile()
-      } else {
-        scriptElement.addEventListener('load', renderTurnstile)
-      }
-    } else {
-      const script = document.createElement('script')
-      script.src = TURNSTILE_SCRIPT_SRC
-      script.async = true
-      script.defer = true
-      script.setAttribute('data-turnstile-script', 'true')
-      script.addEventListener('load', renderTurnstile)
-      document.head.appendChild(script)
-      scriptElement = script
-    }
-
-    return () => {
-      cancelled = true
-      if (scriptElement) scriptElement.removeEventListener('load', renderTurnstile)
-      if (window.turnstile && turnstileWidgetIdRef.current !== null) {
-        window.turnstile.remove(turnstileWidgetIdRef.current)
-        turnstileWidgetIdRef.current = null
-      }
-    }
-  }, [turnstileEnabled, turnstileSiteKey, hasPerformances])
 
   // Early return after hooks (React rules of hooks: no conditional hook calls)
   if (!hasPerformances) return null
@@ -107,17 +62,11 @@ export default function LockInLineupPanel({ performanceIds, bandCount }) {
         throw new Error(err.error || 'Something went wrong — please try again.')
       }
       setFollowStatus('success')
-      setTurnstileToken('')
-      if (turnstileEnabled && window.turnstile && turnstileWidgetIdRef.current !== null) {
-        window.turnstile.reset(turnstileWidgetIdRef.current)
-      }
+      resetTurnstile()
     } catch (err) {
       setFollowStatus('error')
       setFollowError(err.message)
-      setTurnstileToken('')
-      if (turnstileEnabled && window.turnstile && turnstileWidgetIdRef.current !== null) {
-        window.turnstile.reset(turnstileWidgetIdRef.current)
-      }
+      resetTurnstile()
     }
   }
 
@@ -151,7 +100,11 @@ export default function LockInLineupPanel({ performanceIds, bandCount }) {
                 id="lineup-follow-email"
                 type="email"
                 value={followEmail}
-                onChange={e => setFollowEmail(e.target.value)}
+                onFocus={() => setFollowEngaged(true)}
+                onChange={e => {
+                  setFollowEngaged(true)
+                  setFollowEmail(e.target.value)
+                }}
                 placeholder="your@email.com"
                 required
                 disabled={followStatus === 'loading'}
@@ -165,7 +118,7 @@ export default function LockInLineupPanel({ performanceIds, bandCount }) {
                 {followStatus === 'loading' ? 'Saving…' : 'Notify me'}
               </button>
             </div>
-            {turnstileEnabled && <div ref={turnstileContainerRef} className="mt-2" />}
+            {turnstileEnabled && followEngaged && <div ref={turnstileContainerRef} className="mt-2" />}
           </form>
         )}
       </div>

--- a/frontend/src/hooks/__tests__/useTurnstile.test.jsx
+++ b/frontend/src/hooks/__tests__/useTurnstile.test.jsx
@@ -109,4 +109,30 @@ describe('useTurnstile', () => {
     unmount()
     expect(window.turnstile.remove).toHaveBeenCalledWith('widget-1')
   })
+
+  it('deactivating tears down and re-activating renders a fresh widget', () => {
+    // The consumer contract for form remounts (band-to-band navigation, an
+    // emptied list): flip active false, then a later focus re-activates.
+    const { rerender } = render(<Harness active={true} />)
+    const [, config] = renderMock.mock.calls[0]
+    act(() => config.callback('tok-stale'))
+
+    rerender(<Harness active={false} />)
+    expect(window.turnstile.remove).toHaveBeenCalledWith('widget-1')
+    expect(screen.getByTestId('token').textContent).toBe('') // stale token cleared
+
+    rerender(<Harness active={true} />)
+    expect(renderMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('survives teardown of a widget whose DOM is already gone', () => {
+    window.turnstile.remove.mockImplementation(() => {
+      throw new Error('widget not found')
+    })
+    const { rerender } = render(<Harness active={true} />)
+    expect(() => rerender(<Harness active={false} />)).not.toThrow()
+    // A fresh activation still works after the failed teardown.
+    rerender(<Harness active={true} />)
+    expect(renderMock).toHaveBeenCalledTimes(2)
+  })
 })

--- a/frontend/src/hooks/__tests__/useTurnstile.test.jsx
+++ b/frontend/src/hooks/__tests__/useTurnstile.test.jsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { useTurnstile } from '../useTurnstile'
+
+// A real (placeholder) site key so `enabled` is true — the components' own
+// tests cover the disabled path via an empty key.
+vi.stubEnv('VITE_TURNSTILE_SITE_KEY', 'test-placeholder-site-key')
+
+function Harness({ active }) {
+  const { enabled, token, containerRef, reset } = useTurnstile(active)
+  return (
+    <div>
+      <div data-testid="container" ref={containerRef} />
+      <span data-testid="token">{token}</span>
+      <span data-testid="enabled">{String(enabled)}</span>
+      <button type="button" onClick={reset}>
+        reset
+      </button>
+    </div>
+  )
+}
+
+describe('useTurnstile', () => {
+  let renderMock
+
+  // Simulate the Turnstile script already being present and loaded — the
+  // hook's script-injection branch waits for a real network `load` event,
+  // which jsdom can't provide.
+  const injectLoadedScript = () => {
+    const script = document.createElement('script')
+    script.setAttribute('data-turnstile-script', 'true')
+    document.head.appendChild(script)
+  }
+
+  beforeEach(() => {
+    renderMock = vi.fn(() => 'widget-1')
+    window.turnstile = {
+      render: renderMock,
+      remove: vi.fn(),
+      reset: vi.fn(),
+    }
+    injectLoadedScript()
+  })
+
+  afterEach(() => {
+    cleanup()
+    delete window.turnstile
+    document.querySelectorAll('script[data-turnstile-script="true"]').forEach(s => s.remove())
+  })
+
+  it('stays fully dormant while active is false', () => {
+    render(<Harness active={false} />)
+    expect(renderMock).not.toHaveBeenCalled()
+    expect(screen.getByTestId('enabled').textContent).toBe('true')
+  })
+
+  it('renders the widget once active, with interaction-only appearance', () => {
+    render(<Harness active={true} />)
+    expect(renderMock).toHaveBeenCalledTimes(1)
+    const [container, config] = renderMock.mock.calls[0]
+    expect(container).toBe(screen.getByTestId('container'))
+    expect(config.sitekey).toBe('test-placeholder-site-key')
+    expect(config.appearance).toBe('interaction-only')
+  })
+
+  it('activating after mount defers the render until the flip', () => {
+    const { rerender } = render(<Harness active={false} />)
+    expect(renderMock).not.toHaveBeenCalled()
+    rerender(<Harness active={true} />)
+    expect(renderMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not inject a second script tag for a second active instance', () => {
+    render(
+      <>
+        <Harness active={true} />
+        <Harness active={true} />
+      </>
+    )
+    expect(document.querySelectorAll('script[data-turnstile-script="true"]')).toHaveLength(1)
+    expect(renderMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('exposes the token from the widget callback and clears it on expiry', () => {
+    render(<Harness active={true} />)
+    const [, config] = renderMock.mock.calls[0]
+
+    fireEvent.click(screen.getByRole('button', { name: 'reset' })) // no-op before token, must not throw
+    act(() => config.callback('tok-123'))
+    expect(screen.getByTestId('token').textContent).toBe('tok-123')
+
+    act(() => config['expired-callback']())
+    expect(screen.getByTestId('token').textContent).toBe('')
+  })
+
+  it('reset() clears the token and resets the widget', () => {
+    render(<Harness active={true} />)
+    const [, config] = renderMock.mock.calls[0]
+    act(() => config.callback('tok-456'))
+    expect(screen.getByTestId('token').textContent).toBe('tok-456')
+
+    fireEvent.click(screen.getByRole('button', { name: 'reset' }))
+    expect(screen.getByTestId('token').textContent).toBe('')
+    expect(window.turnstile.reset).toHaveBeenCalledWith('widget-1')
+  })
+
+  it('removes the widget on unmount', () => {
+    const { unmount } = render(<Harness active={true} />)
+    unmount()
+    expect(window.turnstile.remove).toHaveBeenCalledWith('widget-1')
+  })
+})

--- a/frontend/src/hooks/useTurnstile.js
+++ b/frontend/src/hooks/useTurnstile.js
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const TURNSTILE_SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+
+/**
+ * Shared Cloudflare Turnstile widget lifecycle (script injection, explicit
+ * render, token state, cleanup) for the public email-input forms.
+ *
+ * `active` defers EVERYTHING until the visitor actually engages with the form
+ * (first focus/change on the email field): no Turnstile script, no iframe, no
+ * reserved layout space, and no challenge ambushing people who never touch
+ * the form. Cloudflare still challenges on its own schedule once rendered —
+ * `appearance: 'interaction-only'` keeps the widget invisible unless a human
+ * check is genuinely required.
+ *
+ * Returns `{ enabled, token, containerRef, reset }`:
+ * - `enabled` — site key is configured (submit guards should be skipped when false)
+ * - `token`   — current Turnstile token ('' until issued / after expiry)
+ * - `containerRef` — attach to the div the widget renders into; the div only
+ *   needs to exist once `active` is true
+ * - `reset`   — clear the token and reset the widget; call after every submit
+ *   attempt (tokens are single-use, so a retry needs a fresh challenge)
+ */
+export function useTurnstile(active) {
+  const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY || ''
+  const enabled = Boolean(siteKey)
+  const containerRef = useRef(null)
+  const widgetIdRef = useRef(null)
+  const [token, setToken] = useState('')
+
+  useEffect(() => {
+    if (!enabled || !active) {
+      return undefined
+    }
+
+    let cancelled = false
+    let scriptElement = document.querySelector('script[data-turnstile-script="true"]')
+
+    const renderTurnstile = () => {
+      if (cancelled || !window.turnstile || !containerRef.current) {
+        return
+      }
+      if (widgetIdRef.current !== null) {
+        return
+      }
+
+      widgetIdRef.current = window.turnstile.render(containerRef.current, {
+        sitekey: siteKey,
+        // Invisible unless Turnstile actually needs a human challenge — keeps
+        // the form uncluttered for legit visitors while preserving bot
+        // protection.
+        appearance: 'interaction-only',
+        callback: newToken => {
+          setToken(newToken)
+        },
+        'expired-callback': () => {
+          setToken('')
+        },
+        'error-callback': () => {
+          setToken('')
+        },
+      })
+    }
+
+    if (scriptElement) {
+      if (window.turnstile) {
+        renderTurnstile()
+      } else {
+        scriptElement.addEventListener('load', renderTurnstile)
+      }
+    } else {
+      const script = document.createElement('script')
+      script.src = TURNSTILE_SCRIPT_SRC
+      script.async = true
+      script.defer = true
+      script.setAttribute('data-turnstile-script', 'true')
+      script.addEventListener('load', renderTurnstile)
+      document.head.appendChild(script)
+      scriptElement = script
+    }
+
+    return () => {
+      cancelled = true
+      if (scriptElement) {
+        scriptElement.removeEventListener('load', renderTurnstile)
+      }
+      if (window.turnstile && widgetIdRef.current !== null) {
+        window.turnstile.remove(widgetIdRef.current)
+        widgetIdRef.current = null
+      }
+    }
+  }, [enabled, active, siteKey])
+
+  const reset = useCallback(() => {
+    setToken('')
+    if (window.turnstile && widgetIdRef.current !== null) {
+      window.turnstile.reset(widgetIdRef.current)
+    }
+  }, [])
+
+  return { enabled, token, containerRef, reset }
+}

--- a/frontend/src/hooks/useTurnstile.js
+++ b/frontend/src/hooks/useTurnstile.js
@@ -20,6 +20,13 @@ const TURNSTILE_SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api
  *   needs to exist once `active` is true
  * - `reset`   — clear the token and reset the widget; call after every submit
  *   attempt (tokens are single-use, so a retry needs a fresh challenge)
+ *
+ * Contract: the container is expected to stay mounted for the lifetime of
+ * `active === true`. If the consumer's form can unmount/remount while the
+ * component survives (band-to-band navigation, a list emptying), the consumer
+ * must flip `active` back to false when that happens — the widget dies with
+ * its container DOM, and this hook only re-renders a widget on an
+ * inactive→active transition.
  */
 export function useTurnstile(active) {
   const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY || ''
@@ -85,8 +92,17 @@ export function useTurnstile(active) {
         scriptElement.removeEventListener('load', renderTurnstile)
       }
       if (window.turnstile && widgetIdRef.current !== null) {
-        window.turnstile.remove(widgetIdRef.current)
+        // try/catch: the widget's DOM may already be gone (container unmounted
+        // before this cleanup ran, e.g. the consumer flipped `active` false
+        // after its form left the tree) — remove() on a dead widget must not
+        // take the whole component down.
+        try {
+          window.turnstile.remove(widgetIdRef.current)
+        } catch {
+          // Widget already torn down with its container — nothing to release.
+        }
         widgetIdRef.current = null
+        setToken('')
       }
     }
   }, [enabled, active, siteKey])
@@ -94,7 +110,12 @@ export function useTurnstile(active) {
   const reset = useCallback(() => {
     setToken('')
     if (window.turnstile && widgetIdRef.current !== null) {
-      window.turnstile.reset(widgetIdRef.current)
+      try {
+        window.turnstile.reset(widgetIdRef.current)
+      } catch {
+        // Widget already torn down with its container — a fresh one renders on
+        // the next activation.
+      }
     }
   }, [])
 

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -24,8 +24,8 @@ import { fetchPublicJson } from '../utils/publicApi'
 import { getSelectedBands, saveSelectedBands, hasAnySchedule, getScheduleEventSlug } from '../utils/scheduleStorage'
 import { formatTimeRange, parseLocalDate } from '../utils/timeFormat'
 import { safeExternalHref, safeInstagramHref } from '../utils/urlSafety'
+import { useTurnstile } from '../hooks/useTurnstile'
 
-const TURNSTILE_SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
 const ZERO_WIDTH_ENTITY_REGEX = /&shy;|&#173;|&#xad;|&ZeroWidthSpace;|&#8203;|&#x200B;/gi
 
 const NBSP_ENTITY_REGEX = /&nbsp;|&#160;|&#xA0;/gi
@@ -98,11 +98,17 @@ export default function BandProfilePage() {
   const [followEmail, setFollowEmail] = useState('')
   const [followStatus, setFollowStatus] = useState('idle') // 'idle' | 'loading' | 'success' | 'error'
   const [followError, setFollowError] = useState('')
-  const turnstileContainerRef = useRef(null)
-  const turnstileWidgetIdRef = useRef(null)
-  const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY || ''
-  const turnstileEnabled = Boolean(turnstileSiteKey)
-  const [turnstileToken, setTurnstileToken] = useState('')
+  // Turnstile stays dormant until the visitor engages with the follow email
+  // field. Engagement requires the form to be mounted, so this also replaces
+  // the old loading/error/profile effect gating (the null-container-on-skeleton
+  // race can no longer happen).
+  const [followEngaged, setFollowEngaged] = useState(false)
+  const {
+    enabled: turnstileEnabled,
+    token: turnstileToken,
+    containerRef: turnstileContainerRef,
+    reset: resetTurnstile,
+  } = useTurnstile(followEngaged)
   const [userHasSchedule] = useState(() => hasAnySchedule())
   const scheduleEventSlug = useMemo(() => getScheduleEventSlug(), [])
   const sourceEventSlug = searchParams.get('fromEvent') || location.state?.fromEventSlug || null
@@ -277,76 +283,6 @@ export default function BandProfilePage() {
   )
 
   useEffect(() => {
-    // The Turnstile container lives inside the follow form, which is NOT mounted
-    // while the page shows its loading skeleton (`if (loading) return <Skeleton>`).
-    // Gate on the loaded state AND depend on it so the effect re-runs once the
-    // form (and the container ref) actually exists. Without this, when
-    // window.turnstile becomes ready before the profile fetch resolves — always
-    // the case on SPA client-nav with a cached script — render() is attempted
-    // against a null container, bails, and never retries, leaving the Follow
-    // button permanently disabled.
-    if (!turnstileEnabled || loading || error || !profile) {
-      return undefined
-    }
-
-    let cancelled = false
-    let scriptElement = document.querySelector('script[data-turnstile-script="true"]')
-
-    const renderTurnstile = () => {
-      if (cancelled || !window.turnstile || !turnstileContainerRef.current) {
-        return
-      }
-      if (turnstileWidgetIdRef.current !== null) {
-        return
-      }
-
-      turnstileWidgetIdRef.current = window.turnstile.render(turnstileContainerRef.current, {
-        sitekey: turnstileSiteKey,
-        // Invisible unless Turnstile actually needs a human challenge — keeps the
-        // form uncluttered for legit visitors while preserving bot protection.
-        appearance: 'interaction-only',
-        callback: token => {
-          setTurnstileToken(token)
-        },
-        'expired-callback': () => {
-          setTurnstileToken('')
-        },
-        'error-callback': () => {
-          setTurnstileToken('')
-        },
-      })
-    }
-
-    if (scriptElement) {
-      if (window.turnstile) {
-        renderTurnstile()
-      } else {
-        scriptElement.addEventListener('load', renderTurnstile)
-      }
-    } else {
-      const script = document.createElement('script')
-      script.src = TURNSTILE_SCRIPT_SRC
-      script.async = true
-      script.defer = true
-      script.setAttribute('data-turnstile-script', 'true')
-      script.addEventListener('load', renderTurnstile)
-      document.head.appendChild(script)
-      scriptElement = script
-    }
-
-    return () => {
-      cancelled = true
-      if (scriptElement) {
-        scriptElement.removeEventListener('load', renderTurnstile)
-      }
-      if (window.turnstile && turnstileWidgetIdRef.current !== null) {
-        window.turnstile.remove(turnstileWidgetIdRef.current)
-        turnstileWidgetIdRef.current = null
-      }
-    }
-  }, [turnstileEnabled, turnstileSiteKey, loading, error, profile])
-
-  useEffect(() => {
     document.title = pageTitle
   }, [pageTitle])
 
@@ -371,17 +307,11 @@ export default function BandProfilePage() {
         throw new Error(err.error || 'Something went wrong')
       }
       setFollowStatus('success')
-      setTurnstileToken('')
-      if (turnstileEnabled && window.turnstile && turnstileWidgetIdRef.current !== null) {
-        window.turnstile.reset(turnstileWidgetIdRef.current)
-      }
+      resetTurnstile()
     } catch (err) {
       setFollowStatus('error')
       setFollowError(err.message)
-      setTurnstileToken('')
-      if (turnstileEnabled && window.turnstile && turnstileWidgetIdRef.current !== null) {
-        window.turnstile.reset(turnstileWidgetIdRef.current)
-      }
+      resetTurnstile()
     }
   }
 
@@ -730,7 +660,11 @@ export default function BandProfilePage() {
                     id="follow-email"
                     type="email"
                     value={followEmail}
-                    onChange={e => setFollowEmail(e.target.value)}
+                    onFocus={() => setFollowEngaged(true)}
+                    onChange={e => {
+                      setFollowEngaged(true)
+                      setFollowEmail(e.target.value)
+                    }}
                     placeholder="your@email.com"
                     required
                     className="flex-1 min-w-0 px-3 py-2 rounded bg-bg-navy text-text-primary border border-text-primary/20 focus:border-accent-500 focus:outline-none text-sm"
@@ -743,7 +677,7 @@ export default function BandProfilePage() {
                     {followStatus === 'loading' ? 'Saving…' : 'Follow'}
                   </Button>
                 </div>
-                {turnstileEnabled && <div ref={turnstileContainerRef} className="mt-2" />}
+                {turnstileEnabled && followEngaged && <div ref={turnstileContainerRef} className="mt-2" />}
               </form>
             )}
           </div>

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -286,6 +286,15 @@ export default function BandProfilePage() {
     document.title = pageTitle
   }, [pageTitle])
 
+  // Band-to-band navigation reuses this component instance: the follow form
+  // (and the Turnstile container inside it) unmounts for the loading skeleton
+  // and remounts for the new band. The widget dies with its container, so
+  // engagement must reset — the next focus re-activates a fresh widget
+  // (useTurnstile only renders on an inactive→active transition).
+  useEffect(() => {
+    setFollowEngaged(false)
+  }, [profile?.id])
+
   const submitFollow = async e => {
     e.preventDefault()
     if (!followEmail.trim()) return

--- a/frontend/src/pages/SubscribePage.jsx
+++ b/frontend/src/pages/SubscribePage.jsx
@@ -1,18 +1,22 @@
 import { CalendarDays, Rss } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
-
-const TURNSTILE_SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+import { useTurnstile } from '../hooks/useTurnstile'
 
 const PAGE_TITLE = 'Subscribe — Never Miss a Show | SetTimes'
 const PAGE_DESCRIPTION =
   'Get notified about new live music events and lineup announcements in Waterloo Region. Subscribe for show alerts from SetTimes.'
 
 export default function SubscribePage() {
-  const turnstileContainerRef = useRef(null)
-  const turnstileWidgetIdRef = useRef(null)
-  const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY || ''
-  const turnstileEnabled = Boolean(turnstileSiteKey)
+  // Turnstile stays fully dormant (no script, no iframe, no layout space)
+  // until the visitor engages with the email field.
+  const [formEngaged, setFormEngaged] = useState(false)
+  const {
+    enabled: turnstileEnabled,
+    token: turnstileToken,
+    containerRef: turnstileContainerRef,
+    reset: resetTurnstile,
+  } = useTurnstile(formEngaged)
 
   const [formData, setFormData] = useState({
     email: '',
@@ -20,7 +24,6 @@ export default function SubscribePage() {
     genre: 'all',
     frequency: 'weekly',
   })
-  const [turnstileToken, setTurnstileToken] = useState('')
   const [status, setStatus] = useState('idle') // idle, submitting, success, error
   const [message, setMessage] = useState('')
 
@@ -29,68 +32,6 @@ export default function SubscribePage() {
   useEffect(() => {
     document.title = PAGE_TITLE
   }, [])
-
-  useEffect(() => {
-    if (!turnstileEnabled) {
-      return undefined
-    }
-
-    let cancelled = false
-    let scriptElement = document.querySelector('script[data-turnstile-script="true"]')
-
-    const renderTurnstile = () => {
-      if (cancelled || !window.turnstile || !turnstileContainerRef.current) {
-        return
-      }
-      if (turnstileWidgetIdRef.current !== null) {
-        return
-      }
-
-      turnstileWidgetIdRef.current = window.turnstile.render(turnstileContainerRef.current, {
-        sitekey: turnstileSiteKey,
-        // Invisible unless Turnstile actually needs a human challenge — keeps the
-        // form uncluttered for legit visitors while preserving bot protection.
-        appearance: 'interaction-only',
-        callback: token => {
-          setTurnstileToken(token)
-        },
-        'expired-callback': () => {
-          setTurnstileToken('')
-        },
-        'error-callback': () => {
-          setTurnstileToken('')
-        },
-      })
-    }
-
-    if (scriptElement) {
-      if (window.turnstile) {
-        renderTurnstile()
-      } else {
-        scriptElement.addEventListener('load', renderTurnstile)
-      }
-    } else {
-      const script = document.createElement('script')
-      script.src = TURNSTILE_SCRIPT_SRC
-      script.async = true
-      script.defer = true
-      script.setAttribute('data-turnstile-script', 'true')
-      script.addEventListener('load', renderTurnstile)
-      document.head.appendChild(script)
-      scriptElement = script
-    }
-
-    return () => {
-      cancelled = true
-      if (scriptElement) {
-        scriptElement.removeEventListener('load', renderTurnstile)
-      }
-      if (window.turnstile && turnstileWidgetIdRef.current !== null) {
-        window.turnstile.remove(turnstileWidgetIdRef.current)
-        turnstileWidgetIdRef.current = null
-      }
-    }
-  }, [turnstileEnabled, turnstileSiteKey])
 
   const handleSubmit = async e => {
     e.preventDefault()
@@ -119,10 +60,7 @@ export default function SubscribePage() {
         setStatus('success')
         setMessage('Check your email to confirm your subscription!')
         setFormData({ email: '', city: 'kitchener', genre: 'all', frequency: 'weekly' })
-        setTurnstileToken('')
-        if (turnstileEnabled && window.turnstile && turnstileWidgetIdRef.current !== null) {
-          window.turnstile.reset(turnstileWidgetIdRef.current)
-        }
+        resetTurnstile()
       } else {
         setStatus('error')
         setMessage(data.error || 'Subscription failed. Please try again.')
@@ -170,7 +108,11 @@ export default function SubscribePage() {
                 id="email"
                 required
                 value={formData.email}
-                onChange={e => setFormData({ ...formData, email: e.target.value })}
+                onFocus={() => setFormEngaged(true)}
+                onChange={e => {
+                  setFormEngaged(true)
+                  setFormData({ ...formData, email: e.target.value })
+                }}
                 className="w-full px-4 py-3 rounded-lg bg-surface text-text-primary border border-border focus:border-accent-500 focus:outline-hidden placeholder-text-tertiary"
                 placeholder="you@example.com"
               />
@@ -232,7 +174,7 @@ export default function SubscribePage() {
             </div>
 
             {/* Submit */}
-            {turnstileEnabled && <div ref={turnstileContainerRef} className="min-h-[65px]" />}
+            {turnstileEnabled && formEngaged && <div ref={turnstileContainerRef} />}
             <button
               type="submit"
               disabled={status === 'submitting'}

--- a/frontend/src/pages/SubscribePage.jsx
+++ b/frontend/src/pages/SubscribePage.jsx
@@ -64,10 +64,14 @@ export default function SubscribePage() {
       } else {
         setStatus('error')
         setMessage(data.error || 'Subscription failed. Please try again.')
+        // Tokens are single-use: without a reset here, a failed submit leaves a
+        // dead token in state and every retry 403s until a full page reload.
+        resetTurnstile()
       }
     } catch {
       setStatus('error')
       setMessage('Network error. Please try again.')
+      resetTurnstile()
     }
   }
 


### PR DESCRIPTION
## Summary

Dre found the always-present Cloudflare check jarring. Investigation showed all three public email forms (subscribe, band follow, My Route lock-in) already used `appearance: 'interaction-only'` — but the widget still loaded its script + iframe at page load for every visitor and reserved layout space even when invisible (the ~100px gap between the subscribe form's last field and its button), and anyone Cloudflare chose to challenge got ambushed before touching the form.

Now nothing loads until the visitor first focuses (or changes) the email field: no script, no iframe, no reserved space, no page-load challenge. The three copy-pasted ~50-line widget lifecycles collapse into one shared `useTurnstile(active)` hook. Server-side token verification is untouched (still fails closed in production).

Closes: none — direct request.

## What changed

| File | Change |
|------|--------|
| `frontend/src/hooks/useTurnstile.js` (new) | Shared lifecycle: script injection/dedup, explicit render (interaction-only), token state, `reset()`, cleanup |
| `frontend/src/hooks/__tests__/useTurnstile.test.jsx` (new) | 7 tests: dormant-until-active, deferred activation, script dedup, token/expiry flow, reset, unmount cleanup |
| `frontend/src/pages/SubscribePage.jsx` | Hook + engagement gate; **also fixes a retry deadlock**: failed submits never reset the single-use token, so retries 403'd until page reload (pre-PR review catch — pre-existing bug) |
| `frontend/src/pages/BandProfilePage.jsx` | Hook + engagement gate; the engagement gate subsumes the documented null-container-on-skeleton race (form must be mounted to be focusable) |
| `frontend/src/components/LockInLineupPanel.jsx` | Hook + engagement gate; subsumes the hasPerformances effect gating |

## Security / correctness notes

- Every `handleSubmit` still blocks when `turnstileEnabled && !turnstileToken` — no path submits without a token while enabled.
- `verifyTurnstile()` server-side is unchanged (fails closed in production per CLAUDE.md).
- Known edge (pre-existing shape, reviewed and accepted): a password-manager extension that fills the field without firing React events would leave the widget dormant; the submit guard still blocks and shows the challenge prompt, and first focus activates it.

## Verification

- [x] Tests: frontend 397 pass (45 files, incl. 7 new hook tests + 14 LockInLineupPanel)
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [ ] `validate:openapi`: N/A — not changed
- [x] Manual smoke: verified the reserved-space gap exists on the live subscribe page pre-change; post-change behaviour covered by the dormant-until-active and deferred-activation tests
- [x] Pre-PR review (code-reviewer agent): 1 critical (subscribe reset deadlock — fixed), 1 important (hook test coverage — added)

---
Built by Theo · Reviewed by Vera · 🤖 [Claude Code](https://claude.ai/claude-code)