### PR TITLE
feat: move roster card icons below the text row

### DIFF
--- a/frontend/src/pages/ArtistsPage.jsx
+++ b/frontend/src/pages/ArtistsPage.jsx
@@ -59,10 +59,10 @@ function ArtistCard({ artist }) {
   const socialLinks = getCardSocialLinks(artist.social)
 
   return (
-    <div className="relative flex items-center gap-4 rounded-xl border border-border bg-gradient-card p-4 transition hover:border-accent-400/50">
+    <div className="rounded-xl border border-border bg-gradient-card p-4 transition hover:border-accent-400/50">
       <Link
         to={buildBandProfileHref(artist.name)}
-        className="flex min-w-0 flex-1 items-center gap-4 rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+        className="flex min-w-0 items-center gap-4 rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
       >
         {artist.photo_url ? (
           <img
@@ -82,8 +82,12 @@ function ArtistCard({ artist }) {
           <p className="mt-0.5 text-xs text-text-tertiary">{shows}</p>
         </div>
       </Link>
+      {/* Icons live on their own row below the text so a long band name never
+          competes with them for width (the card grows vertically instead —
+          per Dre). pl-[68px] lines the icon glyphs up with the text column:
+          64px photo + 16px gap, minus the 12px inset of the 40px hit area. */}
       {socialLinks.length > 0 && (
-        <div className="flex shrink-0 items-center gap-1">
+        <div className="mt-1 flex items-center gap-1 pl-[68px]">
           {socialLinks.map(({ key, label, Icon, href }) => (
             <a
               key={key}


### PR DESCRIPTION
## Summary

Follow-up to #609 (merged) from Dre's review: a long band name truncated against the right-aligned icon cluster ("THE TIME TRAVEL…"). The icon row now sits **below** the name/meta block, aligned with the text column — the name gets the full card width and the card grows vertically instead. Cards without links keep their original height. Verified with a seeded worst case ("The Time Travelling Garbage Collectors" + 4 icons) in both dark and light themes; screenshots shared with Dre in-session.

Refs #607.

## What changed

| File | Change |
|------|--------|
| `frontend/src/pages/ArtistsPage.jsx` | Icon cluster moved from a right-aligned flex sibling to its own row under the text (`pl-[68px]` aligns icon glyphs with the text column: 64px photo + 16px gap − 12px hit-area inset); name column no longer competes for width |

## Security / correctness notes

None — layout-only change; hrefs, sanitization, metrics, and aria-labels unchanged.

## Verification

- [x] Tests: frontend 519 pass (50 files) — icon-cluster tests query by role/aria-label, unaffected by layout
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: n/a
- [x] Manual smoke: local wrangler + seeded long-name band, both themes screenshotted

---
Built by Theo · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)