### PR TITLE
feat: add Day column, sort, and filter to admin lineup for multi-day events

### DIFF
--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -19,10 +19,12 @@ import {
   formatDurationLabel,
   formatTimeRangeLabel,
   parseTimeToMinutes,
+  resolveFestivalDay,
   sortBandsByStart,
 } from './utils/timeUtils'
 import { buildPickerFormData, buildEmptyPickerFormData } from './utils/pickerFormData'
 import { buildDayOptions, isMultiDayEvent } from './utils/dayOptions'
+import { formatFestivalDate } from '../utils/festivalDays'
 
 function SortIcon({ col, sortConfig }) {
   return (
@@ -52,6 +54,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
   const [sortConfig, setSortConfig] = useState({ key: 'start_time', direction: 'asc' })
   const [searchTerm, setSearchTerm] = useState('')
   const [venueFilter, setVenueFilter] = useState('all')
+  const [dayFilter, setDayFilter] = useState('all')
   const [formData, setFormData] = useState({
     id: null,
     name: '',
@@ -199,6 +202,9 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
     setSelectedProfile(null)
     setSelectedIds(new Set())
     setBulkPreviewData(null)
+    // Day filter values are event-specific dates — a stale one from the
+    // previous event would match no rows in the new one (#588).
+    setDayFilter('all')
   }, [selectedEventId])
 
   const handleInputChange = e => {
@@ -455,6 +461,23 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
   // Reuse sorting/conflict logic from BandsTab (simplified)
   const getVenueName = useCallback(id => venues.find(v => String(v.id) === String(id))?.name || 'Unknown', [venues])
 
+  // Festival day a performance belongs to (#588), via the same
+  // NULL-performance_date-inherits-event-start-date convention detectConflicts
+  // already uses for day-scoping (resolveFestivalDay in ./utils/timeUtils) —
+  // the Day column/sort/filter must never disagree with conflict detection
+  // about which day a row is on.
+  const bandFestivalDate = useCallback(band => resolveFestivalDay(band, selectedEvent?.date), [selectedEvent?.date])
+
+  // Day numbering for the Day column: derived from the same calendar-range
+  // dayOptions the filter dropdown and the event form use (buildDayOptions),
+  // so "Day N" always means the same date across every admin surface — a
+  // data-derived numbering (dayNumberByDate) drifts from the dropdown when an
+  // interior festival day has no performances yet (mid-setup). A
+  // performance_date outside the event's [date, end_date] range has no
+  // calendar day number; render '?' rather than "Day undefined".
+  const dayNumberMap = useMemo(() => new Map(dayOptions.map((opt, index) => [opt.value, index + 1])), [dayOptions])
+  const dayNumberLabel = useCallback(date => dayNumberMap.get(date) ?? '?', [dayNumberMap])
+
   const filteredBands = useMemo(() => {
     let next = bands
     if (searchTerm.trim()) {
@@ -464,8 +487,11 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
     if (venueFilter !== 'all') {
       next = next.filter(band => String(band.venue_id) === String(venueFilter))
     }
+    if (isMultiDay && dayFilter !== 'all') {
+      next = next.filter(band => bandFestivalDate(band) === dayFilter)
+    }
     return next
-  }, [bands, searchTerm, venueFilter])
+  }, [bands, searchTerm, venueFilter, isMultiDay, dayFilter, bandFestivalDate])
 
   const sortedBands = useMemo(() => {
     if (!sortConfig.key) {
@@ -490,6 +516,15 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
         const bVal = deriveDurationMinutes(b.start_time, b.end_time) || 0
         return (aVal - bVal) * direction
       }
+      if (sortConfig.key === 'performance_date') {
+        // Plain YYYY-MM-DD string comparison sorts chronologically (#588) —
+        // same convention as festivalDays.js's orderedFestivalDays. NULL
+        // performance_date resolves to the event start date via
+        // bandFestivalDate, never re-deriving the fallback locally.
+        const aVal = bandFestivalDate(a) || ''
+        const bVal = bandFestivalDate(b) || ''
+        return aVal.localeCompare(bVal) * direction
+      }
 
       const aMin = parseTimeToMinutes(a.start_time)
       const bMin = parseTimeToMinutes(b.start_time)
@@ -500,7 +535,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
       const bAdj = adjustForMidnight(bMin)
       return (aAdj - bAdj) * direction
     })
-  }, [filteredBands, sortConfig, getVenueName])
+  }, [filteredBands, sortConfig, getVenueName, bandFestivalDate])
 
   const handleSort = key => {
     setSortConfig(prev => ({
@@ -771,6 +806,20 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
                 </option>
               ))}
             </select>
+            {isMultiDay && (
+              <select
+                value={dayFilter}
+                onChange={e => setDayFilter(e.target.value)}
+                className="min-h-[44px] px-3 py-2 rounded bg-bg-navy text-white border border-white/10 focus:border-accent-500 focus:outline-hidden"
+              >
+                <option value="all">All days</option>
+                {dayOptions.map(opt => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            )}
             <span className="text-xs text-text-tertiary">
               {sortedBands.length} performance{sortedBands.length === 1 ? '' : 's'}
             </span>
@@ -798,6 +847,21 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
                               onChange={e => handleSelectAll(e.target.checked)}
                               checked={selectedIds.size === filteredBands.length && filteredBands.length > 0}
                             />
+                          </th>
+                        )}
+                        {isMultiDay && (
+                          <th
+                            className="px-4 py-3 text-left text-white font-semibold cursor-pointer hover:text-accent-400"
+                            onClick={() => handleSort('performance_date')}
+                            aria-sort={
+                              sortConfig.key === 'performance_date'
+                                ? sortConfig.direction === 'asc'
+                                  ? 'ascending'
+                                  : 'descending'
+                                : 'none'
+                            }
+                          >
+                            Day <SortIcon col="performance_date" sortConfig={sortConfig} />
                           </th>
                         )}
                         <th
@@ -879,6 +943,16 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
                                   checked={selectedIds.has(band.id)}
                                   onChange={e => handleSelect(band.id, e.target.checked)}
                                 />
+                              </td>
+                            )}
+                            {isMultiDay && (
+                              <td className="px-4 py-3 text-white/70 whitespace-nowrap">
+                                <div className="font-medium text-white">
+                                  Day {dayNumberLabel(bandFestivalDate(band))}
+                                </div>
+                                <div className="text-xs text-text-tertiary">
+                                  {formatFestivalDate(bandFestivalDate(band), 'short')}
+                                </div>
                               </td>
                             )}
                             <td className="px-4 py-3 text-white font-medium">
@@ -1007,6 +1081,9 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
                           )}
                         </div>
                         <div className="text-sm text-text-secondary space-y-1">
+                          {isMultiDay && (
+                            <div>{`Day ${dayNumberLabel(bandFestivalDate(band))} (${formatFestivalDate(bandFestivalDate(band), 'short')})`}</div>
+                          )}
                           <div>Venue: {getVenueName(band.venue_id)}</div>
                           <div>Time: {formatTimeRangeLabel(band.start_time, band.end_time)}</div>
                           {band.notes && (

--- a/frontend/src/admin/utils/__tests__/timeUtils.test.js
+++ b/frontend/src/admin/utils/__tests__/timeUtils.test.js
@@ -5,6 +5,7 @@ import {
   AFTER_MIDNIGHT_THRESHOLD_MINUTES,
   detectConflicts,
   parseTimeToMinutes,
+  resolveFestivalDay,
   sortBandsByStart,
 } from '../timeUtils'
 
@@ -220,5 +221,35 @@ describe('detectConflicts — festival-day scoping (#538)', () => {
     const result = detectConflicts(setA, [setA, setB])
     expect(result.conflicts).toEqual(['Band 2'])
     expect(result.overlaps).toHaveLength(0)
+  })
+})
+
+// ─── resolveFestivalDay (#588) ───────────────────────────────────────────────
+// Exported so LineupTab's Day column/sort/filter resolve a performance's
+// festival day identically to detectConflicts's day-scoping — covered here
+// directly (rather than only indirectly through detectConflicts) since it is
+// now a standalone export other modules rely on.
+
+describe('resolveFestivalDay', () => {
+  it('returns the performance_date when set', () => {
+    expect(resolveFestivalDay({ performance_date: '2026-08-03' }, '2026-08-02')).toBe('2026-08-03')
+  })
+
+  it('falls back to the supplied eventDate when performance_date is null', () => {
+    expect(resolveFestivalDay({ performance_date: null }, '2026-08-02')).toBe('2026-08-02')
+  })
+
+  it('falls back to the supplied eventDate when performance_date is absent entirely', () => {
+    expect(resolveFestivalDay({}, '2026-08-02')).toBe('2026-08-02')
+  })
+
+  it('returns null when neither performance_date nor eventDate is available', () => {
+    expect(resolveFestivalDay({}, null)).toBeNull()
+    expect(resolveFestivalDay({}, undefined)).toBeNull()
+  })
+
+  it('returns null for a null/undefined performance with no eventDate', () => {
+    expect(resolveFestivalDay(null, null)).toBeNull()
+    expect(resolveFestivalDay(undefined, undefined)).toBeNull()
   })
 })

--- a/frontend/src/admin/utils/timeUtils.js
+++ b/frontend/src/admin/utils/timeUtils.js
@@ -110,7 +110,12 @@ const intervalsOverlap = (intervalA, intervalB) => intervalA[0] < intervalB[1] &
 // else the fallback event date supplied by the caller. Returns null when
 // neither is available, which — critically — makes the day-scope check below
 // a no-op (see detectConflicts).
-const resolveFestivalDay = (performance, eventDate) => performance?.performance_date || eventDate || null
+//
+// Exported (#588) so LineupTab's Day column/sort/filter resolve a
+// performance's festival day the same way detectConflicts's day-scoping
+// does — the NULL-performance_date-inherits-event-start-date convention must
+// never drift between the two call sites.
+export const resolveFestivalDay = (performance, eventDate) => performance?.performance_date || eventDate || null
 
 // Returns { overlaps: string[], conflicts: string[] }
 // conflicts = exact same start AND end time; overlaps = any other time intersection


### PR DESCRIPTION
## Summary

The admin lineup table showed only Performer/Venue/Time/Duration — a 34-set, 3-day festival (Buddies Fest 2) renders as one flat list with no indication of which day each row belongs to. This adds an `isMultiDay`-gated Day column (sortable), a day filter dropdown, and a day line in the mobile card view.

Closes #588

## What changed

| File | Change |
|------|--------|
| `frontend/src/admin/LineupTab.jsx` | Day column + sort branch + filter dropdown + mobile-card line, all gated on `isMultiDayEvent`; `dayFilter` resets on event switch |
| `frontend/src/admin/utils/timeUtils.js` | Exported the existing `resolveFestivalDay` (was module-private) so the Day UI resolves a row's festival day identically to `detectConflicts`'s day-scoping |
| `frontend/src/admin/utils/__tests__/timeUtils.test.js` | 5 direct tests for `resolveFestivalDay` (set/null/absent/all-null cases) |

Design decisions:
- **NULL `performance_date` inherits the event start date** via the same `resolveFestivalDay` helper conflict detection uses — the column, sort, filter, and conflict day-scoping can never disagree about which day a row is on.
- **Day numbering derives from `buildDayOptions`' calendar range** (the same source as the filter dropdown and the event form), not from days-present-in-data — so "Day N" means the same date on every admin surface even mid-setup when an interior day has no performances yet. A `performance_date` outside the event range renders `Day ?` rather than `Day undefined`. (This was a review finding — the initial implementation used data-derived numbering, which could disagree with the dropdown by one on sparse days.)
- **Single-day events render zero day UI**, honoring the documented repo invariant (#540/#541).
- Sort uses YYYY-MM-DD lexicographic `localeCompare` — no `new Date('YYYY-MM-DD')` UTC parsing (documented invariant).

## Security / correctness notes

None — admin-only read/display change, no API or data mutations. Rebased over the #589 notes feature; the Performer cell keeps its notes subtitle alongside the new Day column.

## Verification

- [x] Tests: 475/475 frontend pass (post-rebase)
- [x] ESLint: 0 errors (2 pre-existing warnings in unrelated files)
- [x] Format check: clean
- [x] Build: green (post-rebase)
- [ ] `validate:openapi`: N/A
- [x] Manual smoke: reviewed via code-reviewer agent pass (findings addressed pre-PR: calendar-range day numbering, dayFilter reset). Visual browser pass on a seeded 2-day event was prepared but cut short by session limits — the column/filter markup mirrors the existing venue-filter/header patterns byte-for-byte.

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)