### PR TITLE
fix: walk-buffer warning label fails AA contrast on dark themes

### DIFF
--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -614,7 +614,7 @@ function MySchedule({
                         </span>
                         {transition.buffer != null && (
                           <span
-                            className={transition.buffer < 3 ? 'font-semibold text-error-600' : 'text-text-tertiary'}
+                            className={transition.buffer < 3 ? 'font-semibold text-error-400' : 'text-text-tertiary'}
                           >
                             · {bufferLabel(transition.buffer)}
                           </span>


### PR DESCRIPTION
## Summary

Completes #554 (Vol-17 day-of readiness verification). The full scripted walkthrough **passed all five scope items** — lifecycle transitions at simulated event times (15/15 badge assertions incl. doors→first-set→midnight precedence and day-2 no-re-gate), Toronto-local timezone handling incl. the 6 AM after-midnight boundary, My Route walk-time/buffer/conflict math, PWA offline (cached schedule renders offline, no white screen), and mobile legibility/tap-target audit.

One defect was found and is fixed here; three more were filed for triage (#594 P2 tap targets — recommend before Aug 2, #595 P3 offline uncached-route UX, #596 P3 "0 days away" copy). Full verification report with evidence is in the session that ran it; findings are self-contained in the filed issues.

Closes #554

## What changed

| File | Change |
|------|--------|
| `frontend/src/components/MySchedule.jsx` | Tight/negative walk-buffer label ("overlaps by X min" — the core "can I make it?" signal) used `text-error-600` (#dc2626): 3.63:1 at 12px on dark-theme surfaces, an AA failure. Now `text-error-400`, whose theme ramp (dark #f87171 / light #b91c1c) clears AA on all four themes. |

## Security / correctness notes

None — one class swap on an existing element, using the established theme-aware error ramp.

## Verification

- [x] Tests: 490/490 frontend pass
- [x] ESLint: 0 errors (2 pre-existing warnings)
- [x] Format check: clean
- [x] Build: green
- [ ] `validate:openapi`: N/A
- [x] Manual smoke: verified live in-browser post-rebuild during the #554 audit — computed style rgb(248,113,113), re-audit shows zero remaining AA failures on the audited live surfaces

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)