### PR TITLE
feat: surface performance notes to admins and fans

### DIFF
--- a/frontend/src/admin/BandForm.jsx
+++ b/frontend/src/admin/BandForm.jsx
@@ -437,6 +437,30 @@ export default function BandForm({
                 className="w-full min-h-[44px] px-4 py-3 text-base rounded bg-bg-navy text-white border border-gray-600 focus:border-accent-500 focus:outline-hidden sm:text-sm"
               />
             </div>
+
+            <div className="sm:col-span-2">
+              <div className="flex items-center gap-2 mb-2">
+                <label htmlFor="band-notes" className="block text-white text-sm">
+                  Notes <span className="text-gray-400 text-xs ml-2">(optional, shown to fans)</span>
+                </label>
+                <Tooltip content='Short public annotation shown under this set on the schedule (e.g. "Bonus set: ALL w/ Scott (Reynolds) -- sold out"). Keep it fan-appropriate — this is not a private/internal field.'>
+                  <Info size={14} className="text-text-tertiary cursor-help" />
+                </Tooltip>
+              </div>
+              <textarea
+                id="band-notes"
+                name="notes"
+                value={formData.notes || ''}
+                onChange={onChange}
+                maxLength={FIELD_LIMITS.performanceNotes.max}
+                rows={2}
+                className="w-full px-4 py-3 text-base rounded bg-bg-navy text-white border border-gray-600 focus:border-accent-500 focus:outline-hidden sm:text-sm"
+                placeholder='Note shown to fans, e.g. "Bonus set: ALL w/ Scott (Reynolds) -- sold out"'
+              />
+              <p className="text-gray-400 text-xs mt-1">
+                Shown to fans under this set on the public schedule — keep it fan-appropriate, not internal shorthand.
+              </p>
+            </div>
           </>
         )}
 
@@ -605,6 +629,7 @@ BandForm.propTypes = {
     end_time: PropTypes.string,
     duration: PropTypes.string,
     performance_date: PropTypes.string,
+    notes: PropTypes.string,
     url: PropTypes.string,
     origin: PropTypes.string,
     origin_city: PropTypes.string,

--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -61,6 +61,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
     end_time: '',
     duration: '',
     performance_date: '',
+    notes: '',
     url: '',
     description: '',
     photo_url: '',
@@ -310,6 +311,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
         startTime: formData.start_time,
         endTime: formData.end_time,
         performanceDate: formData.performance_date || null,
+        notes: formData.notes,
         genre: formData.genre,
         origin: originDisplay,
         origin_city: formData.origin_city,
@@ -427,6 +429,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
       end_time: band.end_time || '',
       duration: durationMinutes?.toString() || '',
       performance_date: band.performance_date || '',
+      notes: band.notes || '',
       url: band.url || '',
       description: band.description || '',
       photo_url: band.photo_url || '',
@@ -878,7 +881,17 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
                                 />
                               </td>
                             )}
-                            <td className="px-4 py-3 text-white font-medium">{band.name}</td>
+                            <td className="px-4 py-3 text-white font-medium">
+                              <div>{band.name}</div>
+                              {band.notes && (
+                                <div
+                                  className="text-xs font-normal text-text-tertiary mt-0.5 max-w-xs truncate"
+                                  title={band.notes}
+                                >
+                                  {band.notes}
+                                </div>
+                              )}
+                            </td>
                             <td className="px-4 py-3 text-white/70">{getVenueName(band.venue_id)}</td>
                             <td className="px-4 py-3 text-white/70">
                               {formatTimeRangeLabel(band.start_time, band.end_time)}
@@ -996,6 +1009,11 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
                         <div className="text-sm text-text-secondary space-y-1">
                           <div>Venue: {getVenueName(band.venue_id)}</div>
                           <div>Time: {formatTimeRangeLabel(band.start_time, band.end_time)}</div>
+                          {band.notes && (
+                            <div className="text-text-tertiary italic truncate" title={band.notes}>
+                              {band.notes}
+                            </div>
+                          )}
                         </div>
                         {!readOnly && (
                           <div className="flex flex-wrap gap-2">

--- a/frontend/src/admin/components/HelpPanel.jsx
+++ b/frontend/src/admin/components/HelpPanel.jsx
@@ -14,7 +14,7 @@ const HELP_CONTENT = {
     items: [
       'Bulk select bands to reschedule or update venues at once.',
       'Conflict warnings appear when time slots overlap within the same venue.',
-      'Admin-only notes are never exposed to the public API.',
+      'Set notes are shown to fans on the public schedule — keep them fan-appropriate, not internal shorthand.',
     ],
   },
 }

--- a/frontend/src/admin/utils/pickerFormData.js
+++ b/frontend/src/admin/utils/pickerFormData.js
@@ -15,6 +15,7 @@ const BLANK_SCHEDULE = {
   end_time: '',
   duration: '',
   performance_date: '',
+  notes: '',
 }
 
 export function buildPickerFormData(artist, eventId) {

--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -120,6 +120,13 @@ function BandCard({
             </h3>
           )}
         </div>
+        {band.notes && (
+          <p
+            className={`text-xs italic text-center leading-snug line-clamp-2 ${onAmber ? 'text-bg-navy/80' : 'text-text-tertiary'}`}
+          >
+            {band.notes}
+          </p>
+        )}
         <p
           className={`text-sm md:text-base font-medium leading-snug ${
             isPlaying ? 'text-bg-navy font-semibold' : onAmber ? 'text-bg-navy' : 'text-text-secondary'

--- a/frontend/src/utils/validation.js
+++ b/frontend/src/utils/validation.js
@@ -44,6 +44,9 @@ export const FIELD_LIMITS = {
   socialHandle: { min: 0, max: 100 },
   bandContactEmail: { min: 0, max: 255 },
 
+  // Performance fields
+  performanceNotes: { min: 0, max: 1000 },
+
   // Event fields
   eventName: { min: 3, max: 200 },
   eventSlug: { min: 3, max: 100 },

--- a/functions/api/admin/bands.js
+++ b/functions/api/admin/bands.js
@@ -10,6 +10,7 @@ import {
   safeReflectSocialLinksString,
   sanitizeBandSocialLinks,
   sanitizeOptionalHttpUrl,
+  sanitizeOptionalText,
   sanitizeString,
   validatePerformanceDate,
 } from "../../utils/validation.js";
@@ -253,6 +254,7 @@ export async function onRequestPost(context) {
       contact_email,
       is_active,
       social_links, // JSON string from frontend
+      notes,
     } = body;
 
     const resolvedName = sanitizeString(name || "");
@@ -261,10 +263,12 @@ export async function onRequestPost(context) {
     const resolvedGenre = genre !== undefined ? sanitizeString(genre) || null : null;
     let resolvedPhotoUrl;
     let resolvedWebsite;
+    let resolvedNotes;
 
     try {
       resolvedPhotoUrl = sanitizeOptionalHttpUrl(photo_url, FIELD_LIMITS.bandUrl.max, "Photo URL");
       resolvedWebsite = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");
+      resolvedNotes = sanitizeOptionalText(notes, FIELD_LIMITS.performanceNotes.max, "Notes");
     } catch (error) {
       return new Response(JSON.stringify({ error: "Validation error", message: error.message }), {
         status: 400,
@@ -481,11 +485,19 @@ export async function onRequestPost(context) {
       let perfResult;
       try {
         perfResult = await DB.prepare(
-          `INSERT INTO performances (event_id, venue_id, band_profile_id, start_time, end_time, performance_date)
-           VALUES (?, ?, ?, ?, ?, ?)
+          `INSERT INTO performances (event_id, venue_id, band_profile_id, start_time, end_time, performance_date, notes)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
            RETURNING id`,
         )
-          .bind(eventId, resolvedVenueId, bandProfile.id, startTime || null, endTime || null, resolvedPerformanceDate)
+          .bind(
+            eventId,
+            resolvedVenueId,
+            bandProfile.id,
+            startTime || null,
+            endTime || null,
+            resolvedPerformanceDate,
+            resolvedNotes,
+          )
           .first();
       } catch (perfError) {
         // Compensating delete: only undo profiles we just created, not pre-existing ones

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -9,6 +9,7 @@ import {
   safeReflectSocialLinks,
   sanitizeBandSocialLinks,
   sanitizeOptionalHttpUrl,
+  sanitizeOptionalText,
   sanitizeString,
   validatePerformanceDate,
 } from "../../../utils/validation.js";
@@ -145,6 +146,7 @@ export async function onRequestPut(context) {
       photo_url,
       photo_alt_text,
       social_links,
+      notes,
     } = body;
 
     // Normalize venueId: treat "", 0, "0" as null (no venue assigned).
@@ -153,9 +155,12 @@ export async function onRequestPut(context) {
     const normalizedVenueId =
       venueId === undefined ? undefined : !venueId || Number(venueId) <= 0 ? null : Number(venueId);
     let resolvedPhotoUrl;
+    let resolvedNotes;
     try {
       resolvedPhotoUrl =
         photo_url !== undefined ? sanitizeOptionalHttpUrl(photo_url, FIELD_LIMITS.bandUrl.max, "Photo URL") : undefined;
+      resolvedNotes =
+        notes !== undefined ? sanitizeOptionalText(notes, FIELD_LIMITS.performanceNotes.max, "Notes") : undefined;
     } catch (error) {
       return new Response(JSON.stringify({ error: "Validation error", message: error.message }), {
         status: 400,
@@ -217,7 +222,8 @@ export async function onRequestPut(context) {
         normalizedVenueId !== undefined ||
         startTime !== undefined ||
         endTime !== undefined ||
-        performanceDate !== undefined;
+        performanceDate !== undefined ||
+        notes !== undefined;
       if (linkedEvent?.status === "archived" && editsPerformanceFields) {
         return new Response(
           JSON.stringify({
@@ -561,6 +567,10 @@ export async function onRequestPut(context) {
       if (performanceDate !== undefined) {
         updates.push("performance_date = ?");
         params.push(resolvedPerformanceDate);
+      }
+      if (notes !== undefined) {
+        updates.push("notes = ?");
+        params.push(resolvedNotes);
       }
 
       // If performance fields to update

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -75,6 +75,7 @@ export async function onRequestGet(context) {
         p.start_time as startTime,
         p.end_time as endTime,
         p.performance_date as performanceDate,
+        p.notes,
         b.social_links,
         b.photo_url,
         v.name as venue,
@@ -144,6 +145,7 @@ export async function onRequestGet(context) {
         startTime: extractTime(band.startTime),
         endTime: extractTime(band.endTime),
         url: primaryUrl,
+        notes: band.notes || null,
       };
     });
 

--- a/functions/utils/validation.js
+++ b/functions/utils/validation.js
@@ -83,6 +83,9 @@ export const FIELD_LIMITS = {
   socialHandle: { min: 0, max: 100 },
   bandContactEmail: { min: 0, max: 255 },
 
+  // Performance fields
+  performanceNotes: { min: 0, max: 1000 },
+
   // Event fields
   eventName: { min: 3, max: 200 },
   eventSlug: { min: 3, max: 100 },
@@ -248,7 +251,7 @@ export function sanitizeString(input) {
   return input.replace(CONTROL_CHARS_REGEX, "").trim();
 }
 
-function sanitizeOptionalText(value, maxLength, label) {
+export function sanitizeOptionalText(value, maxLength, label) {
   if (value === undefined || value === null) {
     return null;
   }


### PR DESCRIPTION
## Summary

`performances.notes` (freeform TEXT, e.g. "Bonus set: ALL w/ Scott (Reynolds) -- sold out" or "All-ages kids set") existed in the schema but had zero rendering path anywhere — fetched by one admin query and silently discarded, no form field to create/edit it, and never exposed to the public API. Surfaced while setting up Buddies Fest 2 (event id 36), which uses this field for two genuine outliers: ALL performing twice with different guest vocalists, and a Kepi Ghoulie all-ages kids set.

This wires it end-to-end, intentionally reversing the field's prior (undocumented-in-practice, only asserted in a help tooltip) "admin-only" framing to make it fan-facing, per direct confirmation that these annotations need to be visible to users.

## What changed

| File | Change |
|------|--------|
| `functions/utils/validation.js` | Added `FIELD_LIMITS.performanceNotes` (0-1000 chars); exported the existing `sanitizeOptionalText` helper instead of writing a new sanitizer |
| `functions/api/admin/bands.js` | POST: sanitize + insert `notes` on performance create |
| `functions/api/admin/bands/[id].js` | PUT: sanitize + update `notes` (optional-field semantics); added to the archived-event `editsPerformanceFields` guard |
| `functions/api/schedule.js` | SELECT + return `notes` in the public schedule payload |
| `frontend/src/utils/validation.js` | Mirrored `FIELD_LIMITS.performanceNotes` |
| `frontend/src/admin/BandForm.jsx` | New "Notes (optional, shown to fans)" textarea |
| `frontend/src/admin/LineupTab.jsx` | Wired `notes` into formData/handleSubmit/startEdit; list view shows a truncated subtitle (desktop table + mobile card) |
| `frontend/src/admin/utils/pickerFormData.js` | Added `notes: ''` to `BLANK_SCHEDULE` for consistent init |
| `frontend/src/components/BandCard.jsx` | Renders the note as a small italic subtitle under the band name (public schedule), plain JSX interpolation only |
| `frontend/src/admin/components/HelpPanel.jsx` | Reworded copy to match the new fan-facing behavior |

`functions/event/[slug].js` was deliberately **not** touched — that file's performances query only feeds JSON-LD `MusicEvent.performer` (schema.org has no notes-equivalent property), and adding `notes` there would turn a `SELECT DISTINCT bp.id, bp.name` into duplicate `MusicGroup` entries whenever one band has two performances with different notes (exactly the ALL w/ Scott / ALL w/ Chad case). `ScheduleView.jsx`/`MySchedule.jsx` needed no changes — both already delegate band rendering to `BandCard`.

One production data point was audited before this went live: of 4 existing `performances.notes` values, one was an internal audit-trail note (a typo-correction comment, never meant for fans) and was cleared to `NULL` directly in prod ahead of this deploy so no internal shorthand would leak publicly.

## Security / correctness notes

- RBAC unchanged: both mutating endpoints already require `editor`+ via `checkPermission`, not touched by this diff.
- XSS: all rendering is plain JSX interpolation (`{band.notes}`) or a `title` attribute — both auto-escaped by React. No `dangerouslySetInnerHTML` sink touches this field.
- Validation: reuses the existing `sanitizeOptionalText` (trim, null-if-empty, length cap) rather than introducing a new pattern.
- Archived-event guard: `notes` added to the performance-fields check so notes can't be edited on an archived event's performances, consistent with time/venue.

## Verification

- [x] Tests: 470/470 frontend pass, 716/722 backend pass (6 pre-existing skipped/todo)
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [ ] `validate:openapi`: N/A, `docs/api-spec.yaml` not touched
- [x] Manual smoke: ran a local wrangler+D1 stack, logged into `/admin`, confirmed a seeded performance's notes round-trip correctly through the edit form (pre-filled textarea, save/reload), confirmed the admin lineup table shows the truncated subtitle, and confirmed the public `/event/:slug` page renders the same note as an italic subtitle under the band name. Also noticed and ruled out a pre-existing, unrelated CSP inline-style console warning on the admin edit form (reproduces on a performance with *no* notes too, so it predates this change).

Closes: N/A — surfaced and fixed within the same working session, not tracked as a separate issue beforehand.

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)