### PR TITLE
refactor(multiday): unify the 6 AM festival-day boundary into one constant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Canonical active roadmap: `docs/ROADMAP.md`. Use it for handoffs between Claude,
 
 Bands starting before 6 AM are "after-midnight" sets that belong to the *previous evening*. They must be offset by +1 day so they sort after the evening lineup, not at the top of the schedule.
 
-- Threshold: `AFTER_MIDNIGHT_THRESHOLD_HOUR = 6` in `frontend/src/utils/bandUtils.js`
+- Threshold: `AFTER_MIDNIGHT_THRESHOLD_HOUR = 6`, canonically defined in `frontend/src/utils/festivalDays.js` (#550). `frontend/src/utils/bandUtils.js` and `frontend/src/admin/utils/timeUtils.js` (`AFTER_MIDNIGHT_THRESHOLD_MINUTES = AFTER_MIDNIGHT_THRESHOLD_HOUR * 60`) both import it rather than re-encoding `6`.
 - Logic: `prepareBands()` adds `MS_PER_DAY` to `startMs`/`endMs` for times below this threshold
 - **Never remove or lower this threshold.** Any sort, filter, or conflict-detection that touches performance times must apply the same offset or delegate to `prepareBands`.
 

--- a/frontend/src/admin/utils/__tests__/timeUtils.test.js
+++ b/frontend/src/admin/utils/__tests__/timeUtils.test.js
@@ -1,5 +1,20 @@
 import { describe, expect, it } from 'vitest'
-import { adjustForMidnight, detectConflicts, parseTimeToMinutes, sortBandsByStart } from '../timeUtils'
+import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from '../../../utils/festivalDays'
+import {
+  adjustForMidnight,
+  AFTER_MIDNIGHT_THRESHOLD_MINUTES,
+  detectConflicts,
+  parseTimeToMinutes,
+  sortBandsByStart,
+} from '../timeUtils'
+
+// ─── AFTER_MIDNIGHT_THRESHOLD_MINUTES derivation (#550) ─────────────────────
+
+describe('AFTER_MIDNIGHT_THRESHOLD_MINUTES', () => {
+  it('derives from the canonical AFTER_MIDNIGHT_THRESHOLD_HOUR (festivalDays.js), never a separate literal', () => {
+    expect(AFTER_MIDNIGHT_THRESHOLD_MINUTES).toBe(AFTER_MIDNIGHT_THRESHOLD_HOUR * 60)
+  })
+})
 
 // ─── sortBandsByStart ────────────────────────────────────────────────────────
 

--- a/frontend/src/admin/utils/dayOptions.js
+++ b/frontend/src/admin/utils/dayOptions.js
@@ -2,7 +2,7 @@
  * Festival-day helpers for multi-day events (#540).
  *
  * A festival day runs 6 AM -> 6 AM (see AFTER_MIDNIGHT_THRESHOLD_HOUR in
- * frontend/src/utils/bandUtils.js): a set starting at 1 AM belongs to the
+ * frontend/src/utils/festivalDays.js): a set starting at 1 AM belongs to the
  * festival day of the *evening it started*, not the calendar day its clock
  * time falls on. These helpers only build/label the set of festival days for
  * an event — they never re-derive which day a given performance belongs to;

--- a/frontend/src/admin/utils/timeUtils.js
+++ b/frontend/src/admin/utils/timeUtils.js
@@ -1,6 +1,10 @@
+import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from '../../utils/festivalDays'
+
 const MINUTES_PER_DAY = 24 * 60
-// Bands starting before this hour are treated as after-midnight (same night as the preceding evening)
-export const AFTER_MIDNIGHT_THRESHOLD_MINUTES = 6 * 60
+// Bands starting before this hour are treated as after-midnight (same night as the preceding
+// evening). Derived from the canonical AFTER_MIDNIGHT_THRESHOLD_HOUR in festivalDays.js (#550)
+// so this offset can never drift from bandUtils.js's prepareBands offset.
+export const AFTER_MIDNIGHT_THRESHOLD_MINUTES = AFTER_MIDNIGHT_THRESHOLD_HOUR * 60
 
 const isNumber = value => typeof value === 'number' && Number.isFinite(value)
 

--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -11,9 +11,9 @@ const UNSCHEDULED = Symbol('unscheduled')
 const UNSCHEDULED_FILTER_VALUE = '__unscheduled__'
 
 // Groups by (festival day, clock time) rather than bare clock time. `band.date`
-// is already the set's festival day (see AFTER_MIDNIGHT_THRESHOLD_HOUR /
-// prepareBands in bandUtils.js — after-midnight sets keep their *previous*
-// evening's date). Without the day component, two sets at the same clock time
+// is already the set's festival day (see AFTER_MIDNIGHT_THRESHOLD_HOUR in
+// festivalDays.js / prepareBands in bandUtils.js — after-midnight sets keep
+// their *previous* evening's date). Without the day component, two sets at the same clock time
 // on different festival days (e.g. both nights' 8 PM slot) would collapse into
 // one bucket (#538). In the single-day case `date` is constant across every
 // band, so the key degenerates to the old bare-time key and grouping is

--- a/frontend/src/utils/bandUtils.js
+++ b/frontend/src/utils/bandUtils.js
@@ -1,7 +1,9 @@
+import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from './festivalDays'
+
 const MS_PER_DAY = 24 * 60 * 60 * 1000
-// Times starting before 6 AM are treated as after-midnight sets of the event night,
-// so they sort after same-day evening sets rather than appearing at the top of the schedule.
-const AFTER_MIDNIGHT_THRESHOLD_HOUR = 6
+// Times starting before AFTER_MIDNIGHT_THRESHOLD_HOUR are treated as after-midnight sets
+// of the event night, so they sort after same-day evening sets rather than appearing at
+// the top of the schedule. Canonical definition lives in festivalDays.js (#550).
 
 /**
  * Enriches raw band data with precomputed startMs/endMs timestamps.

--- a/frontend/src/utils/festivalDays.js
+++ b/frontend/src/utils/festivalDays.js
@@ -13,6 +13,28 @@
  * already present in the data.
  */
 
+/**
+ * The 6 AM boundary a festival day runs on: 6 AM -> 6 AM, not midnight -> midnight.
+ * A set starting at 1 AM belongs to the festival day of the *evening it
+ * started* (the previous night's lineup), not the calendar day its clock
+ * time falls on.
+ *
+ * This is the single canonical definition (#550) — every consumer imports
+ * it rather than re-encoding `6`:
+ * - `frontend/src/utils/bandUtils.js` (`prepareBands`) offsets sub-6-AM
+ *   start times by `MS_PER_DAY` so they sort after the same evening's
+ *   earlier sets rather than at the top of the schedule.
+ * - `frontend/src/admin/utils/timeUtils.js` derives
+ *   `AFTER_MIDNIGHT_THRESHOLD_MINUTES` (`AFTER_MIDNIGHT_THRESHOLD_HOUR * 60`)
+ *   from this for its own minutes-based offset (`adjustForMidnight`).
+ *
+ * Repo invariant (see CLAUDE.md "After-midnight band sorting"): this value
+ * must never be removed or lowered — doing so is a recurring bug class
+ * (after-midnight sets sorting to the top of the schedule instead of the
+ * end).
+ */
+export const AFTER_MIDNIGHT_THRESHOLD_HOUR = 6
+
 const parseDateParts = dateStr => {
   const [year, month, day] = dateStr.split('-').map(Number)
   return { year, month, day }


### PR DESCRIPTION
## Summary

The 6 AM festival-day boundary ("a festival day runs 6 AM → 6 AM"; sub-6AM sets belong to the previous evening) was encoded in **two** independent places with different units — `AFTER_MIDNIGHT_THRESHOLD_HOUR = 6` in `bandUtils.js` and `AFTER_MIDNIGHT_THRESHOLD_MINUTES = 6 * 60` in `admin/utils/timeUtils.js` — two `6`s that can silently drift. This promotes it to one canonical definition, imported by every consumer. **Zero behavior change**, guarded by the existing after-midnight + multiday tests.

Closes #550

## What changed

| File | Change |
|------|--------|
| `frontend/src/utils/festivalDays.js` | New canonical `export const AFTER_MIDNIGHT_THRESHOLD_HOUR = 6` with the boundary doc + the CLAUDE.md never-lower/remove invariant |
| `frontend/src/utils/bandUtils.js` | Imports the constant (removed its local copy); `prepareBands` unchanged |
| `frontend/src/admin/utils/timeUtils.js` | `AFTER_MIDNIGHT_THRESHOLD_MINUTES` now derives as `AFTER_MIDNIGHT_THRESHOLD_HOUR * 60` (export name kept) |
| `dayOptions.js`, `ScheduleView.jsx` | Doc-comment pointers updated to the canonical location |
| `CLAUDE.md` | Invariant section points at the new home |
| `timeUtils.test.js` | +1 test locking `MINUTES === HOUR * 60` |

No other duplicates found (grepped the whole frontend). No circular imports — `festivalDays.js` stays leaf-level.

## Security / correctness notes

None — pure consolidation. The invariant is **promoted**, never weakened; `AFTER_MIDNIGHT_THRESHOLD_HOUR` must never be removed or lowered (recurring bug class).

## Verification

- [x] Tests: frontend 469 pass (48 files) — **+1** vs main (the derivation-lock test), every other count unchanged → confirms byte-identical behavior — independently re-run by the orchestrator
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [ ] `validate:openapi`: N/A

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)