### PR TITLE
fix: sort collapsed performer chips alphabetically

### DIFF
--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -7,6 +7,7 @@ import { formatTimeRange, parseLocalDate } from '../utils/timeFormat'
 import { trackTicketClick } from '../utils/metrics'
 import { safeExternalHref } from '../utils/urlSafety'
 import { getSelectedBands, saveSelectedBands } from '../utils/scheduleStorage'
+import { sortableName } from '../utils/sortableName'
 import { Alert, Badge, Button, Card, Loading } from './ui'
 import EventsPageSkeleton from './EventsPageSkeleton'
 
@@ -575,7 +576,14 @@ function EventCard({
     })
   }
 
-  const featuredBands = event.bands || []
+  // Collapsed chips show names only (no set times), so fans scan them as a
+  // lookup — alphabetical, article-stripped (#587 convention). The expanded
+  // "All Performers" grid keeps the API's set-time order, where running
+  // order is meaningful.
+  const featuredBands = useMemo(
+    () => [...(event.bands || [])].sort((a, b) => sortableName(a.name).localeCompare(sortableName(b.name))),
+    [event.bands]
+  )
   const resolvedDetails = details
   const isLoadingDetails = expanded && detailsLoading && !resolvedDetails
   const venueList = resolvedDetails?.venues || event.venues || []

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -258,3 +258,62 @@ describe('EventTimeline recap links', () => {
     expect(recapLinks[0]).toHaveAttribute('href', '/events/past-fest/recap')
   })
 })
+
+// The collapsed "Performers:" chips show names only, so they sort
+// alphabetically with the article-stripped #587 convention ("The X" under X's
+// first real word) — regardless of the set-time order the API returns.
+describe('EventTimeline collapsed performer chips ordering', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders chips alphabetically, ignoring leading articles', async () => {
+    const timelineData = {
+      now: [],
+      upcoming: [
+        {
+          id: 3,
+          name: 'Chip Sort Fest',
+          slug: 'chip-sort-fest',
+          date: '2026-09-01',
+          status: 'published',
+          is_published: true,
+          venues: [],
+          // API order is set-time order — deliberately unalphabetical.
+          bands: [
+            { id: 1, name: 'Zebra Mussels' },
+            { id: 2, name: 'The Anti-Queens' },
+            { id: 3, name: 'Mango Static' },
+          ],
+          band_count: 3,
+          venue_count: 0,
+          ticket_url: null,
+        },
+      ],
+      past: [],
+    }
+
+    global.fetch = vi.fn(url => {
+      if (url.startsWith('/api/events/timeline')) {
+        return Promise.resolve(jsonResponse(timelineData))
+      }
+      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Chip Sort Fest')).toBeInTheDocument()
+
+    const chips = screen
+      .getAllByRole('link')
+      .map(el => el.textContent)
+      .filter(text => ['Zebra Mussels', 'The Anti-Queens', 'Mango Static'].includes(text))
+
+    // "The Anti-Queens" files under A (article stripped), then M, then Z.
+    expect(chips).toEqual(['The Anti-Queens', 'Mango Static', 'Zebra Mussels'])
+  })
+})


### PR DESCRIPTION
## Summary

The collapsed "Performers:" chips on public event cards rendered in the API's set-time order — which is running order for timed events (Buddies Fest 2) and effectively random insertion order for events without set times (Vol 17). Chips show names only, so fans scan them as a lookup; they now sort alphabetically using the article-stripped `sortableName()` convention (#587), so "The Mendozaz" files under M. Per Dre's request.

The expanded "All Performers" grid deliberately keeps set-time order — those cards show venue/time, where running order is meaningful.

## What changed

| File | Change |
|------|--------|
| `frontend/src/components/EventTimeline.jsx` | `featuredBands` sorted via `sortableName` in a `useMemo` (chips only) |
| `frontend/src/components/__tests__/EventTimeline.test.jsx` | Regression test: unalphabetical API order renders alphabetically, article stripped |

## Security / correctness notes

None — render-order-only change in one component.

## Verification

- [x] Tests: frontend 515 pass (50 files), incl. the new ordering test
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: n/a — no API change
- [x] Manual smoke: covered by component test asserting rendered chip order

---
Built by Theo · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)