### PR TITLE
test(a11y): axe colour-contrast coverage across all four themes — with the bugs it caught

### DIFF
--- a/e2e/accessibility/theme-contrast.spec.js
+++ b/e2e/accessibility/theme-contrast.spec.js
@@ -1,0 +1,165 @@
+/**
+ * Theme Contrast — Real-Page Axe Colour-Contrast Coverage (#567)
+ *
+ * The light themes shipped with unreadable status colours (fixed in #566) and
+ * no CI layer could have caught it: design-system.spec.js runs axe's
+ * color-contrast rule against hardcoded inline-style fixtures, decoupled from
+ * the real CSS custom properties in index.css, and never renders under
+ * data-theme="daybreak" / "silver-lining".
+ *
+ * This spec renders REAL pages under all four themes (frontend/src/components/
+ * ThemeProvider.jsx) and runs axe restricted to color-contrast against them, so
+ * a future "dark-first colour invisible on a light theme" regression fails CI
+ * instead of shipping as a mobile-screenshot bug report (this was at least the
+ * third instance of the bug class).
+ */
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+// Mirrors frontend/src/components/ThemeProvider.jsx exactly — THEME_KEY and
+// VALID_THEMES. Do not let these drift from that file without updating both.
+const THEME_STORAGE_KEY = 'settimes-theme';
+const THEMES = ['midnight-ember', 'arctic-night', 'daybreak', 'silver-lining'];
+
+/**
+ * Seeds localStorage with the target theme before any page script runs, via
+ * page.addInitScript — this fires before the theme-flash <script> in
+ * frontend/index.html, so data-theme lands on <html> from first paint instead
+ * of racing ThemeProvider's mount effect (which would only apply after React
+ * hydrates, too late for axe to see the "real" first-paint styling).
+ */
+async function primeTheme(page, theme) {
+  await page.addInitScript(
+    ({ key, value }) => {
+      try {
+        window.localStorage.setItem(key, value);
+      } catch {
+        // Private browsing / storage unavailable — the page falls back to the
+        // default theme (midnight-ember), which is exercised by that run anyway.
+      }
+    },
+    { key: THEME_STORAGE_KEY, value: theme }
+  );
+}
+
+/** Renders axe's color-contrast violations (selector + fg/bg colours + ratio)
+ * into a readable block for the assertion message, so a CI failure names the
+ * offending element instead of just "1 violation". */
+function formatViolations(violations) {
+  if (violations.length === 0) return '';
+  return violations
+    .map(violation =>
+      violation.nodes
+        .map(node => {
+          const check = node.any?.find(c => c.id === 'color-contrast') || node.any?.[0];
+          const data = check?.data;
+          const detail = data
+            ? `fg=${data.fgColor} bg=${data.bgColor} ratio=${data.contrastRatio} (needs ${data.expectedContrastRatio})`
+            : node.failureSummary || check?.message || 'no contrast data available';
+          return `  [${violation.id}] ${node.target.join(' ')} — ${detail}`;
+        })
+        .join('\n')
+    )
+    .join('\n');
+}
+
+async function assertNoColorContrastViolations(page, label) {
+  const results = await new AxeBuilder({ page }).withRules(['color-contrast']).analyze();
+  expect(
+    results.violations,
+    `Color-contrast violations on ${label}:\n${formatViolations(results.violations)}`
+  ).toEqual([]);
+}
+
+/**
+ * PrivacyBanner (rendered on /, /event/:slug, and /band/:id — see the
+ * `PrivacyBanner` import in EventsPage.jsx, App.jsx, and BandProfilePage.jsx)
+ * mounts asynchronously: it reads a localStorage flag in a useEffect before
+ * deciding whether to render its "Got it" button. A fresh test context has no
+ * 'privacy-acknowledged' entry, so the banner always ends up shown — but
+ * without waiting for it, the axe scan can race ahead of that effect and miss
+ * the banner on a fast page load, letting a real contrast bug in it (#567)
+ * pass by timing luck rather than by actually being fixed. Call this after the
+ * page's primary content wait on any page that renders PrivacyBanner.
+ */
+async function waitForPrivacyBannerSettled(page) {
+  await expect(page.getByRole('button', { name: 'Got it' })).toBeVisible({ timeout: 10000 });
+}
+
+/** Resolves the seeded upcoming event's slug from the homepage event card —
+ * the same [data-testid="event-card"] locator public-timeline.spec.js uses. */
+async function resolveEventSlug(page) {
+  await page.goto('/');
+  const card = page.locator('[data-testid="event-card"]').first();
+  await expect(card).toBeVisible();
+  const href = await card.locator('h3 a').first().getAttribute('href');
+  return href ? href.replace(/^\/event\//, '') : null;
+}
+
+/** Resolves a seeded band profile link from the homepage's collapsed
+ * "Performers:" preview — the same a[href*="/band/"] locator
+ * band-profile-viewing.spec.js uses. Returns null if the seed provides none,
+ * so the caller can skip gracefully instead of failing. */
+async function resolveBandProfileHref(page) {
+  await page.goto('/');
+  await expect(page.locator('[data-testid="event-card"]').first()).toBeVisible();
+  const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
+  const visible = await bandLink.isVisible().catch(() => false);
+  if (!visible) return null;
+  return bandLink.getAttribute('href');
+}
+
+for (const theme of THEMES) {
+  test.describe(`Colour contrast — ${theme}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await primeTheme(page, theme);
+    });
+
+    test('events list (/)', async ({ page }) => {
+      await page.goto('/');
+      // Use exact:true to avoid matching both "Events" h1 and "Past Events" h2.
+      await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
+      await expect(page.locator('[data-testid="event-card"]').first()).toBeVisible();
+      await waitForPrivacyBannerSettled(page);
+
+      await assertNoColorContrastViolations(page, `${theme} — events list (/)`);
+    });
+
+    test('event schedule page', async ({ page }) => {
+      const slug = await resolveEventSlug(page);
+      test.skip(!slug, 'No seeded event slug found on the homepage event card');
+
+      await page.goto(`/event/${slug}`);
+      // "Full Lineup" is ScheduleView's unconditional heading — waiting for it
+      // guarantees the schedule has rendered past the loading skeleton.
+      await expect(page.getByRole('heading', { name: 'Full Lineup' })).toBeVisible({ timeout: 15000 });
+      await waitForPrivacyBannerSettled(page);
+
+      await assertNoColorContrastViolations(page, `${theme} — event schedule (/event/${slug})`);
+    });
+
+    test('subscribe page (/subscribe)', async ({ page }) => {
+      await page.goto('/subscribe');
+      await expect(page.getByRole('heading', { name: 'Never Miss a Show' })).toBeVisible();
+
+      await assertNoColorContrastViolations(page, `${theme} — subscribe (/subscribe)`);
+    });
+
+    test('band profile page', async ({ page }) => {
+      const href = await resolveBandProfileHref(page);
+      test.skip(!href, 'Seed data provides no band profile link on the homepage');
+
+      await page.goto(href);
+      await expect(page.locator('main h1')).toBeVisible({ timeout: 15000 });
+
+      const notFound = await page
+        .getByRole('heading', { name: /band not found/i })
+        .isVisible()
+        .catch(() => false);
+      test.skip(notFound, 'Resolved band link led to a not-found page');
+
+      await waitForPrivacyBannerSettled(page);
+      await assertNoColorContrastViolations(page, `${theme} — band profile (${href})`);
+    });
+  });
+}

--- a/frontend/src/components/PrivacyBanner.jsx
+++ b/frontend/src/components/PrivacyBanner.jsx
@@ -78,7 +78,7 @@ export default function PrivacyBanner() {
         <button
           type="button"
           onClick={handleDismiss}
-          className="rounded-full border border-accent-500/60 px-4 py-1 text-accent-300 transition hover:border-accent-400 hover:text-text-primary"
+          className="rounded-full border border-accent-500/60 px-4 py-1 text-accent-400 transition hover:border-accent-400 hover:text-text-primary"
         >
           Got it
         </button>

--- a/frontend/src/components/TimeFilter.jsx
+++ b/frontend/src/components/TimeFilter.jsx
@@ -28,7 +28,7 @@ export default function TimeFilter({ selectedFilter, onFilterChange, className =
         className={`min-h-[44px] w-full appearance-none rounded-full border px-4 py-2 pr-10 text-sm font-medium transition-colors focus:border-accent-500 focus:outline-hidden ${
           selectedFilter === 'all'
             ? 'border-border bg-surface text-text-primary hover:bg-surface-hover'
-            : 'border-accent-500/35 bg-accent-500/10 text-accent-300'
+            : 'border-accent-500/35 bg-accent-500/10 text-accent-400'
         }`}
       >
         {options.map(option => (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -310,7 +310,13 @@
   --color-primary-700: #334155;
 
   --color-accent-300: #93c5fd;
-  --color-accent-400: #2563eb;
+  /* Darkened from Tailwind blue-600 (#2563eb, the value silver-lining
+     previously shared with its own info-500/600 ramp): text-accent-400 is
+     commonly paired with its own bg-accent-500/10-20 tint (badges, pills, the
+     "back to event" link on the band profile page — see #567). #2563eb only
+     clears ~3.6:1 against that self-tint, failing WCAG AA; this value clears
+     >5:1 against the tint and >6.9:1 against the plain page background. */
+  --color-accent-400: #1e4fbc;
   --color-accent-500: #1d4ed8;
   --color-accent-600: #1e3a8a;
 


### PR DESCRIPTION
## Summary

First real-page contrast coverage for the theme system: a new spec runs axe's `color-contrast` rule on four fan pages (events list, event schedule, subscribe, band profile) under **all four themes**, applied via the real localStorage mechanism before first paint. This is the CI gap that let the light themes ship unreadable (#566) — and the sweep proved itself immediately by catching real violations, which are fixed here too.

Closes #567

## What changed

| File | Change |
|------|--------|
| `e2e/accessibility/theme-contrast.spec.js` (new) | 16 tests (4 themes × 4 pages), color-contrast rule, dynamic event/band resolution from seed data, deterministic PrivacyBanner settle-wait |
| `frontend/src/components/PrivacyBanner.jsx` | **Real bug caught by the sweep:** "Got it" used `text-accent-300` → 1.47:1 on daybreak. Now `accent-400` |
| `frontend/src/components/TimeFilter.jsx` | Same `accent-300` bug class on the active-filter state — fixed proactively |
| `frontend/src/index.css` | silver-lining's `--color-accent-400` retuned `#2563eb` → `#1e4fbc`: the old value only cleared ~3.6:1 against its own `bg-accent-500/10-20` tints (band-page back-link, badges). New value computed >5:1 vs tint, >6.9:1 vs page bg |

## Security / correctness notes

None — test + colour-token changes. The silver-lining retune darkens one theme's accent text slightly; dark themes and daybreak untouched.

## Verification

- [x] Tests: full `e2e/accessibility` suite **56/56** locally against a fresh seeded wrangler+D1, plus `--repeat-each=2` flake check (33/33); frontend units 441 pass — independently re-run by the orchestrator
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [ ] `validate:openapi`: N/A
- [x] Manual smoke: violations were diagnosed with computed contrast ratios, not eyeballed; CI's `e2e-a11y-visual.yml` re-runs the suite authoritatively on this PR
- [x] Review: code-reviewer gate run during implementation (1 doc-comment finding, fixed). Residual gap flagged for later: axe's `incomplete` results (gradient-backed text) aren't asserted

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)