### PR TITLE
fix: bring live-surface tap targets to 44px minimum

### DIFF
--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -182,7 +182,7 @@ function LiveContextBar({
               aria-label={isFiltersOpen ? 'Hide filters' : 'Show filters'}
               aria-expanded={isFiltersOpen}
               aria-controls="live-filter-panel"
-              className="shrink-0 flex min-h-[36px] items-center gap-1 px-2 text-xs text-text-tertiary hover:text-text-secondary transition-colors"
+              className="shrink-0 flex min-h-[44px] min-w-[44px] items-center justify-center gap-1 px-2 text-xs text-text-tertiary hover:text-text-secondary transition-colors"
             >
               <ChevronDown
                 size={14}
@@ -272,7 +272,7 @@ function LiveContextBar({
             aria-label={isFiltersOpen ? 'Hide filters' : 'Show filters'}
             aria-expanded={isFiltersOpen}
             aria-controls="live-filter-panel"
-            className="ml-auto inline-flex min-h-[40px] items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-2 text-xs text-text-tertiary hover:text-text-secondary transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+            className="ml-auto inline-flex min-h-[44px] items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-2 text-xs text-text-tertiary hover:text-text-secondary transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
           >
             <span>Filters</span>
             <ChevronDown
@@ -291,7 +291,7 @@ function LiveContextBar({
                   type="button"
                   onClick={() => onViewChange?.('all')}
                   aria-pressed={view === 'all'}
-                  className={`min-h-[40px] rounded-full px-4 text-sm font-semibold transition-colors ${
+                  className={`min-h-[44px] rounded-full px-4 text-sm font-semibold transition-colors ${
                     view === 'all' ? 'bg-accent-500 text-bg-navy' : 'text-text-tertiary hover:text-text-primary'
                   }`}
                 >
@@ -301,7 +301,7 @@ function LiveContextBar({
                   type="button"
                   onClick={() => onViewChange?.('mine')}
                   aria-pressed={view === 'mine'}
-                  className={`relative min-h-[40px] rounded-full px-4 text-sm font-semibold transition-colors ${
+                  className={`relative min-h-[44px] rounded-full px-4 text-sm font-semibold transition-colors ${
                     view === 'mine' ? 'bg-accent-500 text-bg-navy' : 'text-text-tertiary hover:text-text-primary'
                   }`}
                 >

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -316,7 +316,7 @@ function MySchedule({
         <div className="mt-4">
           <button
             onClick={onToggleShowPast}
-            className="text-xs px-3 py-1.5 rounded bg-accent-500/20 border border-accent-500/50 text-accent-400 hover:bg-accent-500/30 transition-colors"
+            className="inline-flex min-h-[44px] items-center justify-center text-xs px-3 py-1.5 rounded bg-accent-500/20 border border-accent-500/50 text-accent-400 hover:bg-accent-500/30 transition-colors"
           >
             Show finished sets
           </button>
@@ -466,7 +466,7 @@ function MySchedule({
             {hasFinishedBands && (
               <button
                 onClick={onToggleShowPast}
-                className={`text-xs px-3 py-1.5 rounded border transition-transform duration-150 hover:brightness-110 active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500 ${
+                className={`inline-flex min-h-[44px] items-center justify-center text-xs px-3 py-1.5 rounded border transition-transform duration-150 hover:brightness-110 active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500 ${
                   showPast
                     ? 'bg-accent-500/20 border-accent-500/50 text-accent-400 hover:bg-accent-500/30'
                     : 'bg-bg-purple/50 border-accent-500/50 text-accent-400 hover:bg-bg-purple'
@@ -520,7 +520,7 @@ function MySchedule({
               )}
               <button
                 onClick={onClearSchedule}
-                className="text-xs px-3 py-1.5 rounded bg-error-500/20 border border-error-500/50 text-text-primary flex items-center gap-2 transition-transform duration-150 hover:bg-error-500/30 hover:brightness-110 active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-error-400"
+                className="min-h-[44px] text-xs px-3 py-1.5 rounded bg-error-500/20 border border-error-500/50 text-text-primary flex items-center gap-2 transition-transform duration-150 hover:bg-error-500/30 hover:brightness-110 active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-error-400"
                 title="Clear all selected bands"
               >
                 <Trash2 size={14} aria-hidden="true" />

--- a/frontend/src/components/NextMove.jsx
+++ b/frontend/src/components/NextMove.jsx
@@ -28,7 +28,7 @@ function DirectionsButton({ band }) {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center gap-1.5 rounded-lg bg-accent-500 px-3 py-2 text-sm font-semibold text-bg-navy transition-colors hover:bg-accent-400 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-300"
+      className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg bg-accent-500 px-3 py-2 text-sm font-semibold text-bg-navy transition-colors hover:bg-accent-400 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-300"
       aria-label={`Directions to ${band.venue || 'the venue'}`}
     >
       <Navigation size={15} aria-hidden="true" />
@@ -111,7 +111,7 @@ function Action({ state, onDecide }) {
       <button
         type="button"
         onClick={onDecide}
-        className="inline-flex items-center gap-1.5 rounded-lg bg-accent-500 px-3 py-2 text-sm font-semibold text-bg-navy transition-colors hover:bg-accent-400 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-300"
+        className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg bg-accent-500 px-3 py-2 text-sm font-semibold text-bg-navy transition-colors hover:bg-accent-400 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-300"
       >
         Choose in My Route
         <ArrowRight size={15} aria-hidden="true" />

--- a/frontend/src/components/PrivacyBanner.jsx
+++ b/frontend/src/components/PrivacyBanner.jsx
@@ -78,7 +78,7 @@ export default function PrivacyBanner() {
         <button
           type="button"
           onClick={handleDismiss}
-          className="rounded-full border border-accent-500/60 px-4 py-1 text-accent-400 transition hover:border-accent-400 hover:text-text-primary"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-accent-500/60 px-4 py-1 text-accent-400 transition hover:border-accent-400 hover:text-text-primary"
         >
           Got it
         </button>


### PR DESCRIPTION
## Summary

The #554 day-of readiness audit measured primary live-surface controls between 26px and 40px tall on an iPhone viewport — controls fans hit on a phone, in a dark loud venue, mid-walk between sets. This brings every primary control to ≥44px.

Closes #594

## What changed

| File | Change |
|------|--------|
| `frontend/src/components/LiveContextBar.jsx` | Filters chevron 36→44 (+min-w-[44px]), filters pill 40→44, both view toggle buttons 40→44 |
| `frontend/src/components/MySchedule.jsx` | "Show finished sets" (both render sites) 30→44+, "Clear schedule" →44+ |
| `frontend/src/components/NextMove.jsx` | Directions link + "Choose in My Route" button →44 |
| `frontend/src/components/PrivacyBanner.jsx` | "Got it" 30→44 |

Deliberately **not** changed, per the audit's own classification: band-name inline links (19px) — their parent card is the primary ≥44px target, and inflating them would turn card mis-taps into navigations; the lifecycle badge (26px) is an easter-egg-only interaction.

## Security / correctness notes

None — class-only sizing changes, all semantic tokens preserved (public theme-following surfaces).

## Verification

- [x] Tests: 490/490 frontend pass
- [x] ESLint: 0 errors (2 pre-existing warnings)
- [x] Format check: clean
- [x] Build: green
- [ ] `validate:openapi`: N/A
- [x] Manual smoke: measured live in-browser on a 390×844 viewport against the built worktree (via the `?debugTime` hook to render the live surfaces): filters toggle **44×44**, both view toggles **44**, By time/By venue **44**, Show finished sets **50**, Clear schedule **46**, privacy Got it **44**. The two NextMove buttons couldn't be forced to render in the measurement window (narrow state-machine trigger) but received the byte-identical `min-h-[44px]` change verified on the seven measured controls. Visual check: live surfaces render cleanly, no density regression.

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)