### PR TITLE
fix: day-aware schedule staleness + festival-day Today filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,8 @@ Band selections are stored under the `selectedBandsByEvent` key as `{ [eventSlug
 
 The `__dates__` namespace is used for stale detection. **Always use YYYY-MM-DD lexicographic string comparison** — do NOT use `new Date('YYYY-MM-DD')` which parses as UTC midnight and causes events to appear stale on their own day in UTC-negative timezones.
 
+**`saveSelectedBands`'s date argument must be the event's `end_date || date`, never the start date alone.** Stale detection compares the stored date against today, so passing a multi-day event's START date marks the fan's saved schedule stale on day 2 — silently wiping their selections mid-festival (#542 PR-1). Single-day events have a NULL `end_date`, so the `||` fallback keeps them identical.
+
 All interactions go through `frontend/src/utils/scheduleStorage.js`. Do not write to `selectedBandsByEvent` directly.
 
 ---

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -3188,6 +3188,10 @@ components:
           type: string
         date:
           type: string
+        end_date:
+          type: string
+          nullable: true
+          description: Last day of a multi-day event (YYYY-MM-DD); null for single-day events.
         status:
           type: string
           nullable: true

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -303,8 +303,14 @@ function App() {
   }, [])
 
   useEffect(() => {
-    saveSelectedBands(slug || 'default', selectedBands, eventData?.date)
-  }, [selectedBands, slug, eventData?.date])
+    // Multi-day events: stale-detection in scheduleStorage compares this date
+    // against today (lexicographic YYYY-MM-DD). Passing only the event's
+    // START date silently marks the fan's saved schedule stale starting day
+    // 2 of a multi-day event, wiping their selections mid-festival (#542).
+    // end_date (falling back to date for single-day events) keeps the event
+    // "not stale" for its whole run.
+    saveSelectedBands(slug || 'default', selectedBands, eventData?.end_date || eventData?.date)
+  }, [selectedBands, slug, eventData?.end_date, eventData?.date])
 
   // react-helmet-async does not reliably set document.title in React 19 — set it
   // directly. Mirrors the <Helmet> <title> below. See BandProfilePage.jsx.

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -735,8 +735,13 @@ function EventCard({
           )}
 
           {/* Genre Discovery Wall — upcoming events only */}
+          {/* eventDate feeds saveSelectedBands' stale-detection, so it must be
+              end_date || date (#542 PR-1, see CLAUDE.md "Schedule Storage"):
+              keying staleness on the start date wipes the fan's saved
+              schedule on day 2 of a multi-day event. end_date comes from
+              /api/events/timeline (null for single-day events). */}
           {isUpcoming && allBands && allBands.length > 0 && (
-            <GenreDiscovery bands={allBands} eventSlug={event.slug} eventDate={event.date} />
+            <GenreDiscovery bands={allBands} eventSlug={event.slug} eventDate={event.end_date || event.date} />
           )}
 
           {/* Venues */}

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -262,8 +262,13 @@ export default function BandProfilePage() {
           currentSet.add(scheduleId)
         }
 
-        // Save to localStorage with event date so stale past-event entries can be filtered
-        saveSelectedBands(eventSlug, Array.from(currentSet), performance.event_date)
+        // Save to localStorage with event date so stale past-event entries can
+        // be filtered. The date must be event_end_date || event_date (#542
+        // PR-1, see CLAUDE.md "Schedule Storage"): keying staleness on the
+        // start date wipes the fan's saved schedule on day 2 of a multi-day
+        // event. event_end_date comes from GET /api/bands/stats/:name (null
+        // for single-day events).
+        saveSelectedBands(eventSlug, Array.from(currentSet), performance.event_end_date || performance.event_date)
 
         return { ...prev, [eventSlug]: currentSet }
       })

--- a/frontend/src/utils/__tests__/scheduleStorage.test.js
+++ b/frontend/src/utils/__tests__/scheduleStorage.test.js
@@ -113,3 +113,32 @@ describe('saveSelectedBands + hasAnySchedule round-trip', () => {
     expect(getScheduleEventSlug()).toBeNull()
   })
 })
+
+describe('multi-day event staleness (#542 PR-1 regression)', () => {
+  // Reproduces the exact production bug: a multi-day event that started
+  // yesterday and ends tomorrow must never be treated as stale mid-run.
+  // App.jsx / BandProfilePage.jsx previously called saveSelectedBands with
+  // only the event's START date (eventData.date), so isEventStale() (a
+  // straight YYYY-MM-DD string comparison against today) started marking the
+  // fan's saved schedule stale on day 2 — silently wiping their selections
+  // mid-festival. The fix passes end_date (falling back to date for
+  // single-day events) instead.
+
+  it('is NOT stale when saved with the event end_date, even though the event started yesterday', () => {
+    // Simulates the fixed call sites: callers now pass
+    // eventData.end_date || eventData.date. A multi-day event spanning
+    // yesterday -> tomorrow must keep the fan's schedule live throughout.
+    saveSelectedBands('multiday-fest', ['band-1', 'band-2'], offsetDate(1))
+    expect(hasAnySchedule()).toBe(true)
+    expect(getScheduleEventSlug()).toBe('multiday-fest')
+  })
+
+  it('documents the bug: saving with only the start date would wrongly mark a still-running multi-day event stale', () => {
+    // Pins down the pre-fix behavior for the exact date value the old
+    // call sites passed (eventData.date, the START date) — proving
+    // isEventStale() alone was never the bug; the caller's date choice was.
+    saveSelectedBands('multiday-fest-bug', ['band-1'], offsetDate(-1))
+    expect(hasAnySchedule()).toBe(false)
+    expect(getScheduleEventSlug()).toBeNull()
+  })
+})

--- a/frontend/src/utils/__tests__/timeFilter.test.js
+++ b/frontend/src/utils/__tests__/timeFilter.test.js
@@ -1,5 +1,13 @@
-import { describe, it, expect } from 'vitest'
-import { isStartingSoon } from '../timeFilter.js'
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  isStartingSoon,
+  getStartOfDay,
+  getEndOfDay,
+  getStartOfWeek,
+  getEndOfWeek,
+  isHappeningToday,
+  isHappeningThisWeek,
+} from '../timeFilter.js'
 
 const NOW = 1000000000000 // fixed timestamp, 2001-09-08T21:46:40Z
 
@@ -39,5 +47,143 @@ describe('isStartingSoon', () => {
   it('respects custom thresholdMinutes', () => {
     expect(isStartingSoon({ startMs: NOW + 10 * 60000 }, NOW, 5)).toBe(false)
     expect(isStartingSoon({ startMs: NOW + 4 * 60000 }, NOW, 5)).toBe(true)
+  })
+})
+
+// Fixture dates below use the local `new Date(y, m, d, h)` constructor
+// (never `new Date('YYYY-MM-DD')`, per repo convention) so getDay()/getHours()
+// reflect the intended local wall-clock time regardless of test-runner TZ.
+//
+// Confirmed day-of-week for the fixtures used below:
+//   Fri Jul 31 2026 = 5, Sat Aug 01 2026 = 6, Sun Aug 02 2026 = 0,
+//   Mon Aug 03 2026 = 1, Mon Jul 27 2026 = 1 (one week before Aug 3).
+
+describe('festival-day boundary — getStartOfDay/getEndOfDay (#542)', () => {
+  it('getStartOfDay shifts back a calendar day for times before the 6 AM threshold', () => {
+    // 1 AM Sunday is still part of Saturday's festival day.
+    const oneAmSunday = new Date(2026, 7, 2, 1, 0, 0)
+    const start = getStartOfDay(oneAmSunday)
+    expect(start.getFullYear()).toBe(2026)
+    expect(start.getMonth()).toBe(7) // August
+    expect(start.getDate()).toBe(1) // shifted back to Saturday
+    expect(start.getHours()).toBe(6)
+    expect(start.getMinutes()).toBe(0)
+    expect(start.getSeconds()).toBe(0)
+    expect(start.getMilliseconds()).toBe(0)
+  })
+
+  it('getStartOfDay does not shift exactly at the 6 AM threshold', () => {
+    const sixAmSunday = new Date(2026, 7, 2, 6, 0, 0)
+    const start = getStartOfDay(sixAmSunday)
+    expect(start.getDate()).toBe(2) // stays on Sunday — 6 AM belongs to its own day
+    expect(start.getHours()).toBe(6)
+  })
+
+  it('getStartOfDay does not shift for an ordinary evening time', () => {
+    const eightPmSaturday = new Date(2026, 7, 1, 20, 0, 0)
+    const start = getStartOfDay(eightPmSaturday)
+    expect(start.getDate()).toBe(1) // Saturday, unchanged
+    expect(start.getHours()).toBe(6)
+  })
+
+  it("getEndOfDay is 1 ms before the next festival day's 6 AM boundary", () => {
+    const eightPmSaturday = new Date(2026, 7, 1, 20, 0, 0)
+    const end = getEndOfDay(eightPmSaturday)
+    expect(end.getMonth()).toBe(7)
+    expect(end.getDate()).toBe(2) // early hours of Sunday
+    expect(end.getHours()).toBe(5)
+    expect(end.getMinutes()).toBe(59)
+    expect(end.getSeconds()).toBe(59)
+    expect(end.getMilliseconds()).toBe(999)
+  })
+
+  it("a single-day event's window is otherwise unchanged: any evening time yields the same day window", () => {
+    const noon = getStartOfDay(new Date(2026, 7, 1, 12, 0, 0))
+    const evening = getStartOfDay(new Date(2026, 7, 1, 22, 0, 0))
+    expect(noon.getTime()).toBe(evening.getTime())
+  })
+})
+
+describe('isHappeningToday across the festival-day boundary (#542)', () => {
+  // A Saturday-evening show (8 PM) and an after-midnight set that started at
+  // 1 AM Sunday but belongs to the SAME (Saturday) festival day — mirroring
+  // prepareBands()'s +1-day offset for sub-6AM starts, its real startMs
+  // timestamp already reflects the shift (see bandUtils.js).
+  const eveningPerformance = { startMs: new Date(2026, 7, 1, 20, 0, 0).getTime() }
+  const afterMidnightPerformance = { startMs: new Date(2026, 7, 2, 1, 0, 0).getTime() }
+
+  afterEach(() => {
+    delete globalThis.__debugScheduleTime
+  })
+
+  it.each([
+    ['00:00', new Date(2026, 7, 2, 0, 0, 0)],
+    ['01:00', new Date(2026, 7, 2, 1, 0, 0)],
+    ['05:59', new Date(2026, 7, 2, 5, 59, 0)],
+  ])('at %s (still within the previous festival evening), both sets are "Today"', (_label, clock) => {
+    globalThis.__debugScheduleTime = clock
+    expect(isHappeningToday(eveningPerformance)).toBe(true)
+    expect(isHappeningToday(afterMidnightPerformance)).toBe(true)
+  })
+
+  it.each([
+    ['06:00', new Date(2026, 7, 2, 6, 0, 0)],
+    ['23:59', new Date(2026, 7, 2, 23, 59, 0)],
+  ])(
+    'at %s (the new festival day has started), the previous evening\'s sets are no longer "Today"',
+    (_label, clock) => {
+      globalThis.__debugScheduleTime = clock
+      expect(isHappeningToday(eveningPerformance)).toBe(false)
+      expect(isHappeningToday(afterMidnightPerformance)).toBe(false)
+    }
+  )
+})
+
+describe('week boundary at the 1 AM Monday edge (#542, #550 festival-day convention)', () => {
+  afterEach(() => {
+    delete globalThis.__debugScheduleTime
+  })
+
+  it('getStartOfWeek/getEndOfWeek treat 1 AM Monday as still belonging to the previous (Sunday) festival day', () => {
+    // Monday, Aug 3 2026, 1 AM — festival-day-wise this is Sunday Aug 2's
+    // after-midnight tail, so "this week" must be the week that ENDS with
+    // that Sunday (Mon Jul 27 - Sun Aug 2), not the week starting today.
+    // Getting this wrong (using the raw calendar day-of-week) would return
+    // the wrong week's Monday — an off-by-one at exactly this boundary.
+    const mondayOneAm = new Date(2026, 7, 3, 1, 0, 0)
+    const start = getStartOfWeek(mondayOneAm)
+    const end = getEndOfWeek(mondayOneAm)
+
+    expect(start.getFullYear()).toBe(2026)
+    expect(start.getMonth()).toBe(6) // July
+    expect(start.getDate()).toBe(27) // Monday, Jul 27
+    expect(start.getHours()).toBe(6)
+
+    expect(end.getMonth()).toBe(7) // August
+    expect(end.getDate()).toBe(3) // early hours of the following Monday
+    expect(end.getHours()).toBe(5)
+    expect(end.getMinutes()).toBe(59)
+  })
+
+  it('an ordinary weekday (non-boundary) resolves to the same week', () => {
+    const wednesdayAfternoon = new Date(2026, 6, 29, 14, 0, 0) // Wed Jul 29, 2 PM
+    const start = getStartOfWeek(wednesdayAfternoon)
+    expect(start.getMonth()).toBe(6)
+    expect(start.getDate()).toBe(27) // same Monday as the 1 AM Monday fixture
+    expect(start.getHours()).toBe(6)
+  })
+
+  it('isHappeningThisWeek includes a Sunday-evening after-midnight set when checked at 1 AM Monday', () => {
+    // The Sunday-night show's real timestamp is 1 AM Monday (after-midnight
+    // offset) — the same instant "now" is fixed to below. Still this week.
+    globalThis.__debugScheduleTime = new Date(2026, 7, 3, 1, 0, 0)
+    const sundayNightSet = { startMs: new Date(2026, 7, 3, 1, 0, 0).getTime() }
+    expect(isHappeningThisWeek(sundayNightSet)).toBe(true)
+  })
+
+  it('isHappeningThisWeek excludes a Monday-evening set (the following festival day) when checked at 1 AM Monday', () => {
+    globalThis.__debugScheduleTime = new Date(2026, 7, 3, 1, 0, 0)
+    const mondayEveningSet = { startMs: new Date(2026, 7, 3, 20, 0, 0).getTime() } // Mon 8 PM
+    expect(isHappeningThisWeek(mondayEveningSet)).toBe(false)
   })
 })

--- a/frontend/src/utils/timeFilter.js
+++ b/frontend/src/utils/timeFilter.js
@@ -2,6 +2,8 @@
  * Time filtering utilities for concert performances
  */
 
+import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from './festivalDays'
+
 const DEBUG_TIME_KEY = '__debugScheduleTime'
 
 /**
@@ -19,43 +21,74 @@ export function getCurrentDateTime() {
 }
 
 /**
- * Get start of day (00:00:00) for a given date
+ * A "festival day" runs AFTER_MIDNIGHT_THRESHOLD_HOUR -> AFTER_MIDNIGHT_THRESHOLD_HOUR
+ * (6 AM -> 6 AM), not calendar midnight -> midnight (#542). A set starting at
+ * 1 AM is still "tonight" in festival terms (see AFTER_MIDNIGHT_THRESHOLD_HOUR's
+ * doc in festivalDays.js and prepareBands() in bandUtils.js, which offsets
+ * such sets' startMs/endMs by +1 day so they sort after the same evening's
+ * earlier sets). Returns a new Date at exactly AFTER_MIDNIGHT_THRESHOLD_HOUR
+ * on the calendar day this timestamp's festival day belongs to — shifting
+ * back one calendar day when `date`'s clock time is before the threshold, so
+ * that a 1 AM check and an 11 PM check the same festival evening both land
+ * on the same festival-day boundary.
+ */
+function festivalDayStart(date) {
+  const d = new Date(date)
+  if (d.getHours() < AFTER_MIDNIGHT_THRESHOLD_HOUR) {
+    d.setDate(d.getDate() - 1)
+  }
+  d.setHours(AFTER_MIDNIGHT_THRESHOLD_HOUR, 0, 0, 0)
+  return d
+}
+
+/**
+ * Get start of the festival day (AFTER_MIDNIGHT_THRESHOLD_HOUR, e.g. 6 AM) for
+ * a given date/time.
  */
 export function getStartOfDay(date) {
-  const d = new Date(date)
-  d.setHours(0, 0, 0, 0)
-  return d
+  return festivalDayStart(date)
 }
 
 /**
- * Get end of day (23:59:59) for a given date
+ * Get end of the festival day: 1 ms before the next festival day's start
+ * (AFTER_MIDNIGHT_THRESHOLD_HOUR on the following calendar day). Mirrors the
+ * previous calendar-midnight `23,59,59,999` precision, just shifted to the
+ * festival-day boundary so the instant AFTER_MIDNIGHT_THRESHOLD_HOUR itself
+ * belongs to exactly one day, never both.
  */
 export function getEndOfDay(date) {
-  const d = new Date(date)
-  d.setHours(23, 59, 59, 999)
+  const d = festivalDayStart(date)
+  d.setDate(d.getDate() + 1)
+  d.setMilliseconds(d.getMilliseconds() - 1)
   return d
 }
 
 /**
- * Get start of week (Monday) for a given date
+ * Get start of week (Monday, at the festival-day boundary) for a given date.
+ * Resolves the date to its festival day FIRST (via festivalDayStart, which
+ * also normalizes the time to the threshold hour so the day-of-week lookup
+ * below isn't re-shifted by a leftover pre-threshold hour) before finding
+ * that festival day's Monday — otherwise a 1 AM Monday check would use the
+ * calendar day-of-week (Monday) instead of the festival day-of-week (the
+ * previous Sunday), landing on the wrong week (#542).
  */
 export function getStartOfWeek(date) {
-  const d = new Date(date)
+  const d = festivalDayStart(date)
   const day = d.getDay()
   const diff = d.getDate() - day + (day === 0 ? -6 : 1) // Adjust when day is Sunday
   d.setDate(diff)
-  return getStartOfDay(d)
+  return d
 }
 
 /**
- * Get end of week (Sunday) for a given date
+ * Get end of week: 1 ms before the following week's start, mirroring
+ * getEndOfDay's approach so the two week boundaries never overlap.
  */
 export function getEndOfWeek(date) {
-  const d = new Date(date)
-  const day = d.getDay()
-  const diff = d.getDate() - day + (day === 0 ? 0 : 7) // Adjust when day is Sunday
-  d.setDate(diff)
-  return getEndOfDay(d)
+  const d = getStartOfWeek(date)
+  d.setDate(d.getDate() + 7)
+  d.setMilliseconds(d.getMilliseconds() - 1)
+  return d
 }
 
 /**

--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -114,6 +114,7 @@ export async function onRequestGet(context) {
         e.name as event_name,
         e.slug as event_slug,
         e.date as event_date,
+        e.end_date as event_end_date,
         e.status as event_status
       FROM performances p
       LEFT JOIN venues v ON p.venue_id = v.id
@@ -223,6 +224,10 @@ export async function onRequestGet(context) {
         event_name: p.event_name,
         event_slug: p.event_slug,
         event_date: p.event_date,
+        // NULL for single-day events. Clients key schedule stale-detection
+        // on event_end_date || event_date (#542 PR-1) so a multi-day
+        // event's saved schedule isn't wiped as stale on day 2.
+        event_end_date: p.event_end_date || null,
         event_status: p.event_status,
         venue_id: p.venue_id,
         venue_name: p.venue_name,
@@ -236,6 +241,7 @@ export async function onRequestGet(context) {
         event_name: p.event_name,
         event_slug: p.event_slug,
         event_date: p.event_date,
+        event_end_date: p.event_end_date || null,
         event_status: p.event_status,
         venue_id: p.venue_id,
         venue_name: p.venue_name,

--- a/functions/api/bands/stats/__tests__/stats.test.js
+++ b/functions/api/bands/stats/__tests__/stats.test.js
@@ -161,3 +161,110 @@ describe("GET /api/bands/stats/:name - social_links scheme sanitization (#483)",
     expect(payload.social.website).toBe("https://example.com/band");
   });
 });
+
+// ---------------------------------------------------------------------------
+// #542 PR-1 — event_end_date exposed on performance rows. BandProfilePage
+// keys schedule stale-detection on event_end_date || event_date; keying it
+// on the start date alone wipes a fan's saved schedule on day 2 of a
+// multi-day event. Single-day events (NULL end_date) must stay null-safe.
+// ---------------------------------------------------------------------------
+describe("GET /api/bands/stats/:name — event_end_date exposure (#542 PR-1)", () => {
+  test("multi-day event performance carries event_end_date in upcoming", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Prohibition Warehouse" });
+    const event = insertEvent(rawDb, {
+      name: "Multi-Day Stats Event",
+      slug: "stats-542-multiday",
+      date: "2099-01-01",
+      end_date: "2099-01-03",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    insertBand(rawDb, {
+      name: "Stats Multiday Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+
+    const request = new Request("https://example.test/api/bands/stats/Stats%20Multiday%20Band");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(1);
+    expect(payload.upcoming[0].event_date).toBe("2099-01-01");
+    expect(payload.upcoming[0].event_end_date).toBe("2099-01-03");
+  });
+
+  test("single-day event performance has event_end_date null (upcoming and past)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Blue Room" });
+    const futureEvent = insertEvent(rawDb, {
+      name: "Single-Day Future",
+      slug: "stats-542-single-future",
+      date: "2099-06-01",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(futureEvent.id);
+    insertBand(rawDb, {
+      name: "Stats Singleday Band",
+      event_id: futureEvent.id,
+      venue_id: venue.id,
+    });
+
+    const pastEvent = insertEvent(rawDb, {
+      name: "Single-Day Past",
+      slug: "stats-542-single-past",
+      date: "2001-01-01",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(pastEvent.id);
+    insertBand(rawDb, {
+      name: "Stats Singleday Band",
+      event_id: pastEvent.id,
+      venue_id: venue.id,
+    });
+
+    const request = new Request("https://example.test/api/bands/stats/Stats%20Singleday%20Band");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(1);
+    expect(payload.upcoming[0].event_end_date).toBeNull();
+    expect(payload.past).toHaveLength(1);
+    expect(payload.past[0].event_end_date).toBeNull();
+  });
+
+  test("past multi-day event performance carries event_end_date", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Princess Cafe" });
+    const event = insertEvent(rawDb, {
+      name: "Past Multi-Day Stats Event",
+      slug: "stats-542-past-multiday",
+      date: "2001-03-01",
+      end_date: "2001-03-03",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    insertBand(rawDb, {
+      name: "Stats Past Multiday Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+
+    const request = new Request("https://example.test/api/bands/stats/Stats%20Past%20Multiday%20Band");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.past).toHaveLength(1);
+    expect(payload.past[0].event_end_date).toBe("2001-03-03");
+  });
+});

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -1221,3 +1221,111 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
     expect(data.upcoming[0]?.id).toBe(event.id);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Real-DB — end_date exposed on every timeline bucket (#542 PR-1). Clients key
+// schedule stale-detection on `end_date || date`; keying it on the start date
+// alone wipes a fan's saved schedule on day 2 of a multi-day event. The "now"
+// query always selected e.end_date (for the #539 COALESCE window) but
+// groupEventData dropped it from the response — these tests pin that the
+// field now survives to the JSON in all three buckets, and stays null for
+// single-day events.
+// ---------------------------------------------------------------------------
+describe("Timeline real-DB — end_date exposed on event objects (#542 PR-1)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // 2026-07-11T12:00:00Z = 08:00 EDT → Toronto "today" is 2026-07-11.
+  const pinClock = () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-11T12:00:00Z"));
+  };
+
+  test("mid-run multi-day event in 'now' carries end_date", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    pinClock();
+
+    // Day 2 of a Jul 10-12 event: inside the #539 COALESCE window, and never
+    // start-edge gated (#569 gates the FIRST day only) — the exact
+    // production shape the staleness fix protects.
+    const event = insertEvent(rawDb, {
+      name: "Mid-Run Weekend",
+      slug: "timeline-enddate-now",
+      date: "2026-07-10",
+      end_date: "2026-07-12",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const found = data.now.find((e) => e.id === event.id);
+    expect(found).toBeDefined();
+    expect(found.end_date).toBe("2026-07-12");
+  });
+
+  test("upcoming multi-day event carries end_date; single-day event has end_date null", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    pinClock();
+
+    const multiDay = insertEvent(rawDb, {
+      name: "Future Weekend",
+      slug: "timeline-enddate-upcoming-multi",
+      date: "2026-07-20",
+      end_date: "2026-07-22",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(multiDay.id);
+
+    const singleDay = insertEvent(rawDb, {
+      name: "Future One-Nighter",
+      slug: "timeline-enddate-upcoming-single",
+      date: "2026-07-15",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(singleDay.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const foundMulti = data.upcoming.find((e) => e.id === multiDay.id);
+    expect(foundMulti).toBeDefined();
+    expect(foundMulti.end_date).toBe("2026-07-22");
+
+    const foundSingle = data.upcoming.find((e) => e.id === singleDay.id);
+    expect(foundSingle).toBeDefined();
+    expect(foundSingle.end_date).toBeNull();
+  });
+
+  test("past multi-day event carries end_date", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    pinClock();
+
+    const event = insertEvent(rawDb, {
+      name: "Last Weekend",
+      slug: "timeline-enddate-past",
+      date: "2026-07-04",
+      end_date: "2026-07-05",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const found = data.past.find((e) => e.id === event.id);
+    expect(found).toBeDefined();
+    expect(found.end_date).toBe("2026-07-05");
+  });
+});

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -133,6 +133,11 @@ export async function onRequestGet(context) {
             name: row.event_name,
             slug: row.event_slug,
             date: row.event_date,
+            // NULL for single-day events. Exposed so clients can pass
+            // end_date || date to schedule stale-detection (#542 PR-1) —
+            // keying staleness on the start date wipes a fan's saved
+            // schedule on day 2 of a multi-day event.
+            end_date: row.event_end_date || null,
             status: row.event_status || null,
             ticket_url: normalizeHttpUrl(row.ticket_url),
             bands: includeBands ? [] : null,
@@ -200,6 +205,7 @@ export async function onRequestGet(context) {
         name: event.name,
         slug: event.slug,
         date: event.date,
+        end_date: event.end_date,
         status: event.status,
         ticket_url: normalizeHttpUrl(event.ticket_url),
         band_count: event.bandIds.size,
@@ -281,6 +287,7 @@ export async function onRequestGet(context) {
           e.name as event_name,
           e.slug as event_slug,
           e.date as event_date,
+          e.end_date as event_end_date,
           e.ticket_url as ticket_url,
           p.band_profile_id as band_id,
           b.name as band_name,
@@ -334,6 +341,7 @@ export async function onRequestGet(context) {
           e.name as event_name,
           e.slug as event_slug,
           e.date as event_date,
+          e.end_date as event_end_date,
           e.status as event_status,
           e.ticket_url as ticket_url,
           p.band_profile_id as band_id,


### PR DESCRIPTION
## Summary

Two silent multi-day bugs, both in the "start-date where a day-aware date belongs" family. (1) **Staleness wipe:** all three `saveSelectedBands` call sites passed the event's START date, so stale-detection (correctly comparing date < today) marked a fan's saved schedule stale on day 2 of a multi-day festival — silently wiping their selections mid-event. Callers now pass `end_date || date`, and the two public APIs backing those surfaces now actually return the field. (2) **Festival-day "Today" filter:** `timeFilter.js` day/week windows ran midnight→midnight, so a 1 AM set — still "tonight" in festival terms — wasn't "Today" the evening before, and a 1 AM Monday check landed in the wrong week. Windows now run 6 AM → 6 AM via `AFTER_MIDNIGHT_THRESHOLD_HOUR` (imported from `festivalDays.js`, never re-encoded).

Part of #542 (multiday phase 2 — PR-1 of the blueprint). Does not close it.

## What changed

| File | Change |
|------|--------|
| `frontend/src/App.jsx`, `pages/BandProfilePage.jsx`, `components/EventTimeline.jsx` | `saveSelectedBands(..., end_date \|\| date)` at all three call sites |
| `frontend/src/utils/timeFilter.js` | Day/week windows shifted to the 6 AM festival-day boundary; `getStartOfWeek` resolves the festival day before the day-of-week lookup |
| `functions/api/events/timeline.js` | `end_date` now returned on event objects in all three buckets (was queried, then dropped) |
| `functions/api/bands/stats/[name].js` | `event_end_date` on upcoming/past performance rows |
| `docs/api-spec.yaml` | `TimelineEvent.end_date` (nullable) documented |
| `CLAUDE.md` | Schedule Storage section documents the `end_date \|\| date` convention |
| Tests | 16 frontend (boundary fixtures at 00:00/01:00/05:59/06:00/23:59, 1 AM Monday week edge, multi-day non-stale regression) + 6 backend real-DB (both endpoints, multi-day + single-day-null) |

## Security / correctness notes

Single-day events are byte-identical (`end_date` is NULL → fallback). DST-safe: Toronto transitions at 2 AM, so the 6 AM boundary is never skipped/ambiguous. Adjacent bug found and filed, deliberately not smuggled in: #603 (band stats classifies multi-day events "past" on day 2).

## Verification

- [x] Tests: backend 736 pass | 6 todo; frontend 513 pass, 0 failures (post-rebase)
- [x] ESLint: 0 errors (backend + frontend)
- [x] Format check: clean (both)
- [x] Build: green (`npm run build --prefix frontend`)
- [x] `validate:openapi`: no drift (71 documented routes)
- [x] Manual smoke: reviewed by code-reviewer agent (clean verdict); time math hand-traced at the 05:59/06:00 boundary and DST edges

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)
