### PR TITLE
fix: align transactional email accent with brand orange

### DIFF
--- a/functions/utils/emailTemplates.js
+++ b/functions/utils/emailTemplates.js
@@ -1,6 +1,6 @@
 const BRAND = {
   name: "SetTimes",
-  accent: "#0ea5e9",
+  accent: "#f97316",
   background: "#0c0f1a",
   card: "#141927",
   text: "#e5e7eb",


### PR DESCRIPTION
## Summary

The transactional email template's `BRAND.accent` was still the pre-rebrand cyan (`#0ea5e9`). One-line swap to the brand orange (`#f97316`) per `docs/BRAND.md`. This is the email counterpart of the favicon/PWA icon fix in #582.

Closes #583

## What changed

| File | Change |
|------|--------|
| `functions/utils/emailTemplates.js` | `BRAND.accent: "#0ea5e9"` → `"#f97316"` |

`renderEmail()` backs every styled transactional email (invite, password reset, activation), so this covers all of them. The other email builders (`bandFollowNotify.js`, `announceDigest.js`, follow flows) send unstyled HTML with no colour values — verified no other cyan instance exists anywhere in `functions/`.

## Security / correctness notes

None functional. Accessibility verified: both accent usages (wordmark text on navy `#0c0f1a`, CTA button fill under the card `#141927`) clear WCAG AA — 6.82:1 and 6.25:1 respectively, both better than small-text AA (4.5:1).

Side finding, out of scope: the unsubscribe landing *page* (`functions/api/subscriptions/unsubscribe.js`) uses a different non-brand orange (`#ff6b35`) — noted for a possible follow-up, not touched here.

## Verification

- [x] Tests: 716 pass / 6 todo, 0 failures (`npm test`)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: N/A (backend-only, no frontend change)
- [ ] `validate:openapi`: N/A, spec not touched
- [x] Manual smoke: contrast ratios computed against actual template surface colours (no orange-on-white surface exists in this dark-themed template)

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)