### PR TITLE
feat: ignore leading articles (The/A/An) in band-name sorting

### DIFF
--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -10,6 +10,7 @@ import ArtistPicker from './components/ArtistPicker'
 import ConfirmDialog from '../components/ui/ConfirmDialog'
 import { DEFAULT_GENRES, getNormalizedGenreSuggestions } from '../utils/genres'
 import { parseOrigin } from '../utils/parseOrigin'
+import { sortableName } from '../utils/sortableName'
 import {
   adjustForMidnight,
   calculateEndTimeFromDuration,
@@ -502,8 +503,9 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
 
     return [...filteredBands].sort((a, b) => {
       if (sortConfig.key === 'name') {
-        const aVal = (a.name || '').toLowerCase()
-        const bVal = (b.name || '').toLowerCase()
+        // Article-stripped alphabetization (#587) — "The Anti-Queens" sorts under A.
+        const aVal = sortableName(a.name)
+        const bVal = sortableName(b.name)
         return aVal.localeCompare(bVal) * direction
       }
       if (sortConfig.key === 'venue') {

--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -5,6 +5,7 @@ import { DEFAULT_GENRES, getNormalizedGenreSuggestions } from '../utils/genres'
 import { safeExternalHref, safeHttpsFallbackHref, safeInstagramHref } from '../utils/urlSafety'
 import { Globe } from 'lucide-react'
 import { parseOrigin } from '../utils/parseOrigin'
+import { sortableName } from '../utils/sortableName'
 import {
   AppleMusicIcon,
   BandcampIcon,
@@ -280,6 +281,12 @@ export default function RosterTab({ showToast, readOnly = false }) {
         const aVal = a.follower_count ?? 0
         const bVal = b.follower_count ?? 0
         return sortConfig.direction === 'asc' ? aVal - bVal : bVal - aVal
+      }
+      if (sortConfig.key === 'name') {
+        // Article-stripped alphabetization (#587) — "The Anti-Queens" sorts under A.
+        const aVal = sortableName(a.name)
+        const bVal = sortableName(b.name)
+        return sortConfig.direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
       }
       const aVal = (a[sortConfig.key] || '').toLowerCase()
       const bVal = (b[sortConfig.key] || '').toLowerCase()

--- a/frontend/src/admin/utils/__tests__/timeUtils.test.js
+++ b/frontend/src/admin/utils/__tests__/timeUtils.test.js
@@ -50,6 +50,28 @@ describe('sortBandsByStart — after-midnight ordering', () => {
     expect(result.map(b => b.name)).toEqual(['Evening', 'Late', 'TBD'])
   })
 
+  it('falls back to article-stripped alphabetical order when both bands lack a start time (#587)', () => {
+    const bands = [
+      { id: 1, name: 'Zebras', start_time: null },
+      { id: 2, name: 'The Anti-Queens', start_time: null },
+      { id: 3, name: 'Beatles', start_time: null },
+    ]
+    const result = sortBandsByStart(bands)
+    // Raw byte order would be Beatles, The Anti-Queens, Zebras (T before Z).
+    // Article-stripped order puts "The Anti-Queens" under A.
+    expect(result.map(b => b.name)).toEqual(['The Anti-Queens', 'Beatles', 'Zebras'])
+  })
+
+  it('falls back to article-stripped alphabetical order when adjusted start times tie (#587)', () => {
+    const bands = [
+      { id: 1, name: 'Zebras', start_time: '20:00' },
+      { id: 2, name: 'The Anti-Queens', start_time: '20:00' },
+      { id: 3, name: 'Beatles', start_time: '20:00' },
+    ]
+    const result = sortBandsByStart(bands)
+    expect(result.map(b => b.name)).toEqual(['The Anti-Queens', 'Beatles', 'Zebras'])
+  })
+
   it('keeps TBD bands at the end when sorting descending (LineupTab inline sort regression)', () => {
     // Simulates the manual sort in LineupTab with direction = -1 (descending).
     // Null times must always go last regardless of sort direction.

--- a/frontend/src/admin/utils/timeUtils.js
+++ b/frontend/src/admin/utils/timeUtils.js
@@ -1,4 +1,5 @@
 import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from '../../utils/festivalDays'
+import { compareByName } from '../../utils/sortableName'
 
 const MINUTES_PER_DAY = 24 * 60
 // Bands starting before this hour are treated as after-midnight (same night as the preceding
@@ -209,7 +210,8 @@ export const sortBandsByStart = bands => {
     const bMinutes = parseTimeToMinutes(bandB?.start_time)
 
     if (aMinutes == null && bMinutes == null) {
-      return (bandA?.name || '').localeCompare(bandB?.name || '')
+      // Article-stripped alphabetization (#587) — "The Anti-Queens" sorts under A.
+      return compareByName(bandA, bandB)
     }
 
     if (aMinutes == null) return 1
@@ -219,7 +221,7 @@ export const sortBandsByStart = bands => {
     const bAdj = adjustForMidnight(bMinutes)
 
     if (aAdj === bAdj) {
-      return (bandA?.name || '').localeCompare(bandB?.name || '')
+      return compareByName(bandA, bandB)
     }
 
     return aAdj - bAdj

--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -1,6 +1,7 @@
 import { Check, Copy, Music } from 'lucide-react'
 import { Fragment, memo, useMemo, useState } from 'react'
 import { copyToClipboard } from '../utils/clipboard'
+import { compareByName } from '../utils/sortableName'
 import { dayNumberByDate, isMultiDay } from '../utils/festivalDays'
 import { formatTime, formatTimeRange } from '../utils/timeFormat'
 import { filterPerformancesByTime } from '../utils/timeFilter'
@@ -119,7 +120,7 @@ function ScheduleView({
         const bTBD = !b.startTime || b.startTime === 'TBD'
         if (aTBD && !bTBD) return 1
         if (!aTBD && bTBD) return -1
-        if (aTBD && bTBD) return a.name.localeCompare(b.name)
+        if (aTBD && bTBD) return compareByName(a, b)
         const aTime = typeof a.startMs === 'number' ? a.startMs : Date.parse(`${a.date}T${a.startTime}:00`)
         const bTime = typeof b.startMs === 'number' ? b.startMs : Date.parse(`${b.date}T${b.startTime}:00`)
         return aTime === bTime ? (a.venue ?? '').localeCompare(b.venue ?? '') : aTime - bTime

--- a/frontend/src/utils/__tests__/sortableName.test.js
+++ b/frontend/src/utils/__tests__/sortableName.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { sortableName, compareByName } from '../sortableName'
+
+describe('sortableName', () => {
+  it('strips a leading "The " (case-insensitive) so the name sorts under its first real word', () => {
+    expect(sortableName('The Anti-Queens')).toBe('anti-queens')
+    expect(sortableName('the anti-queens')).toBe('anti-queens')
+    expect(sortableName('THE ANTI-QUEENS')).toBe('anti-queens')
+  })
+
+  it('strips a leading "A " so the name sorts under its first real word', () => {
+    expect(sortableName('A Day to Remember')).toBe('day to remember')
+  })
+
+  it('strips a leading "An " so the name sorts under its first real word', () => {
+    expect(sortableName('An Horse')).toBe('horse')
+  })
+
+  it('does not strip "The"/"A"/"An" when it is the whole name (no trailing word)', () => {
+    expect(sortableName('The')).toBe('the')
+    expect(sortableName('A')).toBe('a')
+    expect(sortableName('An')).toBe('an')
+  })
+
+  it('does not falsely strip words that merely start with an article ("Theory", "Anthem", "Antler")', () => {
+    expect(sortableName('Theory')).toBe('theory')
+    expect(sortableName('Anthem')).toBe('anthem')
+    expect(sortableName('Antler')).toBe('antler')
+    expect(sortableName('Android Apocalypse')).toBe('android apocalypse')
+  })
+
+  it('only strips the article when it is the very first word (not mid-name)', () => {
+    expect(sortableName('Beyond The Valley')).toBe('beyond the valley')
+  })
+
+  it('is null/empty safe', () => {
+    expect(sortableName(null)).toBe('')
+    expect(sortableName(undefined)).toBe('')
+    expect(sortableName('')).toBe('')
+    expect(sortableName('   ')).toBe('')
+    expect(sortableName(42)).toBe('')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(sortableName('  The Beatles  ')).toBe('beatles')
+  })
+
+  it('never mutates the original string (sort key only)', () => {
+    const name = 'The Anti-Queens'
+    sortableName(name)
+    expect(name).toBe('The Anti-Queens')
+  })
+})
+
+describe('compareByName', () => {
+  it('accepts plain strings', () => {
+    expect(compareByName('The Anti-Queens', 'Beatles')).toBeLessThan(0)
+  })
+
+  it('accepts objects with a .name property', () => {
+    expect(compareByName({ name: 'The Anti-Queens' }, { name: 'Beatles' })).toBeLessThan(0)
+  })
+
+  it('is null/empty safe for missing names', () => {
+    expect(compareByName({}, { name: 'Beatles' })).toBeLessThan(0)
+    expect(compareByName(null, undefined)).toBe(0)
+  })
+
+  it('sorts a mixed list of article and non-article band names into correct alphabetical order (#587)', () => {
+    const bands = [
+      { name: 'The Anti-Queens' },
+      { name: 'Beatles' },
+      { name: 'A Day to Remember' },
+      { name: 'An Horse' },
+      { name: 'Zebras' },
+      { name: 'Theory of a Deadman' },
+      { name: 'The' },
+    ]
+
+    const sorted = [...bands].sort(compareByName).map(b => b.name)
+
+    // Expected alpha order by first significant word:
+    // "The" (no strippable word, sorts as "the")
+    // "The Anti-Queens" -> anti-queens
+    // "Beatles" -> beatles
+    // "A Day to Remember" -> day to remember
+    // "An Horse" -> horse
+    // "Theory of a Deadman" -> theory of a deadman
+    // "Zebras" -> zebras
+    expect(sorted).toEqual([
+      'The Anti-Queens',
+      'Beatles',
+      'A Day to Remember',
+      'An Horse',
+      'The',
+      'Theory of a Deadman',
+      'Zebras',
+    ])
+  })
+})

--- a/frontend/src/utils/sortableName.js
+++ b/frontend/src/utils/sortableName.js
@@ -1,0 +1,47 @@
+/**
+ * Alphabetical sort key for a band/artist name that ignores a leading
+ * article ("The ", "A ", "An ") — standard library/catalog alphabetization
+ * convention. "The Anti-Queens" must sort under A, not T (#587).
+ *
+ * Sort-key only — never mutates the displayed name. Callers keep showing
+ * `band.name` as-is; only the value fed to a comparator changes.
+ *
+ * The article must be followed by whitespace to strip, so a band literally
+ * named "The" or "A" (no following word) and names like "Theory" or
+ * "Anthem" (no space after "the"/"an") are left untouched.
+ *
+ * Mirrored in `functions/utils/sortableName.js` — the frontend and Cloudflare
+ * Pages Functions don't share a module graph, so this helper is duplicated
+ * rather than imported across the boundary (same precedent as `FIELD_LIMITS`
+ * between this file's `validation.js` and `functions/utils/validation.js`).
+ * Keep the two copies' behavior identical; update both together.
+ *
+ * @param {string|null|undefined} name
+ * @returns {string} Lowercased sort key, safe to feed to `<`/`>`/`localeCompare`.
+ */
+
+const LEADING_ARTICLE_REGEX = /^(the|an?)\s+/i
+
+export function sortableName(name) {
+  if (typeof name !== 'string') return ''
+  const trimmed = name.trim()
+  if (!trimmed) return ''
+  const stripped = trimmed.replace(LEADING_ARTICLE_REGEX, '').trim()
+  return (stripped || trimmed).toLowerCase()
+}
+
+/**
+ * Comparator for `Array.prototype.sort` that compares two names via
+ * `sortableName` (article-stripped) using `localeCompare`. Accepts either a
+ * raw name string or an object with a `.name` property, since call sites sort
+ * both plain strings and band/performance records.
+ *
+ * @param {string|{name?: string}|null|undefined} a
+ * @param {string|{name?: string}|null|undefined} b
+ * @returns {number}
+ */
+export function compareByName(a, b) {
+  const nameA = typeof a === 'string' ? a : a?.name
+  const nameB = typeof b === 'string' ? b : b?.name
+  return sortableName(nameA).localeCompare(sortableName(nameB))
+}

--- a/functions/api/__tests__/artists.test.js
+++ b/functions/api/__tests__/artists.test.js
@@ -100,4 +100,25 @@ describe("Public artists directory - GET /api/artists", () => {
     const res = await getArtists(env);
     expect(res.status).toBe(503);
   });
+
+  it("orders results alphabetically ignoring a leading article (#587)", async () => {
+    const { env, rawDb } = seedEnv();
+    const venue = insertVenue(rawDb, { name: "Main" });
+    const ev = insertEvent(rawDb, { name: "Sort Fest", slug: "sort-fest" });
+    publish(rawDb, ev.id);
+
+    // Inserted out of both raw-name and article-stripped order.
+    for (const name of ["Zebras", "The Anti-Queens", "Beatles", "An Horse"]) {
+      insertBand(rawDb, { name, event_id: ev.id, venue_id: venue.id });
+    }
+
+    const res = await getArtists(env);
+    expect(res.status).toBe(200);
+    const { artists: list } = await res.json();
+    const names = list.map((a) => a.name);
+
+    // Article-stripped order: Anti-Queens, Beatles, Horse, Zebras — NOT the
+    // raw-byte order (which would put "The Anti-Queens" under T, after "Beatles").
+    expect(names).toEqual(["The Anti-Queens", "Beatles", "An Horse", "Zebras"]);
+  });
 });

--- a/functions/api/admin/bands.js
+++ b/functions/api/admin/bands.js
@@ -17,6 +17,35 @@ import {
 import { buildIntervals, intervalsOverlap } from "../../utils/timeConflicts.js";
 import { parseOrigin } from "../../utils/parseOrigin.js";
 import { normalizeBandName } from "../../utils/bandName.js";
+import { sortableName } from "../../utils/sortableName.js";
+
+// SQLite `ORDER BY` can't strip a leading article inline (#587), so the SQL
+// in onRequestGet below is a coarse pre-sort (correct on start_time/event_date,
+// raw-byte on name) and the exact ordering is re-derived in JS afterward,
+// swapping the name comparison for the article-stripped `sortableName` key.
+// These mirror the NULL-ordering SQLite applies by default: ASC puts NULLs
+// first, DESC puts NULLs last.
+function compareStartTimeNullsLast(a, b) {
+  if (a.start_time == null && b.start_time == null) return 0;
+  if (a.start_time == null) return 1;
+  if (b.start_time == null) return -1;
+  return a.start_time < b.start_time ? -1 : a.start_time > b.start_time ? 1 : 0;
+}
+
+function compareStartTimeNullsFirst(a, b) {
+  if (a.start_time == null && b.start_time == null) return 0;
+  if (a.start_time == null) return -1;
+  if (b.start_time == null) return 1;
+  return a.start_time < b.start_time ? -1 : a.start_time > b.start_time ? 1 : 0;
+}
+
+function compareEventDateDescNullsLast(a, b) {
+  if (a.event_date == null && b.event_date == null) return 0;
+  if (a.event_date == null) return 1;
+  if (b.event_date == null) return -1;
+  if (a.event_date === b.event_date) return 0;
+  return a.event_date > b.event_date ? -1 : 1;
+}
 
 async function getEventStatus(DB, eventId) {
   if (!eventId) return null;
@@ -211,6 +240,22 @@ export async function onRequestGet(context) {
     }
 
     const bands = (result.results || []).map(unpackSocialLinks);
+
+    // Re-derive the exact ordering in JS with the article-stripped sort key
+    // (#587) — see the comparator helpers above. No pagination-boundary risk:
+    // the eventId branch has no LIMIT/OFFSET (one event's full lineup), and
+    // no admin UI consumer requests the "list all" branch beyond its single
+    // default page.
+    if (eventId) {
+      bands.sort((a, b) => compareStartTimeNullsLast(a, b) || sortableName(a.name).localeCompare(sortableName(b.name)));
+    } else {
+      bands.sort(
+        (a, b) =>
+          compareEventDateDescNullsLast(a, b) ||
+          compareStartTimeNullsFirst(a, b) ||
+          sortableName(a.name).localeCompare(sortableName(b.name)),
+      );
+    }
 
     return new Response(JSON.stringify({ success: true, bands }), {
       headers: { "Content-Type": "application/json" },

--- a/functions/api/admin/events/[id]/metrics.js
+++ b/functions/api/admin/events/[id]/metrics.js
@@ -1,5 +1,6 @@
 import { checkPermission } from "../../_middleware.js";
 import { validateId } from "../../../../utils/validation.js";
+import { sortableName } from "../../../../utils/sortableName.js";
 
 export async function onRequestGet(context) {
   const { env, params } = context;
@@ -81,6 +82,17 @@ export async function onRequestGet(context) {
     const shareStats = shareStatsRes.results?.[0];
     const topSharedRoutes = topRoutesRes.results || [];
     const announcementPlanning = announcementPlanningRes.results || [];
+    // bp.name is only the final tiebreaker here (after is_announced, then
+    // follower_count) — SQLite ORDER BY can't strip a leading article inline
+    // (#587), so re-derive that last tiebreaker in JS with the article-stripped
+    // key. Cheap to do since is_announced/follower_count are already correct
+    // from SQL; this only reorders ties on both of those.
+    announcementPlanning.sort(
+      (a, b) =>
+        (a.is_announced ?? 0) - (b.is_announced ?? 0) ||
+        (b.follower_count ?? 0) - (a.follower_count ?? 0) ||
+        sortableName(a.band_name).localeCompare(sortableName(b.band_name)),
+    );
 
     // Share-link analytics: shares created + total views + top routes by views.
     // Derived directly from share_links (creates are rows; views are view_count),

--- a/functions/api/artists.js
+++ b/functions/api/artists.js
@@ -6,9 +6,18 @@
 // PUBLIC_DATA_PUBLISH_ENABLED switch as the rest of the public data.
 
 import { getPublicDataGateResponse } from "../utils/publicGate.js";
+import { sortableName } from "../utils/sortableName.js";
 
 const DEFAULT_LIMIT = 24;
 const MAX_LIMIT = 60;
+// SQLite ORDER BY can't strip a leading "The"/"A"/"An" inline (#587), so this
+// endpoint fetches every matching row (up to this generous safety cap, far
+// beyond any realistic band count for the roster), sorts by the
+// article-stripped key in JS, then paginates in JS. Re-sorting only the
+// LIMIT/OFFSET page returned by SQL would misorder results across page
+// boundaries — this is the primary public artist directory, so pagination
+// must stay globally consistent.
+const FETCH_CAP = 2000;
 
 function formatOrigin(row) {
   const parts = [row.origin_city, row.origin_region].filter(Boolean);
@@ -36,7 +45,8 @@ export async function onRequestGet(context) {
   const like = `%${q.replace(/[%_\\]/g, (m) => `\\${m}`)}%`;
 
   try {
-    // Fetch one extra row to compute hasMore without a separate COUNT query.
+    // Coarse SQL pre-sort (COLLATE NOCASE) — the real article-stripped order
+    // is applied in JS below, across the whole match set, before pagination.
     const rows = await DB.prepare(
       `
       SELECT
@@ -60,15 +70,15 @@ export async function onRequestGet(context) {
         )
       GROUP BY bp.id
       ORDER BY bp.name COLLATE NOCASE
-      LIMIT ? OFFSET ?
+      LIMIT ?
     `,
     )
-      .bind(q, like, like, limit + 1, offset)
+      .bind(q, like, like, FETCH_CAP)
       .all();
 
-    const results = rows.results || [];
-    const hasMore = results.length > limit;
-    const artists = results.slice(0, limit).map((row) => ({
+    const allResults = (rows.results || []).sort((a, b) => sortableName(a.name).localeCompare(sortableName(b.name)));
+    const hasMore = allResults.length > offset + limit;
+    const artists = allResults.slice(offset, offset + limit).map((row) => ({
       id: row.id,
       name: row.name,
       photo_url: row.photo_url,

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -1,4 +1,17 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
+import { sortableName } from "../../../utils/sortableName.js";
+
+// SQLite `ORDER BY` can't strip a leading article inline (#587); the SQL
+// query below is a coarse pre-sort and this comparator re-derives the exact
+// ordering afterward, swapping the name comparison for the article-stripped
+// `sortableName` key. Mirrors SQLite's default NULLS-first-for-ASC handling
+// with an explicit NULLS LAST override (matching `... NULLS LAST` in the SQL).
+function compareStartTimeNullsLast(a, b) {
+  if (a.start_time == null && b.start_time == null) return 0;
+  if (a.start_time == null) return 1;
+  if (b.start_time == null) return -1;
+  return a.start_time < b.start_time ? -1 : a.start_time > b.start_time ? 1 : 0;
+}
 
 /**
  * Public API: Get recap stats and band list for a single archived event
@@ -99,6 +112,8 @@ export async function onRequestGet(context) {
         is_returning: isReturning,
       };
     });
+
+    bands.sort((a, b) => compareStartTimeNullsLast(a, b) || sortableName(a.name).localeCompare(sortableName(b.name)));
 
     const stats = {
       total_sets: rows.length, // performance slots; one band playing two sets counts as 2

--- a/functions/event/[slug].js
+++ b/functions/event/[slug].js
@@ -4,6 +4,7 @@
 import { isPublicDataEnabled } from "../utils/publicGate.js";
 import { escapeAttr, toPlainText, serveWithInjectedMeta, WATERLOO_ADDRESS, CANONICAL_HOST } from "../utils/ssrMeta.js";
 import { normalizeHttpUrl } from "../utils/validation.js";
+import { sortableName } from "../utils/sortableName.js";
 
 export async function onRequest(context) {
   const { params, env, request } = context;
@@ -58,6 +59,11 @@ export async function onRequest(context) {
     // Non-fatal: fall through with empty arrays; MusicEvent still renders.
     console.error("SSR event bands/venues lookup failed:", slug, err);
   }
+
+  // SQLite ORDER BY can't strip a leading article inline (#587); the query
+  // above is a coarse pre-sort and the JSON-LD performer list is re-sorted
+  // here by the article-stripped key so "The Anti-Queens" lists under A.
+  bands.sort((a, b) => sortableName(a.name).localeCompare(sortableName(b.name)));
 
   // Pin to the production host — preview deploys must not self-canonicalise.
   const url = `${CANONICAL_HOST}/event/${event.slug}`;

--- a/functions/utils/__tests__/sortableName.test.js
+++ b/functions/utils/__tests__/sortableName.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { sortableName, compareByName } from "../sortableName.js";
+
+describe("sortableName", () => {
+  it('strips a leading "The " (case-insensitive) so the name sorts under its first real word', () => {
+    expect(sortableName("The Anti-Queens")).toBe("anti-queens");
+    expect(sortableName("the anti-queens")).toBe("anti-queens");
+    expect(sortableName("THE ANTI-QUEENS")).toBe("anti-queens");
+  });
+
+  it('strips a leading "A " so the name sorts under its first real word', () => {
+    expect(sortableName("A Day to Remember")).toBe("day to remember");
+  });
+
+  it('strips a leading "An " so the name sorts under its first real word', () => {
+    expect(sortableName("An Horse")).toBe("horse");
+  });
+
+  it('does not strip "The"/"A"/"An" when it is the whole name (no trailing word)', () => {
+    expect(sortableName("The")).toBe("the");
+    expect(sortableName("A")).toBe("a");
+    expect(sortableName("An")).toBe("an");
+  });
+
+  it('does not falsely strip words that merely start with an article ("Theory", "Anthem", "Antler")', () => {
+    expect(sortableName("Theory")).toBe("theory");
+    expect(sortableName("Anthem")).toBe("anthem");
+    expect(sortableName("Antler")).toBe("antler");
+    expect(sortableName("Android Apocalypse")).toBe("android apocalypse");
+  });
+
+  it("only strips the article when it is the very first word (not mid-name)", () => {
+    expect(sortableName("Beyond The Valley")).toBe("beyond the valley");
+  });
+
+  it("is null/empty safe", () => {
+    expect(sortableName(null)).toBe("");
+    expect(sortableName(undefined)).toBe("");
+    expect(sortableName("")).toBe("");
+    expect(sortableName("   ")).toBe("");
+    expect(sortableName(42)).toBe("");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(sortableName("  The Beatles  ")).toBe("beatles");
+  });
+
+  it("never mutates the original string (sort key only)", () => {
+    const name = "The Anti-Queens";
+    sortableName(name);
+    expect(name).toBe("The Anti-Queens");
+  });
+});
+
+describe("compareByName", () => {
+  it("accepts plain strings", () => {
+    expect(compareByName("The Anti-Queens", "Beatles")).toBeLessThan(0);
+  });
+
+  it("accepts objects with a .name property", () => {
+    expect(compareByName({ name: "The Anti-Queens" }, { name: "Beatles" })).toBeLessThan(0);
+  });
+
+  it("is null/empty safe for missing names", () => {
+    expect(compareByName({}, { name: "Beatles" })).toBeLessThan(0);
+    expect(compareByName(null, undefined)).toBe(0);
+  });
+
+  it("sorts a mixed list of article and non-article band names into correct alphabetical order (#587)", () => {
+    const bands = [
+      { name: "The Anti-Queens" },
+      { name: "Beatles" },
+      { name: "A Day to Remember" },
+      { name: "An Horse" },
+      { name: "Zebras" },
+      { name: "Theory of a Deadman" },
+      { name: "The" },
+    ];
+
+    const sorted = [...bands].sort(compareByName).map((b) => b.name);
+
+    expect(sorted).toEqual([
+      "The Anti-Queens",
+      "Beatles",
+      "A Day to Remember",
+      "An Horse",
+      "The",
+      "Theory of a Deadman",
+      "Zebras",
+    ]);
+  });
+});

--- a/functions/utils/sortableName.js
+++ b/functions/utils/sortableName.js
@@ -1,0 +1,50 @@
+// Alphabetical sort key for a band/artist name that ignores a leading
+// article ("The ", "A ", "An ") — standard library/catalog alphabetization
+// convention. "The Anti-Queens" must sort under A, not T (#587).
+//
+// Sort-key only — never mutates the displayed name. Callers keep returning
+// `name` as-is; only the value fed to a comparator/ORDER-BY-replacement
+// changes. SQLite's `ORDER BY` can't strip the article inline, so backend
+// endpoints use a coarse SQL pre-sort (or none) and re-sort in JS with this
+// helper before responding.
+//
+// The article must be followed by whitespace to strip, so a band literally
+// named "The" or "A" (no following word) and names like "Theory" or
+// "Anthem" (no space after "the"/"an") are left untouched.
+//
+// Mirrored in `frontend/src/utils/sortableName.js` — the frontend and
+// Cloudflare Pages Functions don't share a module graph, so this helper is
+// duplicated rather than imported across the boundary (same precedent as
+// `FIELD_LIMITS` between this file's `validation.js` and
+// `frontend/src/utils/validation.js`). Keep the two copies' behavior
+// identical; update both together.
+
+const LEADING_ARTICLE_REGEX = /^(the|an?)\s+/i;
+
+/**
+ * @param {string|null|undefined} name
+ * @returns {string} Lowercased sort key, safe to feed to `<`/`>`/`localeCompare`.
+ */
+export function sortableName(name) {
+  if (typeof name !== "string") return "";
+  const trimmed = name.trim();
+  if (!trimmed) return "";
+  const stripped = trimmed.replace(LEADING_ARTICLE_REGEX, "").trim();
+  return (stripped || trimmed).toLowerCase();
+}
+
+/**
+ * Comparator for `Array.prototype.sort` that compares two names via
+ * `sortableName` (article-stripped) using `localeCompare`. Accepts either a
+ * raw name string or an object with a `.name` property, since call sites sort
+ * both plain strings and band/performance rows.
+ *
+ * @param {string|{name?: string}|null|undefined} a
+ * @param {string|{name?: string}|null|undefined} b
+ * @returns {number}
+ */
+export function compareByName(a, b) {
+  const nameA = typeof a === "string" ? a : a?.name;
+  const nameB = typeof b === "string" ? b : b?.name;
+  return sortableName(nameA).localeCompare(sortableName(nameB));
+}


### PR DESCRIPTION
## Summary

"The Anti-Queens" sorted under **T** in every alphabetical band listing — surfaced while entering Buddies Fest 2, where the band's officially-branded name starts with "The". Adds a shared `sortableName()` / `compareByName()` helper that strips a leading article (The/A/An, case-insensitive, only when followed by a space) for **sort keys only** — displayed names are never mutated — and applies it at every naive sort site from the issue's verified inventory.

Closes #587

## What changed

| File | Change |
|------|--------|
| `frontend/src/utils/sortableName.js` + `functions/utils/sortableName.js` | New mirrored helper (mirroring precedent: `FIELD_LIMITS` across the two validation.js files); regex `/^(the\|an?)\s+/i` so "Theory"/"Anthem"/bare "The" are untouched |
| `frontend/src/admin/RosterTab.jsx` | Name-column sort uses the helper (other columns untouched) |
| `frontend/src/admin/LineupTab.jsx` | Name-column sort uses the helper |
| `frontend/src/admin/utils/timeUtils.js` | Both `sortBandsByStart` name tiebreaks use `compareByName` |
| `frontend/src/components/ScheduleView.jsx` | **Review catch:** the both-TBD tiebreak — which orders the entire fan schedule before set times are announced — now uses `compareByName` |
| `functions/api/artists.js` | Public directory: SQL keeps `COLLATE NOCASE` as coarse pre-sort; JS sorts the full match set (capped 2000 rows, documented) then slices for pagination so page boundaries stay correct; response shape (`{artists, hasMore}`) unchanged |
| `functions/api/admin/bands.js` | Both branches re-sorted in JS with comparators replicating the original SQL ordering exactly (NULLS-first/last semantics verified in review) |
| `functions/event/[slug].js` | JSON-LD performer list re-sorted post-fetch (in-place reorder, DISTINCT semantics preserved) |
| `functions/api/events/[id]/recap.js`, `functions/api/admin/events/[id]/metrics.js` | Same treatment (metrics: name is only the final tiebreaker) |
| Tests | New unit suites for both helper copies (article cases, false-positive guards, null-safety, list-order assertion); end-to-end order test on `/api/artists`; two `sortBandsByStart` call-site tests |

## Security / correctness notes

None auth/data-related. Reviewed by a code-reviewer agent pass: comparator NULL-handling verified exact against prior SQL semantics at all four backend re-sort sites; `artists.js` pagination contract verified against its consumer (`ArtistsPage.jsx`); the one Important finding (fan-schedule TBD tiebreak missed) fixed before opening this PR. Known follow-up-grade notes: the 2000-row fetch cap truncates un-alphabetically past 2000 artists (documented in code, ~200 artists today), and the pagination slice path itself has no dedicated test.

## Verification

- [x] Tests: 730 backend pass (6 todo), 490 frontend pass — both post-rebase
- [x] ESLint: 0 errors (2 pre-existing warnings, unrelated)
- [x] Format check: clean
- [x] Build: green
- [ ] `validate:openapi`: N/A
- [x] Manual smoke: helper behavior pinned by unit tests incl. "The Anti-Queens"→A ordering assertion; live `/api/artists` order test runs against the real endpoint in the backend suite

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)