### PR TITLE
fix(conflicts): day-scope bulk move/retime conflict detection

### DIFF
--- a/functions/utils/__tests__/timeConflicts.test.js
+++ b/functions/utils/__tests__/timeConflicts.test.js
@@ -5,7 +5,9 @@ import {
   buildIntervals,
   intervalsOverlap,
   computeNewEndTime,
+  detectBulkConflicts,
 } from "../timeConflicts.js";
+import { createTestEnv, insertBand, insertEvent, insertVenue } from "../../api/test-utils.js";
 
 describe("toMinutes", () => {
   it("converts HH:MM to total minutes", () => {
@@ -79,5 +81,287 @@ describe("computeNewEndTime", () => {
   it("handles a set that shifts across midnight", () => {
     // 22:00–23:00 is 60 minutes. Shift to 23:30 → should end at 00:30.
     expect(computeNewEndTime("22:00", "23:00", "23:30")).toBe("00:30");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectBulkConflicts — festival-day scoping (#551)
+//
+// #540 day-scoped the single create/update conflict check (checkConflicts in
+// functions/api/admin/bands.js). detectBulkConflicts (bulk move_venue /
+// change_time) was left out of that scope: it matched purely on
+// event_id + venue_id + clock overlap, so a multi-day event's bulk move/retime
+// would false-conflict against a different festival day. These tests cover
+// both action branches (move_venue, change_time) across both comparison sites
+// (batch member vs. existing performance, and pairwise within the batch).
+// ---------------------------------------------------------------------------
+
+describe("detectBulkConflicts — festival-day scoping (#551)", () => {
+  function multiDayFixture() {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, {
+      name: "Multi Day Event 551",
+      slug: "multi-day-event-551",
+      date: "2026-08-01",
+      end_date: "2026-08-02",
+      status: "draft",
+    });
+    const venueA = insertVenue(rawDb, { name: "Source Venue 551" });
+    const venueB = insertVenue(rawDb, { name: "Target Venue 551" });
+    return { env, rawDb, event, venueA, venueB };
+  }
+
+  function setPerformanceDate(rawDb, performanceId, date) {
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run(date, performanceId);
+  }
+
+  it("move_venue: different performance_date at same venue/time → no conflict", async () => {
+    const { env, rawDb, event, venueA, venueB } = multiDayFixture();
+
+    const moving = insertBand(rawDb, {
+      name: "Day Two Mover",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    setPerformanceDate(rawDb, moving.id, "2026-08-02");
+
+    const existing = insertBand(rawDb, {
+      name: "Day One Resident",
+      event_id: event.id,
+      venue_id: venueB.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    setPerformanceDate(rawDb, existing.id, "2026-08-01");
+
+    const conflicts = await detectBulkConflicts(env, {
+      action: "move_venue",
+      bandIds: [moving.id],
+      params: { venue_id: venueB.id },
+    });
+    expect(conflicts).toEqual([]);
+  });
+
+  it("move_venue: same performance_date at same venue/time → conflict still detected", async () => {
+    const { env, rawDb, event, venueA, venueB } = multiDayFixture();
+
+    const moving = insertBand(rawDb, {
+      name: "Day One Mover",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    setPerformanceDate(rawDb, moving.id, "2026-08-01");
+
+    const existing = insertBand(rawDb, {
+      name: "Day One Resident",
+      event_id: event.id,
+      venue_id: venueB.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    setPerformanceDate(rawDb, existing.id, "2026-08-01");
+
+    const conflicts = await detectBulkConflicts(env, {
+      action: "move_venue",
+      bandIds: [moving.id],
+      params: { venue_id: venueB.id },
+    });
+    expect(conflicts.length).toBeGreaterThan(0);
+    expect(conflicts[0].severity).toBe("error");
+  });
+
+  it("move_venue: NULL performance_date on both sides falls back to event date (single-day, still conflicts)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, {
+      name: "Single Day Event 551",
+      slug: "single-day-event-551",
+      date: "2026-08-01",
+      status: "draft",
+    });
+    const venueA = insertVenue(rawDb, { name: "Single Source Venue" });
+    const venueB = insertVenue(rawDb, { name: "Single Target Venue" });
+
+    // performance_date is left NULL on both — single-day event, byte-identical
+    // to pre-#551 behavior (both sides fall back to the same event date).
+    const moving = insertBand(rawDb, {
+      name: "Single Day Mover",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    insertBand(rawDb, {
+      name: "Single Day Resident",
+      event_id: event.id,
+      venue_id: venueB.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+
+    const conflicts = await detectBulkConflicts(env, {
+      action: "move_venue",
+      bandIds: [moving.id],
+      params: { venue_id: venueB.id },
+    });
+    expect(conflicts.length).toBeGreaterThan(0);
+  });
+
+  it("change_time: different performance_date at same venue/time → no conflict", async () => {
+    const { env, rawDb, event, venueA } = multiDayFixture();
+
+    const changing = insertBand(rawDb, {
+      name: "Day Two Changer",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
+    setPerformanceDate(rawDb, changing.id, "2026-08-02");
+
+    const existing = insertBand(rawDb, {
+      name: "Day One Resident At Venue A",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    setPerformanceDate(rawDb, existing.id, "2026-08-01");
+
+    // Shift the Day-Two set's start onto the Day-One resident's clock slot.
+    const conflicts = await detectBulkConflicts(env, {
+      action: "change_time",
+      bandIds: [changing.id],
+      params: { start_time: "20:00" },
+    });
+    expect(conflicts).toEqual([]);
+  });
+
+  it("change_time: same performance_date at same venue/time → conflict still detected", async () => {
+    const { env, rawDb, event, venueA } = multiDayFixture();
+
+    const changing = insertBand(rawDb, {
+      name: "Day One Changer",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
+    setPerformanceDate(rawDb, changing.id, "2026-08-01");
+
+    const existing = insertBand(rawDb, {
+      name: "Day One Resident At Venue A",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    setPerformanceDate(rawDb, existing.id, "2026-08-01");
+
+    const conflicts = await detectBulkConflicts(env, {
+      action: "change_time",
+      bandIds: [changing.id],
+      params: { start_time: "20:00" },
+    });
+    expect(conflicts.length).toBeGreaterThan(0);
+    expect(conflicts[0].severity).toBe("error");
+  });
+
+  it("move_venue pairwise: two batch members at same venue/time but different performance_date → no conflict", async () => {
+    const { env, rawDb, event, venueB } = multiDayFixture();
+    const venueSource = insertVenue(rawDb, { name: "Pairwise Source Venue 551" });
+
+    const memberDay1 = insertBand(rawDb, {
+      name: "Pairwise Day One",
+      event_id: event.id,
+      venue_id: venueSource.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    setPerformanceDate(rawDb, memberDay1.id, "2026-08-01");
+
+    const memberDay2 = insertBand(rawDb, {
+      name: "Pairwise Day Two",
+      event_id: event.id,
+      venue_id: venueSource.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    setPerformanceDate(rawDb, memberDay2.id, "2026-08-02");
+
+    // Both batch members move to the same target venue at the same clock
+    // time. venueB has no existing performances, so only the pairwise check
+    // could report a conflict here — and it must not, since they're on
+    // different festival days.
+    const conflicts = await detectBulkConflicts(env, {
+      action: "move_venue",
+      bandIds: [memberDay1.id, memberDay2.id],
+      params: { venue_id: venueB.id },
+    });
+    expect(conflicts).toEqual([]);
+  });
+
+  it("move_venue pairwise: two batch members at same venue/time with same performance_date → conflict detected", async () => {
+    const { env, rawDb, event, venueB } = multiDayFixture();
+    const venueSource = insertVenue(rawDb, { name: "Pairwise Source Venue 551b" });
+
+    const memberA = insertBand(rawDb, {
+      name: "Pairwise Same Day A",
+      event_id: event.id,
+      venue_id: venueSource.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    setPerformanceDate(rawDb, memberA.id, "2026-08-01");
+
+    const memberB = insertBand(rawDb, {
+      name: "Pairwise Same Day B",
+      event_id: event.id,
+      venue_id: venueSource.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    setPerformanceDate(rawDb, memberB.id, "2026-08-01");
+
+    const conflicts = await detectBulkConflicts(env, {
+      action: "move_venue",
+      bandIds: [memberA.id, memberB.id],
+      params: { venue_id: venueB.id },
+    });
+    expect(conflicts.length).toBeGreaterThan(0);
+  });
+
+  it("change_time pairwise: two batch members at same venue with different performance_date → no conflict", async () => {
+    const { env, rawDb, event, venueA } = multiDayFixture();
+
+    const memberDay1 = insertBand(rawDb, {
+      name: "CT Pairwise Day One",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
+    setPerformanceDate(rawDb, memberDay1.id, "2026-08-01");
+
+    const memberDay2 = insertBand(rawDb, {
+      name: "CT Pairwise Day Two",
+      event_id: event.id,
+      venue_id: venueA.id,
+      start_time: "19:00",
+      end_time: "20:00",
+    });
+    setPerformanceDate(rawDb, memberDay2.id, "2026-08-02");
+
+    // Both shift to the same new start_time, landing at the same venue/clock
+    // slot — but different festival days must not conflict.
+    const conflicts = await detectBulkConflicts(env, {
+      action: "change_time",
+      bandIds: [memberDay1.id, memberDay2.id],
+      params: { start_time: "20:00" },
+    });
+    expect(conflicts).toEqual([]);
   });
 });

--- a/functions/utils/timeConflicts.js
+++ b/functions/utils/timeConflicts.js
@@ -56,7 +56,7 @@ export async function detectBulkConflicts(env, { action, bandIds, params }) {
   // filter out archived-event rows before scheduling-conflict checks. Callers
   // that need archived-event error messages (bulk-preview) handle those separately.
   const bands = await env.DB.prepare(
-    `SELECT p.id, p.start_time, p.end_time, p.venue_id, p.event_id, bp.name, e.status AS event_status
+    `SELECT p.id, p.start_time, p.end_time, p.venue_id, p.event_id, p.performance_date, bp.name, e.status AS event_status, e.date AS event_date
      FROM performances p
      JOIN band_profiles bp ON p.band_profile_id = bp.id
      JOIN events e ON p.event_id = e.id
@@ -66,6 +66,14 @@ export async function detectBulkConflicts(env, { action, bandIds, params }) {
     .all();
 
   const bandResults = (bands.results || []).filter((b) => b.event_status !== "archived");
+
+  // Festival-day scoping (#551): two sets on different festival days never
+  // conflict, even at the same venue and clock time (mirrors checkConflicts in
+  // functions/api/admin/bands.js, #540). Falls back to the event's date for a
+  // NULL performance_date, so single-day events (both sides NULL → same day)
+  // conflict exactly as before. move_venue/change_time never mutate
+  // performance_date, so a batch member's festival day is just its stored value.
+  const festivalDayOf = (row) => row.performance_date || row.event_date;
 
   if (action === "move_venue") {
     const { venue_id } = params;
@@ -82,9 +90,10 @@ export async function detectBulkConflicts(env, { action, bandIds, params }) {
     const venuePerformancesByEvent = new Map();
     for (const eventId of eventIds) {
       const rows = await env.DB.prepare(
-        `SELECT p.id, p.start_time, p.end_time, bp.name
+        `SELECT p.id, p.start_time, p.end_time, p.performance_date, bp.name, e.date AS event_date
          FROM performances p
          JOIN band_profiles bp ON p.band_profile_id = bp.id
+         JOIN events e ON p.event_id = e.id
          WHERE p.venue_id = ? AND p.event_id = ? AND p.id NOT IN (${placeholders})`,
       )
         .bind(venue_id, eventId, ...bandIds)
@@ -96,9 +105,12 @@ export async function detectBulkConflicts(env, { action, bandIds, params }) {
     for (const band of bandResults) {
       if (!band.start_time || !band.end_time) continue;
       const bandIntervals = buildIntervals(band.start_time, band.end_time);
+      const bandDay = festivalDayOf(band);
       const existing = venuePerformancesByEvent.get(band.event_id) || [];
       for (const other of existing) {
         if (!other.start_time || !other.end_time) continue;
+        const otherDay = festivalDayOf(other);
+        if (bandDay && otherDay && bandDay !== otherDay) continue;
         const otherIntervals = buildIntervals(other.start_time, other.end_time);
         if (bandIntervals.some((a) => otherIntervals.some((b) => intervalsOverlap(a, b)))) {
           const isExact = other.start_time === band.start_time && other.end_time === band.end_time;
@@ -122,11 +134,14 @@ export async function detectBulkConflicts(env, { action, bandIds, params }) {
       const bandA = bandResults[i];
       if (!bandA.start_time || !bandA.end_time) continue;
       const intervalsA = buildIntervals(bandA.start_time, bandA.end_time);
+      const dayA = festivalDayOf(bandA);
 
       for (let j = i + 1; j < bandResults.length; j++) {
         const bandB = bandResults[j];
         if (!bandB.start_time || !bandB.end_time) continue;
         if (bandA.event_id !== bandB.event_id) continue;
+        const dayB = festivalDayOf(bandB);
+        if (dayA && dayB && dayA !== dayB) continue;
 
         const intervalsB = buildIntervals(bandB.start_time, bandB.end_time);
         if (!intervalsA.some((a) => intervalsB.some((b) => intervalsOverlap(a, b)))) continue;
@@ -158,9 +173,10 @@ export async function detectBulkConflicts(env, { action, bandIds, params }) {
 
       if (!changeTimeCache.has(cacheKey)) {
         const rows = await env.DB.prepare(
-          `SELECT p.id, p.start_time, p.end_time, bp.name
+          `SELECT p.id, p.start_time, p.end_time, p.performance_date, bp.name, e.date AS event_date
            FROM performances p
            JOIN band_profiles bp ON p.band_profile_id = bp.id
+           JOIN events e ON p.event_id = e.id
            WHERE p.venue_id = ? AND p.event_id = ? AND p.id NOT IN (${placeholders})`,
         )
           .bind(band.venue_id, band.event_id, ...bandIds)
@@ -170,9 +186,12 @@ export async function detectBulkConflicts(env, { action, bandIds, params }) {
 
       const existing = changeTimeCache.get(cacheKey);
       const bandIntervals = buildIntervals(start_time, newEndTime);
+      const bandDay = festivalDayOf(band);
 
       for (const other of existing) {
         if (!other.start_time || !other.end_time) continue;
+        const otherDay = festivalDayOf(other);
+        if (bandDay && otherDay && bandDay !== otherDay) continue;
         const otherIntervals = buildIntervals(other.start_time, other.end_time);
         if (bandIntervals.some((a) => otherIntervals.some((b) => intervalsOverlap(a, b)))) {
           const isExact = other.start_time === start_time && other.end_time === newEndTime;
@@ -194,11 +213,14 @@ export async function detectBulkConflicts(env, { action, bandIds, params }) {
     for (let i = 0; i < bandResults.length; i++) {
       const bandA = bandResults[i];
       if (!bandA.start_time || !bandA.end_time || !bandA.venue_id) continue;
+      const dayA = festivalDayOf(bandA);
 
       for (let j = i + 1; j < bandResults.length; j++) {
         const bandB = bandResults[j];
         if (!bandB.start_time || !bandB.end_time || !bandB.venue_id) continue;
         if (bandA.venue_id !== bandB.venue_id || bandA.event_id !== bandB.event_id) continue;
+        const dayB = festivalDayOf(bandB);
+        if (dayA && dayB && dayA !== dayB) continue;
 
         const newEndA = computeNewEndTime(bandA.start_time, bandA.end_time, start_time);
         const newEndB = computeNewEndTime(bandB.start_time, bandB.end_time, start_time);


### PR DESCRIPTION
## Summary

`detectBulkConflicts` (`functions/utils/timeConflicts.js`, used by bulk move_venue / change_time ops) matched conflicts on event_id + venue_id + clock overlap only — no `performance_date` dimension. On a multi-day event, a bulk move/retime landing sets at a venue+time already used on a **different festival day** reported false conflicts. #540 fixed this for single edits; this closes the last day-blind path.

Closes #551

## What changed

`functions/utils/timeConflicts.js`: added `p.performance_date` + `e.date AS event_date` to the batch and existing-performances SELECTs (with the events JOIN), and a `festivalDayOf(row) = row.performance_date || row.event_date` guard (`if (dayA && dayB && dayA !== dayB) continue`) at all **four** comparison sites — batch-vs-existing and pairwise, in both the move_venue and change_time branches. Exact mirror of `checkConflicts` in `functions/api/admin/bands.js` (#540): NULL performance_date falls back to the event date, so single-day events are byte-identical.

The new SELECT columns are internal only — `bulk.js`/`bulk-preview.js` consume just the returned `conflicts` array (band_id/type/message/severity), so no API-shape change.

## Security / correctness notes

None — read-only conflict computation; no auth/storage change.

## Verification

- [x] Tests: backend 714 pass / 6 todo (73 files) under TZ=UTC — independently re-run by the orchestrator; +8 new cases (move_venue & change_time × cross-day-no-conflict / same-day-conflict / pairwise), plus bulk.js + bands.js regression suites green
- [x] ESLint: 0 errors
- [x] Format check: clean
- [ ] `validate:openapi`: N/A
- [x] Manual reasoning: verified all 4 comparison sites are guarded and the fallback keeps single-day byte-identical

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)