### PR TITLE
feat(events): social icon links in the event header

### DIFF
--- a/frontend/src/components/EventSocialLinks.jsx
+++ b/frontend/src/components/EventSocialLinks.jsx
@@ -1,0 +1,65 @@
+import { InstagramIcon, TikTokIcon, XIcon } from './ui/SocialIcons'
+import { safeInstagramHref, safeTikTokHref, safeXHref } from '../utils/urlSafety'
+
+// Order mirrors the server's reflected keys (functions/api/schedule.js
+// safeReflectSocialLinks(event.social_links, ["instagram", "x", "tiktok"])).
+// All three are handle-or-URL fields on both the write path
+// (sanitizeOptionalHandleOrUrl) and the read path (safeReflectHandleOrUrl),
+// so each needs its handle-aware href helper here too — a plain
+// safeExternalHref would silently drop the bare-handle form the admin form
+// itself recommends ("@handle or URL").
+const SOCIAL_CONFIG = [
+  { key: 'instagram', label: 'Instagram', Icon: InstagramIcon, getHref: safeInstagramHref },
+  { key: 'x', label: 'X', Icon: XIcon, getHref: safeXHref },
+  { key: 'tiktok', label: 'TikTok', Icon: TikTokIcon, getHref: safeTikTokHref },
+]
+
+/**
+ * EventSocialLinks - small icon-link row for an event's own socials
+ * (event.social_links from GET /api/schedule, #563).
+ *
+ * `socialLinks` is the already-sanitized object the API reflects
+ * (`{ instagram, x, tiktok }`, any key may be absent or null, and each may
+ * be a bare handle or a full URL). Hrefs are re-derived client-side through
+ * the handle-aware safe-href helpers in utils/urlSafety.js (the same
+ * pattern used for band socials on BandProfilePage), so a value that fails
+ * validation (or resolves to '#') is silently skipped rather than rendered
+ * as a dead/unsafe link.
+ *
+ * Renders null when there is nothing safe to show, so events without social
+ * data (the vast majority today) are unaffected.
+ */
+function EventSocialLinks({ socialLinks, eventName, className = '' }) {
+  if (!socialLinks) return null
+
+  const links = SOCIAL_CONFIG.map(({ key, label, Icon, getHref }) => {
+    const value = socialLinks[key]
+    if (!value) return null
+
+    const href = getHref(value)
+    if (href === '#') return null
+
+    return { key, label, Icon, href }
+  }).filter(Boolean)
+
+  if (links.length === 0) return null
+
+  return (
+    <div className={`flex items-center gap-1 ${className}`}>
+      {links.map(({ key, label, Icon, href }) => (
+        <a
+          key={key}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={eventName ? `${eventName} on ${label}` : label}
+          className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full text-text-tertiary transition-colors hover:text-accent-400 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+        >
+          <Icon size={18} />
+        </a>
+      ))}
+    </div>
+  )
+}
+
+export default EventSocialLinks

--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -3,6 +3,7 @@ import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { getDoorsTimeForDate } from '../utils/doorsTime'
 import { getLifecycleLabel } from '../utils/liveLabel'
 import { formatTime } from '../utils/timeFormat'
+import EventSocialLinks from './EventSocialLinks'
 import GhostEasterEgg from './GhostEasterEgg'
 import TimeFilter from './TimeFilter'
 
@@ -171,6 +172,7 @@ function LiveContextBar({
           >
             {eventData.name}
           </h2>
+          <EventSocialLinks socialLinks={eventData.social_links} eventName={eventData.name} className="-ml-2 mt-0.5" />
 
           <div className="mt-1 flex items-center justify-between gap-2">
             <p className="truncate text-xs text-text-tertiary">{mobileSummary}</p>
@@ -212,6 +214,11 @@ function LiveContextBar({
               <h2 className="min-w-0 truncate text-base font-semibold text-text-primary md:text-lg">
                 {eventData.name}
               </h2>
+              <EventSocialLinks
+                socialLinks={eventData.social_links}
+                eventName={eventData.name}
+                className="-ml-2 shrink-0"
+              />
             </div>
             <p className="mt-1 truncate text-xs text-text-tertiary sm:hidden">{mobileSummary}</p>
             <p className="mt-1 hidden text-sm text-text-tertiary md:block">

--- a/frontend/src/components/__tests__/EventSocialLinks.test.jsx
+++ b/frontend/src/components/__tests__/EventSocialLinks.test.jsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import EventSocialLinks from '../EventSocialLinks'
+
+describe('EventSocialLinks', () => {
+  it('renders a link for each present, safe key', () => {
+    render(
+      <EventSocialLinks
+        socialLinks={{
+          instagram: 'bad_livin_roadshow',
+          x: 'https://x.com/settimesca',
+          tiktok: 'https://www.tiktok.com/@settimesca',
+        }}
+        eventName="Bad Livin' Roadshow 3"
+      />
+    )
+
+    expect(screen.getByRole('link', { name: "Bad Livin' Roadshow 3 on Instagram" })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: "Bad Livin' Roadshow 3 on X" })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: "Bad Livin' Roadshow 3 on TikTok" })).toBeInTheDocument()
+  })
+
+  it('skips null keys and only renders the present ones', () => {
+    render(
+      <EventSocialLinks
+        socialLinks={{ instagram: 'bad_livin_roadshow', x: null, tiktok: null }}
+        eventName="Bad Livin' Roadshow 3"
+      />
+    )
+
+    expect(screen.getByRole('link', { name: "Bad Livin' Roadshow 3 on Instagram" })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /on X$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /on TikTok/ })).not.toBeInTheDocument()
+  })
+
+  it('returns null for an empty object', () => {
+    const { container } = render(<EventSocialLinks socialLinks={{}} eventName="Test Event" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('returns null when every key is null', () => {
+    const { container } = render(
+      <EventSocialLinks socialLinks={{ instagram: null, x: null, tiktok: null }} eventName="Test Event" />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('returns null when socialLinks is undefined', () => {
+    const { container } = render(<EventSocialLinks socialLinks={undefined} eventName="Test Event" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('returns null when socialLinks is null', () => {
+    const { container } = render(<EventSocialLinks socialLinks={null} eventName="Test Event" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('turns a bare Instagram handle into a proper instagram.com URL', () => {
+    render(<EventSocialLinks socialLinks={{ instagram: 'bad_livin_roadshow' }} eventName="Bad Livin' Roadshow 3" />)
+
+    const link = screen.getByRole('link', { name: "Bad Livin' Roadshow 3 on Instagram" })
+    expect(link).toHaveAttribute('href', 'https://instagram.com/bad_livin_roadshow')
+  })
+
+  it('leaves a full Instagram URL untouched', () => {
+    render(
+      <EventSocialLinks
+        socialLinks={{ instagram: 'https://www.instagram.com/bad_livin_roadshow' }}
+        eventName="Bad Livin' Roadshow 3"
+      />
+    )
+
+    const link = screen.getByRole('link', { name: "Bad Livin' Roadshow 3 on Instagram" })
+    expect(link).toHaveAttribute('href', 'https://www.instagram.com/bad_livin_roadshow')
+  })
+
+  it('turns a bare X handle into a proper x.com URL (the admin form recommends @handle or URL)', () => {
+    render(<EventSocialLinks socialLinks={{ x: 'settimesca' }} eventName="Test Event" />)
+
+    const link = screen.getByRole('link', { name: 'Test Event on X' })
+    expect(link).toHaveAttribute('href', 'https://x.com/settimesca')
+  })
+
+  it('turns a bare TikTok handle into a proper tiktok.com URL with the leading @ in the path', () => {
+    render(<EventSocialLinks socialLinks={{ tiktok: '@settimesca' }} eventName="Test Event" />)
+
+    const link = screen.getByRole('link', { name: 'Test Event on TikTok' })
+    expect(link).toHaveAttribute('href', 'https://www.tiktok.com/@settimesca')
+  })
+
+  it('skips an unsafe javascript: URL for x/tiktok rather than rendering it', () => {
+    render(
+      <EventSocialLinks
+        socialLinks={{ x: 'javascript:alert(1)', tiktok: 'javascript:alert(1)' }}
+        eventName="Test Event"
+      />
+    )
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('sets target=_blank and rel=noopener noreferrer on rendered links', () => {
+    render(<EventSocialLinks socialLinks={{ instagram: 'bad_livin_roadshow' }} eventName="Test Event" />)
+
+    const link = screen.getByRole('link', { name: 'Test Event on Instagram' })
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('gives each link a minimum 44px tap target', () => {
+    render(<EventSocialLinks socialLinks={{ instagram: 'bad_livin_roadshow' }} eventName="Test Event" />)
+
+    const link = screen.getByRole('link', { name: 'Test Event on Instagram' })
+    expect(link.className).toMatch(/min-h-\[44px\]/)
+    expect(link.className).toMatch(/min-w-\[44px\]/)
+  })
+
+  it('falls back to the plain platform label when eventName is not provided', () => {
+    render(<EventSocialLinks socialLinks={{ instagram: 'bad_livin_roadshow' }} />)
+
+    expect(screen.getByRole('link', { name: 'Instagram' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/SocialIcons.jsx
+++ b/frontend/src/components/ui/SocialIcons.jsx
@@ -15,6 +15,40 @@ export function InstagramIcon({ size = 24, className = '', ...props }) {
   )
 }
 
+export function XIcon({ size = 24, className = '', ...props }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M13.682 10.622 20.239 3h-1.554l-5.693 6.618L8.445 3H3.2l6.876 10.007L3.2 21h1.554l6.012-6.989L15.568 21h5.245l-7.131-10.378Zm-2.128 2.473-.697-.997-5.544-7.93h2.387l4.474 6.4.697.996 5.815 8.318h-2.387l-4.745-6.787Z" />
+    </svg>
+  )
+}
+
+export function TikTokIcon({ size = 24, className = '', ...props }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M16.6 5.82c-1.03-.9-1.6-2.2-1.6-3.57h-3.09v12.4a2.59 2.59 0 0 1-2.59 2.5c-1.42 0-2.6-1.16-2.6-2.6 0-1.72 1.66-3.01 3.37-2.48V8.9c-3.45-.46-6.47 2.22-6.47 5.64 0 3.33 2.76 5.7 5.69 5.7 3.14 0 5.69-2.55 5.69-5.7V9.01a7.35 7.35 0 0 0 4.3 1.38V7.31c-1.14 0-2.2-.55-2.7-1.49Z" />
+    </svg>
+  )
+}
+
 export function FacebookIcon({ size = 24, className = '', ...props }) {
   return (
     <svg

--- a/frontend/src/utils/__tests__/urlSafety.test.js
+++ b/frontend/src/utils/__tests__/urlSafety.test.js
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { safeExternalHref, safeHttpsFallbackHref, safeSocialProfileHref, safeInstagramHref } from '../urlSafety'
+import {
+  safeExternalHref,
+  safeHttpsFallbackHref,
+  safeSocialProfileHref,
+  safeInstagramHref,
+  safeXHref,
+  safeTikTokHref,
+} from '../urlSafety'
 
 describe('safeExternalHref', () => {
   it('returns # for empty/nullish input', () => {
@@ -83,6 +90,10 @@ describe('safeSocialProfileHref', () => {
   it('returns # when a handle normalizes to empty', () => {
     expect(safeSocialProfileHref('@', base)).toBe('#')
   })
+
+  it('rejects a handle containing a colon (any URL scheme, e.g. javascript:)', () => {
+    expect(safeSocialProfileHref('javascript:alert(1)', base)).toBe('#')
+  })
 })
 
 describe('safeInstagramHref', () => {
@@ -92,5 +103,59 @@ describe('safeInstagramHref', () => {
 
   it('returns # for empty input', () => {
     expect(safeInstagramHref('')).toBe('#')
+  })
+
+  it('rejects a javascript: value passed as a bare handle', () => {
+    expect(safeInstagramHref('javascript:alert(1)')).toBe('#')
+  })
+})
+
+describe('safeXHref', () => {
+  it('builds an x.com profile URL from a bare handle', () => {
+    expect(safeXHref('settimesca')).toBe('https://x.com/settimesca')
+  })
+
+  it('builds an x.com profile URL from an @handle', () => {
+    expect(safeXHref('@settimesca')).toBe('https://x.com/settimesca')
+  })
+
+  it('passes through a full profile URL untouched', () => {
+    expect(safeXHref('https://x.com/settimesca')).toBe('https://x.com/settimesca')
+  })
+
+  it('returns # for empty input', () => {
+    expect(safeXHref('')).toBe('#')
+    expect(safeXHref(null)).toBe('#')
+  })
+
+  it('rejects a javascript: value passed as a bare handle', () => {
+    expect(safeXHref('javascript:alert(1)')).toBe('#')
+  })
+})
+
+describe('safeTikTokHref', () => {
+  it('builds a tiktok.com profile URL with a leading @ from a bare handle', () => {
+    expect(safeTikTokHref('settimesca')).toBe('https://www.tiktok.com/@settimesca')
+  })
+
+  it('builds a tiktok.com profile URL with a leading @ from an @handle (no doubling)', () => {
+    expect(safeTikTokHref('@settimesca')).toBe('https://www.tiktok.com/@settimesca')
+  })
+
+  it('passes through a full profile URL untouched', () => {
+    expect(safeTikTokHref('https://www.tiktok.com/@settimesca')).toBe('https://www.tiktok.com/@settimesca')
+  })
+
+  it('returns # for empty input', () => {
+    expect(safeTikTokHref('')).toBe('#')
+    expect(safeTikTokHref(null)).toBe('#')
+  })
+
+  it('rejects a handle containing whitespace', () => {
+    expect(safeTikTokHref('two words')).toBe('#')
+  })
+
+  it('rejects a javascript: value passed as a bare handle', () => {
+    expect(safeTikTokHref('javascript:alert(1)')).toBe('#')
   })
 })

--- a/frontend/src/utils/urlSafety.js
+++ b/frontend/src/utils/urlSafety.js
@@ -36,8 +36,12 @@ export function safeSocialProfileHref(value, baseUrl) {
     return safeExternalHref(text)
   }
 
+  // A colon is the necessary condition for any URL scheme (javascript:,
+  // data:, vbscript:, ...), and no real platform handle contains one, so
+  // reject it here too — mirrors the read-path guard in
+  // functions/utils/validation.js safeReflectHandleOrUrl.
   const normalized = text.replace(/^@/, '').replace(/^\/+/, '')
-  if (!normalized || /\s/.test(normalized)) {
+  if (!normalized || /\s/.test(normalized) || normalized.includes(':')) {
     return '#'
   }
 
@@ -46,4 +50,31 @@ export function safeSocialProfileHref(value, baseUrl) {
 
 export function safeInstagramHref(value) {
   return safeSocialProfileHref(value, 'https://instagram.com')
+}
+
+export function safeXHref(value) {
+  return safeSocialProfileHref(value, 'https://x.com')
+}
+
+// TikTok profile URLs require the leading `@` inside the path itself
+// (https://www.tiktok.com/@handle) — unlike Instagram/X, where the bare
+// username follows the domain. safeSocialProfileHref strips a leading `@`
+// as decoration, so it can't be reused here; this always re-adds exactly
+// one `@` after normalizing the input.
+export function safeTikTokHref(value) {
+  if (!value) return '#'
+
+  const text = String(value).trim()
+  if (!text) return '#'
+
+  if (/^https?:\/\//i.test(text)) {
+    return safeExternalHref(text)
+  }
+
+  const normalized = text.replace(/^@/, '').replace(/^\/+/, '')
+  if (!normalized || /\s/.test(normalized) || normalized.includes(':')) {
+    return '#'
+  }
+
+  return safeExternalHref(`https://www.tiktok.com/@${normalized}`)
 }


### PR DESCRIPTION
## Summary

The event header (LiveContextBar) now shows icon links for the event's own socials — instagram/x/tiktok from the sanitized `event.social_links` payload that #572's era left reflected-but-unrendered. Hidden entirely for events without social data (i.e., every event except BLR3 today). BLR3's @bad_livin_roadshow becomes the first live consumer.

Closes #563

## What changed

| File | Change |
|------|--------|
| `frontend/src/components/EventSocialLinks.jsx` (new) | Icon row; returns null when nothing renders; 44px tap targets; aria-labels per link |
| `frontend/src/utils/urlSafety.js` | `safeXHref` + `safeTikTokHref` — handle-or-URL aware (TikTok needs the `@` inside the path so it can't reuse the shared helper); both reject colon-bearing handles, mirroring the server's scheme guard |
| `frontend/src/components/ui/SocialIcons.jsx` | X + TikTok icons in the existing style |
| `frontend/src/components/LiveContextBar.jsx` | Row wired next to the event name (mobile + desktop blocks) |
| Tests | 14 component tests + urlSafety coverage incl. bare-handle and colon-rejection regressions |

**Review catch worth noting:** the first implementation used full-URL-only sanitizers for x/tiktok, silently dropping the bare-@handle format the admin form recommends — caught by the implementation-time code-review gate, fixed with the handle-aware helpers + regression tests.

## Security / correctness notes

All hrefs pass through the safe-href helpers (scheme-guarded); handles containing `:` resolve to '#' and are skipped. `rel="noopener noreferrer"` on all links. Semantic theme tokens only.

## Verification

- [x] Tests: frontend 468 pass (48 files) — independently re-run by the orchestrator
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [ ] `validate:openapi`: N/A — no API change
- [x] Manual smoke: BLR3's production payload shape (instagram: bare handle) is the primary test fixture; post-merge the row is verifiable live on settimes.ca/event/blr3

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)