### PR TITLE
fix: stamp iCal VEVENTs with per-set performance_date, not event start date

### DIFF
--- a/functions/api/feeds/__tests__/ical.test.js
+++ b/functions/api/feeds/__tests__/ical.test.js
@@ -326,3 +326,156 @@ describe("GET /api/feeds/ical — reveal_mode gate (real-DB)", () => {
     expect(icalData.split("BEGIN:VEVENT").length - 1).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Day-aware iCal export (#542 PR-2, real-DB).
+// Before this fix, every VEVENT was stamped with e.date (the event's overall
+// start date) regardless of which festival day a set fell on — a fan
+// importing a multi-day festival got every set on day 1. These tests exercise
+// the actual SQL (SELECT + ORDER BY) added to ical.js, not a hand-rolled mock.
+// ---------------------------------------------------------------------------
+describe("GET /api/feeds/ical — day-aware performance_date (real-DB)", () => {
+  const day1 = "2099-03-01";
+  const day2 = "2099-03-02";
+
+  test("day-2 VEVENT's DTSTART, DTEND, and UID all carry day-2's date, not the event's start date", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const event = insertEvent(rawDb, {
+      name: "Two Day Ical Event",
+      slug: "ical-two-day",
+      date: day1,
+      end_date: day2,
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    const venue = insertVenue(rawDb, { name: "Roost" });
+
+    const day2Perf = insertBand(rawDb, {
+      name: "Day Two Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "14:00",
+      end_time: "15:00",
+    });
+    // Explicit performance_date on the day-2 row (the multi-day convention
+    // from migration 0051 — NULL rows inherit the event's single date).
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run(day2, day2Perf.id);
+
+    const request = new Request("https://example.test/api/feeds/ical");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const icalData = await response.text();
+
+    const day2Compact = day2.replace(/-/g, "");
+    const day1Compact = day1.replace(/-/g, "");
+
+    expect(icalData).toContain(`DTSTART:${day2Compact}T140000`);
+    expect(icalData).toContain(`DTEND:${day2Compact}T150000`);
+    expect(icalData).toContain(`UID:performance-${day2Perf.id}-${day2}@settimes.ca`);
+    // Must not be stamped with the event's start date — that's the bug this fixes.
+    expect(icalData).not.toContain(`DTSTART:${day1Compact}T140000`);
+  });
+
+  test("after-midnight set (01:00) keeps day-1's calendar date in DTSTART — no +1-day sort offset applied", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const event = insertEvent(rawDb, {
+      name: "After Midnight Ical Event",
+      slug: "ical-after-midnight",
+      date: day1,
+      end_date: day2,
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    const venue = insertVenue(rawDb, { name: "Prohibition Warehouse" });
+
+    const lateNightPerf = insertBand(rawDb, {
+      name: "After Midnight Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "01:00",
+      end_time: "02:00",
+    });
+    // Migration 0051's stored-day convention: a 1 AM set on the night of day 1
+    // stores day 1's calendar date (not day 2's) — the after-midnight set is
+    // "understood" via the 01:00 clock time, not a shifted date.
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run(day1, lateNightPerf.id);
+
+    const request = new Request("https://example.test/api/feeds/ical");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const icalData = await response.text();
+
+    // Wall-clock date+time pair: day-1's calendar date with the 01:00 clock
+    // time. iCal must NOT apply prepareBands' frontend-only +1-day sort
+    // offset (that offset is for display ordering only, not wall-clock time).
+    expect(icalData).toContain(`DTSTART:${day1.replace(/-/g, "")}T010000`);
+    expect(icalData).not.toContain(`DTSTART:${day2.replace(/-/g, "")}T010000`);
+  });
+
+  test("VEVENTs are ordered by festival day then by time-of-day, not interleaved by raw clock time", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const event = insertEvent(rawDb, {
+      name: "Ordering Ical Event",
+      slug: "ical-ordering",
+      date: day1,
+      end_date: day2,
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    const venue = insertVenue(rawDb, { name: "Room 47" });
+
+    // Day-1 early set (NULL performance_date — inherits the event's date).
+    insertBand(rawDb, {
+      name: "Day1 Early Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+
+    // Day-1 late set (NULL performance_date — inherits the event's date).
+    insertBand(rawDb, {
+      name: "Day1 Late Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "22:00",
+      end_time: "23:00",
+    });
+
+    // Day-2 morning set: an earlier clock time than either day-1 set, which
+    // would sort FIRST under the old "ORDER BY e.date ASC, p.start_time ASC"
+    // query (interleaving day 2 ahead of day 1's evening lineup — the bug).
+    const morningDay2 = insertBand(rawDb, {
+      name: "Day2 Morning Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "10:00",
+      end_time: "11:00",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run(day2, morningDay2.id);
+
+    const request = new Request("https://example.test/api/feeds/ical");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const icalData = await response.text();
+
+    const idxEarly = icalData.indexOf("SUMMARY:Day1 Early Band");
+    const idxLate = icalData.indexOf("SUMMARY:Day1 Late Band");
+    const idxMorning = icalData.indexOf("SUMMARY:Day2 Morning Band");
+
+    expect(idxEarly).toBeGreaterThan(-1);
+    expect(idxLate).toBeGreaterThan(-1);
+    expect(idxMorning).toBeGreaterThan(-1);
+
+    // Exact VEVENT order: day 1's full lineup (by time-of-day), then day 2's —
+    // never day 2 slotted ahead of day 1 by raw clock time.
+    expect(idxEarly).toBeLessThan(idxLate);
+    expect(idxLate).toBeLessThan(idxMorning);
+  });
+});

--- a/functions/api/feeds/ical.js
+++ b/functions/api/feeds/ical.js
@@ -42,6 +42,7 @@ export async function onRequestGet(context) {
         p.id as performance_id,
         p.start_time,
         p.end_time,
+        p.performance_date,
         v.name as venue_name,
         v.address
       FROM events e
@@ -64,7 +65,7 @@ export async function onRequestGet(context) {
       params.push(genre);
     }
 
-    query += ` ORDER BY e.date ASC, p.start_time ASC`;
+    query += ` ORDER BY e.date ASC, COALESCE(p.performance_date, e.date) ASC, p.start_time ASC`;
 
     const { results: bands } = await env.DB.prepare(query)
       .bind(...params)
@@ -103,7 +104,10 @@ function generateICal(bands, city, genre) {
     if (!band.band_name) continue;
 
     // Parse date and time
-    const eventDate = band.date; // YYYY-MM-DD
+    // Per-set festival day: a performance carries its own performance_date
+    // when the event spans multiple days (epic #543); NULL inherits the
+    // event's single date, keeping single-day events byte-identical.
+    const eventDate = band.performance_date || band.date; // YYYY-MM-DD
     const startTime = band.start_time || "20:00"; // HH:MM
     const endTime = band.end_time || "21:00";
 


### PR DESCRIPTION
## Summary

The iCal feed never selected `p.performance_date`, so every VEVENT was stamped with `e.date` — the event's overall start date. A fan importing a multi-day festival (e.g. BLR3, Buddies Fest 2) into their calendar got **every set scheduled on day 1**. This adds the per-set festival day to the query, falls back to the event date when `performance_date` is NULL (single-day events stay byte-identical), and fixes the ORDER BY so day-2+ sets no longer interleave with day 1 by raw clock time.

Part of #542 (multiday phase 2 — item: day-aware ICS export). Does not close it; remaining items land in follow-up PRs.

## What changed

| File | Change |
|------|--------|
| `functions/api/feeds/ical.js` | SELECT `p.performance_date`; `eventDate = band.performance_date \|\| band.date` for DTSTART/DTEND/UID; `ORDER BY e.date, COALESCE(p.performance_date, e.date), p.start_time` |
| `functions/api/feeds/__tests__/ical.test.js` | 3 new real-DB tests: day-2 DTSTART/DTEND/UID stamping, after-midnight set keeps its stored wall-clock date (no +1-day sort offset), exact VEVENT ordering across festival days |

## Security / correctness notes

None — read-only public feed; no auth surface touched. After-midnight convention respected: iCal emits the *stored* calendar date + clock time (wall-clock truth), never the frontend's +1-day sort offset. UID keeps its `performance-{id}-{date}` shape, so a set moved between days changes UID (calendar clients treat it as a new event rather than silently keeping the stale day — acceptable, matches existing behaviour for date edits).

## Verification

- [x] Tests: 733 pass | 6 todo, 0 failures (`npm test`, full backend suite; ical file 14/14)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: green (frontend untouched; N/A)
- [x] `validate:openapi`: no drift (spec unchanged)
- [x] Manual smoke: TDD-verified — stashing the fix makes the 2 new day-stamping tests fail exactly as the bug predicts; restoring it goes green

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
