### PR TITLE
fix(sw): precache canonical URLs so the offline page actually caches

### DIFF
--- a/e2e/offline-experience.spec.js
+++ b/e2e/offline-experience.spec.js
@@ -1,0 +1,105 @@
+import { test, expect } from "@playwright/test";
+
+/* global navigator -- referenced inside a page.waitForFunction browser callback */
+
+/**
+ * Offline resilience (#578, #554).
+ *
+ * The killer scenario for this app is a no-signal venue (a rural campground,
+ * a basement stage): a fan loads their schedule, then the network drops. The
+ * service worker must keep serving the saved schedule and the fan's route.
+ *
+ * This exercises the real SW: register → install → activate → control, then
+ * `context.setOffline(true)` and assert a reload still renders the schedule
+ * (from the SW's shell + /api/schedule caches) and the route (localStorage).
+ * Requires the #578 precache fix — before it, the SW never activated because
+ * cache.add() choked on Pages' clean-URL 308 redirects.
+ */
+
+const uniqueSuffix = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+const localToday = () => new Date().toLocaleDateString("en-CA");
+const localInstant = (dateStr, hours, minutes = 0) => {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d, hours, minutes);
+};
+
+const getCsrfToken = async (page) => (await page.context().cookies()).find((c) => c.name === "csrf_token")?.value;
+
+const apiGet = async (page, url) => {
+  const res = await page.request.get(url);
+  expect(res.ok(), `GET ${url} → ${res.status()}`).toBeTruthy();
+  return res.json();
+};
+
+const apiPost = async (page, url, data) => {
+  const csrfToken = await getCsrfToken(page);
+  const headers = csrfToken ? { "X-CSRF-Token": csrfToken } : {};
+  const res = await page.request.post(url, { data, headers });
+  expect(res.ok(), `POST ${url} → ${res.status()}: ${await res.text()}`).toBeTruthy();
+  return res.json();
+};
+
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+test.describe("Offline resilience (#578)", () => {
+  test("a saved schedule and route survive a network drop", async ({ page, context }) => {
+    const suffix = uniqueSuffix();
+    const today = localToday();
+    const slug = `offline-${suffix}`;
+    const bandName = `Offline Openers ${suffix}`;
+
+    // Seed a published event dated today with an evening set.
+    const created = await apiPost(page, "/api/admin/events", {
+      name: `Offline Test ${suffix}`,
+      slug,
+      date: today,
+      city: "Waterloo, ON",
+    });
+    const eventId = created.event?.id ?? created.id;
+    const venue = (await apiGet(page, "/api/admin/venues")).venues?.[0];
+    await apiPost(page, "/api/admin/bands", {
+      eventId,
+      venueId: venue.id,
+      name: bandName,
+      startTime: "19:15",
+      endTime: "19:45",
+    });
+    await apiPost(page, `/api/admin/events/${eventId}/publish`, { publish: true });
+
+    // Fixed clock in the morning: the set is upcoming, so it always renders
+    // regardless of when the suite runs.
+    await page.clock.setFixedTime(localInstant(today, 10, 0));
+
+    const eventPage = `/event/${slug}`;
+
+    // First online load: register + activate + take control of the page.
+    await page.goto(eventPage);
+    await expect(page.getByText(bandName).first()).toBeVisible();
+    await page.waitForFunction(() => navigator.serviceWorker.controller !== null, null, {
+      timeout: 20000,
+    });
+
+    // Save the band to My Route and confirm the selection registered (the
+    // button flips Add → Remove, and the route is written to localStorage)
+    // before moving on — don't race the reload against the state write.
+    await page.getByRole("button", { name: `Add ${bandName} to my route` }).click();
+    await expect(page.getByRole("button", { name: `Remove ${bandName} from my route` })).toBeVisible();
+
+    // Reload ONCE while online and SW-controlled — this pass populates the
+    // shell, JS chunk, and /api/schedule caches (the first load's fetches
+    // predated SW control). The selection persists from localStorage.
+    await page.reload();
+    await expect(page.getByRole("button", { name: `Remove ${bandName} from my route` })).toBeVisible();
+
+    // The network dies. A reload must still render the saved schedule (SW
+    // caches) and the saved route (localStorage) — no white screen.
+    await context.setOffline(true);
+    await page.reload();
+    await expect(page.getByText(bandName).first()).toBeVisible({ timeout: 20000 });
+    await expect(page.getByRole("button", { name: `Remove ${bandName} from my route` })).toBeVisible({
+      timeout: 20000,
+    });
+
+    await context.setOffline(false);
+  });
+});

--- a/e2e/offline-experience.spec.js
+++ b/e2e/offline-experience.spec.js
@@ -1,6 +1,22 @@
 import { test, expect } from "@playwright/test";
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
 
 /* global navigator -- referenced inside a page.waitForFunction browser callback */
+
+// Re-establish the admin session in THIS context. The shared storageState
+// session (from auth.setup) is invalidated whenever another spec logs in —
+// lucia.invalidateUserSessions() kills all other sessions on re-auth — so
+// admin-mutating specs must log in themselves. Mirrors event-creation.spec.js.
+const loginAsAdmin = async (page) => {
+  await page.goto("/admin");
+  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
+  if (await page.locator('input[type="email"]').isVisible()) {
+    await page.fill('input[type="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
+  }
+};
 
 /**
  * Offline resilience (#578, #554).
@@ -39,14 +55,16 @@ const apiPost = async (page, url, data) => {
   return res.json();
 };
 
-test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
-
 test.describe("Offline resilience (#578)", () => {
   test("a saved schedule and route survive a network drop", async ({ page, context }) => {
     const suffix = uniqueSuffix();
     const today = localToday();
     const slug = `offline-${suffix}`;
     const bandName = `Offline Openers ${suffix}`;
+
+    // Admin login + seeding at desktop viewport — the dark-pinned admin panel's
+    // tabs aren't reliably visible at a 390px mobile width.
+    await loginAsAdmin(page);
 
     // Seed a published event dated today with an evening set.
     const created = await apiPost(page, "/api/admin/events", {
@@ -65,6 +83,10 @@ test.describe("Offline resilience (#578)", () => {
       endTime: "19:45",
     });
     await apiPost(page, `/api/admin/events/${eventId}/publish`, { publish: true });
+
+    // Switch to a phone viewport for the fan-facing flow — the venue scenario
+    // this covers (no-signal campground) is a phone in someone's pocket.
+    await page.setViewportSize({ width: 390, height: 844 });
 
     // Fixed clock in the morning: the set is upcoming, so it always renders
     // regardless of when the suite runs.

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v4'
+const CACHE_VERSION = 'v5'
 const STATIC_CACHE = `schedule-${CACHE_VERSION}`
 const API_CACHE = `api-${CACHE_VERSION}`
 
@@ -12,7 +12,14 @@ const CURRENT_CACHES = [STATIC_CACHE, API_CACHE]
 // Only cache stable, non-hashed assets on install.
 // Vite hashes JS/CSS filenames (e.g. assets/index-a3f9c.js) so those
 // cannot be precached by name — they are picked up by runtime caching instead.
-const STATIC_ASSETS = ['/', '/index.html', '/manifest.json', '/offline.html']
+//
+// Use the CANONICAL (clean) URLs Cloudflare Pages actually serves at 200:
+// Pages redirects `/index.html` → `/` and `/offline.html` → `/offline` (308).
+// cache.add() follows the redirect and then rejects on the redirected
+// response, so precaching the `.html` forms silently dropped the offline
+// page (and stalled install under some runtimes). `/` already covers the
+// shell; `/offline` serves the branded offline page content directly (#578).
+const STATIC_ASSETS = ['/', '/manifest.json', '/offline']
 
 // Install: cache static assets
 self.addEventListener('install', event => {
@@ -21,8 +28,16 @@ self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(STATIC_CACHE).then(cache => {
       console.log('[SW] Caching static assets')
-      // Don't let one missing optional asset (e.g. offline.html) abort install.
-      return Promise.allSettled(STATIC_ASSETS.map(asset => cache.add(asset)))
+      // allSettled so one unreachable asset (e.g. /offline) can't abort install.
+      // Log rejections so a silently-dropped precache entry (the #578 bug class:
+      // an asset that starts 308-redirecting) is visible rather than swallowed.
+      return Promise.allSettled(STATIC_ASSETS.map(asset => cache.add(asset))).then(results => {
+        results.forEach((result, i) => {
+          if (result.status === 'rejected') {
+            console.warn('[SW] precache failed for', STATIC_ASSETS[i], result.reason)
+          }
+        })
+      })
     })
   )
 
@@ -38,11 +53,7 @@ self.addEventListener('activate', event => {
     caches.keys().then(cacheNames => {
       return Promise.all(
         cacheNames
-          .filter(
-            name =>
-              (name.startsWith('schedule-') || name.startsWith('api-')) &&
-              !CURRENT_CACHES.includes(name)
-          )
+          .filter(name => (name.startsWith('schedule-') || name.startsWith('api-')) && !CURRENT_CACHES.includes(name))
           .map(name => {
             console.log('[SW] Deleting old cache:', name)
             return caches.delete(name)
@@ -112,11 +123,10 @@ async function navigationStrategy(request) {
 
     return response
   } catch (error) {
-    const cachedShell =
-      (await caches.match('/index.html')) || (await caches.match('/'))
+    const cachedShell = (await caches.match('/index.html')) || (await caches.match('/'))
     if (cachedShell) return cachedShell
 
-    const offlinePage = await caches.match('/offline.html')
+    const offlinePage = await caches.match('/offline')
     if (offlinePage) return offlinePage
 
     return new Response('Offline - content not cached', {
@@ -149,7 +159,7 @@ async function cacheFirstStrategy(request) {
   } catch (error) {
     console.error('[SW] Fetch failed:', error)
 
-    const offlinePage = await caches.match('/offline.html')
+    const offlinePage = await caches.match('/offline')
     if (offlinePage) return offlinePage
 
     return new Response('Offline - content not cached', {

--- a/frontend/src/test/sw.test.js
+++ b/frontend/src/test/sw.test.js
@@ -32,6 +32,9 @@ function makeCacheStorage() {
     async delete(req) {
       return store.delete(cacheKey(req))
     },
+    async add(req) {
+      store.set(cacheKey(req), { ok: true })
+    },
     async addAll(reqs) {
       for (const r of reqs) store.set(cacheKey(r), { ok: true })
     },
@@ -214,11 +217,11 @@ describe('service worker fetch routing', () => {
       mode: 'navigate',
     })
 
-    // After the fix this is routed to networkFirstStrategy (api-v4), not
+    // After the fix this is routed to networkFirstStrategy (api-v5), not
     // navigationStrategy, so the static cache must stay empty.
     expect(await globalThis.caches.match('/index.html')).toBeUndefined()
     // The response should be cached under its own URL in the API cache.
-    const apiStore = globalThis.caches._stores.get('api-v4')
+    const apiStore = globalThis.caches._stores.get('api-v5')
     expect(apiStore?.has(`${ORIGIN}/api/feeds/ical`)).toBe(true)
   })
 
@@ -289,18 +292,48 @@ describe('service worker activate', () => {
     await globalThis.caches.open('api-v3')
     await globalThis.caches.open('schedule-v4')
     await globalThis.caches.open('api-v4')
+    await globalThis.caches.open('schedule-v5')
+    await globalThis.caches.open('api-v5')
     await globalThis.caches.open('some-other-cache')
 
     const promises = []
     handlers.activate({ waitUntil: p => promises.push(p) })
     await Promise.all(promises)
 
-    // Old-version schedule-/api- families must be gone.
+    // Every older schedule-/api- version must be gone.
     expect(globalThis.caches._stores.has('schedule-v3')).toBe(false)
     expect(globalThis.caches._stores.has('api-v3')).toBe(false)
+    expect(globalThis.caches._stores.has('schedule-v4')).toBe(false)
+    expect(globalThis.caches._stores.has('api-v4')).toBe(false)
     // Current-version caches and unrelated cache must survive.
-    expect(globalThis.caches._stores.has('schedule-v4')).toBe(true)
-    expect(globalThis.caches._stores.has('api-v4')).toBe(true)
+    expect(globalThis.caches._stores.has('schedule-v5')).toBe(true)
+    expect(globalThis.caches._stores.has('api-v5')).toBe(true)
     expect(globalThis.caches._stores.has('some-other-cache')).toBe(true)
+  })
+})
+
+describe('service worker install', () => {
+  beforeEach(async () => {
+    await loadServiceWorker()
+  })
+
+  it('precaches only canonical (non-.html, non-redirecting) URLs', async () => {
+    const promises = []
+    handlers.install({ waitUntil: p => promises.push(p) })
+    await Promise.all(promises)
+
+    const store = globalThis.caches._stores.get('schedule-v5')
+    const keys = [...store.keys()]
+
+    // The shell, manifest, and branded offline page — by the 200 URLs Pages
+    // actually serves.
+    expect(keys).toContain(`${ORIGIN}/`)
+    expect(keys).toContain(`${ORIGIN}/manifest.json`)
+    expect(keys).toContain(`${ORIGIN}/offline`)
+
+    // Regression guard (#578): NO `.html`-suffixed entries. Pages 308-redirects
+    // /index.html and /offline.html; cache.add() rejects on the redirect and
+    // silently drops them. Precaching a `.html` name must never come back.
+    expect(keys.some(k => k.endsWith('.html'))).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

The service worker precached `['/', '/index.html', '/manifest.json', '/offline.html']`, but Cloudflare Pages **308-redirects** `/index.html` → `/` and `/offline.html` → `/offline` (clean URLs — confirmed in **production and `wrangler pages dev`**). `cache.add()` follows the redirect and then rejects on the redirected response, so:

- the branded offline page was **never cached** (and is unreachable at `/offline.html` — it 308s), and
- under some runtimes the SW install **stalled** (stuck at `installing`, never `activated`), which also blocked any offline E2E coverage.

Found while building offline coverage for #554 — the no-signal-campground scenario (BLR3 at a rural campground) makes offline resilience the highest-value live feature for those venues.

Fix: precache the canonical 200 URLs `['/', '/manifest.json', '/offline']`. `/` already covers the app shell; `/offline` serves the branded offline page content directly. Offline navigation/asset fallbacks now match `/offline`. `CACHE_VERSION` v4 → v5 so clients pick up the new worker (required because the asset set changed).

Closes #578
Refs #554

## What changed

| File | Change |
|------|--------|
| `frontend/public/sw.js` | Precache canonical URLs; offline fallbacks match `/offline`; v4→v5; log precache rejections so a future silent drop is visible |
| `frontend/src/test/sw.test.js` | Update cache-version assertions to v5 (older versions now purged); **new install test** asserting the precache list contains the canonical URLs and **no `.html` entries** — a fast CI guard against reintroducing this exact bug |
| `e2e/offline-experience.spec.js` (new) | Real offline walkthrough: seed event → load online until the SW controls the page → save a route → `context.setOffline(true)` → reload → assert the schedule (SW caches) and route (localStorage) still render |

## Security / correctness notes

- Fetch routing is unchanged: `/api/admin/` stays network-only (never cached), `/api/` network-first, then navigations — verified no regression.
- Navigation remains **network-first** (the documented mitigation for the post-deploy ChunkLoadError/stale-shell class); this change doesn't alter that path.
- Reviewed by the code-reviewer agent (no ≥80-confidence findings; two sub-threshold hardening suggestions — the install regression test and precache-failure logging — adopted here; the `/index.html` runtime cache-key rename was declined as a behavior change to a delicate file for weak benefit).

## Verification

- [x] Tests: frontend 469 pass (48 files, incl. the new SW install test); offline E2E stable across **16 repeat runs**
- [x] ESLint: 0 errors (frontend; e2e spec lint-clean too)
- [x] Format check: clean
- [x] Build: green
- [ ] `validate:openapi`: N/A
- [x] Manual verification: probed the real SW under `wrangler pages dev` — **before**: stuck `installing` indefinitely; **after**: reaches `activated`, `/offline` serves 200, offline reload renders the saved schedule

---
Built & reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)