### PR TITLE
fix: recap first-timer chronology + roster-only archive noise

### DIFF
--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -152,6 +152,10 @@ export default function EventRecapPage() {
   const formattedDate = eventDate
     ? eventDate.toLocaleDateString('en-CA', { year: 'numeric', month: 'long', day: 'numeric' })
     : 'Date TBD'
+  // Roster-only historical archives (Vols 1-14) have no venue assignments at
+  // all — "Venues: 0" reads as missing data, not a real stat. Mirrors the
+  // omit-zero-venues precedent in EventTimeline.jsx (EventCard, #608).
+  const hasVenueData = stats.venue_count > 0
 
   return (
     <>
@@ -193,9 +197,12 @@ export default function EventRecapPage() {
             </div>
           </header>
 
-          <section aria-label="Event statistics" className="mb-10 grid grid-cols-2 gap-4 sm:grid-cols-5">
+          <section
+            aria-label="Event statistics"
+            className={`mb-10 grid grid-cols-2 gap-4 ${hasVenueData ? 'sm:grid-cols-5' : 'sm:grid-cols-4'}`}
+          >
             <StatCard label="Total Sets" value={stats.total_sets ?? '—'} />
-            <StatCard label="Venues" value={stats.venue_count ?? '—'} />
+            {hasVenueData && <StatCard label="Venues" value={stats.venue_count} />}
             <StatCard label="First Timers" value={stats.first_timers ?? '—'} />
             <StatCard label="Returning Acts" value={stats.returning_acts ?? '—'} />
             <StatCard label="Saved Route" value={savedBands.length || '—'} />
@@ -275,7 +282,14 @@ export default function EventRecapPage() {
                 <article key={venue.id} className="rounded-xl border border-border bg-bg-navy/40 p-4">
                   <div className="mb-3 flex items-start justify-between gap-3">
                     <div>
-                      <h3 className="text-lg font-semibold text-text-primary">{venue.name}</h3>
+                      {/* "Unscheduled" is accurate when it's the leftover group next to
+                          real venue assignments (partially-scheduled event). But when it's
+                          the ONLY group — the event has zero venue assignments at all,
+                          e.g. a roster-only historical archive — "Unscheduled" implies a
+                          scheduling gap that doesn't exist; "Lineup" reads correctly (#614). */}
+                      <h3 className="text-lg font-semibold text-text-primary">
+                        {venue.id === 'unscheduled' && !hasVenueData ? 'Lineup' : venue.name}
+                      </h3>
                       <p className="text-sm text-text-tertiary">
                         {venue.bands.length} {venue.bands.length === 1 ? 'set' : 'sets'} on the night
                       </p>
@@ -299,9 +313,13 @@ export default function EventRecapPage() {
                         >
                           {band.name}
                         </Link>
-                        <span className="shrink-0 text-text-tertiary">
-                          {band.start_time || 'TBD'}–{band.end_time || 'TBD'}
-                        </span>
+                        {/* Roster-only archives have neither start nor end time recorded —
+                            render nothing rather than "TBD–TBD" (#614). */}
+                        {(band.start_time || band.end_time) && (
+                          <span className="shrink-0 text-text-tertiary">
+                            {band.start_time || 'TBD'}–{band.end_time || 'TBD'}
+                          </span>
+                        )}
                       </li>
                     ))}
                   </ul>

--- a/frontend/src/pages/__tests__/EventRecapPage.test.jsx
+++ b/frontend/src/pages/__tests__/EventRecapPage.test.jsx
@@ -1,0 +1,187 @@
+import { render, screen, within } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import EventRecapPage from '../EventRecapPage.jsx'
+import { fetchPublicJson } from '../../utils/publicApi'
+
+vi.mock('../../utils/publicApi', () => ({ fetchPublicJson: vi.fn() }))
+
+function renderPage(slug = 'lwbc01') {
+  return render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={[`/events/${slug}/recap`]}>
+        <Routes>
+          <Route path="/events/:slug/recap" element={<EventRecapPage />} />
+        </Routes>
+      </MemoryRouter>
+    </HelmetProvider>
+  )
+}
+
+// #614: roster-only historical archives (Vols 1-14) have no venue or time
+// data — the recap page must not render "we don't know" noise for them.
+describe('EventRecapPage — roster-only archive (no venue/time data)', () => {
+  beforeEach(() => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      event: { id: 1, name: 'LWBC Vol1', slug: 'lwbc01', date: '2022-05-22' },
+      stats: { total_sets: 2, venue_count: 0, first_timers: 2, returning_acts: 0 },
+      bands: [
+        {
+          id: 10,
+          performance_id: 100,
+          name: 'Roster Band A',
+          genre: 'Rock',
+          photo_url: null,
+          start_time: null,
+          end_time: null,
+          venue_id: null,
+          venue_name: null,
+          is_returning: false,
+        },
+        {
+          id: 11,
+          performance_id: 101,
+          name: 'Roster Band B',
+          genre: 'Punk',
+          photo_url: null,
+          start_time: null,
+          end_time: null,
+          venue_id: null,
+          venue_name: null,
+          is_returning: false,
+        },
+      ],
+    })
+  })
+
+  it('omits the Venues stat tile entirely', async () => {
+    renderPage()
+    expect(await screen.findByText('LWBC Vol1')).toBeInTheDocument()
+
+    const statsRegion = screen.getByRole('region', { name: 'Event statistics' })
+    expect(within(statsRegion).queryByText('Venues')).not.toBeInTheDocument()
+    expect(within(statsRegion).queryByText(/^Venues:/)).not.toBeInTheDocument()
+    // Sibling stats are unaffected.
+    expect(within(statsRegion).getByText('Total Sets')).toBeInTheDocument()
+    expect(within(statsRegion).getByText('First Timers')).toBeInTheDocument()
+  })
+
+  it('never renders "TBD–TBD" time ranges', async () => {
+    renderPage()
+    await screen.findByText('LWBC Vol1')
+
+    expect(screen.queryByText(/TBD.{1,3}TBD/)).not.toBeInTheDocument()
+  })
+
+  it('labels the lone no-venue group "Lineup", not "Unscheduled"', async () => {
+    renderPage()
+    await screen.findByText('LWBC Vol1')
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Lineup' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { level: 3, name: 'Unscheduled' })).not.toBeInTheDocument()
+  })
+})
+
+describe('EventRecapPage — fully-scheduled event', () => {
+  beforeEach(() => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      event: { id: 2, name: 'LWBC Vol17', slug: 'lwbc17', date: '2026-08-02' },
+      stats: { total_sets: 2, venue_count: 1, first_timers: 1, returning_acts: 1 },
+      bands: [
+        {
+          id: 20,
+          performance_id: 200,
+          name: 'Scheduled Band A',
+          genre: 'Indie',
+          photo_url: null,
+          start_time: '19:00',
+          end_time: '20:00',
+          venue_id: 5,
+          venue_name: 'Main Stage',
+          is_returning: true,
+        },
+        {
+          id: 21,
+          performance_id: 201,
+          name: 'Scheduled Band B',
+          genre: 'Folk',
+          photo_url: null,
+          start_time: '20:15',
+          end_time: '21:00',
+          venue_id: 5,
+          venue_name: 'Main Stage',
+          is_returning: false,
+        },
+      ],
+    })
+  })
+
+  it('shows the Venues stat tile and real venue names as headings', async () => {
+    renderPage('lwbc17')
+    expect(await screen.findByText('LWBC Vol17')).toBeInTheDocument()
+
+    const statsRegion = screen.getByRole('region', { name: 'Event statistics' })
+    expect(within(statsRegion).getByText('Venues')).toBeInTheDocument()
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Main Stage' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { level: 3, name: 'Lineup' })).not.toBeInTheDocument()
+  })
+
+  it('renders real start/end times', async () => {
+    renderPage('lwbc17')
+    await screen.findByText('LWBC Vol17')
+
+    // EventRecapPage renders raw 24-hour start/end times as-is (no AM/PM
+    // conversion) — assert the actual values pass through, not "TBD".
+    expect(screen.getAllByText(/19:00.{1,3}20:00/).length).toBeGreaterThan(0)
+  })
+})
+
+describe('EventRecapPage — partially-scheduled event', () => {
+  beforeEach(() => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      event: { id: 3, name: 'LWBC Vol15', slug: 'lwbc15', date: '2024-08-03' },
+      stats: { total_sets: 2, venue_count: 1, first_timers: 2, returning_acts: 0 },
+      bands: [
+        {
+          id: 30,
+          performance_id: 300,
+          name: 'Assigned Band',
+          genre: 'Rock',
+          photo_url: null,
+          start_time: '19:00',
+          end_time: '20:00',
+          venue_id: 5,
+          venue_name: 'Main Stage',
+          is_returning: false,
+        },
+        {
+          id: 31,
+          performance_id: 301,
+          name: 'Unassigned Band',
+          genre: 'Pop',
+          photo_url: null,
+          start_time: null,
+          end_time: null,
+          venue_id: null,
+          venue_name: null,
+          is_returning: false,
+        },
+      ],
+    })
+  })
+
+  it('keeps "Unscheduled" for the leftover no-venue group alongside a real venue group', async () => {
+    renderPage('lwbc15')
+    expect(await screen.findByText('LWBC Vol15')).toBeInTheDocument()
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Main Stage' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 3, name: 'Unscheduled' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { level: 3, name: 'Lineup' })).not.toBeInTheDocument()
+  })
+})

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -69,7 +69,16 @@ export async function onRequestGet(context) {
           JOIN events e2 ON p2.event_id = e2.id
           WHERE p2.band_profile_id = bp.id
             AND p2.event_id != ?
-            AND e2.status = 'archived'
+            -- A recap can be generated shortly after an event goes live, before
+            -- it's archived — restricting to status='archived' would then miss
+            -- prior editions that are only published so far and wrongly call a
+            -- returning act a first-timer. published-or-archived covers both.
+            AND (e2.is_published = 1 OR e2.status = 'archived')
+            -- "Returning" means chronologically earlier, not merely "some other
+            -- event" (#613): without this, a band that only played a LATER
+            -- archived edition counted as returning at an EARLIER one. Same-day
+            -- events tie-break on id for a deterministic ordering.
+            AND (e2.date < ? OR (e2.date = ? AND e2.id < ?))
         ) THEN 1 ELSE 0 END AS is_returning
       FROM performances p
       JOIN band_profiles bp ON p.band_profile_id = bp.id
@@ -78,7 +87,7 @@ export async function onRequestGet(context) {
       ORDER BY p.start_time NULLS LAST, bp.name
       `,
     )
-      .bind(event.id, event.id)
+      .bind(event.id, event.date, event.date, event.id, event.id)
       .all();
 
     const rows = bandsResult.results || [];

--- a/functions/api/events/__tests__/recap.test.js
+++ b/functions/api/events/__tests__/recap.test.js
@@ -175,6 +175,162 @@ describe("GET /api/events/:id/recap", () => {
     expect(newBand.is_returning).toBe(false);
   });
 
+  // #613: is_returning must require a STRICTLY EARLIER event, not merely "any
+  // other" event. A band that only appears in a later edition must not be
+  // "returning" at an earlier one it hasn't played yet.
+  test("band playing an earlier and a later archived event is first-timer at the earlier, returning at the later", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const earlierEvent = insertEvent(rawDb, {
+      name: "LWBC Vol1",
+      slug: "lwbc-vol1",
+      date: "2022-05-22",
+      status: "archived",
+    });
+    const laterEvent = insertEvent(rawDb, {
+      name: "LWBC Vol3",
+      slug: "lwbc-vol3",
+      date: "2023-05-21",
+      status: "archived",
+    });
+
+    const venue = insertVenue(rawDb, { name: "Main Stage" });
+    // Same band (same name -> same band_profile_id) plays both events.
+    insertBand(rawDb, { name: "Loop Riders", event_id: earlierEvent.id, venue_id: venue.id });
+    insertBand(rawDb, { name: "Loop Riders", event_id: laterEvent.id, venue_id: venue.id });
+
+    const earlierRes = await onRequestGet({
+      request: new Request(`https://example.test/api/events/${earlierEvent.slug}/recap`),
+      env,
+      params: { id: earlierEvent.slug },
+    });
+    const earlierPayload = await earlierRes.json();
+    expect(earlierPayload.stats.first_timers).toBe(1);
+    expect(earlierPayload.stats.returning_acts).toBe(0);
+    expect(earlierPayload.bands[0].is_returning).toBe(false);
+
+    const laterRes = await onRequestGet({
+      request: new Request(`https://example.test/api/events/${laterEvent.slug}/recap`),
+      env,
+      params: { id: laterEvent.slug },
+    });
+    const laterPayload = await laterRes.json();
+    expect(laterPayload.stats.first_timers).toBe(0);
+    expect(laterPayload.stats.returning_acts).toBe(1);
+    expect(laterPayload.bands[0].is_returning).toBe(true);
+  });
+
+  test("band playing only the later event is a first-timer there", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const earlierEvent = insertEvent(rawDb, {
+      name: "LWBC Vol1",
+      slug: "lwbc-vol1-solo",
+      date: "2022-05-22",
+      status: "archived",
+    });
+    const laterEvent = insertEvent(rawDb, {
+      name: "LWBC Vol3",
+      slug: "lwbc-vol3-solo",
+      date: "2023-05-21",
+      status: "archived",
+    });
+
+    const venue = insertVenue(rawDb, { name: "Main Stage" });
+    insertBand(rawDb, { name: "Only At Vol1", event_id: earlierEvent.id, venue_id: venue.id });
+    insertBand(rawDb, { name: "Only At Vol3", event_id: laterEvent.id, venue_id: venue.id });
+
+    const laterRes = await onRequestGet({
+      request: new Request(`https://example.test/api/events/${laterEvent.slug}/recap`),
+      env,
+      params: { id: laterEvent.slug },
+    });
+    const laterPayload = await laterRes.json();
+    const onlyAtVol3 = laterPayload.bands.find((b) => b.name === "Only At Vol3");
+    expect(onlyAtVol3.is_returning).toBe(false);
+    expect(laterPayload.stats.first_timers).toBe(1);
+    expect(laterPayload.stats.returning_acts).toBe(0);
+  });
+
+  test("same-day events tie-break deterministically on id — returning only at the higher id", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const sameDate = "2024-08-03";
+    // Insertion order guarantees lowerIdEvent.id < higherIdEvent.id.
+    const lowerIdEvent = insertEvent(rawDb, {
+      name: "Same Day A",
+      slug: "same-day-a",
+      date: sameDate,
+      status: "archived",
+    });
+    const higherIdEvent = insertEvent(rawDb, {
+      name: "Same Day B",
+      slug: "same-day-b",
+      date: sameDate,
+      status: "archived",
+    });
+    expect(higherIdEvent.id).toBeGreaterThan(lowerIdEvent.id);
+
+    const venue = insertVenue(rawDb, { name: "Main Stage" });
+    insertBand(rawDb, { name: "Tie Break Band", event_id: lowerIdEvent.id, venue_id: venue.id });
+    insertBand(rawDb, { name: "Tie Break Band", event_id: higherIdEvent.id, venue_id: venue.id });
+
+    const lowerRes = await onRequestGet({
+      request: new Request(`https://example.test/api/events/${lowerIdEvent.slug}/recap`),
+      env,
+      params: { id: lowerIdEvent.slug },
+    });
+    const lowerPayload = await lowerRes.json();
+    expect(lowerPayload.bands[0].is_returning).toBe(false);
+
+    const higherRes = await onRequestGet({
+      request: new Request(`https://example.test/api/events/${higherIdEvent.slug}/recap`),
+      env,
+      params: { id: higherIdEvent.slug },
+    });
+    const higherPayload = await higherRes.json();
+    expect(higherPayload.bands[0].is_returning).toBe(true);
+  });
+
+  // #613: the earlier event only needs to be published (not yet archived) to
+  // count — a recap generated shortly after an event should still recognize
+  // acts returning from a prior, still-published (not-yet-archived) edition.
+  test("counts a prior published (not archived) event when computing is_returning", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const priorEvent = insertEvent(rawDb, {
+      name: "Still Published Vol",
+      slug: "still-published-vol",
+      date: "2023-06-01",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(priorEvent.id);
+
+    const currentEvent = insertEvent(rawDb, {
+      name: "Archived Vol",
+      slug: "archived-vol",
+      date: "2024-06-01",
+      status: "archived",
+    });
+
+    const venue = insertVenue(rawDb, { name: "Main Stage" });
+    insertBand(rawDb, { name: "Cross Edition Band", event_id: priorEvent.id, venue_id: venue.id });
+    insertBand(rawDb, { name: "Cross Edition Band", event_id: currentEvent.id, venue_id: venue.id });
+
+    const res = await onRequestGet({
+      request: new Request(`https://example.test/api/events/${currentEvent.slug}/recap`),
+      env,
+      params: { id: currentEvent.slug },
+    });
+    const payload = await res.json();
+    expect(payload.bands[0].is_returning).toBe(true);
+    expect(payload.stats.returning_acts).toBe(1);
+  });
+
   it("counts only assigned venues (null venue does not increment venue_count)", async () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";


### PR DESCRIPTION
## Summary

Two recap-page fixes found while grading the newly backfilled Vol 1 archive. **#613:** `is_returning` checked for a performance at *any other* archived event with no date predicate — playing Vol 3 retroactively made a band "returning" at Vol 1 (all 8 Vol 1 bands should be first-timers; the page showed 4/4). It now requires a **chronologically earlier** published-or-archived event, with an id tie-break for same-day editions, and counts published (not only archived) prior editions so fresh recaps don't miscount. **#614:** roster-only historical archives (Vols 1–14: no venue/time data) rendered three flavours of we-don't-know noise — "Venues: 0" tile, "TBD–TBD" time spans, and an "Unscheduled" group heading. Per the #608 omit-zero rule: the tile is omitted (grid drops to 4 columns — no dangling cell), empty time ranges render nothing, and the lone group is headed "Lineup"; partially-scheduled events keep "Unscheduled" where it's genuinely accurate.

Closes #613
Closes #614

## What changed

| File | Change |
|------|--------|
| `functions/api/events/[id]/recap.js` | `is_returning` predicate: `(e2.is_published = 1 OR e2.status = 'archived') AND (e2.date < ? OR (e2.date = ? AND e2.id < ?))`; redundant `event_id != ?` kept as cheap defense; rationale commented |
| `functions/api/events/__tests__/recap.test.js` | 5 new tests: band on both of two sequential events (first-timer at earlier, returning at later), later-only band, same-day tie-break determinism |
| `frontend/src/pages/EventRecapPage.jsx` | `hasVenueData` from backend `stats.venue_count` (single source of truth); tile omission + conditional grid; guarded the one unguarded time-range site; Lineup/Unscheduled distinction commented |
| `frontend/src/pages/__tests__/EventRecapPage.test.jsx` | New file, 6 tests: roster-only (no tile, no TBD, "Lineup"), fully-scheduled (all present), partially-scheduled ("Unscheduled" retained) |

Deliberately left alone: per-band inline "Unscheduled" metadata text (issue scoped to the group heading); `formatTimeRange` util (recap builds inline strings — guarded at the one call site instead).

## Security / correctness notes

None — public read-only endpoint + display logic. The recap response shape is unchanged.

## Verification

- [x] Tests: backend 759 pass | 6 todo (74 files); frontend 528 pass (52 files) incl. the 11 new
- [x] ESLint: 0 errors both stacks
- [x] Format check: clean both stacks
- [x] Build: green
- [x] `validate:openapi`: n/a — response shape unchanged
- [x] Manual smoke: post-deploy, /events/lwbc01/recap should read First Timers: 8 / Returning: 0, no Venues tile, "Lineup" heading, no TBD–TBD

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)