### PR TITLE
fix: dedupe bands with multiple sets on public event cards

### DIFF
--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -432,8 +432,21 @@ function GenreDiscovery({ bands, eventSlug, eventDate }) {
 
   // Group bands by genre, case-insensitive. Bands without a genre go to "Other".
   const genreGroups = useMemo(() => {
+    // `bands` here is the details endpoint's per-performance list — a band
+    // playing two sets appears as two entries sharing the same band.id. The
+    // wall shows one photo tile per ACT, not per set, and selection is keyed
+    // by band id, so dedupe (keep the first/earliest-set occurrence) before
+    // grouping. Without this a two-set act rendered two tiles and tapping
+    // either one toggled the same underlying selection.
+    const seenBandIds = new Set()
+    const dedupedBands = bands.filter(band => {
+      if (seenBandIds.has(band.id)) return false
+      seenBandIds.add(band.id)
+      return true
+    })
+
     const groups = new Map()
-    for (const band of bands) {
+    for (const band of dedupedBands) {
       const raw = (band.genre || '').trim()
       const genre = raw || 'Other'
       const key = genre.toLowerCase()
@@ -630,10 +643,15 @@ function EventCard({
                 <span className="font-bold text-text-primary">{allBandCount}</span>
                 <span className="text-text-tertiary">{allBandCount === 1 ? 'Band' : 'Bands'}</span>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="font-bold text-text-primary">{allVenueCount}</span>
-                <span className="text-text-tertiary">{allVenueCount === 1 ? 'Venue' : 'Venues'}</span>
-              </div>
+              {/* Historical volumes have roster-only lineups with no venue
+                  assignments — "0 Venues" reads as missing data, so omit the
+                  stat entirely rather than showing a zero. */}
+              {allVenueCount > 0 && (
+                <div className="flex items-center gap-2">
+                  <span className="font-bold text-text-primary">{allVenueCount}</span>
+                  <span className="text-text-tertiary">{allVenueCount === 1 ? 'Venue' : 'Venues'}</span>
+                </div>
+              )}
             </div>
           </div>
 
@@ -769,7 +787,7 @@ function EventCard({
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 {allBands.map(band => (
                   <Card
-                    key={band.id}
+                    key={band.performance_id ?? band.id}
                     as={Link}
                     to={buildBandProfileHref(band.name, event.slug)}
                     padding="sm"

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -92,6 +92,123 @@ describe('EventTimeline', () => {
   })
 })
 
+// Regression: a band playing two sets at one event rendered as duplicate
+// entries wherever the frontend treated per-performance rows as per-band
+// rows. The details endpoint's `bands` array stays per-performance (each
+// set carries its own `performance_id`), so this exercises both consumers:
+// GenreDiscovery must dedupe by band id (one photo tile per act), while the
+// "All Performers" grid intentionally keeps one card per set.
+describe('EventTimeline duplicate performer chips (#605)', () => {
+  let resolveDetails
+
+  beforeEach(() => {
+    const timelineData = {
+      now: [],
+      upcoming: [
+        {
+          id: 1,
+          name: 'Two-Set Event',
+          slug: 'two-set-event',
+          date: '2026-05-10',
+          status: 'published',
+          is_published: true,
+          venues: [],
+          bands: [],
+          band_count: 2,
+          venue_count: 1,
+          ticket_url: null,
+        },
+      ],
+      past: [],
+    }
+
+    const detailsPromise = new Promise(resolve => {
+      resolveDetails = resolve
+    })
+
+    global.fetch = vi.fn(url => {
+      if (url.startsWith('/api/events/timeline')) {
+        return Promise.resolve(jsonResponse(timelineData))
+      }
+      if (url === '/api/events/1/details') {
+        return detailsPromise
+      }
+      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders one GenreDiscovery tile but two All Performers cards for a two-set band', async () => {
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Two-Set Event')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }))
+    expect(await screen.findByText(/loading performers and venues/i)).toBeInTheDocument()
+
+    resolveDetails(
+      jsonResponse({
+        venues: [{ id: 7, name: 'Blue Room', band_count: 2, address: '123 King St' }],
+        bands: [
+          {
+            id: 9,
+            performance_id: 101,
+            name: 'Two Set Band',
+            genre: 'Punk',
+            venue_id: 7,
+            venue_name: 'Blue Room',
+            start_time: '19:00',
+            end_time: '20:00',
+          },
+          {
+            id: 10,
+            performance_id: 102,
+            name: 'Solo Band',
+            genre: 'Rock',
+            venue_id: 7,
+            venue_name: 'Blue Room',
+            start_time: '20:30',
+            end_time: '21:30',
+          },
+          {
+            id: 9,
+            performance_id: 103,
+            name: 'Two Set Band',
+            genre: 'Punk',
+            venue_id: 7,
+            venue_name: 'Blue Room',
+            start_time: '22:00',
+            end_time: '23:00',
+          },
+        ],
+        band_count: 2,
+        venue_count: 1,
+      })
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading performers and venues/i)).not.toBeInTheDocument()
+    })
+
+    // GenreDiscovery wall: one photo-tile button per ACT — the two-set band
+    // must be deduped to a single tile, not one per performance.
+    const genreTiles = await screen.findAllByRole('button', { name: /Two Set Band/i })
+    expect(genreTiles).toHaveLength(1)
+    expect(screen.getAllByRole('button', { name: /Solo Band/i })).toHaveLength(1)
+
+    // All Performers grid: per-performance cards — the two-set band
+    // legitimately renders twice (once per set), each with a distinct key.
+    const performerCards = screen.getAllByRole('link', { name: /Two Set Band/i })
+    expect(performerCards).toHaveLength(2)
+  })
+})
+
 // Recap links on past editions (#555): the recap page was previously
 // unreachable except by typing the URL.
 describe('EventTimeline recap links', () => {

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -317,7 +317,10 @@ export default function EventRecapPage() {
                 <li className="text-text-tertiary text-sm py-4 text-center">No performers recorded for this event.</li>
               ) : (
                 bands.map(band => (
-                  <li key={band.id} className="bg-surface rounded-lg p-4 flex items-center justify-between gap-4">
+                  <li
+                    key={band.performance_id}
+                    className="bg-surface rounded-lg p-4 flex items-center justify-between gap-4"
+                  >
                     <div className="flex-1 min-w-0">
                       <Link
                         to={buildBandProfileHref(band.name, event.slug)}

--- a/functions/api/events/[id]/details.js
+++ b/functions/api/events/[id]/details.js
@@ -88,21 +88,38 @@ export async function onRequestGet(context) {
 
     const rows = bandsResult.results || [];
     const venuesMap = new Map();
+    // Distinct band ids across the whole event — a band playing two sets
+    // must count once in band_count even though `bands` below stays
+    // per-performance (the expanded lineup grid legitimately shows each set).
+    const distinctBandIds = new Set();
     const bands = rows.map((row) => {
-      if (row.venue_id && !venuesMap.has(row.venue_id)) {
-        venuesMap.set(row.venue_id, {
-          id: row.venue_id,
-          name: row.venue_name,
-          address: row.venue_address || formatVenueAddress(row),
-          band_count: 0,
-        });
+      if (row.band_id) {
+        distinctBandIds.add(row.band_id);
       }
+
+      // Per-venue band_count must also be distinct bands, not a per-row
+      // tally — a band playing the same venue twice (two sets) must count
+      // once. `bandIds` is stripped from the response below.
       if (row.venue_id) {
-        venuesMap.get(row.venue_id).band_count++;
+        if (!venuesMap.has(row.venue_id)) {
+          venuesMap.set(row.venue_id, {
+            id: row.venue_id,
+            name: row.venue_name,
+            address: row.venue_address || formatVenueAddress(row),
+            band_count: 0,
+            bandIds: new Set(),
+          });
+        }
+        const venue = venuesMap.get(row.venue_id);
+        if (row.band_id && !venue.bandIds.has(row.band_id)) {
+          venue.bandIds.add(row.band_id);
+          venue.band_count++;
+        }
       }
 
       return {
         id: row.band_id,
+        performance_id: row.performance_id,
         name: row.band_name,
         start_time: row.start_time,
         end_time: row.end_time,
@@ -117,8 +134,8 @@ export async function onRequestGet(context) {
       JSON.stringify({
         event,
         bands,
-        venues: Array.from(venuesMap.values()),
-        band_count: bands.length,
+        venues: Array.from(venuesMap.values()).map(({ bandIds: _bandIds, ...venue }) => venue),
+        band_count: distinctBandIds.size,
         venue_count: venuesMap.size,
       }),
       {

--- a/functions/api/events/__tests__/details.test.js
+++ b/functions/api/events/__tests__/details.test.js
@@ -80,6 +80,72 @@ describe("GET /api/events/:id/details", () => {
   });
 });
 
+// Regression: a band playing two sets at one event was counted twice in
+// band_count (the details endpoint's expanded lineup flips the stat row from
+// "32 Bands" collapsed to 34 after expanding). `bands` stays per-performance
+// (the expanded grid legitimately shows each set with its own venue/time),
+// but band_count/venue band_count must count DISTINCT bands, and each
+// per-performance entry must carry `performance_id` so the frontend can key
+// on it instead of the duplicated band id.
+describe("GET /api/events/:id/details - duplicate performer counting (#605)", () => {
+  test("a band with two performances: bands has 3 per-performance entries, band_count is distinct (2), venue band_count is distinct", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Two-Set Details Event",
+      slug: "details-two-set-band",
+      date: "2026-08-02",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "Blue Room" });
+    const firstSet = insertBand(rawDb, {
+      name: "Two Set Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "19:00",
+      end_time: "20:00",
+    });
+    const secondSet = insertBand(rawDb, {
+      name: "Two Set Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "22:00",
+      end_time: "23:00",
+    });
+    const soloSet = insertBand(rawDb, {
+      name: "Solo Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:30",
+      end_time: "21:30",
+    });
+
+    const request = new Request(`https://example.test/api/events/${event.id}/details`);
+    const response = await onRequestGet({
+      request,
+      env,
+      params: { id: String(event.id) },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    // Per-performance: 3 sets total, one entry each.
+    expect(payload.bands).toHaveLength(3);
+    const performanceIds = payload.bands.map((b) => b.performance_id).sort((a, b) => a - b);
+    expect(performanceIds).toEqual([firstSet.id, secondSet.id, soloSet.id].sort((a, b) => a - b));
+
+    // Distinct bands: "Two Set Band" + "Solo Band" = 2.
+    expect(payload.band_count).toBe(2);
+
+    // The single venue hosts 2 distinct bands (not 3 performances).
+    expect(payload.venues).toHaveLength(1);
+    expect(payload.venues[0].band_count).toBe(2);
+    expect(payload.venues[0].bandIds).toBeUndefined();
+  });
+});
+
 describe("GET /api/events/:id/details - reveal_mode gate", () => {
   test("hides unannounced band when reveal_mode=1", async () => {
     const { env, rawDb } = createTestEnv();

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -580,6 +580,90 @@ describe("Timeline API - Optimized JOIN Queries", () => {
       expect(data.now[0].venues[0].band_count).toBe(2);
       expect(data.now[0].bands).toHaveLength(2);
     });
+
+    // Regression: a band playing two sets at one event produced one row per
+    // performance in `bands`, so the public event card rendered duplicate
+    // chips (KEPI GHOULIE ×2 on prod "Buddies Fest 2"). groupEventData must
+    // collapse rows sharing a band_id into a single `bands` entry (first/
+    // earliest set's data wins, since rows are ordered by start_time), while
+    // band_count (already Set-backed) stays correct.
+    it("should dedupe a band with two performances at the same event into one bands entry", async () => {
+      const results = [
+        {
+          event_id: 1,
+          event_name: "Two Set Event",
+          event_slug: "two-set-event",
+          event_date: "2025-11-05",
+          band_id: 1,
+          band_name: "Two Set Band",
+          start_time: "19:00",
+          end_time: "20:00",
+          url: null,
+          genre: "Punk",
+          origin: null,
+          photo_url: null,
+          venue_id: 1,
+          venue_name: "Same Venue",
+          venue_address: "123 St",
+        },
+        {
+          event_id: 1,
+          event_name: "Two Set Event",
+          event_slug: "two-set-event",
+          event_date: "2025-11-05",
+          band_id: 1,
+          band_name: "Two Set Band",
+          start_time: "22:00",
+          end_time: "23:00",
+          url: null,
+          genre: "Punk",
+          origin: null,
+          photo_url: null,
+          venue_id: 1,
+          venue_name: "Same Venue",
+          venue_address: "123 St",
+        },
+        {
+          event_id: 1,
+          event_name: "Two Set Event",
+          event_slug: "two-set-event",
+          event_date: "2025-11-05",
+          band_id: 2,
+          band_name: "Solo Band",
+          start_time: "20:30",
+          end_time: "21:30",
+          url: null,
+          genre: "Rock",
+          origin: null,
+          photo_url: null,
+          venue_id: 1,
+          venue_name: "Same Venue",
+          venue_address: "123 St",
+        },
+      ];
+      mockContext.env.DB = {
+        prepare: () => ({ bind: () => ({ all: async () => ({ results }) }) }),
+        batch: async (statements) => statements.map(() => ({ results })),
+      };
+
+      const response = await onRequestGet(mockContext);
+      const data = await response.json();
+
+      const event = data.now[0];
+      expect(event.band_count).toBe(2);
+      expect(event.bands).toHaveLength(2);
+      const twoSetEntries = event.bands.filter((b) => b.name === "Two Set Band");
+      expect(twoSetEntries).toHaveLength(1);
+      // First (earliest) row's data wins
+      expect(twoSetEntries[0].start_time).toBe("19:00");
+
+      // The venue's band_count counts distinct bands, not rows — the two-set
+      // band must not be double-counted even though it has two rows there.
+      expect(event.venues).toHaveLength(1);
+      expect(event.venues[0].band_count).toBe(2);
+      // Internal per-venue bandIds Set must never leak into the response shape.
+      expect(event.venues[0].bandIds).toBeUndefined();
+    });
   });
 });
 
@@ -1327,5 +1411,73 @@ describe("Timeline real-DB — end_date exposed on event objects (#542 PR-1)", (
     const found = data.past.find((e) => e.id === event.id);
     expect(found).toBeDefined();
     expect(found.end_date).toBe("2026-07-05");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-DB regression — duplicate performer chips for a band with two sets.
+// Prod ("Buddies Fest 2") showed 34 chips for 32 bands because groupEventData
+// pushed one `bands` entry per JOIN row (= per performance) instead of per
+// band. Exercises the actual SQL JOIN (insertBand creates a new performance
+// per call, reusing the band_profile by normalized name), not just the
+// in-memory grouping mocked above.
+// ---------------------------------------------------------------------------
+describe("Timeline real-DB — duplicate performer chips for a two-set band (#605)", () => {
+  test("a band with two performances appears once in bands/band_count; venue band_count is distinct bands", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // Far enough out to land in "upcoming" unambiguously — sidesteps the
+    // start-edge gate (#569) that only applies to the "now" bucket.
+    const farFuture = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString().split("T")[0];
+
+    const event = insertEvent(rawDb, {
+      name: "Two-Set Event",
+      slug: "timeline-realdb-two-set-band",
+      date: farFuture,
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "Blue Room" });
+    insertBand(rawDb, {
+      name: "Two Set Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "19:00",
+      end_time: "20:00",
+    });
+    insertBand(rawDb, {
+      name: "Two Set Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "22:00",
+      end_time: "23:00",
+    });
+    insertBand(rawDb, {
+      name: "Solo Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:30",
+      end_time: "21:30",
+    });
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const found = data.upcoming.find((e) => e.id === event.id);
+    expect(found).toBeDefined();
+    expect(found.band_count).toBe(2);
+    expect(found.bands).toHaveLength(2);
+    const twoSetEntries = found.bands.filter((b) => b.name === "Two Set Band");
+    expect(twoSetEntries).toHaveLength(1);
+    expect(twoSetEntries[0].start_time).toBe("19:00"); // earliest set's data wins
+
+    const venueEntry = found.venues.find((v) => v.id === venue.id);
+    expect(venueEntry).toBeDefined();
+    expect(venueEntry.band_count).toBe(2);
+    expect(venueEntry.bandIds).toBeUndefined();
   });
 });

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -150,8 +150,16 @@ export async function onRequestGet(context) {
 
         // Add band if it exists
         if (row.band_id) {
+          // A band playing two sets at the same event must only produce one
+          // "band" entry — rows are ordered by start_time, so checking
+          // membership BEFORE adding to the Set means the first (earliest)
+          // set's data wins and is the only one pushed to `event.bands`.
+          // Without this, a two-set band shows up as a duplicate chip on the
+          // public event card even though band_count (which already used the
+          // Set) correctly counted it once.
+          const isFirstSetForBand = !event.bandIds.has(row.band_id);
           event.bandIds.add(row.band_id);
-          if (includeBands) {
+          if (includeBands && isFirstSetForBand) {
             let url = normalizeHttpUrl(row.url);
             // Try to extract URL from social_links if url is missing. A bare
             // handle (e.g. an Instagram handle with no scheme) never worked
@@ -185,17 +193,26 @@ export async function onRequestGet(context) {
           }
 
           // Track venue (guard against NULL venue_id — a performance with no
-          // venue assigned must not be counted as a venue; see #479)
-          if (row.venue_id && !event.venues.has(row.venue_id)) {
-            event.venues.set(row.venue_id, {
-              id: row.venue_id,
-              name: row.venue_name,
-              address: row.venue_address || formatVenueAddress(row),
-              band_count: 0,
-            });
-          }
+          // venue assigned must not be counted as a venue; see #479).
+          // band_count must be a count of DISTINCT bands playing that venue,
+          // not a per-row tally — a band playing the same venue twice (two
+          // sets) must count once, so a per-venue `bandIds` Set (stripped
+          // from the final response below) gates the increment.
           if (row.venue_id) {
-            event.venues.get(row.venue_id).band_count++;
+            if (!event.venues.has(row.venue_id)) {
+              event.venues.set(row.venue_id, {
+                id: row.venue_id,
+                name: row.venue_name,
+                address: row.venue_address || formatVenueAddress(row),
+                band_count: 0,
+                bandIds: new Set(),
+              });
+            }
+            const venue = event.venues.get(row.venue_id);
+            if (!venue.bandIds.has(row.band_id)) {
+              venue.bandIds.add(row.band_id);
+              venue.band_count++;
+            }
           }
         }
       }
@@ -211,7 +228,9 @@ export async function onRequestGet(context) {
         band_count: event.bandIds.size,
         venue_count: event.venues.size,
         bands: includeBands ? event.bands : undefined,
-        venues: Array.from(event.venues.values()),
+        // Strip the internal `bandIds` Set — the public shape stays
+        // { id, name, address, band_count } as before.
+        venues: Array.from(event.venues.values()).map(({ bandIds: _bandIds, ...venue }) => venue),
       }));
     }
 


### PR DESCRIPTION
## Summary

A band playing two sets at one event appeared twice in the public event card's collapsed "Performers:" chips (prod: Buddies Fest 2 showed 34 chips for 32 bands — KEPI GHOULIE ×2, ALL ×2), and the stat row flipped from 32 to 34 Bands when the card expanded. Root cause: `/api/events/timeline` and `/api/events/:id/details` emit one array entry per **performance** JOIN row while consumers treat entries as **bands**. This dedupes what should be per-band, keeps what is legitimately per-set, and fixes the duplicate React keys that came with it.

Closes #605

## What changed

| File | Change |
|------|--------|
| `functions/api/events/timeline.js` | `groupEventData()` pushes one `bands` entry per distinct band (rows are start_time-ordered, so the earliest set's data wins); per-venue `band_count` now counts distinct bands via an internal Set that is stripped before JSON (public shape unchanged) |
| `functions/api/events/[id]/details.js` | `band_count` counts distinct bands instead of performances (the 32→34 flip); each per-set `bands` entry now carries `performance_id`; same per-venue distinct-count fix |
| `frontend/src/components/EventTimeline.jsx` | "All Performers" grid keyed by `performance_id ?? id` (it stays per-set — each card shows its own venue/time); GenreDiscovery wall dedupes by band id (was: two tiles, tapping one highlighted both); venue stat omitted entirely when an event has no venue data (historical roster-only volumes showed "0 Venues" — per Dre) |
| `frontend/src/pages/EventRecapPage.jsx` | Archived-lineup rows keyed by `performance_id` (last stray `band.id` key in the file) |
| `functions/api/events/__tests__/timeline.test.js` | Mock-level dedupe test + real-DB regression: two-set band appears once, distinct band_count, venue distinct count, no `bandIds` leak |
| `functions/api/events/__tests__/details.test.js` | Real-DB: 3 performances / 2 bands → per-set `bands` with `performance_id`, distinct `band_count` |
| `frontend/src/components/__tests__/EventTimeline.test.jsx` | Two-set band renders one genre tile and two per-set All Performers cards |

**Deliberate design choice (flagged by review):** the expanded "All Performers (N)" header counts distinct **acts** (consistent with the collapsed "N Bands" stat), while the grid below renders per-**set** cards — so a two-set act shows one chip collapsed and two time/venue-distinct cards expanded. Veto welcome.

**Consumer audit:** only `EventTimeline.jsx` consumes these endpoints; `functions/event/[slug].js` SSR meta runs its own `SELECT DISTINCT` (already deduped); the service worker caches opaquely. `performance_id` is additive; the `venues` shape is byte-compatible.

## Security / correctness notes

None security-wise — public read-only endpoints, no auth/CSRF surface. Correctness: the #569 start-edge gate derives from raw JOIN rows, not grouped output, and is unaffected (pinned by existing tests, re-verified in review).

## Verification

- [x] Tests: backend 742 pass | 6 todo (74 files), frontend 514 pass (50 files) — post-rebase on main
- [x] ESLint: 0 errors both stacks (2 pre-existing warnings in untouched admin files)
- [x] Format check: clean (`npm run format:check` both stacks)
- [x] Build: green (`npm run build --prefix frontend`)
- [x] `validate:openapi`: n/a — `docs/api-spec.yaml` unchanged
- [ ] Manual smoke: pending — verify on the Buddies Fest 2 card post-deploy (expect 32 unique chips, count stable on expand)

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)