### PR TITLE
feat(events): per-day doors time + gate "started" status on the real start edge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,14 @@ Bands starting before 6 AM are "after-midnight" sets that belong to the *previou
 - Logic: `prepareBands()` adds `MS_PER_DAY` to `startMs`/`endMs` for times below this threshold
 - **Never remove or lower this threshold.** Any sort, filter, or conflict-detection that touches performance times must apply the same offset or delegate to `prepareBands`.
 
+### Server-side "today"/"now" is Toronto-local — never UTC-sliced
+
+Server-side event-day classification (timeline now/upcoming/past, any "is it today?" check) must use `eventLocalToday()` / `eventLocalClock()` from `functions/utils/eventDay.js` — never `new Date().toISOString().slice(0, 10)`, which flips to tomorrow at 8 PM Eastern and marked events "Happening Now" the evening before (bug class fixed in PR #568).
+
+### `events.doors_json` + the "started" start edge (#569)
+
+`events.doors_json` (TEXT, nullable) is a JSON map of festival date → 24h time, e.g. `{"2026-07-10":"16:00","2026-07-11":"10:00"}`. Absent/malformed = no doors info. On an event's **first day only**, the "started" edge (timeline "Happening Now", fan "Live Tonight") is, in precedence order: **doors time → first set start → local midnight**; the earliest available signal wins, so an already-playing set is never "upcoming". Day 2+ of a multi-day event is never re-gated, and sets before 6 AM never define the day-1 edge (after-midnight convention above). Validation is `validateDoorsJson()` in `functions/utils/validation.js` (keys within `[date, end_date]`, values `HH:MM`); event duplication deliberately drops `doors_json` (stale date keys).
+
 ### SQLite datetime format — do NOT use ISO 8601 T-separator
 
 D1's `datetime('now')` returns `YYYY-MM-DD HH:MM:SS` (space separator).  

--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS events (
   slug TEXT NOT NULL UNIQUE,             -- URL-friendly identifier, e.g., "vol-5"
   is_published INTEGER NOT NULL DEFAULT 0, -- 0 = draft, 1 = published (visible to public)
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
-, created_by_user_id INTEGER REFERENCES users(id), updated_by_user_id INTEGER REFERENCES users(id), updated_at TEXT DEFAULT (datetime('now')), status TEXT DEFAULT 'draft', archived_at TEXT, ticket_url TEXT, theme_colors TEXT, venue_info TEXT, social_links TEXT, city TEXT, description TEXT, reveal_mode INTEGER NOT NULL DEFAULT 0, end_date TEXT);
+, created_by_user_id INTEGER REFERENCES users(id), updated_by_user_id INTEGER REFERENCES users(id), updated_at TEXT DEFAULT (datetime('now')), status TEXT DEFAULT 'draft', archived_at TEXT, ticket_url TEXT, theme_colors TEXT, venue_info TEXT, social_links TEXT, city TEXT, description TEXT, reveal_mode INTEGER NOT NULL DEFAULT 0, end_date TEXT, doors_json TEXT);
 
 CREATE TABLE IF NOT EXISTS venues (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -831,6 +831,7 @@ function App() {
             onVenueFilterChange={setVenueFilter}
             showVenueFilter={false}
             eventSlug={slug || eventData?.slug}
+            doorsJson={eventData?.doors_json}
           />
         ) : (
           <Suspense
@@ -850,6 +851,7 @@ function App() {
               onBrowseAll={() => setView('all')}
               eventSlug={slug || eventData?.slug}
               eventId={eventData?.id}
+              doorsJson={eventData?.doors_json}
             />
           </Suspense>
         )}

--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -1,6 +1,8 @@
-import { CalendarDays, ChevronDown, Clock, Route, Warehouse } from 'lucide-react'
+import { CalendarDays, ChevronDown, Clock, DoorOpen, Route, Warehouse } from 'lucide-react'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
+import { getDoorsTimeForDate } from '../utils/doorsTime'
 import { getLifecycleLabel } from '../utils/liveLabel'
+import { formatTime } from '../utils/timeFormat'
 import GhostEasterEgg from './GhostEasterEgg'
 import TimeFilter from './TimeFilter'
 
@@ -47,8 +49,16 @@ function LiveContextBar({
   }, [eventData?.venue_info, venueOptions.length])
 
   const lifecycle = useMemo(
-    () => getLifecycleLabel(eventData?.date, currentTime, bands),
-    [bands, currentTime, eventData?.date]
+    () => getLifecycleLabel(eventData?.date, currentTime, bands, eventData?.doors_json),
+    [bands, currentTime, eventData?.date, eventData?.doors_json]
+  )
+
+  // Doors time for the event's FIRST date only (#569) — this header isn't
+  // per-day, so it always reflects day 1's gates-open time. Later festival
+  // days show their own doors time on the DayDivider instead.
+  const doorsTime = useMemo(
+    () => getDoorsTimeForDate(eventData?.doors_json, eventData?.date),
+    [eventData?.doors_json, eventData?.date]
   )
   const [isFiltersOpen, setIsFiltersOpen] = useState(true)
   const [showGhost, setShowGhost] = useState(false)
@@ -113,12 +123,16 @@ function LiveContextBar({
       `${bands.length} ${bands.length === 1 ? 'set' : 'sets'}`,
     ]
 
+    if (doorsTime) {
+      summaryItems.push(`Doors ${formatTime(doorsTime)}`)
+    }
+
     if (daysUntil !== null) {
       summaryItems.push(`${daysUntil} ${daysUntil === 1 ? 'day away' : 'days away'}`)
     }
 
     return summaryItems.join(' • ')
-  }, [bands.length, daysUntil, uniqueVenues])
+  }, [bands.length, daysUntil, doorsTime, uniqueVenues])
 
   if (!eventData?.name) {
     return null
@@ -226,6 +240,12 @@ function LiveContextBar({
               {bands.length} {bands.length === 1 ? 'set' : 'sets'}
             </span>
           </div>
+          {doorsTime && (
+            <div className="inline-flex min-h-[40px] items-center gap-2 rounded-full border border-border bg-surface px-3 py-2 text-text-secondary">
+              <DoorOpen size={14} aria-hidden="true" className="text-accent-400" />
+              <span>Doors {formatTime(doorsTime)}</span>
+            </div>
+          )}
           <div className="inline-flex min-h-[40px] items-center gap-2 rounded-full border border-accent-500/25 bg-accent-500/10 px-3 py-2 text-accent-400">
             <Route size={14} aria-hidden="true" />
             <span>

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -96,6 +96,7 @@ function MySchedule({
   onBrowseAll,
   eventSlug,
   eventId,
+  doorsJson = null,
 }) {
   const [currentTime, setCurrentTime] = useState(() => (nowOverride ? new Date(nowOverride) : new Date()))
   const [copyButtonLabel, setCopyButtonLabel] = useState('Copy Schedule')
@@ -598,7 +599,9 @@ function MySchedule({
 
           return (
             <Fragment key={band.id}>
-              {showDayDivider && <DayDivider date={band.date} dayNumber={dayNumberByDateMap.get(band.date)} />}
+              {showDayDivider && (
+                <DayDivider date={band.date} dayNumber={dayNumberByDateMap.get(band.date)} doorsJson={doorsJson} />
+              )}
               <div className="relative mb-6">
                 {/* Walk / break transition from the previous set */}
                 {transition && (

--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -51,6 +51,7 @@ function ScheduleView({
   onVenueFilterChange,
   showVenueFilter = true,
   eventSlug,
+  doorsJson = null,
 }) {
   const [copyAllLabel, setCopyAllLabel] = useState('Copy Visible Schedule')
   const [isCopyingAll, setIsCopyingAll] = useState(false)
@@ -503,7 +504,9 @@ function ScheduleView({
                 const showDayDivider = multiDayEvent && date !== previousDate
                 return (
                   <Fragment key={`${date ?? ''}-${time}`}>
-                    {showDayDivider && <DayDivider date={date} dayNumber={dayNumberByDateMap.get(date)} />}
+                    {showDayDivider && (
+                      <DayDivider date={date} dayNumber={dayNumberByDateMap.get(date)} doorsJson={doorsJson} />
+                    )}
                     <div className="relative ml-0 sm:ml-4">
                       <div className="flex items-center mb-4">
                         <h3 className="bg-bg-navy text-text-primary font-mono font-semibold text-base md:text-lg px-4 py-2 rounded-lg shadow">
@@ -547,7 +550,9 @@ function ScheduleView({
                 const showDayDivider = multiDayEvent && date !== previousDate
                 return (
                   <Fragment key={`${date ?? ''}-${time}`}>
-                    {showDayDivider && <DayDivider date={date} dayNumber={dayNumberByDateMap.get(date)} />}
+                    {showDayDivider && (
+                      <DayDivider date={date} dayNumber={dayNumberByDateMap.get(date)} doorsJson={doorsJson} />
+                    )}
                     <div className="relative ml-0 sm:ml-4 opacity-60">
                       <div className="flex items-center mb-4">
                         <h3 className="bg-surface text-text-tertiary font-mono font-semibold text-base md:text-lg px-4 py-2 rounded-lg shadow">

--- a/frontend/src/components/__tests__/LiveContextBar.test.jsx
+++ b/frontend/src/components/__tests__/LiveContextBar.test.jsx
@@ -78,4 +78,44 @@ describe('LiveContextBar', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /show filters/i })[0])
     expect(screen.getByLabelText(/Time filter/i)).toBeInTheDocument()
   })
+
+  it('does not show a Doors chip when the event has no doors_json (#569)', () => {
+    render(
+      <LiveContextBar
+        eventData={eventData}
+        currentTime={new Date('2026-05-06T19:30:00')}
+        bands={bands}
+        selectedCount={0}
+        view="all"
+        onViewChange={vi.fn()}
+        venueFilter={null}
+        onVenueFilterChange={vi.fn()}
+        timeFilter="all"
+        onTimeFilterChange={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText(/Doors \d/i)).not.toBeInTheDocument()
+  })
+
+  it('shows a "Doors" chip for the event\'s first date when doors_json has a time for it (#569)', () => {
+    const eventWithDoors = { ...eventData, doors_json: JSON.stringify({ '2026-05-06': '18:30' }) }
+
+    render(
+      <LiveContextBar
+        eventData={eventWithDoors}
+        currentTime={new Date('2026-05-06T12:00:00')}
+        bands={bands}
+        selectedCount={0}
+        view="all"
+        onViewChange={vi.fn()}
+        venueFilter={null}
+        onVenueFilterChange={vi.fn()}
+        timeFilter="all"
+        onTimeFilterChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText('Doors 6:30 PM').length).toBeGreaterThan(0)
+  })
 })

--- a/frontend/src/components/ui/DayDivider.jsx
+++ b/frontend/src/components/ui/DayDivider.jsx
@@ -1,6 +1,9 @@
+import { DoorOpen } from 'lucide-react'
 import { memo } from 'react'
 import PropTypes from 'prop-types'
+import { getDoorsTimeForDate } from '../../utils/doorsTime'
 import { formatFestivalDate } from '../../utils/festivalDays'
+import { formatTime } from '../../utils/timeFormat'
 
 /**
  * DayDivider - Design System v1.0
@@ -9,13 +12,19 @@ import { formatFestivalDate } from '../../utils/festivalDays'
  * event (#541): "DAY N · Saturday, August 2". Public / theme-following
  * surface — semantic tokens only, never hardcoded white.
  *
+ * When `doorsJson` (the event's `doors_json`) has a time for this day's
+ * `date`, appends a "Gates 4:00 PM"-style label (#569) — absent/malformed
+ * doorsJson renders nothing extra.
+ *
  * Shared between ScheduleView and MySchedule so both fan-facing surfaces
  * render identical day-divider styling.
  *
  * @example
- * <DayDivider date="2026-08-02" dayNumber={1} />
+ * <DayDivider date="2026-08-02" dayNumber={1} doorsJson={event.doors_json} />
  */
-const DayDivider = memo(function DayDivider({ date, dayNumber, className = '' }) {
+const DayDivider = memo(function DayDivider({ date, dayNumber, doorsJson = null, className = '' }) {
+  const doorsTime = getDoorsTimeForDate(doorsJson, date)
+
   return (
     <div
       className={`flex items-center gap-3 pt-2 ${className}`.trim()}
@@ -25,6 +34,12 @@ const DayDivider = memo(function DayDivider({ date, dayNumber, className = '' })
       <span className="text-xs font-bold tracking-widest uppercase text-text-primary bg-surface border border-border px-3 py-1.5 rounded-full whitespace-nowrap">
         Day {dayNumber} &middot; {formatFestivalDate(date, 'long')}
       </span>
+      {doorsTime && (
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-text-secondary whitespace-nowrap">
+          <DoorOpen size={12} aria-hidden="true" className="text-text-tertiary" />
+          Gates {formatTime(doorsTime)}
+        </span>
+      )}
       <div className="flex-1 h-px bg-border"></div>
     </div>
   )
@@ -33,6 +48,7 @@ const DayDivider = memo(function DayDivider({ date, dayNumber, className = '' })
 DayDivider.propTypes = {
   date: PropTypes.string.isRequired,
   dayNumber: PropTypes.number,
+  doorsJson: PropTypes.string,
   className: PropTypes.string,
 }
 

--- a/frontend/src/utils/__tests__/doorsTime.test.js
+++ b/frontend/src/utils/__tests__/doorsTime.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { parseDoorsJson, getDoorsTimeForDate } from '../doorsTime'
+
+describe('parseDoorsJson (#569)', () => {
+  it('parses a valid map', () => {
+    expect(parseDoorsJson('{"2026-07-10":"16:00","2026-07-11":"10:00"}')).toEqual({
+      '2026-07-10': '16:00',
+      '2026-07-11': '10:00',
+    })
+  })
+
+  it('returns null for null/undefined/empty input', () => {
+    expect(parseDoorsJson(null)).toBeNull()
+    expect(parseDoorsJson(undefined)).toBeNull()
+    expect(parseDoorsJson('')).toBeNull()
+  })
+
+  it('returns null for malformed JSON (never throws)', () => {
+    expect(parseDoorsJson('{not valid json')).toBeNull()
+  })
+
+  it('returns null for a non-object JSON value (array, string, number)', () => {
+    expect(parseDoorsJson('[]')).toBeNull()
+    expect(parseDoorsJson('"18:30"')).toBeNull()
+    expect(parseDoorsJson('42')).toBeNull()
+  })
+
+  it('returns null for a non-string input', () => {
+    expect(parseDoorsJson({ '2026-07-10': '16:00' })).toBeNull()
+  })
+})
+
+describe('getDoorsTimeForDate (#569)', () => {
+  const doorsJson = JSON.stringify({ '2026-07-10': '16:00', '2026-07-11': '10:00' })
+
+  it('returns the time for a date present in the map', () => {
+    expect(getDoorsTimeForDate(doorsJson, '2026-07-10')).toBe('16:00')
+    expect(getDoorsTimeForDate(doorsJson, '2026-07-11')).toBe('10:00')
+  })
+
+  it('returns null for a date absent from the map', () => {
+    expect(getDoorsTimeForDate(doorsJson, '2026-07-12')).toBeNull()
+  })
+
+  it('returns null when doorsJson is absent', () => {
+    expect(getDoorsTimeForDate(null, '2026-07-10')).toBeNull()
+    expect(getDoorsTimeForDate(undefined, '2026-07-10')).toBeNull()
+  })
+
+  it('returns null when date is absent', () => {
+    expect(getDoorsTimeForDate(doorsJson, null)).toBeNull()
+    expect(getDoorsTimeForDate(doorsJson, undefined)).toBeNull()
+  })
+
+  it('returns null for a malformed time value in an otherwise-valid map', () => {
+    expect(getDoorsTimeForDate('{"2026-07-10":"6:30 PM"}', '2026-07-10')).toBeNull()
+    expect(getDoorsTimeForDate('{"2026-07-10":25}', '2026-07-10')).toBeNull()
+  })
+
+  it('returns null for malformed doorsJson', () => {
+    expect(getDoorsTimeForDate('{not valid json', '2026-07-10')).toBeNull()
+  })
+})

--- a/frontend/src/utils/__tests__/liveLabel.test.js
+++ b/frontend/src/utils/__tests__/liveLabel.test.js
@@ -124,6 +124,22 @@ describe('getLifecycleLabel — start-edge gate (#569): doors → first set → 
     ]
     expect(labelOf('2026-08-02', new Date(2026, 7, 3, 8, 0), bands, multiDayDoors)).toBe('Live Tonight')
   })
+
+  it("day 1 with no sets of its own is Live from midnight — a later day's sets never gate day 1", () => {
+    // Regression: day-1 lineup empty, all sets belong to day 2 (`band.date`
+    // carries the festival day in multi-day payloads, #543). With no day-1
+    // signal at all the midnight fallback applies — day 2's noon set must
+    // not hold day 1 at "Upcoming".
+    const bands = [{ ...band(at(2026, 8, 3, 12, 0), at(2026, 8, 3, 13, 0)), date: '2026-08-03' }]
+    expect(labelOf('2026-08-02', at(2026, 8, 2, 9, 0), bands)).toBe('Live Tonight')
+  })
+
+  it('day 1 with no sets still gates on a day-1 doors time when one exists', () => {
+    const doors = JSON.stringify({ '2026-08-02': '16:00' })
+    const bands = [{ ...band(at(2026, 8, 3, 12, 0), at(2026, 8, 3, 13, 0)), date: '2026-08-03' }]
+    expect(labelOf('2026-08-02', at(2026, 8, 2, 9, 0), bands, doors)).toBe('Upcoming')
+    expect(labelOf('2026-08-02', at(2026, 8, 2, 16, 30), bands, doors)).toBe('Live Tonight')
+  })
 })
 
 describe('isSameLocalDay', () => {

--- a/frontend/src/utils/__tests__/liveLabel.test.js
+++ b/frontend/src/utils/__tests__/liveLabel.test.js
@@ -68,6 +68,64 @@ describe('getLifecycleLabel — no set times entered yet (date-based fallback)',
   })
 })
 
+describe('getLifecycleLabel — start-edge gate (#569): doors → first set → midnight', () => {
+  // LWBC Vol 17: doors 6:30 PM, first set 6:45 PM, single-day.
+  const doorsJson = JSON.stringify({ '2026-08-02': '18:30' })
+  const lwbcBands = [band(at(2026, 8, 2, 18, 45), at(2026, 8, 2, 19, 45))]
+
+  it("is Upcoming before doors open on the event's first day", () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 12, 0), lwbcBands, doorsJson)).toBe('Upcoming')
+  })
+
+  it('is Live once doors open, even before the first set actually starts', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 18, 35), lwbcBands, doorsJson)).toBe('Live Tonight')
+  })
+
+  it('is Live at the exact doors instant (now >= doors, not strictly after)', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 18, 30), lwbcBands, doorsJson)).toBe('Live Tonight')
+  })
+
+  it('a set already playing wins over a later doors time (earliest signal wins)', () => {
+    // Inconsistent data (doors logged later than the set actually started) —
+    // the crawl is provably running, so Live wins regardless of doorsJson.
+    const lateDoors = JSON.stringify({ '2026-08-02': '21:00' })
+    const bands = [band(at(2026, 8, 2, 19, 0), at(2026, 8, 2, 20, 0))]
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 19, 30), bands, lateDoors)).toBe('Live Tonight')
+  })
+
+  it('without doorsJson, falls back to the first set start (Upcoming before, Live after)', () => {
+    // Spec: start-edge precedence is doors → first set start → local midnight.
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 12, 0), lwbcBands, null)).toBe('Upcoming')
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 18, 50), lwbcBands, null)).toBe('Live Tonight')
+    // 4th arg omitted entirely — exercises the default parameter.
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 12, 0), lwbcBands)).toBe('Upcoming')
+  })
+
+  it('with neither doorsJson nor set times, is Live from local midnight (last-resort fallback)', () => {
+    const noTimes = [band(0, 0)]
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 0, 30), noTimes, null)).toBe('Live Tonight')
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 12, 0), [], null)).toBe('Live Tonight')
+  })
+
+  it('malformed doorsJson is treated as absent (falls back to first set, never throws)', () => {
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 12, 0), lwbcBands, '{not valid json')).toBe('Upcoming')
+    expect(labelOf('2026-08-02', new Date(2026, 7, 2, 18, 50), lwbcBands, '{not valid json')).toBe('Live Tonight')
+  })
+
+  it("does not re-gate day 2+ of a multi-day event (only the event's first day is gated)", () => {
+    // BLR3-style: Friday doors 16:00/first set 19:15, Saturday doors
+    // 10:00/first set 12:00. `eventDate` is always the event's first day
+    // (Friday) — day-2 (Saturday) morning stays Live via the firstStart
+    // rule, same as the existing after-midnight/multi-day behaviour.
+    const multiDayDoors = JSON.stringify({ '2026-08-02': '16:00', '2026-08-03': '10:00' })
+    const bands = [
+      band(at(2026, 8, 2, 19, 15), at(2026, 8, 2, 20, 15)),
+      band(at(2026, 8, 3, 12, 0), at(2026, 8, 3, 13, 0)),
+    ]
+    expect(labelOf('2026-08-02', new Date(2026, 7, 3, 8, 0), bands, multiDayDoors)).toBe('Live Tonight')
+  })
+})
+
 describe('isSameLocalDay', () => {
   it('matches the event calendar day', () => {
     expect(isSameLocalDay('2026-08-02', new Date(2026, 7, 2, 23, 0))).toBe(true)

--- a/frontend/src/utils/doorsTime.js
+++ b/frontend/src/utils/doorsTime.js
@@ -1,0 +1,43 @@
+/**
+ * Shared helpers for `events.doors_json` (#569) — a JSON map of festival
+ * date (YYYY-MM-DD) -> 24h doors/gates-open time ("HH:MM"), e.g.
+ * `{"2026-07-10":"16:00","2026-07-11":"10:00"}`. Nullable; absent or
+ * malformed always means "no doors info" — every consumer of this module
+ * must stay byte-identical to current behaviour in that case.
+ *
+ * Used by `liveLabel.js` (the "started"/live gate) and the day-divider /
+ * event-header doors display — kept in one place so parsing never drifts
+ * between the two.
+ */
+
+const DOORS_TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/
+
+/**
+ * Parses the raw doors_json string defensively. Never throws — malformed
+ * JSON, non-object shapes (arrays, primitives), and null/undefined input all
+ * resolve to `null` ("no doors info") rather than surfacing an error to fans.
+ * @param {string|null|undefined} doorsJson
+ * @returns {Record<string, string>|null}
+ */
+export function parseDoorsJson(doorsJson) {
+  if (!doorsJson || typeof doorsJson !== 'string') return null
+  try {
+    const parsed = JSON.parse(doorsJson)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * @param {string|null|undefined} doorsJson - raw doors_json string
+ * @param {string|null|undefined} date - YYYY-MM-DD festival day to look up
+ * @returns {string|null} the "HH:MM" doors time for `date`, or null if absent/invalid
+ */
+export function getDoorsTimeForDate(doorsJson, date) {
+  if (!date) return null
+  const map = parseDoorsJson(doorsJson)
+  const value = map?.[date]
+  return typeof value === 'string' && DOORS_TIME_REGEX.test(value) ? value : null
+}

--- a/frontend/src/utils/liveLabel.js
+++ b/frontend/src/utils/liveLabel.js
@@ -67,6 +67,27 @@ function scheduleWindow(bands) {
 }
 
 /**
+ * Earliest set start among bands belonging to one festival day (`band.date`,
+ * already after-midnight-corrected by prepareBands). The day-1 start-edge
+ * gate must only consider DAY-1 sets — mirroring the server-side gate in
+ * functions/api/events/timeline.js — or a multi-day event whose first day has
+ * no sets yet would gate against a later day's timestamp and read "Upcoming"
+ * all of day 1 instead of falling back to the local-midnight rule.
+ *
+ * A band without a `.date` inherits the event's own date — the same rule the
+ * schedule payload applies to a NULL `performance_date` (#543) and the exact
+ * mirror of the server gate's `performance_date == null` branch.
+ */
+function firstStartOnDay(bands, date) {
+  let first = Infinity
+  for (const band of bands ?? []) {
+    const bandDay = band?.date ?? date
+    if (bandDay === date && band?.startMs > 0 && band.startMs < first) first = band.startMs
+  }
+  return first === Infinity ? null : first
+}
+
+/**
  * @param {string} eventDate - YYYY-MM-DD
  * @param {Date|number} currentTime
  * @param {Array<{startMs:number,endMs:number}>} bands - prepared bands (prepareBands)
@@ -103,7 +124,8 @@ export function getLifecycleLabel(eventDate, currentTime, bands = [], doorsJson 
     // LOCAL-time construction, same pattern as baselineEnd above — never
     // bare `new Date('YYYY-MM-DD')` (see CLAUDE.md).
     const doorsMs = doorsTime ? new Date(eventDate + 'T' + doorsTime + ':00').getTime() : null
-    const signals = [doorsMs, firstStart].filter(value => value != null)
+    // Day-1 sets only — a later day's first set must never gate day 1.
+    const signals = [doorsMs, firstStartOnDay(bands, eventDate)].filter(value => value != null)
     if (signals.length > 0 && now < Math.min(...signals)) return LABELS.upcoming
     return LABELS.live
   }

--- a/frontend/src/utils/liveLabel.js
+++ b/frontend/src/utils/liveLabel.js
@@ -1,3 +1,5 @@
+import { getDoorsTimeForDate } from './doorsTime'
+
 /**
  * Fan-facing event lifecycle label (the badge in LiveContextBar).
  *
@@ -10,6 +12,17 @@
  * Deliberately independent of the admin edit-protection lifecycle
  * (`getEventState` in `eventLifecycle.js`) — coupling the two is what caused
  * #558. This is display only; that is data-mutation protection.
+ *
+ * Start-edge gate (#569): on the event's FIRST local day, the event isn't
+ * "Live" at local midnight. The start edge is, in precedence order: the
+ * day's doors/gates time (`doorsJson`) → the first set's actual start →
+ * local midnight (no gate — the pre-#569 behaviour, kept when neither
+ * signal exists). The earliest available signal wins, so a set already
+ * playing is never "Upcoming" even if doorsJson claims a later opening.
+ * Days after the first keep the existing firstStart rule (the
+ * after-midnight window and mid-festival mornings stay Live). Malformed
+ * doorsJson is treated as absent. Only the START edge changes — the
+ * end-side logic (#559) is untouched.
  */
 
 const GRACE_PERIOD_MS = 48 * 60 * 60 * 1000
@@ -57,9 +70,10 @@ function scheduleWindow(bands) {
  * @param {string} eventDate - YYYY-MM-DD
  * @param {Date|number} currentTime
  * @param {Array<{startMs:number,endMs:number}>} bands - prepared bands (prepareBands)
+ * @param {string|null} [doorsJson] - raw `events.doors_json` string from the schedule payload
  * @returns {{label:string, classes:string}}
  */
-export function getLifecycleLabel(eventDate, currentTime, bands = []) {
+export function getLifecycleLabel(eventDate, currentTime, bands = [], doorsJson = null) {
   const { firstStart, lastEnd } = scheduleWindow(bands)
 
   // Baseline: the event day's local end (23:59:59), matching the prior
@@ -77,11 +91,25 @@ export function getLifecycleLabel(eventDate, currentTime, bands = []) {
   const now = toMs(currentTime)
   if (now >= liveEnd + GRACE_PERIOD_MS) return LABELS.archive
   if (now >= liveEnd) return LABELS.recap
-  // Before the crawl ends: "Live" on the event's local day, or once the first
-  // set has started — the latter keeps it Live through the after-midnight
-  // window, when the local calendar day has rolled over but the crawl is on.
-  if (isSameLocalDay(eventDate, currentTime) || (firstStart != null && now >= firstStart)) {
+
+  // Before the crawl ends, on the event's first local day: Live once the
+  // start edge has passed (#569). The edge is the earliest available signal
+  // of doors time / first set start — an already-playing set is therefore
+  // never "Upcoming" even when doorsJson claims a later opening. With
+  // neither signal (no doors info AND no set times entered), the event is
+  // Live from local midnight, exactly the pre-#569 behaviour.
+  if (isSameLocalDay(eventDate, currentTime)) {
+    const doorsTime = getDoorsTimeForDate(doorsJson, eventDate)
+    // LOCAL-time construction, same pattern as baselineEnd above — never
+    // bare `new Date('YYYY-MM-DD')` (see CLAUDE.md).
+    const doorsMs = doorsTime ? new Date(eventDate + 'T' + doorsTime + ':00').getTime() : null
+    const signals = [doorsMs, firstStart].filter(value => value != null)
+    if (signals.length > 0 && now < Math.min(...signals)) return LABELS.upcoming
     return LABELS.live
   }
+  // Off the event's calendar day (the after-midnight window, or day 2+ of a
+  // multi-day event): Live once the first set has started — keeps the badge
+  // Live when the local day has rolled over but the crawl is still on.
+  if (firstStart != null && now >= firstStart) return LABELS.live
   return LABELS.upcoming
 }

--- a/functions/api/admin/events.js
+++ b/functions/api/admin/events.js
@@ -10,6 +10,7 @@ import {
   safeReflectSocialLinksString,
   sanitizeEventSocialLinks,
   sanitizeVenueInfo,
+  validateDoorsJson,
 } from "../../utils/validation.js";
 import { getClientIP } from "../../utils/request.js";
 
@@ -132,6 +133,7 @@ export async function onRequestPost(context) {
       venue_info,
       social_links,
       theme_colors,
+      doors_json,
     } = validation.sanitized;
 
     let sanitizedVenueInfo;
@@ -142,6 +144,14 @@ export async function onRequestPost(context) {
     } catch (error) {
       return validationErrorResponse(error.message);
     }
+
+    // Cross-field check (needs date/end_date, so it can't live in the
+    // schema-level `validate` above) — mirrors validatePerformanceDate.
+    const doorsCheck = validateDoorsJson(doors_json, { date, end_date });
+    if (!doorsCheck.valid) {
+      return validationErrorResponse(doorsCheck.error);
+    }
+    const sanitizedDoorsJson = doorsCheck.value;
     if (status === "archived" && currentUser.role !== "admin") {
       return new Response(
         JSON.stringify({
@@ -213,9 +223,10 @@ export async function onRequestPost(context) {
         venue_info,
         social_links,
         theme_colors,
+        doors_json,
         created_by_user_id
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       RETURNING *
     `,
     )
@@ -232,6 +243,7 @@ export async function onRequestPost(context) {
         sanitizedVenueInfo,
         sanitizedSocialLinks,
         theme_colors,
+        sanitizedDoorsJson,
         currentUser.userId,
       )
       .first();

--- a/functions/api/admin/events/[id].js
+++ b/functions/api/admin/events/[id].js
@@ -13,6 +13,7 @@ import {
   sanitizeString,
   sanitizeVenueInfo,
   validateDate,
+  validateDoorsJson,
 } from "../../../utils/validation.js";
 import { getClientIP } from "../../../utils/request.js";
 
@@ -102,8 +103,19 @@ export async function onRequestPatch(context) {
     if (body.ticketLink && !body.ticket_url) {
       body.ticket_url = body.ticketLink;
     }
-    const { name, date, end_date, status, description, city, ticket_url, venue_info, social_links, theme_colors } =
-      body;
+    const {
+      name,
+      date,
+      end_date,
+      status,
+      description,
+      city,
+      ticket_url,
+      venue_info,
+      social_links,
+      theme_colors,
+      doors_json,
+    } = body;
 
     // Build update query dynamically based on provided fields
     const updates = [];
@@ -358,6 +370,26 @@ export async function onRequestPatch(context) {
       }
       updates.push("theme_colors = ?");
       params.push(parsed.value ?? null);
+    }
+
+    if (doors_json !== undefined) {
+      // Validate against the EFFECTIVE date span — if this same request also
+      // changes date/end_date, doors_json must be checked against the new
+      // span, not the stale one on `event` (mirrors the end_date block above).
+      const effectiveDate = date !== undefined ? date : event.date;
+      const effectiveEndDate = end_date !== undefined ? end_date || null : event.end_date;
+      const doorsCheck = validateDoorsJson(doors_json, { date: effectiveDate, end_date: effectiveEndDate });
+      if (!doorsCheck.valid) {
+        return new Response(
+          JSON.stringify({
+            error: "Validation error",
+            message: doorsCheck.error,
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      updates.push("doors_json = ?");
+      params.push(doorsCheck.value);
     }
 
     // Always update updated_by_user_id

--- a/functions/api/admin/events/[id]/duplicate.js
+++ b/functions/api/admin/events/[id]/duplicate.js
@@ -65,7 +65,12 @@ export async function onRequestPost(context) {
     }
 
     // Create the new event as an unpublished draft, carrying over the source's
-    // descriptive fields but not its publish state.
+    // descriptive fields but not its publish state. doors_json is deliberately
+    // NOT in this column list: the new event has a different date (and
+    // possibly no end_date at all), so the source's date-keyed doors times
+    // would no longer fall within the new event's festival-day span and
+    // would fail validateDoorsJson on the next edit anyway (#569). Leaving it
+    // out of INSERT defaults the column to NULL — start clean.
     const newEvent = await DB.prepare(
       `INSERT INTO events (
          name, date, slug, status, is_published, description, city,

--- a/functions/api/admin/events/__tests__/events.test.js
+++ b/functions/api/admin/events/__tests__/events.test.js
@@ -127,6 +127,122 @@ describe("Event API - handler integration", () => {
     expect(data.event.name).toBe("New Name");
   });
 
+  // ---------------------------------------------------------------------
+  // #569 — events.doors_json create/update wiring, end-to-end through the
+  // admin handlers (the validateDoorsJson unit tests in validation.test.js
+  // cover the pure-function rules; these confirm the handlers actually call
+  // it and persist/reflect the result).
+  // ---------------------------------------------------------------------
+  it("onRequestPost persists a valid doors_json map", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const body = {
+      name: "BLR3",
+      slug: "blr3-doors",
+      date: "2099-07-10",
+      end_date: "2099-07-11",
+      doors_json: JSON.stringify({ "2099-07-10": "16:00", "2099-07-11": "10:00" }),
+    };
+    const request = new Request("https://example.test/api/admin/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify(body),
+    });
+
+    const res = await eventsHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(JSON.parse(data.event.doors_json)).toEqual({ "2099-07-10": "16:00", "2099-07-11": "10:00" });
+
+    const stored = rawDb.prepare("SELECT doors_json FROM events WHERE id = ?").get(data.event.id);
+    expect(JSON.parse(stored.doors_json)).toEqual({ "2099-07-10": "16:00", "2099-07-11": "10:00" });
+  });
+
+  it("onRequestPost rejects doors_json with a date key outside the event span", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const body = {
+      name: "Bad Doors Event",
+      slug: "bad-doors-event",
+      date: "2099-07-10",
+      doors_json: JSON.stringify({ "2099-07-15": "16:00" }),
+    };
+    const request = new Request("https://example.test/api/admin/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify(body),
+    });
+
+    const res = await eventsHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.message).toMatch(/between/);
+
+    // Nothing was written — the whole request was rejected up front.
+    const stored = rawDb.prepare("SELECT id FROM events WHERE slug = ?").get("bad-doors-event");
+    expect(stored).toBeUndefined();
+  });
+
+  it("onRequestPatch updates doors_json, validated against the event's existing span", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const ev = insertEvent(rawDb, { name: "LWBC", slug: "lwbc-doors", date: "2099-08-02" });
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ doors_json: JSON.stringify({ "2099-08-02": "18:30" }) }),
+    });
+
+    const res = await eventIdHandler.onRequestPatch({ request, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(JSON.parse(data.event.doors_json)).toEqual({ "2099-08-02": "18:30" });
+  });
+
+  it("onRequestPatch rejects a doors_json value with a bad HH:MM time format", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const ev = insertEvent(rawDb, { name: "LWBC", slug: "lwbc-doors-bad-time", date: "2099-08-02" });
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ doors_json: JSON.stringify({ "2099-08-02": "6:30 PM" }) }),
+    });
+
+    const res = await eventIdHandler.onRequestPatch({ request, env });
+    expect(res.status).toBe(400);
+  });
+
+  it("onRequestPatch validates doors_json against a simultaneously-updated end_date (multi-day)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    // Single-day at creation; this request both extends it to a 2nd day AND
+    // sets doors for that new day in the same call — must validate against
+    // the NEW span, not the stale single-day one.
+    const ev = insertEvent(rawDb, { name: "BLR3", slug: "blr3-extend", date: "2099-07-10" });
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({
+        end_date: "2099-07-11",
+        doors_json: JSON.stringify({ "2099-07-10": "16:00", "2099-07-11": "10:00" }),
+      }),
+    });
+
+    const res = await eventIdHandler.onRequestPatch({ request, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(JSON.parse(data.event.doors_json)).toEqual({ "2099-07-10": "16:00", "2099-07-11": "10:00" });
+  });
+
   it("onRequestPatch response sanitizes a javascript: scheme in social_links untouched by the request (#493)", async () => {
     const rawDb = createTestDB();
     const env = { DB: createDBEnv(rawDb) };
@@ -441,6 +557,40 @@ describe("Event API - handler integration", () => {
     const data = await res.json();
     expect(data.event.slug).toBe("original-copy");
     expect(data.bands_copied).toBeGreaterThanOrEqual(2);
+  });
+
+  it("duplicate endpoint does NOT copy doors_json to the new event (#569)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const original = insertEvent(rawDb, {
+      name: "BLR3 Source",
+      slug: "blr3-doors-source",
+      date: "2099-07-10",
+      end_date: "2099-07-11",
+      doors_json: JSON.stringify({ "2099-07-10": "16:00", "2099-07-11": "10:00" }),
+    });
+
+    // New event has a different date span — the source's date-keyed doors
+    // times would no longer fall within it.
+    const body = { name: "BLR4", date: "2100-07-09", slug: "blr4-doors-copy" };
+    const request = new Request(`https://example.test/api/admin/events/${original.id}/duplicate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify(body),
+    });
+
+    const res = await duplicateHandler.onRequestPost({
+      request,
+      env,
+      params: { id: String(original.id) },
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.event.doors_json).toBeNull();
+
+    const stored = rawDb.prepare("SELECT doors_json FROM events WHERE id = ?").get(data.event.id);
+    expect(stored.doors_json).toBeNull();
   });
 
   it("duplicate endpoint sanitizes a legacy javascript: social_links value at the write path (#499)", async () => {

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -5,7 +5,7 @@
  * Validates N+1 query fix and correct data grouping
  */
 
-import { describe, it, test, expect, beforeEach, vi } from "vitest";
+import { describe, it, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { onRequestGet as timelineHandler } from "../timeline.js";
 import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
 import { eventLocalToday } from "../../../utils/eventDay.js";
@@ -676,9 +676,19 @@ describe("Timeline real-DB — upcoming has no fixed day-window cap (SQL exercis
 // for #479.
 // ---------------------------------------------------------------------------
 describe("Timeline real-DB — NULL venue_id must not inflate venue_count (#479)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test("venue_count is 0 when all performances have venue_id = NULL", async () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // Pin the clock to a Toronto evening: the start-edge gate (#569) would
+    // otherwise move this today-dated event (set at 18:00) into "upcoming"
+    // whenever the suite runs before 6 PM Toronto time.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T23:00:00Z")); // 19:00 EDT
 
     const today = eventLocalToday();
 
@@ -717,9 +727,19 @@ describe("Timeline real-DB — NULL venue_id must not inflate venue_count (#479)
 // them. Regression for #483.
 // ---------------------------------------------------------------------------
 describe("Timeline real-DB — derived band url is scheme-validated (#483)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test("a band whose only link is a javascript: scheme resolves to url: null", async () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // Pinned to a Toronto evening so the start-edge gate (#569) never moves
+    // this today-dated event (set at 18:00) out of "now" — see the #479
+    // describe above.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T23:00:00Z")); // 19:00 EDT
 
     const today = eventLocalToday();
 
@@ -756,6 +776,9 @@ describe("Timeline real-DB — derived band url is scheme-validated (#483)", () 
   test("falls through to a valid https bandcamp URL when website is unsafe", async () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T23:00:00Z")); // 19:00 EDT
 
     const today = eventLocalToday();
 
@@ -852,5 +875,349 @@ describe("Timeline real-DB — event ticket_url is scheme-validated (#504)", () 
     const found = data.now.find((e) => e.id === event.id);
     expect(found).toBeDefined();
     expect(found.ticket_url).toBe("https://tickets.example.com/crawl");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-DB — start-edge gate (#569). An event's FIRST day isn't "Happening
+// Now" at local midnight; it's held in "upcoming" (moved to the front) until
+// its start edge, which is in precedence order: that day's doors/gates time →
+// the first set's start time → local midnight (no gate). Day 2+ of a
+// multi-day event is never re-gated. Uses fake timers (`vi.setSystemTime`)
+// since `eventLocalToday`/`eventLocalClock` read the real clock by default —
+// Intl.DateTimeFormat still resolves against the faked `Date`, so
+// America/Toronto conversion is exercised for real, not stubbed out.
+// ---------------------------------------------------------------------------
+describe("Timeline real-DB — start-edge gate (#569)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("first day, before doors → moved out of 'now' and into the front of 'upcoming'", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-07-10T18:00:00Z = 14:00 EDT — before the 16:00 doors time.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T18:00:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "BLR3 Friday",
+      slug: "timeline-doors-before",
+      date: "2026-07-10",
+      status: "published",
+      doors_json: JSON.stringify({ "2026-07-10": "16:00" }),
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeUndefined();
+    expect(data.upcoming[0]?.id).toBe(event.id);
+  });
+
+  test("first day, after doors → stays in 'now'", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-07-10T21:00:00Z = 17:00 EDT — after the 16:00 doors time.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T21:00:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "BLR3 Friday",
+      slug: "timeline-doors-after",
+      date: "2026-07-10",
+      status: "published",
+      doors_json: JSON.stringify({ "2026-07-10": "16:00" }),
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeDefined();
+    expect(data.upcoming.find((e) => e.id === event.id)).toBeUndefined();
+  });
+
+  test("multi-day event, day 2 morning before that day's doors → still 'now' (not re-gated)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-07-11T12:00:00Z = 08:00 EDT on day 2 — well before day 2's 10:00
+    // doors, but day 2 is never re-gated (only the event's FIRST day is).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-11T12:00:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "BLR3",
+      slug: "timeline-doors-day2",
+      date: "2026-07-10",
+      end_date: "2026-07-11",
+      status: "published",
+      doors_json: JSON.stringify({ "2026-07-10": "16:00", "2026-07-11": "10:00" }),
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeDefined();
+    expect(data.upcoming.find((e) => e.id === event.id)).toBeUndefined();
+  });
+
+  test("malformed doors_json is treated as absent — stays in 'now', never throws", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // Same instant as the "before doors" case above — if the malformed JSON
+    // were mishandled, this would either throw or wrongly gate the event.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T18:00:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "Malformed Doors Event",
+      slug: "timeline-doors-malformed",
+      date: "2026-07-10",
+      status: "published",
+    });
+    // Seed malformed JSON directly — bypasses validateDoorsJson, simulating a
+    // legacy/corrupt row.
+    rawDb.prepare("UPDATE events SET is_published=1, doors_json=? WHERE id=?").run("{not valid json", event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeDefined();
+    expect(data.upcoming.find((e) => e.id === event.id)).toBeUndefined();
+  });
+
+  test("no doors_json and no set times — 'now' from local midnight (last-resort fallback, pre-#569 behaviour)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // Just past local midnight on the event's day with NO start-edge signals
+    // at all — pre-#569 this was already "now"; that must not change.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T04:01:00Z")); // 00:01 EDT
+
+    const event = insertEvent(rawDb, {
+      name: "No Doors Info Event",
+      slug: "timeline-doors-absent",
+      date: "2026-07-10",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeDefined();
+  });
+
+  test("no doors_json, before the first set → gated to 'upcoming' (first-set fallback)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-07-10T18:00:00Z = 14:00 EDT — before the 19:00 first set, no doors.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T18:00:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "No Doors Timed Event",
+      slug: "timeline-firstset-before",
+      date: "2026-07-10",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    insertBand(rawDb, {
+      name: "Evening Opener",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "19:00",
+      end_time: "20:00",
+    });
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeUndefined();
+    expect(data.upcoming[0]?.id).toBe(event.id);
+  });
+
+  test("no doors_json, after the first set has started → stays in 'now'", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-07-10T23:30:00Z = 19:30 EDT — the 19:00 set is playing.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T23:30:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "No Doors Timed Event Live",
+      slug: "timeline-firstset-after",
+      date: "2026-07-10",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    insertBand(rawDb, {
+      name: "Evening Opener Live",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "19:00",
+      end_time: "20:00",
+    });
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeDefined();
+    expect(data.upcoming.find((e) => e.id === event.id)).toBeUndefined();
+  });
+
+  test("doors beats the first set start (live from doors, before the set begins)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-07-10T20:30:00Z = 16:30 EDT — after 16:00 doors, before the 19:15
+    // first set. Doors is the earlier signal, so the event is already "now".
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T20:30:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "BLR3 Doors Open",
+      slug: "timeline-doors-vs-firstset",
+      date: "2026-07-10",
+      status: "published",
+      doors_json: JSON.stringify({ "2026-07-10": "16:00" }),
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    insertBand(rawDb, {
+      name: "BLR3 Opener",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "19:15",
+      end_time: "20:15",
+    });
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeDefined();
+    expect(data.upcoming.find((e) => e.id === event.id)).toBeUndefined();
+  });
+
+  test("an after-midnight set (before 6 AM) never defines the first-day start edge", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-07-10T06:00:00Z = 02:00 EDT on the event's first day. The lineup
+    // has a 01:00 after-midnight set (which belongs to the PREVIOUS evening,
+    // i.e. it actually plays ~25h later) and a 19:00 evening set. If the
+    // 6 AM threshold were ignored, 02:00 >= 01:00 would wrongly mark the
+    // event started; the real edge is the 19:00 evening set → gated.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T06:00:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "After Midnight Edge Event",
+      slug: "timeline-firstset-aftermidnight",
+      date: "2026-07-10",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    insertBand(rawDb, {
+      name: "Night Owl Set",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "01:00",
+      end_time: "02:00",
+    });
+    insertBand(rawDb, {
+      name: "Evening Headliner",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "19:00",
+      end_time: "20:00",
+    });
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeUndefined();
+    expect(data.upcoming[0]?.id).toBe(event.id);
+  });
+
+  test("day-2 set times never define day 1's start edge (performance_date filter)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-07-10T17:00:00Z = 13:00 EDT on day 1. Day 2 has a noon set; if it
+    // leaked into day 1's edge, 13:00 >= 12:00 would wrongly mark the event
+    // started. Day 1's own first set is 19:15 → still gated.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T17:00:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "BLR3 Weekend",
+      slug: "timeline-firstset-day2-leak",
+      date: "2026-07-10",
+      end_date: "2026-07-11",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    const fridayPerf = insertBand(rawDb, {
+      name: "Friday Opener",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "19:15",
+      end_time: "20:15",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-07-10", fridayPerf.id);
+    const saturdayPerf = insertBand(rawDb, {
+      name: "Saturday Noon Act",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "12:00",
+      end_time: "13:00",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-07-11", saturdayPerf.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeUndefined();
+    expect(data.upcoming[0]?.id).toBe(event.id);
   });
 });

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -1,6 +1,77 @@
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { normalizeHttpUrl } from "../../utils/validation.js";
-import { eventLocalToday } from "../../utils/eventDay.js";
+import { eventLocalToday, eventLocalClock } from "../../utils/eventDay.js";
+
+/**
+ * 24-hour "HH:MM" time regex — mirrors DOORS_TIME_REGEX in validation.js.
+ * Kept local (not imported) so a malformed/legacy doors_json or start_time
+ * value here is simply treated as "no info" rather than throwing.
+ */
+const HHMM_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+/**
+ * Sets starting before 06:00 are after-midnight sets that belong to the
+ * PREVIOUS evening (the AFTER_MIDNIGHT_THRESHOLD_HOUR = 6 convention, see
+ * frontend/src/utils/bandUtils.js and CLAUDE.md). They must never define the
+ * first day's start edge — a 1 AM set would otherwise mark the event
+ * "started" in the small hours of a morning whose show doesn't begin until
+ * evening.
+ */
+const AFTER_MIDNIGHT_THRESHOLD = "06:00";
+
+/**
+ * Normalizes a performances.start_time value ("HH:MM", "HH:MM:SS", or legacy
+ * "YYYY-MM-DD HH:MM") to zero-padded "HH:MM"; null when absent/unparseable.
+ */
+function normalizeStartTime(startTime) {
+  if (!startTime || typeof startTime !== "string") return null;
+  const timePart = startTime.includes(" ") ? startTime.split(" ")[1] : startTime;
+  const hhmm = timePart ? timePart.slice(0, 5) : "";
+  return HHMM_REGEX.test(hhmm) ? hhmm : null;
+}
+
+/**
+ * Start-edge gate (#569): an event's FIRST day isn't "Happening Now" at local
+ * midnight. The start edge is, in precedence order: the day's doors/gates
+ * time (doors_json) → the first set's start time → local midnight (no gate —
+ * pre-#569 behaviour when neither signal exists). The earliest available
+ * signal wins, so a set that is already playing is never gated even if
+ * doors_json claims a later opening. Only the first day is gated
+ * (`info.date === clock.date`); day 2+ of a multi-day event stays "now" from
+ * midnight (mid-festival mornings aren't re-gated). Malformed/missing
+ * doors_json is treated as absent — this never throws.
+ *
+ * @param {{ date: string, doors_json: string|null|undefined, firstDayStart: string|null }} info
+ * @param {{ date: string, time: string }} clock - eventLocalClock()
+ * @returns {boolean} true when the event should be held out of "now" until its start edge
+ */
+function isGatedBeforeStart(info, clock) {
+  if (info.date !== clock.date) {
+    return false;
+  }
+
+  let doorsTime = null;
+  if (info.doors_json) {
+    try {
+      const parsed = JSON.parse(info.doors_json);
+      const value = parsed?.[info.date];
+      if (typeof value === "string" && HHMM_REGEX.test(value)) {
+        doorsTime = value;
+      }
+    } catch {
+      // Malformed doors_json — treated as absent, fall through to first set.
+    }
+  }
+
+  const signals = [doorsTime, info.firstDayStart].filter(Boolean);
+  if (signals.length === 0) {
+    return false; // midnight fallback: never gated (pre-#569 behaviour)
+  }
+  const startEdge = signals.reduce((a, b) => (a < b ? a : b));
+  // Zero-padded HH:MM string compare — same trick used throughout the repo
+  // for YYYY-MM-DD (see CLAUDE.md).
+  return clock.time < startEdge;
+}
 
 /**
  * Public API: Get events timeline (now, upcoming, past)
@@ -159,11 +230,14 @@ export async function onRequestGet(context) {
           e.name as event_name,
           e.slug as event_slug,
           e.date as event_date,
+          e.end_date as event_end_date,
+          e.doors_json as doors_json,
           e.ticket_url as ticket_url,
           p.band_profile_id as band_id,
           b.name as band_name,
           p.start_time,
           p.end_time,
+          p.performance_date,
           b.social_links,
           b.genre,
           b.origin,
@@ -305,14 +379,65 @@ export async function onRequestGet(context) {
     // returned in the same order statements were pushed (tracked by `slots`).
     if (statements.length > 0) {
       const batchResults = await DB.batch(statements);
+
+      // Events bumped out of "now" by the start-edge gate below, prepended to
+      // `upcoming` once it's been computed.
+      const gatedToUpcoming = [];
+
       if (slots.now !== undefined) {
-        response.now = groupEventData(batchResults[slots.now].results || []);
+        const nowRows = batchResults[slots.now].results || [];
+        const groupedNow = groupEventData(nowRows);
+
+        // Start-edge gate (#569): groupEventData's output carries neither
+        // doors_json nor per-set festival days, so derive both per event
+        // straight from the raw rows (event-level columns repeat on every
+        // row). firstDayStart = earliest FIRST-day set: NULL performance_date
+        // inherits the event's own date (#543) so it counts; day-2+ sets
+        // never define day 1's edge; sub-06:00 sets are after-midnight sets
+        // of the previous evening and are excluded.
+        const gateInfoByEventId = new Map();
+        for (const row of nowRows) {
+          let info = gateInfoByEventId.get(row.event_id);
+          if (!info) {
+            info = { date: row.event_date, doors_json: row.doors_json, firstDayStart: null };
+            gateInfoByEventId.set(row.event_id, info);
+          }
+          if (row.performance_date == null || row.performance_date === row.event_date) {
+            const start = normalizeStartTime(row.start_time);
+            if (
+              start &&
+              start >= AFTER_MIDNIGHT_THRESHOLD &&
+              (info.firstDayStart === null || start < info.firstDayStart)
+            ) {
+              info.firstDayStart = start;
+            }
+          }
+        }
+
+        const clock = eventLocalClock(); // { date, time } in America/Toronto
+        const stillNow = [];
+        for (const event of groupedNow) {
+          const info = gateInfoByEventId.get(event.id);
+          if (info && isGatedBeforeStart(info, clock)) {
+            gatedToUpcoming.push(event);
+          } else {
+            stillNow.push(event);
+          }
+        }
+        response.now = stillNow;
       }
+
       if (slots.upcoming !== undefined) {
         response.upcoming = groupEventData(batchResults[slots.upcoming].results || []);
       }
       if (slots.past !== undefined) {
         response.past = groupEventData(batchResults[slots.past].results || []);
+      }
+
+      // Only merge into `upcoming` if the caller actually asked for it
+      // (`upcoming=false` means "omit entirely", not "gate into now").
+      if (gatedToUpcoming.length > 0 && includeUpcoming) {
+        response.upcoming = [...gatedToUpcoming, ...response.upcoming];
       }
     }
 

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -27,7 +27,7 @@ export async function onRequestGet(context) {
       // sets that span past midnight (e.g. 11:30pm-12:30am)
       event = await DB.prepare(
         `
-        SELECT id, name, date, end_date, city, slug, status, ticket_url, theme_colors, venue_info, social_links, reveal_mode
+        SELECT id, name, date, end_date, city, slug, status, ticket_url, theme_colors, venue_info, social_links, doors_json, reveal_mode
         FROM events
         WHERE is_published = 1
           AND COALESCE(end_date, date) >= date('now', '-6 hours')
@@ -39,7 +39,7 @@ export async function onRequestGet(context) {
       // Get event by slug — includes archived events for read-only history browsing
       event = await DB.prepare(
         `
-        SELECT id, name, date, end_date, city, slug, status, ticket_url, theme_colors, venue_info, social_links, reveal_mode
+        SELECT id, name, date, end_date, city, slug, status, ticket_url, theme_colors, venue_info, social_links, doors_json, reveal_mode
         FROM events
         WHERE slug = ? AND (is_published = 1 OR status = 'archived')
       `,
@@ -160,6 +160,9 @@ export async function onRequestGet(context) {
       theme_colors: event.theme_colors,
       venue_info: event.venue_info,
       social_links: safeReflectSocialLinks(event.social_links, ["instagram", "x", "tiktok"]),
+      // Raw pass-through, same as venue_info — the client parses defensively
+      // (absent/malformed = no doors info, #569).
+      doors_json: event.doors_json ?? null,
       reveal_mode: event.reveal_mode ?? 0,
     };
 

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -107,6 +107,7 @@ export function createTestDB() {
       venue_info TEXT,
       social_links TEXT,
       theme_colors TEXT,
+      doors_json TEXT,
       archived_at TEXT,
       created_by_user_id INTEGER REFERENCES users(id),
       updated_by_user_id INTEGER,
@@ -379,12 +380,13 @@ export function insertEvent(
     end_date = null,
     status = "draft",
     created_by = 1,
+    doors_json = null,
   } = {},
 ) {
   const stmt = db.prepare(
-    "INSERT INTO events (name, slug, date, end_date, status, created_by_user_id) VALUES (?, ?, ?, ?, ?, ?)",
+    "INSERT INTO events (name, slug, date, end_date, status, created_by_user_id, doors_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
   );
-  const info = stmt.run(name, slug, date, end_date, status, created_by);
+  const info = stmt.run(name, slug, date, end_date, status, created_by, doors_json);
   return db.prepare("SELECT * FROM events WHERE id = ?").get(info.lastInsertRowid);
 }
 

--- a/functions/utils/__tests__/eventDay.test.js
+++ b/functions/utils/__tests__/eventDay.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { eventLocalToday } from "../eventDay.js";
+import { eventLocalToday, eventLocalClock } from "../eventDay.js";
 
 describe("eventLocalToday", () => {
   it("returns YYYY-MM-DD", () => {
@@ -28,5 +28,45 @@ describe("eventLocalToday", () => {
 
   it("agrees with the UTC day in the Toronto afternoon", () => {
     expect(eventLocalToday(new Date("2026-07-10T18:00:00Z"))).toBe("2026-07-10");
+  });
+});
+
+describe("eventLocalClock", () => {
+  it("returns { date, time } in YYYY-MM-DD / zero-padded HH:MM", () => {
+    const clock = eventLocalClock(new Date("2026-07-10T18:00:00Z"));
+    expect(clock.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(clock.time).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  // #569 doors gate: BLR3 Friday doors at 16:00 EDT. These two instants
+  // straddle a 16:00 doors time by one minute on each side (EDT = UTC-4, so
+  // 16:00 local is 20:00Z) — the exact comparison the timeline gate depends on.
+  it("is before a 16:00 EDT doors time one minute prior", () => {
+    const clock = eventLocalClock(new Date("2026-07-10T19:59:00Z"));
+    expect(clock.date).toBe("2026-07-10");
+    expect(clock.time).toBe("15:59");
+    expect(clock.time < "16:00").toBe(true);
+  });
+
+  it("is at/after a 16:00 EDT doors time at the exact instant", () => {
+    const clock = eventLocalClock(new Date("2026-07-10T20:00:00Z"));
+    expect(clock.date).toBe("2026-07-10");
+    expect(clock.time).toBe("16:00");
+    expect(clock.time < "16:00").toBe(false);
+  });
+
+  it("handles EST (winter, UTC-5) as well as EDT", () => {
+    // 20:00Z on Jan 10 is 15:00 EST (UTC-5), not 16:00 — confirms the offset
+    // isn't hardcoded to EDT's -4.
+    const clock = eventLocalClock(new Date("2026-01-10T20:00:00Z"));
+    expect(clock.date).toBe("2026-01-10");
+    expect(clock.time).toBe("15:00");
+  });
+
+  it("rolls the date at Toronto local midnight, matching eventLocalToday", () => {
+    const clock = eventLocalClock(new Date("2026-07-10T04:00:00Z"));
+    expect(clock.date).toBe("2026-07-10");
+    expect(clock.time).toBe("00:00");
+    expect(clock.date).toBe(eventLocalToday(new Date("2026-07-10T04:00:00Z")));
   });
 });

--- a/functions/utils/__tests__/validation.test.js
+++ b/functions/utils/__tests__/validation.test.js
@@ -15,6 +15,7 @@ import {
   safeReflectSocialLinks,
   safeReflectSocialLinksString,
   sanitizeBandSocialLinks,
+  validateDoorsJson,
 } from "../validation.js";
 
 describe("Email Validation", () => {
@@ -224,6 +225,98 @@ describe("Event schema end_date validation", () => {
     const result = validateEntity({ ...validBase, end_date: "not-a-date" }, VALIDATION_SCHEMAS.event);
     expect(result.valid).toBe(false);
     expect(result.errors.end_date).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #569 — events.doors_json: JSON map of festival date -> 24h "HH:MM" doors
+// time, validated against the event's [date, end_date] festival-day span
+// (same rule as validatePerformanceDate).
+// ---------------------------------------------------------------------------
+describe("validateDoorsJson (#569)", () => {
+  const singleDayEvent = { date: "2026-08-02", end_date: null };
+  const multiDayEvent = { date: "2026-07-10", end_date: "2026-07-11" };
+
+  it("absent/null/empty doors_json is valid (no doors info)", () => {
+    expect(validateDoorsJson(undefined, singleDayEvent)).toEqual({ valid: true, error: null, value: null });
+    expect(validateDoorsJson(null, singleDayEvent)).toEqual({ valid: true, error: null, value: null });
+    expect(validateDoorsJson("", singleDayEvent)).toEqual({ valid: true, error: null, value: null });
+  });
+
+  it("accepts a valid single-day map", () => {
+    const result = validateDoorsJson('{"2026-08-02":"18:30"}', singleDayEvent);
+    expect(result.valid).toBe(true);
+    expect(JSON.parse(result.value)).toEqual({ "2026-08-02": "18:30" });
+  });
+
+  it("accepts a valid multi-day map (BLR3-style: one key per festival day)", () => {
+    const result = validateDoorsJson('{"2026-07-10":"16:00","2026-07-11":"10:00"}', multiDayEvent);
+    expect(result.valid).toBe(true);
+    expect(JSON.parse(result.value)).toEqual({ "2026-07-10": "16:00", "2026-07-11": "10:00" });
+  });
+
+  it("accepts an already-parsed object (not just a JSON string)", () => {
+    const result = validateDoorsJson({ "2026-08-02": "18:30" }, singleDayEvent);
+    expect(result.valid).toBe(true);
+    expect(JSON.parse(result.value)).toEqual({ "2026-08-02": "18:30" });
+  });
+
+  it("rejects a key outside the event's festival-day span", () => {
+    const result = validateDoorsJson('{"2026-08-03":"18:30"}', singleDayEvent);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/between/);
+  });
+
+  it("rejects a key one day before a multi-day event's span", () => {
+    const result = validateDoorsJson('{"2026-07-09":"16:00"}', multiDayEvent);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a key one day after a multi-day event's span", () => {
+    const result = validateDoorsJson('{"2026-07-12":"10:00"}', multiDayEvent);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a malformed key (not YYYY-MM-DD)", () => {
+    const result = validateDoorsJson('{"not-a-date":"18:30"}', singleDayEvent);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a bad time format", () => {
+    expect(validateDoorsJson('{"2026-08-02":"6:30 PM"}', singleDayEvent).valid).toBe(false);
+    expect(validateDoorsJson('{"2026-08-02":"25:00"}', singleDayEvent).valid).toBe(false);
+    expect(validateDoorsJson('{"2026-08-02":"18:60"}', singleDayEvent).valid).toBe(false);
+    expect(validateDoorsJson('{"2026-08-02":18.5}', singleDayEvent).valid).toBe(false);
+  });
+
+  it("rejects a non-object JSON value", () => {
+    expect(validateDoorsJson("[]", singleDayEvent).valid).toBe(false);
+    expect(validateDoorsJson('["2026-08-02"]', singleDayEvent).valid).toBe(false);
+    expect(validateDoorsJson('"18:30"', singleDayEvent).valid).toBe(false);
+    expect(validateDoorsJson("42", singleDayEvent).valid).toBe(false);
+  });
+
+  it("rejects invalid JSON", () => {
+    const result = validateDoorsJson("{not json", singleDayEvent);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/valid JSON/);
+  });
+
+  it("normalizes an empty object to null", () => {
+    expect(validateDoorsJson("{}", singleDayEvent)).toEqual({ valid: true, error: null, value: null });
+  });
+
+  it("rejects oversize input (cap ~2000 chars)", () => {
+    // A single absurdly long time value pushes the raw string over the cap.
+    const oversized = `{"2026-08-02":"${"1".repeat(3000)}:30"}`;
+    const result = validateDoorsJson(oversized, singleDayEvent);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/no more than/);
+  });
+
+  it("rejects when the event has no date to anchor the span", () => {
+    const result = validateDoorsJson('{"2026-08-02":"18:30"}', null);
+    expect(result.valid).toBe(false);
   });
 });
 

--- a/functions/utils/eventDay.js
+++ b/functions/utils/eventDay.js
@@ -19,10 +19,37 @@ const TORONTO_DAY = new Intl.DateTimeFormat("en-CA", {
   day: "2-digit",
 });
 
+// Same reasoning as TORONTO_DAY above, but also extracts the clock time —
+// needed to gate an event's FIRST day on its doors/gates-open time (#569):
+// "today" alone can't tell you whether doors have opened yet. `hour12: false`
+// plus a manual "24:MM" -> "00:MM" fix (see eventLocalClock) keeps the output
+// zero-padded HH:MM so it stays safe for the repo's string comparisons.
+const TORONTO_TIME = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "America/Toronto",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
 /**
  * @param {Date} [now] - injectable for tests; defaults to the current instant
  * @returns {string} the current calendar date in America/Toronto, YYYY-MM-DD
  */
 export function eventLocalToday(now = new Date()) {
   return TORONTO_DAY.format(now);
+}
+
+/**
+ * @param {Date} [now] - injectable for tests; defaults to the current instant
+ * @returns {{ date: string, time: string }} the current America/Toronto
+ *   calendar date (YYYY-MM-DD) and clock time (zero-padded 24h HH:MM),
+ *   comparable lexicographically against `doors_json` values (#569).
+ */
+export function eventLocalClock(now = new Date()) {
+  const date = TORONTO_DAY.format(now);
+  // Some ICU implementations format midnight as "24:00" under hour12: false;
+  // normalize to "00:MM" so string comparisons against HH:MM doors times
+  // never break at exactly midnight.
+  const time = TORONTO_TIME.format(now).replace(/^24:/, "00:");
+  return { date, time };
 }

--- a/functions/utils/validation.js
+++ b/functions/utils/validation.js
@@ -38,6 +38,11 @@ const VALID_EVENT_STATUSES = ["draft", "published", "archived"];
 const ALLOWED_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
 
 /**
+ * 24-hour "HH:MM" time regex for `events.doors_json` values (#569).
+ */
+const DOORS_TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+/**
  * Control characters to remove during sanitization
  * Removes: null bytes (\x00), control characters except tab/newline (\x0B-\x1F), and DEL (\x7F)
  */
@@ -87,6 +92,7 @@ export const FIELD_LIMITS = {
   eventVenueInfo: { min: 0, max: 5000 },
   eventSocialLinks: { min: 0, max: 2000 },
   eventThemeColors: { min: 0, max: 1000 },
+  eventDoorsJson: { min: 0, max: 2000 },
 
   // Generic
   url: { min: 0, max: 2000 },
@@ -769,6 +775,89 @@ export function validatePerformanceDate(performanceDate, event) {
 }
 
 /**
+ * Validate an event's per-day doors/gates-open time map (#569).
+ *
+ * `doorsJson` is optional — null/undefined/"" all mean "no doors info" (the
+ * default for every pre-#569 row) and are always valid. When provided it
+ * must be a JSON object whose keys are YYYY-MM-DD dates that fall within the
+ * event's festival-day span [event.date, event.end_date] (same rule and same
+ * lexicographic YYYY-MM-DD comparisons as `validatePerformanceDate` — never
+ * `new Date(...)`, see CLAUDE.md) and whose values are 24-hour "HH:MM"
+ * times. An empty object is normalized to null (equivalent to absent).
+ *
+ * @param {string|object|null|undefined} doorsJson - raw JSON string or already-parsed object
+ * @param {{ date: string, end_date: string|null }|null} event
+ * @returns {{ valid: boolean, error: string|null, value: string|null }}
+ */
+export function validateDoorsJson(doorsJson, event) {
+  if (doorsJson === undefined || doorsJson === null || doorsJson === "") {
+    return { valid: true, error: null, value: null };
+  }
+
+  let parsed;
+  if (typeof doorsJson === "string") {
+    if (doorsJson.length > FIELD_LIMITS.eventDoorsJson.max) {
+      return {
+        valid: false,
+        error: `Doors times must be no more than ${FIELD_LIMITS.eventDoorsJson.max} characters`,
+        value: null,
+      };
+    }
+    try {
+      parsed = JSON.parse(doorsJson);
+    } catch {
+      return { valid: false, error: "Doors times must be valid JSON", value: null };
+    }
+  } else if (typeof doorsJson === "object") {
+    parsed = doorsJson;
+  } else {
+    return { valid: false, error: "Doors times must be a JSON object", value: null };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { valid: false, error: "Doors times must be a JSON object", value: null };
+  }
+
+  const entries = Object.entries(parsed);
+  if (entries.length === 0) {
+    return { valid: true, error: null, value: null };
+  }
+
+  const minDate = event?.date || null;
+  const maxDate = event?.end_date || event?.date || null;
+
+  for (const [dateKey, timeValue] of entries) {
+    const dateCheck = validateDate(dateKey);
+    if (!dateCheck.valid) {
+      return { valid: false, error: `Doors times key "${dateKey}" must be a valid YYYY-MM-DD date`, value: null };
+    }
+
+    if (!minDate || dateKey < minDate || dateKey > maxDate) {
+      return {
+        valid: false,
+        error: `Doors times date "${dateKey}" must be between ${minDate || "the event start"} and ${maxDate || "the event end"}`,
+        value: null,
+      };
+    }
+
+    if (typeof timeValue !== "string" || !DOORS_TIME_REGEX.test(timeValue)) {
+      return { valid: false, error: `Doors time for "${dateKey}" must be in 24-hour HH:MM format`, value: null };
+    }
+  }
+
+  const serialized = JSON.stringify(parsed);
+  if (serialized.length > FIELD_LIMITS.eventDoorsJson.max) {
+    return {
+      valid: false,
+      error: `Doors times must be no more than ${FIELD_LIMITS.eventDoorsJson.max} characters`,
+      value: null,
+    };
+  }
+
+  return { valid: true, error: null, value: serialized };
+}
+
+/**
  * Validate a positive integer ID
  * @param {any} id - ID to validate
  * @returns {Object} { valid: boolean, value: number|null, error: string|null }
@@ -1253,6 +1342,25 @@ export const VALIDATION_SCHEMAS = {
           return { valid: true };
         } catch {
           return { valid: false, error: "Theme colors must be valid JSON" };
+        }
+      },
+    },
+    // Schema-level check is deliberately shallow (generic JSON parseability,
+    // mirroring venue_info/social_links above) — the real semantic check
+    // (date-span + HH:MM shape) is `validateDoorsJson`, called explicitly by
+    // the create/update handlers once `date`/`end_date` are known (#569).
+    doors_json: {
+      type: "string",
+      required: false,
+      label: "Doors times",
+      min: FIELD_LIMITS.eventDoorsJson.min,
+      max: FIELD_LIMITS.eventDoorsJson.max,
+      validate: (value) => {
+        try {
+          JSON.parse(value);
+          return { valid: true };
+        } catch {
+          return { valid: false, error: "Doors times must be valid JSON" };
         }
       },
     },

--- a/migrations/0052_add_event_doors_json.sql
+++ b/migrations/0052_add_event_doors_json.sql
@@ -1,0 +1,8 @@
+-- Migration: 0052_add_event_doors_json
+-- Adds doors_json for per-day doors/gates-open times (#569).
+-- JSON map of festival date -> 24h time, e.g.
+-- {"2026-07-10":"16:00","2026-07-11":"10:00"}. NULL means "no doors info" —
+-- current behaviour everywhere (display and "started"/"Happening Now" gating
+-- both no-op when this is absent).
+
+ALTER TABLE events ADD COLUMN doors_json TEXT;


### PR DESCRIPTION
## Summary

Events get an optional per-day **doors/gates time** (`events.doors_json`: JSON map `"YYYY-MM-DD" → "HH:MM"`), shown to fans and — the core of the change — used to stop marking events "started" at local midnight. On an event's **first day only**, the start edge for the homepage's "Happening Now" and the fan-facing "Live Tonight" badge is, in precedence order: **doors time → first set start → local midnight** (pre-existing behaviour when neither signal exists). The earliest available signal wins, so an already-playing set is never "Upcoming". Day 2+ of a multi-day event is never re-gated (mid-festival mornings stay live), and sets before 6 AM never define the day-1 edge (after-midnight invariant).

Driven by BLR3: gates open Friday 4 PM / Saturday 10 AM while music starts later — and pre-#569 the event read "Happening Now" from midnight.

Closes #569

## What changed

| Layer | Change |
|---|---|
| `migrations/0052` + `setup-complete.sql` | `events.doors_json TEXT` (regenerated, drift check clean) |
| `functions/utils/validation.js` | `validateDoorsJson()`: keys must be real dates within `[date, end_date]`, values `HH:MM`, 2000-char cap, `{}`→null |
| Admin API (`events.js`, `events/[id].js`) | create/update accept + validate against the *effective* date span; duplication deliberately drops doors_json (stale keys) |
| `functions/api/schedule.js` | `doors_json` in event metadata (raw pass-through like venue_info) |
| `functions/utils/eventDay.js` | `eventLocalClock()` → Toronto-local `{date, time}` |
| `functions/api/events/timeline.js` | start-edge gate; gated events move to the front of "upcoming"; malformed doors_json treated as absent, never throws |
| `frontend/src/utils/doorsTime.js` (new) | shared defensive parser |
| `frontend/src/utils/liveLabel.js` | same gate client-side; day-1 edge scoped to day-1 sets (review catch — see below); end-side #558/#559 logic untouched |
| `LiveContextBar` / `DayDivider` / callers | "Doors 6:30 PM" chip + "Gates 4:00 PM" day-divider labels, semantic tokens only |
| `CLAUDE.md` | two new invariants: Toronto-local today/now helpers; doors_json + start-edge precedence |

## Security / correctness notes

- doors_json is validated on write (shape, span, time format, size) and parsed defensively on read — malformed data degrades to "no doors info", never a throw.
- Behaviour change for existing events, intended: events with timed sets but no doors now show "upcoming" until their first set on day 1 (per Dre). Events with no set times (Vol 17 today) are byte-identical.
- Review (code-reviewer agent) confirmed: no=now&upcoming=false semantics, reveal_mode symmetry, effective-span PATCH validation, duplicate handling, migration numbering. One Important finding — the client day-1 gate used cross-day firstStart (empty day-1 lineup would gate against day 2) — fixed and regression-tested in the second commit.

## Verification

- [x] Tests: backend 706 pass / 6 todo (73 files); frontend 413 pass (45 files) — independently re-run by the orchestrator in the worktree
- [x] ESLint: 0 errors (both)
- [x] Format check: clean (both)
- [x] Build: green
- [x] Schema drift: `check-schema-drift.mjs` OK (27 tables)
- [ ] `validate:openapi`: spec not yet updated for doors_json (matches existing venue_info/theme_colors precedent) — tracked in the follow-up issue
- [x] Manual smoke: gate behaviour table verified against 7 scenarios (no-doors/no-times, before/after doors, playing-set-wins, day-2 morning, malformed JSON) via targeted unit tests at both layers

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)