### PR TITLE
fix: admin roster returns one row per profile, not per performance

### DIFF
--- a/functions/api/admin/bands.js
+++ b/functions/api/admin/bands.js
@@ -148,9 +148,16 @@ export async function onRequestGet(context) {
 
   const url = new URL(request.url);
   const eventId = url.searchParams.get("event_id");
-  const requestedLimit = Number.parseInt(url.searchParams.get("limit") || "200", 10);
+  // limit/offset only apply to the no-event_id (roster) branch below — the
+  // event_id branch returns a single event's full lineup, unpaginated.
+  // Default is 500 (the existing cap), not 200: since #618, this branch
+  // returns one row per active band_profile, and prod already has ~220
+  // active profiles — a 200 default would silently truncate the roster
+  // again. Callers (RosterTab, LineupTab's ArtistPicker) request no limit,
+  // so they get whatever the default is.
+  const requestedLimit = Number.parseInt(url.searchParams.get("limit") || "500", 10);
   const requestedOffset = Number.parseInt(url.searchParams.get("offset") || "0", 10);
-  const limit = Number.isFinite(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 500) : 200;
+  const limit = Number.isFinite(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 500) : 500;
   const offset = Number.isFinite(requestedOffset) ? Math.max(requestedOffset, 0) : 0;
 
   try {
@@ -195,14 +202,34 @@ export async function onRequestGet(context) {
         .bind(eventId)
         .all();
     } else {
-      // List all bands (performances AND profiles without performances)
-      // We use a LEFT JOIN starting from band_profiles to include everyone.
-      // If a profile has no performance, p.id is null.
-      // We construct a synthetic ID for profile-only rows: 'profile_' || bp.id
+      // List all active band PROFILES (roster view), one row per profile (#618).
+      // A profile can have zero, one, or many performances across many events;
+      // the old query LEFT JOINed to performances with no GROUP BY, so a band
+      // with N performances produced N rows. Combined with `ORDER BY e.date
+      // DESC` + `LIMIT`, any profile whose only performances were on older
+      // events could sort past the limit and vanish entirely (#618 — Adelleda,
+      // whose sole performance was a 2024 event, was missing from the roster).
+      // GROUP BY bp.id collapses that back to one row per profile, so the
+      // LIMIT now bounds roster size (~220 active profiles in prod), not
+      // performance-row count.
+      //
+      // The per-performance columns (event/venue name, event date, etc.) are
+      // kept for a "last played" display, sourced from the band's MOST RECENT
+      // performance: SQLite's bare-column-with-MAX() semantics say that when a
+      // query has exactly one MAX() aggregate, bare columns in the same result
+      // row are pulled from the input row that produced the max — including
+      // per GROUP BY group, not just whole-table aggregates. So MAX(e.date)
+      // plus the bare v.name/e.name/p.* columns below consistently resolve to
+      // the same (most recent) performance row, without a subquery or window
+      // function. Profiles with zero performances get NULLs throughout (LEFT
+      // JOIN), same as before.
+      // We construct a synthetic ID: 'profile_' || bp.id (unique per profile —
+      // no consumer in this branch reads `id` as a real performance id; both
+      // RosterTab and LineupTab's ArtistPicker key off `band_profile_id`).
       result = await DB.prepare(
         `
         SELECT
-          COALESCE(p.id, 'profile_' || bp.id) as id,
+          'profile_' || bp.id as id,
           p.event_id,
           p.venue_id,
           p.start_time,
@@ -224,13 +251,14 @@ export async function onRequestGet(context) {
           (SELECT COUNT(*) FROM band_follows bf WHERE bf.band_profile_id = bp.id AND bf.verified = 1) AS follower_count,
           v.name as venue_name,
           e.name as event_name,
-          e.date as event_date
+          MAX(e.date) as event_date
         FROM band_profiles bp
         LEFT JOIN performances p ON bp.id = p.band_profile_id
         LEFT JOIN venues v ON p.venue_id = v.id
         LEFT JOIN events e ON p.event_id = e.id
         WHERE bp.is_active = 1
-        ORDER BY e.date DESC, p.start_time, bp.name
+        GROUP BY bp.id
+        ORDER BY event_date DESC, bp.name
         LIMIT ?
         OFFSET ?
       `,
@@ -242,10 +270,13 @@ export async function onRequestGet(context) {
     const bands = (result.results || []).map(unpackSocialLinks);
 
     // Re-derive the exact ordering in JS with the article-stripped sort key
-    // (#587) — see the comparator helpers above. No pagination-boundary risk:
-    // the eventId branch has no LIMIT/OFFSET (one event's full lineup), and
-    // no admin UI consumer requests the "list all" branch beyond its single
-    // default page.
+    // (#587) — see the comparator helpers above. Pagination-boundary
+    // guarantee: the eventId branch has no LIMIT/OFFSET (one event's full
+    // lineup). The no-eventId branch is GROUP BY bp.id (#618) — exactly one
+    // row per active band_profile — so its row count is bounded by roster
+    // size, not by how many performances a band has; the JS re-sort below
+    // never has to worry about a truncated LIMIT window splitting a single
+    // band across pages.
     if (eventId) {
       bands.sort((a, b) => compareStartTimeNullsLast(a, b) || sortableName(a.name).localeCompare(sortableName(b.name)));
     } else {

--- a/functions/api/admin/bands/__tests__/bands.test.js
+++ b/functions/api/admin/bands/__tests__/bands.test.js
@@ -155,6 +155,113 @@ describe("Admin bands API - CRUD operations", () => {
   });
 });
 
+describe("Admin bands API - GET without event_id returns one row per profile (#618)", () => {
+  it("a band whose only performance is on the OLDEST event still appears when total performance rows exceed the requested limit", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const oldEvent = insertEvent(rawDb, { name: "Old Event 618", slug: "old-event-618", date: "2020-01-01" });
+    const midEvent = insertEvent(rawDb, { name: "Mid Event 618", slug: "mid-event-618", date: "2024-06-01" });
+    const newEvent = insertEvent(rawDb, { name: "New Event 618", slug: "new-event-618", date: "2026-08-01" });
+    const venue = insertVenue(rawDb, { name: "Regression Venue 618" });
+
+    // Band whose ONLY performance is on the oldest event — the #618 regression
+    // case (Adelleda: sole performance on lwbc07, a 2024 event).
+    insertBand(rawDb, {
+      name: "Adelleda Regression",
+      event_id: oldEvent.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
+
+    // A prolific band with many performances on newer events inflates the
+    // PERFORMANCE row count well past a small explicit limit, without
+    // inflating the PROFILE count (still just 1 profile, 5 performances).
+    for (let i = 0; i < 5; i++) {
+      insertBand(rawDb, {
+        name: "Prolific Band 618",
+        event_id: i % 2 === 0 ? midEvent.id : newEvent.id,
+        venue_id: venue.id,
+        start_time: `${18 + i}:00`,
+        end_time: `${19 + i}:00`,
+      });
+    }
+
+    // Old (buggy) query: LEFT JOIN with no GROUP BY produces 1 (Adelleda) + 5
+    // (Prolific) = 6 performance rows, `ORDER BY e.date DESC` + `LIMIT 3`
+    // returns the 3 newest-event performance rows — all Prolific Band's — so
+    // Adelleda's row never makes the page. Fixed query: GROUP BY bp.id
+    // produces exactly 2 rows (one per profile), both well under limit=3.
+    const getReq = new Request("https://example.test/api/admin/bands?limit=3", { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    expect(getRes.status).toBe(200);
+    const data = await getRes.json();
+
+    const names = data.bands.map((b) => b.name);
+    expect(names).toContain("Adelleda Regression");
+  });
+
+  it("returns exactly one row per profile even when the band has multiple performances", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const ev1 = insertEvent(rawDb, { name: "Dedup Event 1", slug: "dedup-event-1", date: "2025-01-01" });
+    const ev2 = insertEvent(rawDb, { name: "Dedup Event 2", slug: "dedup-event-2", date: "2025-06-01" });
+    const ev3 = insertEvent(rawDb, { name: "Dedup Event 3", slug: "dedup-event-3", date: "2025-12-01" });
+    const venue = insertVenue(rawDb, { name: "Dedup Venue" });
+
+    insertBand(rawDb, {
+      name: "Triple Booked Band",
+      event_id: ev1.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "19:00",
+    });
+    insertBand(rawDb, {
+      name: "Triple Booked Band",
+      event_id: ev2.id,
+      venue_id: venue.id,
+      start_time: "19:00",
+      end_time: "20:00",
+    });
+    insertBand(rawDb, {
+      name: "Triple Booked Band",
+      event_id: ev3.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+
+    const getReq = new Request("https://example.test/api/admin/bands", { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    expect(getRes.status).toBe(200);
+    const data = await getRes.json();
+
+    const matches = data.bands.filter((b) => b.name === "Triple Booked Band");
+    expect(matches.length).toBe(1);
+    // "Last played" context should reflect the band's MOST RECENT event (ev3),
+    // via SQLite's bare-column-with-MAX() semantics.
+    expect(matches[0].event_name).toBe("Dedup Event 3");
+    expect(matches[0].event_date).toBe("2025-12-01");
+  });
+
+  it("excludes inactive profiles from the roster branch (#619 deferred — surfacing them is out of scope here)", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized, is_active) VALUES (?, ?, ?)")
+      .run("Active Roster Band 618", "activerosterband618", 1);
+    rawDb
+      .prepare("INSERT INTO band_profiles (name, name_normalized, is_active) VALUES (?, ?, ?)")
+      .run("Retired Roster Band 618", "retiredrosterband618", 0);
+
+    const getReq = new Request("https://example.test/api/admin/bands", { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    expect(getRes.status).toBe(200);
+    const data = await getRes.json();
+
+    const names = data.bands.map((b) => b.name);
+    expect(names).toContain("Active Roster Band 618");
+    expect(names).not.toContain("Retired Roster Band 618");
+  });
+});
+
 describe("Admin bands API - Validation", () => {
   it("create rejects performances for archived events", async () => {
     const { env, rawDb, headers } = createTestEnv({ role: "editor" });


### PR DESCRIPTION
## Summary

The admin roster silently truncated: the all-bands query returned one row per **performance** (LEFT JOIN, no GROUP BY), ordered newest-event-first, and applied LIMIT 200 — so bands whose only performances were on older events fell past the cutoff before RosterTab's client-side dedupe ever saw them. Reported by Dre: Adelleda (sole set on lwbc07, Feb 2024) was visible on the public site but uneditable in admin. The branch now does `GROUP BY bp.id` — one row per active profile — so the result is bounded by roster size, not performance count.

Closes #618

## What changed

| File | Change |
|------|--------|
| `functions/api/admin/bands.js` | No-`event_id` branch: `GROUP BY bp.id`; "last played" context (event/venue name, date) sourced from the band's most recent performance via SQLite's bare-column-with-`MAX()` semantics — **validated against production D1 directly** (Burnaby, on Vols 1+2, resolves to Vol 2 with matching event name; Suplex with 3 sets resolves to Vol 17); synthetic id is now always `profile_N` (verified no consumer reads it as a performance id — RosterTab and ArtistPicker key off `band_profile_id`); default limit 200 → 500 (prod already holds 218 active profiles, over the old default); the false "no pagination-boundary risk" comment rewritten to state the real guarantee |
| `functions/api/admin/bands/__tests__/bands.test.js` | 3 regression tests: old-event band survives when performance rows exceed the limit (fails on the old query); one row per profile for a 3-set band; inactive profile still excluded (pins current behaviour — surfacing inactive is #619) |

**Deliberate behaviour change:** RosterTab's Delete now always sends `profile_N`, which hits the existing "has performances → 409" guard instead of deleting one arbitrary performance row — strictly safer, and consistent with the guard `bulk.js` already enforces.

**Out of scope:** the `event_id` branch (untouched); `is_active = 1` filter stays (#619 covers surfacing inactive profiles).

## Security / correctness notes

Admin-only endpoint behind `checkPermission("viewer")`, unchanged. Correctness: `follower_count` correlated subquery verified under GROUP BY via the existing dedicated test.

## Verification

- [x] Tests: backend 755 pass | 6 todo (74 files); `bands.test.js` 81/81 (78 + 3 new); follower-count test green
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: n/a backend-only; frontend suite sanity-run green (519) with no frontend changes
- [x] `validate:openapi`: n/a — response shape field-compatible (same columns, per-profile rows)
- [x] Manual smoke: the exact GROUP BY + MAX() query shape executed against production D1 read-only — per-group max-row resolution confirmed on real data

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)