### PR TITLE
feat(admin): per-day doors time inputs in the event form + OpenAPI docs for doors_json

### DIFF
--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -3097,6 +3097,13 @@ components:
         venue_info:
           type: string
           nullable: true
+        doors_json:
+          type: string
+          nullable: true
+          description: >-
+            JSON object mapping festival date "YYYY-MM-DD" to 24-hour "HH:MM"
+            gates-open time, e.g. {"2026-08-02":"16:00"}. Absent/null means no
+            doors info.
         social_links:
           nullable: true
           oneOf:
@@ -3436,6 +3443,13 @@ components:
           oneOf:
             - type: string
             - $ref: "#/components/schemas/GenericRecord"
+        doors_json:
+          type: string
+          nullable: true
+          description: >-
+            JSON object mapping festival date "YYYY-MM-DD" to 24-hour "HH:MM"
+            gates-open time, e.g. {"2026-08-02":"16:00"}. Absent/null means no
+            doors info.
 
     EventPatchInput:
       type: object
@@ -3474,6 +3488,13 @@ components:
           oneOf:
             - type: string
             - $ref: "#/components/schemas/GenericRecord"
+        doors_json:
+          type: string
+          nullable: true
+          description: >-
+            JSON object mapping festival date "YYYY-MM-DD" to 24-hour "HH:MM"
+            gates-open time, e.g. {"2026-08-02":"16:00"}. Absent/null means no
+            doors info.
 
     EventEditInput:
       type: object

--- a/frontend/src/admin/EventFormModal.jsx
+++ b/frontend/src/admin/EventFormModal.jsx
@@ -3,6 +3,9 @@ import EventStatusBadge from './components/EventStatusBadge'
 import { Button } from '../components/ui'
 import { eventsApi } from '../utils/adminApi'
 import { FIELD_LIMITS } from '../utils/validation'
+import { buildDayOptions, enumerateFestivalDays, isMultiDayEvent } from './utils/dayOptions'
+import { formatFestivalDate } from '../utils/festivalDays'
+import { parseDoorsJsonToForm, serializeDoorsForm } from './utils/doorsFormData'
 
 /**
  * EventFormModal - Modal for creating and editing events
@@ -44,6 +47,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
     social_youtube: '',
     reveal_mode: false,
   })
+  const [doorsForm, setDoorsForm] = useState({})
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [slugEdited, setSlugEdited] = useState(false)
@@ -102,6 +106,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
         social_youtube: socialLinks.youtube || '',
         reveal_mode: event?.reveal_mode === 1 || event?.reveal_mode === true,
       })
+      setDoorsForm(parseDoorsJsonToForm(event.doors_json, enumerateFestivalDays(event.date, event.end_date)))
       setSlugEdited(true) // Prevent auto-generation when editing
     } else {
       setFormData({
@@ -121,10 +126,30 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
         social_youtube: '',
         reveal_mode: false,
       })
+      setDoorsForm({})
       setSlugEdited(false)
     }
     setError('')
   }, [event, isOpen])
+
+  // Re-derive the festival-day list whenever date/end_date change (both on
+  // initial load and on live edits) and keep doorsForm's keys in sync: add a
+  // blank entry for a newly-added day, preserve values for days still in
+  // range, and drop entries for days no longer in range. This is a UI-level
+  // mirror of the pruning `serializeDoorsForm` does at submit time — belt
+  // and suspenders against a stale key ever reaching the payload (#573).
+  useEffect(() => {
+    const days = enumerateFestivalDays(formData.date, formData.end_date)
+    setDoorsForm(prev => {
+      const next = {}
+      let changed = days.length !== Object.keys(prev).length
+      for (const day of days) {
+        next[day] = Object.prototype.hasOwnProperty.call(prev, day) ? prev[day] : ''
+        if (next[day] !== prev[day]) changed = true
+      }
+      return changed ? next : prev
+    })
+  }, [formData.date, formData.end_date])
 
   // Auto-generate slug from name (only when creating)
   const handleNameChange = e => {
@@ -246,6 +271,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
 
     try {
       const socialLinksPayload = buildSocialLinksPayload(formData)
+      const currentDays = enumerateFestivalDays(formData.date, formData.end_date)
       const payload = {
         name: formData.name,
         slug: formData.slug,
@@ -256,6 +282,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
         city: formData.city,
         ticket_url: formData.ticket_url,
         social_links: socialLinksPayload,
+        doors_json: serializeDoorsForm(doorsForm, currentDays),
       }
 
       if (isEditing && formData.status === 'archived') {
@@ -294,6 +321,19 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
   // Not toISOString(): that is the UTC day, which flips to tomorrow at 8 PM
   // Eastern and blocks the admin from picking today's date in the evening.
   const today = new Date().toLocaleDateString('en-CA')
+
+  // One doors-time input per festival day; re-derived on every render from
+  // the live date/end_date fields so picking a date (or extending/shrinking
+  // a multi-day span) updates the inputs immediately. Single-day events never
+  // show a "Day 1" label (redundant on a single-day event, see CLAUDE.md) —
+  // only genuinely multi-day spans use buildDayOptions' "Day N (...)" label.
+  const isMultiDay = isMultiDayEvent({ date: formData.date, end_date: formData.end_date || null })
+  const festivalDays = isMultiDay
+    ? buildDayOptions(formData.date, formData.end_date)
+    : enumerateFestivalDays(formData.date, formData.end_date).map(value => ({
+        value,
+        label: formatFestivalDate(value, 'short'),
+      }))
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
@@ -415,6 +455,35 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
                 className="w-full min-h-[44px] px-4 py-2 rounded bg-bg-navy text-white border border-gray-600 focus:border-accent-500 focus:outline-hidden focus:ring-1 focus:ring-accent-500"
               />
             </div>
+
+            {/* Doors / Gates Times */}
+            <fieldset>
+              <legend className="block text-white mb-2 text-sm font-medium">Doors</legend>
+              <p className="text-xs text-white/50 mb-2">Optional — when gates open; leave blank if unknown.</p>
+              {festivalDays.length === 0 ? (
+                <p className="text-xs text-white/50">Set an event date to add doors times.</p>
+              ) : (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {festivalDays.map(day => (
+                    <div key={day.value}>
+                      <label htmlFor={`event-doors-${day.value}`} className="block text-white mb-1 text-xs font-medium">
+                        {day.label}
+                      </label>
+                      <input
+                        id={`event-doors-${day.value}`}
+                        type="time"
+                        value={doorsForm[day.value] || ''}
+                        onChange={e => {
+                          const time = e.target.value
+                          setDoorsForm(prev => ({ ...prev, [day.value]: time }))
+                        }}
+                        className="w-full min-h-[44px] px-4 py-2 rounded bg-bg-navy text-white border border-gray-600 focus:border-accent-500 focus:outline-hidden focus:ring-1 focus:ring-accent-500"
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </fieldset>
 
             {/* Description */}
             <div>

--- a/frontend/src/admin/utils/__tests__/doorsFormData.test.js
+++ b/frontend/src/admin/utils/__tests__/doorsFormData.test.js
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { parseDoorsJsonToForm, serializeDoorsForm } from '../doorsFormData'
+
+const TWO_DAYS = ['2026-08-02', '2026-08-03']
+
+describe('parseDoorsJsonToForm', () => {
+  it('maps a valid JSON string onto matching day keys', () => {
+    const doorsJson = JSON.stringify({ '2026-08-02': '16:00', '2026-08-03': '10:00' })
+    expect(parseDoorsJsonToForm(doorsJson, TWO_DAYS)).toEqual({
+      '2026-08-02': '16:00',
+      '2026-08-03': '10:00',
+    })
+  })
+
+  it('accepts an already-parsed object (not just a JSON string)', () => {
+    const doorsJson = { '2026-08-02': '16:00' }
+    expect(parseDoorsJsonToForm(doorsJson, TWO_DAYS)).toEqual({
+      '2026-08-02': '16:00',
+      '2026-08-03': '',
+    })
+  })
+
+  it('returns all-empty for malformed JSON rather than throwing', () => {
+    expect(parseDoorsJsonToForm('{not valid json', TWO_DAYS)).toEqual({
+      '2026-08-02': '',
+      '2026-08-03': '',
+    })
+  })
+
+  it('returns all-empty for a JSON array (not an object map)', () => {
+    expect(parseDoorsJsonToForm('["16:00", "10:00"]', TWO_DAYS)).toEqual({
+      '2026-08-02': '',
+      '2026-08-03': '',
+    })
+  })
+
+  it('returns all-empty for null doors_json', () => {
+    expect(parseDoorsJsonToForm(null, TWO_DAYS)).toEqual({
+      '2026-08-02': '',
+      '2026-08-03': '',
+    })
+  })
+
+  it('returns all-empty for undefined doors_json', () => {
+    expect(parseDoorsJsonToForm(undefined, TWO_DAYS)).toEqual({
+      '2026-08-02': '',
+      '2026-08-03': '',
+    })
+  })
+
+  it('returns all-empty for an empty string', () => {
+    expect(parseDoorsJsonToForm('', TWO_DAYS)).toEqual({
+      '2026-08-02': '',
+      '2026-08-03': '',
+    })
+  })
+
+  it('drops keys outside the current day span', () => {
+    const doorsJson = JSON.stringify({ '2026-08-02': '16:00', '2026-08-09': '18:00' })
+    expect(parseDoorsJsonToForm(doorsJson, TWO_DAYS)).toEqual({
+      '2026-08-02': '16:00',
+      '2026-08-03': '',
+    })
+  })
+
+  it('ignores non-string time values for an otherwise-matching key', () => {
+    const doorsJson = { '2026-08-02': 1600, '2026-08-03': '10:00' }
+    expect(parseDoorsJsonToForm(doorsJson, TWO_DAYS)).toEqual({
+      '2026-08-02': '',
+      '2026-08-03': '10:00',
+    })
+  })
+
+  it('returns an empty object when days is empty', () => {
+    expect(parseDoorsJsonToForm(JSON.stringify({ '2026-08-02': '16:00' }), [])).toEqual({})
+  })
+
+  it('handles a single-day event (one key)', () => {
+    expect(parseDoorsJsonToForm(JSON.stringify({ '2026-08-02': '19:00' }), ['2026-08-02'])).toEqual({
+      '2026-08-02': '19:00',
+    })
+  })
+})
+
+describe('serializeDoorsForm', () => {
+  it('serializes a normal fully-filled map to a JSON string', () => {
+    const result = serializeDoorsForm({ '2026-08-02': '16:00', '2026-08-03': '10:00' }, TWO_DAYS)
+    expect(JSON.parse(result)).toEqual({ '2026-08-02': '16:00', '2026-08-03': '10:00' })
+  })
+
+  it('prunes keys outside the CURRENT span (stale-keys gap, #573)', () => {
+    // Event's span shrank to a single day, but the form still carries a
+    // leftover value for the day that's no longer in range.
+    const result = serializeDoorsForm({ '2026-08-02': '16:00', '2026-08-03': '10:00' }, ['2026-08-02'])
+    expect(JSON.parse(result)).toEqual({ '2026-08-02': '16:00' })
+  })
+
+  it('omits empty-string values', () => {
+    const result = serializeDoorsForm({ '2026-08-02': '16:00', '2026-08-03': '' }, TWO_DAYS)
+    expect(JSON.parse(result)).toEqual({ '2026-08-02': '16:00' })
+  })
+
+  it('returns null when every value is empty', () => {
+    expect(serializeDoorsForm({ '2026-08-02': '', '2026-08-03': '' }, TWO_DAYS)).toBeNull()
+  })
+
+  it('returns null for an empty formValues object', () => {
+    expect(serializeDoorsForm({}, TWO_DAYS)).toBeNull()
+  })
+
+  it('returns null when days is empty, even with values present', () => {
+    expect(serializeDoorsForm({ '2026-08-02': '16:00' }, [])).toBeNull()
+  })
+
+  it('round-trips through parseDoorsJsonToForm for the same day span', () => {
+    const original = JSON.stringify({ '2026-08-02': '16:00', '2026-08-03': '10:00' })
+    const form = parseDoorsJsonToForm(original, TWO_DAYS)
+    const result = serializeDoorsForm(form, TWO_DAYS)
+    expect(JSON.parse(result)).toEqual(JSON.parse(original))
+  })
+
+  it('round-trip through a shrunk span drops the pruned day permanently', () => {
+    const original = JSON.stringify({ '2026-08-02': '16:00', '2026-08-03': '10:00' })
+    const form = parseDoorsJsonToForm(original, TWO_DAYS)
+    // Event shrank to day 1 only after parsing.
+    const result = serializeDoorsForm(form, ['2026-08-02'])
+    expect(JSON.parse(result)).toEqual({ '2026-08-02': '16:00' })
+  })
+})

--- a/frontend/src/admin/utils/doorsFormData.js
+++ b/frontend/src/admin/utils/doorsFormData.js
@@ -1,0 +1,94 @@
+/**
+ * Doors-time form-state helpers for EventFormModal (#573).
+ *
+ * `events.doors_json` is a JSON map of festival date (YYYY-MM-DD) -> 24h
+ * "HH:MM" gates-open time (see the `events.doors_json` invariant in
+ * CLAUDE.md, #569). EventFormModal renders one <input type="time"> per
+ * festival day and keeps that as flat `{ [date]: 'HH:MM' | '' }` form
+ * state. These two pure functions convert between that flat state and the
+ * `doors_json` payload shape, so the conversion logic can be unit-tested
+ * without importing the modal component itself (see the coverage-ratchet
+ * note in CLAUDE.md — importing a large untested component tanks the
+ * global coverage number).
+ */
+
+/**
+ * Parses a stored `doors_json` value into flat form state keyed by festival
+ * day, always returning exactly one key per entry in `days`.
+ *
+ * Defensive: malformed JSON, a non-object/array payload, or a missing value
+ * all collapse to an all-empty map rather than throwing — the form should
+ * never crash on a legacy or hand-edited row. Keys outside `days` are
+ * dropped (a stale doors_json key from a since-shrunk event span should
+ * never surface a phantom input), and non-string values are ignored.
+ *
+ * @param {string|object|null|undefined} doorsJson - raw `event.doors_json`
+ * @param {string[]} days - festival day values, e.g. from `enumerateFestivalDays`
+ * @returns {Object<string, string>} `{ [date]: 'HH:MM' | '' }`, one key per day
+ */
+export function parseDoorsJsonToForm(doorsJson, days) {
+  const dayList = Array.isArray(days) ? days : []
+  const empty = Object.fromEntries(dayList.map(day => [day, '']))
+
+  if (!doorsJson) {
+    return empty
+  }
+
+  let parsed
+  if (typeof doorsJson === 'object') {
+    parsed = doorsJson
+  } else if (typeof doorsJson === 'string') {
+    try {
+      parsed = JSON.parse(doorsJson)
+    } catch {
+      return empty
+    }
+  } else {
+    return empty
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return empty
+  }
+
+  const dayValues = new Set(dayList)
+  const result = { ...empty }
+  for (const [date, time] of Object.entries(parsed)) {
+    if (dayValues.has(date) && typeof time === 'string') {
+      result[date] = time
+    }
+  }
+  return result
+}
+
+/**
+ * Serializes flat doors form state back into the `doors_json` payload shape
+ * expected by the admin events API (a JSON string, or `null`).
+ *
+ * Entries for dates outside the CURRENT `days` span are pruned before
+ * serializing — this is what closes the stale-keys gap named in #573: if
+ * the admin shrinks the event's date span in the same edit, `days` (re-
+ * derived from the live date/end_date form fields) no longer includes the
+ * dropped day, so any leftover value for it is discarded here rather than
+ * round-tripped back to the API as an orphaned key. Blank values are
+ * omitted, and an all-empty result serializes to `null` (equivalent to "no
+ * doors info", matching `validateDoorsJson` on the backend).
+ *
+ * @param {Object<string, string>} formValues - `{ [date]: 'HH:MM' | '' }`
+ * @param {string[]} days - CURRENT festival day values to keep
+ * @returns {string|null}
+ */
+export function serializeDoorsForm(formValues, days) {
+  const dayValues = new Set(Array.isArray(days) ? days : [])
+  const values = formValues && typeof formValues === 'object' ? formValues : {}
+
+  const entries = Object.entries(values).filter(
+    ([date, time]) => dayValues.has(date) && typeof time === 'string' && time !== ''
+  )
+
+  if (entries.length === 0) {
+    return null
+  }
+
+  return JSON.stringify(Object.fromEntries(entries))
+}


### PR DESCRIPTION
## Summary

Completes the doors feature (#572) for admins: the event form now has a **Doors** section with one optional time input per festival day (single-day events get one input labeled with the bare date — no redundant "Day 1" prefix, per the repo convention; multi-day spans use the standard "Day N (…)" labels and re-derive live as the date span changes). Also documents `doors_json` in the OpenAPI spec, closing that drift.

Closes #573

## What changed

| File | Change |
|------|--------|
| `frontend/src/admin/utils/doorsFormData.js` (new) | Pure `parseDoorsJsonToForm` / `serializeDoorsForm` — defensive parse, empty-omission, all-empty → null, and **out-of-span key pruning** (closes the stale-keys gap when a date span shrinks) |
| `frontend/src/admin/utils/__tests__/doorsFormData.test.js` (new) | 19 tests: malformed JSON, out-of-span keys, round-trips, prune/omit/null cases |
| `frontend/src/admin/EventFormModal.jsx` | Doors fieldset; day list re-derives on date/end_date edits with non-clobbering key reconciliation; submit re-derives days fresh so a stale key can never reach the payload |
| `docs/api-spec.yaml` | `doors_json` on ScheduleEvent / EventInput / EventPatchInput (mirrors venue_info/theme_colors placement) |

## Security / correctness notes

Client form only — the server-side `validateDoorsJson()` from #572 remains the enforcement point; the form's pruning is UX hygiene on top. Admin surface is dark-pinned, styling matches adjacent inputs.

## Verification

- [x] Tests: frontend 441 pass (47 files, incl. 19 new util tests); backend 706 pass / 6 todo — independently re-run by the orchestrator
- [x] ESLint: 0 errors (2 pre-existing admin warnings)
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: 71 documented + 1 internal, no drift
- [x] Manual smoke: implementation-time code-review gate caught and fixed a single-day "Day 1" label violation before completion; modal mount path traced against EventsTab usage
- [x] Review: code-reviewer gate run during implementation (1 finding, fixed); orchestrator diff review + independent gate re-run

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)