### PR TITLE
fix: classify band-profile shows per-performance, not per-event

### DIFF
--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -101,6 +101,7 @@ export async function onRequestGet(context) {
         p.id as performance_id,
         p.start_time,
         p.end_time,
+        p.performance_date,
         v.id as venue_id,
         v.name as venue_name,
         v.address as venue_address,
@@ -133,10 +134,18 @@ export async function onRequestGet(context) {
     // Calculate statistics
     const today = eventLocalToday();
 
-    // Separate upcoming and past performances
-    // Archived events always go to past regardless of date
-    const upcomingPerformances = allPerformances.filter((p) => p.event_date >= today && p.event_status !== "archived");
-    const pastPerformances = allPerformances.filter((p) => p.event_date < today || p.event_status === "archived");
+    // Separate upcoming and past performances — per-performance (#603), not
+    // per-event: on a multi-day event, each set's OWN day decides its bucket,
+    // so a band's day-1 set can already be "past" while its day-3 set is
+    // still "upcoming" mid-festival. NULL performance_date inherits the
+    // event's start date (the #543 convention: day-1 sets and single-day
+    // events store NULL). Archived events always go to past regardless of date.
+    const upcomingPerformances = allPerformances.filter(
+      (p) => (p.performance_date || p.event_date) >= today && p.event_status !== "archived",
+    );
+    const pastPerformances = allPerformances.filter(
+      (p) => (p.performance_date || p.event_date) < today || p.event_status === "archived",
+    );
 
     // Get unique venues
     const venueMap = new Map();

--- a/functions/api/bands/stats/__tests__/stats.test.js
+++ b/functions/api/bands/stats/__tests__/stats.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, afterEach, vi } from "vitest";
 import { onRequestGet } from "../[name].js";
 import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils.js";
 
@@ -266,5 +266,132 @@ describe("GET /api/bands/stats/:name — event_end_date exposure (#542 PR-1)", (
     const payload = await response.json();
     expect(payload.past).toHaveLength(1);
     expect(payload.past[0].event_end_date).toBe("2001-03-03");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #603 — upcoming/past classification is per-performance, not per-event.
+// On a multi-day event, a set's OWN day (performance_date, falling back to
+// the event's start date for the #543 NULL convention) decides its bucket —
+// so a band's day-1 set can already be "past" while its day-3 set is still
+// "upcoming" mid-festival, instead of the whole band flipping to "past" the
+// moment the event's start date has elapsed. Archived events still force
+// every set to "past" regardless of date.
+// ---------------------------------------------------------------------------
+describe("GET /api/bands/stats/:name — per-performance classification (#603)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // 2026-07-11T12:00:00Z = 08:00 EDT → Toronto "today" is 2026-07-11,
+  // day 2 of a 2026-07-10..2026-07-12 event (same idiom as timeline.test.js
+  // "#542 PR-1" real-DB describe block).
+  const pinDayTwoClock = () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-11T12:00:00Z"));
+  };
+
+  test("day-1 set is past and day-3 set is upcoming on day 2 of a multi-day event", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    pinDayTwoClock();
+
+    const venue = insertVenue(rawDb, { name: "Prohibition Warehouse" });
+    const event = insertEvent(rawDb, {
+      name: "Multi-Day 603 Event",
+      slug: "stats-603-multiday",
+      date: "2026-07-10",
+      end_date: "2026-07-12",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const day1Perf = insertBand(rawDb, {
+      name: "Stats 603 Multiday Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-07-10", day1Perf.id);
+
+    const day3Perf = insertBand(rawDb, {
+      name: "Stats 603 Multiday Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-07-12", day3Perf.id);
+
+    const request = new Request("https://example.test/api/bands/stats/Stats%20603%20Multiday%20Band");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.past).toHaveLength(1);
+    expect(payload.past[0].id).toBe(day1Perf.id);
+    expect(payload.upcoming).toHaveLength(1);
+    expect(payload.upcoming[0].id).toBe(day3Perf.id);
+  });
+
+  test("NULL performance_date inherits the event start date and is past on day 2", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    pinDayTwoClock();
+
+    const venue = insertVenue(rawDb, { name: "Room 47" });
+    const event = insertEvent(rawDb, {
+      name: "Multi-Day 603 Null Event",
+      slug: "stats-603-null-perf-date",
+      date: "2026-07-10",
+      end_date: "2026-07-12",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    // performance_date left NULL — the #543 convention for day-1 sets and
+    // single-day events — so it must inherit event_date (2026-07-10), which
+    // has already elapsed by the day-2 pinned clock.
+    const perf = insertBand(rawDb, {
+      name: "Stats 603 Null Perf Date Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+
+    const request = new Request("https://example.test/api/bands/stats/Stats%20603%20Null%20Perf%20Date%20Band");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.past).toHaveLength(1);
+    expect(payload.past[0].id).toBe(perf.id);
+    expect(payload.upcoming).toHaveLength(0);
+  });
+
+  test("archived event with a future-dated performance is still past", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    pinDayTwoClock();
+
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    const event = insertEvent(rawDb, {
+      name: "Archived 603 Event",
+      slug: "stats-603-archived",
+      date: "2099-01-01",
+      status: "archived",
+    });
+
+    const perf = insertBand(rawDb, {
+      name: "Stats 603 Archived Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2099-01-01", perf.id);
+
+    const request = new Request("https://example.test/api/bands/stats/Stats%20603%20Archived%20Band");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.past).toHaveLength(1);
+    expect(payload.past[0].id).toBe(perf.id);
+    expect(payload.upcoming).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

`/api/bands/stats/:name` split a band's shows into upcoming/past by the **event's start date**, so on day 2 of a multi-day festival every set flipped to "past" — a band playing day 3 showed under history while their set was days away (#603). Per Dre's decision on the issue, classification is now **per-performance**: each set stays "upcoming" until its own day has passed, then automatically drops below into performance history — so a day-1 set correctly moves down mid-festival while a day-3 set stays up top. No frontend change needed: BandProfilePage renders the API's arrays as-is.

Closes #603

## What changed

| File | Change |
|------|--------|
| `functions/api/bands/stats/[name].js` | `p.performance_date` added to the SELECT; upcoming/past filters use `(p.performance_date \|\| p.event_date)` vs today (Toronto-local `eventLocalToday()`, unchanged); archived force-past preserved. All other stats (`total_performances`, venues, debut/latest) derive from the unsplit list — verified unaffected |
| `functions/api/bands/stats/__tests__/stats.test.js` | #603 describe: day-1 set past + day-3 set upcoming on a pinned day-2 Toronto clock; NULL `performance_date` inherits event start date; archived event with future performance stays past |

## Security / correctness notes

None — public read-only endpoint, classification logic only; response shape unchanged.

## Verification

- [x] Tests: backend 749 pass | 6 todo (74 files); stats file 11/11 (8 pre-existing + 3 new)
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: n/a — no frontend change
- [x] `validate:openapi`: n/a — response shape unchanged
- [x] Manual smoke: covered by clock-pinned real-DB tests exercising the exact day-2 scenario from the issue

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)