### PR TITLE
fix: three live-experience polish items from the #554 audit (brand orange, Tonight copy, offline UX)

### DIFF
--- a/e2e/offline-experience.spec.js
+++ b/e2e/offline-experience.spec.js
@@ -124,4 +124,30 @@ test.describe("Offline resilience (#578)", () => {
 
     await context.setOffline(false);
   });
+
+  test("navigating to an uncached event route while offline shows branded offline messaging, not the generic error card (#595)", async ({
+    page,
+    context,
+  }) => {
+    // Deliberately never seeded/visited — nothing in the API cache for this
+    // slug, so offline navigation exercises the true cache-miss path.
+    const slug = `uncached-offline-${uniqueSuffix()}`;
+
+    // Register + activate the SW and cache the shell via a normal online
+    // visit (mirrors the recipe above). The event route/API response for
+    // `slug` is never fetched online, so it stays uncached.
+    await page.goto("/");
+    await page.waitForFunction(() => navigator.serviceWorker.controller !== null, null, {
+      timeout: 20000,
+    });
+    await page.reload();
+
+    await context.setOffline(true);
+    await page.goto(`/event/${slug}`);
+
+    await expect(page.getByRole("heading", { name: "You're offline" })).toBeVisible({ timeout: 20000 });
+    await expect(page.getByText(/oops! something went wrong/i)).not.toBeVisible();
+
+    await context.setOffline(false);
+  });
 });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { Archive, Bell, CircleAlert, X } from 'lucide-react'
+import { Archive, Bell, CircleAlert, WifiOff, X } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
@@ -162,6 +162,7 @@ function App() {
   )
   const [loading, setLoading] = useState(!HAS_FALLBACK)
   const [error, setError] = useState(null)
+  const [isOfflineError, setIsOfflineError] = useState(false)
   const [showPast, setShowPast] = useState(false)
   const [timeFilter, setTimeFilter] = useState(() => getStoredTimeFilter(slug))
   const [venueFilter, setVenueFilter] = useState(null)
@@ -202,6 +203,7 @@ function App() {
         }
 
         setError(null)
+        setIsOfflineError(false)
         setBands(prepareBands(bandsData))
         setEventData(eventInfo)
         setLoading(false)
@@ -211,6 +213,14 @@ function App() {
         }
         console.error('Failed to load bands:', err)
         if (!HAS_FALLBACK) {
+          // A fetch that never reached the server (offline, or the service
+          // worker's network-first strategy re-throwing after a cache miss —
+          // see sw.js networkFirstStrategy) surfaces as a TypeError, never an
+          // HTTP-status Error. Combined with navigator.onLine, that's enough
+          // signal to show branded offline messaging instead of the generic
+          // error card for a route this device never cached (#595).
+          const offline = (typeof navigator !== 'undefined' && navigator.onLine === false) || err instanceof TypeError
+          setIsOfflineError(offline)
           setError(err.message || 'Failed to load schedule. Please try refreshing the page.')
         }
         setLoading(false)
@@ -592,6 +602,29 @@ function App() {
 
   if (shouldShowLoading) {
     return <ScheduleSkeleton />
+  }
+
+  if (error && isOfflineError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="max-w-md text-center">
+          <div className="text-warning-400 mb-4" aria-hidden="true">
+            <WifiOff size={64} />
+          </div>
+          <h2 className="text-text-primary text-2xl font-bold mb-2">You&apos;re offline</h2>
+          <p className="text-text-secondary mb-6">
+            This event hasn&apos;t been loaded on this device yet, so there&apos;s nothing saved to show. Reconnect and
+            try again.
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            className="px-6 py-3 bg-accent-500 text-bg-navy font-semibold rounded-lg hover:brightness-110 transition-all"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    )
   }
 
   if (error) {

--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -1,5 +1,6 @@
 import { CalendarDays, ChevronDown, Clock, DoorOpen, Route, Warehouse } from 'lucide-react'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
+import { getDaysAwayAriaLabel, getDaysAwayLabel } from '../utils/daysAway'
 import { getDoorsTimeForDate } from '../utils/doorsTime'
 import { getLifecycleLabel } from '../utils/liveLabel'
 import { formatTime } from '../utils/timeFormat'
@@ -129,7 +130,7 @@ function LiveContextBar({
     }
 
     if (daysUntil !== null) {
-      summaryItems.push(`${daysUntil} ${daysUntil === 1 ? 'day away' : 'days away'}`)
+      summaryItems.push(getDaysAwayLabel(daysUntil))
     }
 
     return summaryItems.join(' • ')
@@ -261,9 +262,7 @@ function LiveContextBar({
           </div>
           {daysUntil !== null && (
             <div className="inline-flex min-h-[40px] items-center gap-2 rounded-full border border-warning-400/35 bg-warning-400/10 px-3 py-2 font-semibold text-warning-400">
-              <span aria-label={`${daysUntil} ${daysUntil === 1 ? 'day' : 'days'} until the event`}>
-                {daysUntil} {daysUntil === 1 ? 'day away' : 'days away'}
-              </span>
+              <span aria-label={getDaysAwayAriaLabel(daysUntil)}>{getDaysAwayLabel(daysUntil)}</span>
             </div>
           )}
           <button

--- a/frontend/src/components/__tests__/LiveContextBar.test.jsx
+++ b/frontend/src/components/__tests__/LiveContextBar.test.jsx
@@ -118,4 +118,26 @@ describe('LiveContextBar', () => {
 
     expect(screen.getAllByText('Doors 6:30 PM').length).toBeGreaterThan(0)
   })
+
+  it('shows "Tonight" instead of "0 days away" pre-doors on the event\'s own day (#596)', () => {
+    const eventWithDoors = { ...eventData, doors_json: JSON.stringify({ '2026-05-06': '18:30' }) }
+
+    render(
+      <LiveContextBar
+        eventData={eventWithDoors}
+        currentTime={new Date('2026-05-06T12:00:00')}
+        bands={bands}
+        selectedCount={0}
+        view="all"
+        onViewChange={vi.fn()}
+        venueFilter={null}
+        onVenueFilterChange={vi.fn()}
+        timeFilter="all"
+        onTimeFilterChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText('Tonight').length).toBeGreaterThan(0)
+    expect(screen.queryByText(/0 days away/)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/utils/__tests__/daysAway.test.js
+++ b/frontend/src/utils/__tests__/daysAway.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { getDaysAwayAriaLabel, getDaysAwayLabel } from '../daysAway'
+
+describe('getDaysAwayLabel', () => {
+  it('reads "Tonight" on the event\'s own day (#596 — was "0 days away")', () => {
+    expect(getDaysAwayLabel(0)).toBe('Tonight')
+  })
+
+  it('singularizes for exactly 1 day away', () => {
+    expect(getDaysAwayLabel(1)).toBe('1 day away')
+  })
+
+  it('pluralizes for more than 1 day away', () => {
+    expect(getDaysAwayLabel(2)).toBe('2 days away')
+    expect(getDaysAwayLabel(14)).toBe('14 days away')
+  })
+})
+
+describe('getDaysAwayAriaLabel', () => {
+  it('describes the event as today when 0 days away', () => {
+    expect(getDaysAwayAriaLabel(0)).toBe('Tonight — the event is today')
+  })
+
+  it('singularizes for exactly 1 day away', () => {
+    expect(getDaysAwayAriaLabel(1)).toBe('1 day until the event')
+  })
+
+  it('pluralizes for more than 1 day away', () => {
+    expect(getDaysAwayAriaLabel(2)).toBe('2 days until the event')
+  })
+})

--- a/frontend/src/utils/daysAway.js
+++ b/frontend/src/utils/daysAway.js
@@ -1,0 +1,29 @@
+/**
+ * Fan-facing "N days away" countdown chip (LiveContextBar's warning-styled
+ * badge, shown while the event is "Upcoming" — see liveLabel.js/#569).
+ *
+ * On the event's own day, pre-doors, the day-granularity distance is 0 —
+ * "0 days away" reads wrong at exactly the moment fans are most likely to
+ * check the page (#596). Render "Tonight" instead. For every other value,
+ * pluralize: "1 day away" vs "N days away".
+ *
+ * @param {number} daysUntil
+ * @returns {string}
+ */
+export function getDaysAwayLabel(daysUntil) {
+  if (daysUntil === 0) return 'Tonight'
+  return `${daysUntil} ${daysUntil === 1 ? 'day away' : 'days away'}`
+}
+
+/**
+ * Screen-reader text for the same chip. Kept separate from the visible label
+ * because the accessible phrasing reads better as a full sentence fragment
+ * ("N days until the event") than the terse visible chip text.
+ *
+ * @param {number} daysUntil
+ * @returns {string}
+ */
+export function getDaysAwayAriaLabel(daysUntil) {
+  if (daysUntil === 0) return 'Tonight — the event is today'
+  return `${daysUntil} ${daysUntil === 1 ? 'day' : 'days'} until the event`
+}

--- a/functions/api/subscriptions/unsubscribe.js
+++ b/functions/api/subscriptions/unsubscribe.js
@@ -65,7 +65,7 @@ export async function onRequestGet(context) {
           <style>
             body {
               font-family: system-ui, sans-serif;
-              background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+              background: linear-gradient(180deg, #0c0f1a 0%, #141927 100%);
               color: white;
               margin: 0;
               padding: 2rem;
@@ -78,7 +78,7 @@ export async function onRequestGet(context) {
               text-align: center;
               max-width: 400px;
             }
-            h1 { color: #ff6b35; }
+            h1 { color: #f97316; }
             p { opacity: 0.9; }
           </style>
         </head>
@@ -86,7 +86,7 @@ export async function onRequestGet(context) {
           <div class="container">
             <h1>✓ Unsubscribed</h1>
             <p>You've been removed from ${escapeHtml(subscription.city)} ${escapeHtml(subscription.genre)} show notifications.</p>
-            <p>You can resubscribe anytime at <a href="${escapeHtml(env.PUBLIC_URL)}/subscribe" style="color: #ff6b35;">${escapeHtml(env.PUBLIC_URL)}/subscribe</a></p>
+            <p>You can resubscribe anytime at <a href="${escapeHtml(env.PUBLIC_URL)}/subscribe" style="color: #f97316;">${escapeHtml(env.PUBLIC_URL)}/subscribe</a></p>
           </div>
         </body>
       </html>


### PR DESCRIPTION
## Summary

Three small p3 fixes, one commit each — the remaining polish items surfaced by the #554 day-of readiness audit plus the #583 side-finding.

Closes #591
Closes #595
Closes #596

## What changed

| Commit | Issue | Change |
|--------|-------|--------|
| 1 | #591 | `functions/api/subscriptions/unsubscribe.js`: `#ff6b35` → brand orange `#f97316`; ad-hoc gradient → the canonical dark gradient already used in `index.css` and the email templates. Contrast computed (worst-case stop): h1 6.3:1, body 14.3:1, link 5.3:1 — all AA-clear. |
| 2 | #596 | New `frontend/src/utils/daysAway.js` helper (extracted from duplicated inline logic in `LiveContextBar.jsx`): day-of pre-doors now reads **"Tonight"** instead of "0 days away", with separate screen-reader phrasing. Unit tests + a DOM assertion reproducing the exact pre-doors scenario. |
| 3 | #595 | `App.jsx`: navigating to an *uncached* event while offline now shows a branded "You're offline" card (WifiOff icon, warning/amber semantic tokens matching `OfflineIndicator`) instead of the generic "Oops! Something went wrong" card. Detection: `navigator.onLine === false` OR the fetch threw `TypeError` (a request that never reached the server — real HTTP 4xx/5xx throw plain `Error` and still get the generic card). 34 lines, no new routing. |

## Security / correctness notes

The #595 error classification cannot mask real server errors: HTTP-status failures throw plain `Error` (not `TypeError`), keeping the generic card; the offline flag resets on every successful load. Accepted p3 edge: a DNS-level failure while nominally online reads as "offline" — the connectivity-flavoured message is still more accurate than the generic card there.

## Verification

- [x] Tests: 497/497 frontend, 730/736 backend (6 todo) — both post-rebase
- [x] ESLint: 0 errors both suites
- [x] Format check: clean both suites
- [x] Build: green post-rebase
- [ ] `validate:openapi`: N/A
- [x] Manual smoke: #595 verified against a real wrangler+D1+service-worker stack via a new Playwright case in `e2e/offline-experience.spec.js` (SW activates online → go offline → navigate to a never-visited event slug → "You're offline" renders, "Oops!" does not); #596 verified via DOM assertion at a simulated pre-doors `?debugTime`; #591 contrast verified by computation against both gradient stops. (Known pre-existing local-only failure in the sibling "network drop" e2e spec is stale schema drift in copied local D1 state, unrelated.)

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)