### PR TITLE
feat: per-event poster image (poster_url)

### DIFF
--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS events (
   slug TEXT NOT NULL UNIQUE,             -- URL-friendly identifier, e.g., "vol-5"
   is_published INTEGER NOT NULL DEFAULT 0, -- 0 = draft, 1 = published (visible to public)
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
-, created_by_user_id INTEGER REFERENCES users(id), updated_by_user_id INTEGER REFERENCES users(id), updated_at TEXT DEFAULT (datetime('now')), status TEXT DEFAULT 'draft', archived_at TEXT, ticket_url TEXT, theme_colors TEXT, venue_info TEXT, social_links TEXT, city TEXT, description TEXT, reveal_mode INTEGER NOT NULL DEFAULT 0, end_date TEXT, doors_json TEXT);
+, created_by_user_id INTEGER REFERENCES users(id), updated_by_user_id INTEGER REFERENCES users(id), updated_at TEXT DEFAULT (datetime('now')), status TEXT DEFAULT 'draft', archived_at TEXT, ticket_url TEXT, theme_colors TEXT, venue_info TEXT, social_links TEXT, city TEXT, description TEXT, reveal_mode INTEGER NOT NULL DEFAULT 0, end_date TEXT, doors_json TEXT, poster_url TEXT);
 
 CREATE TABLE IF NOT EXISTS venues (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -1816,6 +1816,51 @@ paths:
         "500":
           $ref: "#/components/responses/ServerError"
 
+  /api/admin/events/posters:
+    post:
+      tags:
+        - Admin - Events
+      summary: Upload an event poster image
+      description: |
+        Mirrors `/api/admin/bands/photos` (#616): same magic-byte MIME
+        validation and 5MB cap, same R2 bucket under an `event-posters/` key
+        prefix. `event_id` is optional — a poster can be uploaded while
+        creating a brand-new event that has no id yet, in which case the
+        caller gets back only the public URL to include in the create
+        payload. When `event_id` is provided it must reference an existing
+        event; the event's `poster_url` is updated immediately in that case.
+      security:
+        - AdminSessionCookie: []
+          CsrfToken: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - poster
+              properties:
+                poster:
+                  type: string
+                  format: binary
+                event_id:
+                  type: string
+                  description: Optional event ID to attach the uploaded poster to
+      responses:
+        "200":
+          description: Poster uploaded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhotoUploadResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
   /api/admin/events/{id}/reveal-mode:
     post:
       tags:

--- a/frontend/src/admin/EventFormModal.jsx
+++ b/frontend/src/admin/EventFormModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import EventStatusBadge from './components/EventStatusBadge'
+import PhotoUpload from './components/PhotoUpload'
 import { Button } from '../components/ui'
 import { eventsApi } from '../utils/adminApi'
 import { FIELD_LIMITS } from '../utils/validation'
@@ -39,6 +40,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
     description: '',
     city: '',
     ticket_url: '',
+    poster_url: '',
     social_website: '',
     social_instagram: '',
     social_facebook: '',
@@ -98,6 +100,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
         description: event.description || '',
         city: event.city || '',
         ticket_url: event.ticket_url || '',
+        poster_url: event.poster_url || '',
         social_website: socialLinks.website || '',
         social_instagram: socialLinks.instagram || '',
         social_facebook: socialLinks.facebook || '',
@@ -118,6 +121,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
         description: '',
         city: '',
         ticket_url: '',
+        poster_url: '',
         social_website: '',
         social_instagram: '',
         social_facebook: '',
@@ -281,6 +285,7 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
         description: formData.description,
         city: formData.city,
         ticket_url: formData.ticket_url,
+        poster_url: formData.poster_url,
         social_links: socialLinksPayload,
         doors_json: serializeDoorsForm(doorsForm, currentDays),
       }
@@ -543,6 +548,21 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
               <p className="text-xs text-white/50 mt-1">
                 {formData.ticket_url.length}/{FIELD_LIMITS.ticketLink.max}
               </p>
+            </div>
+
+            {/* Poster */}
+            <div>
+              <PhotoUpload
+                currentPhoto={formData.poster_url}
+                onPhotoChange={url => setFormData(prev => ({ ...prev, poster_url: url || '' }))}
+                uploadUrl="/api/admin/events/posters"
+                fieldName="poster"
+                entityIdField="event_id"
+                entityId={isEditing && event?.id ? event.id : null}
+                label="Event Poster"
+                helpText="Optional — used for social share cards and the event's archive recap. Large images are auto-resized for the web."
+                maxDimension={1600}
+              />
             </div>
 
             {/* Social Links */}

--- a/frontend/src/admin/components/PhotoUpload.jsx
+++ b/frontend/src/admin/components/PhotoUpload.jsx
@@ -3,22 +3,101 @@ import { useState, useRef } from 'react'
 import { getAdminFormDataHeaders } from '../../utils/adminApi'
 
 /**
+ * Downscale an image client-side via canvas before upload (#616 leanness
+ * budget): longest edge clamped to maxDimension, re-encoded as JPEG at
+ * quality 0.82. GIFs are skipped — re-encoding through canvas flattens
+ * animation to a single frame, and GIF uploads are rare/small enough that
+ * the tradeoff isn't worth it. Falls back to the original file on any
+ * failure (unsupported format, canvas error) so a downscale bug can never
+ * block an upload outright.
+ *
+ * @param {File} file
+ * @param {number} maxDimension - Longest-edge cap in pixels
+ * @returns {Promise<File>} The downscaled file, or the original if no
+ *   downscale was needed/possible.
+ */
+async function downscaleImage(file, maxDimension) {
+  if (file.type === 'image/gif') {
+    return file
+  }
+
+  try {
+    // eslint-disable-next-line no-undef
+    const bitmap = await createImageBitmap(file)
+    const longestEdge = Math.max(bitmap.width, bitmap.height)
+
+    if (longestEdge <= maxDimension) {
+      bitmap.close?.()
+      return file
+    }
+
+    const scale = maxDimension / longestEdge
+    const targetWidth = Math.max(1, Math.round(bitmap.width * scale))
+    const targetHeight = Math.max(1, Math.round(bitmap.height * scale))
+
+    const canvas = document.createElement('canvas')
+    canvas.width = targetWidth
+    canvas.height = targetHeight
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      bitmap.close?.()
+      return file
+    }
+    ctx.drawImage(bitmap, 0, 0, targetWidth, targetHeight)
+    bitmap.close?.()
+
+    const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', 0.82))
+    if (!blob) {
+      return file
+    }
+
+    const baseName = file.name.replace(/\.[^./\\]+$/, '') || 'image'
+    // eslint-disable-next-line no-undef
+    return new File([blob], `${baseName}.jpg`, { type: 'image/jpeg' })
+  } catch (err) {
+    console.error('Image downscale failed, uploading original file instead:', err)
+    return file
+  }
+}
+
+/**
  * PhotoUpload Component
  *
- * Reusable component for uploading band photos with:
+ * Reusable component for uploading images (band photos, event posters, ...) with:
  * - Drag and drop support
  * - Image preview
  * - File validation
+ * - Client-side downscale (optional, via maxDimension)
  * - Progress indication
  * - R2 bucket integration
  *
  * @param {Object} props
  * @param {string} props.currentPhoto - Current photo URL (if exists)
  * @param {Function} props.onPhotoChange - Callback when photo is uploaded/removed
- * @param {number} props.bandId - Optional band ID to associate with upload
+ * @param {number} props.bandId - Optional band ID to associate with upload (legacy/default usage)
  * @param {string} props.bandName - Optional band name for display
+ * @param {string} props.uploadUrl - Upload endpoint (default: band photos endpoint)
+ * @param {string} props.fieldName - Multipart field name for the file (default: 'photo')
+ * @param {string} props.entityIdField - Multipart field name for the associated entity id (default: 'band_id')
+ * @param {number|string} props.entityId - Value for entityIdField; falls back to bandId when unset
+ * @param {string} props.label - Field label (default: 'Band Photo')
+ * @param {string} props.helpText - Help text under the upload area
+ * @param {number} [props.maxDimension] - When set, downscale client-side so the longest edge is
+ *   at most this many pixels before upload (JPEG q0.82; GIFs are never downscaled)
  */
-export default function PhotoUpload({ currentPhoto, onPhotoChange, bandId = null, bandName = '' }) {
+export default function PhotoUpload({
+  currentPhoto,
+  onPhotoChange,
+  bandId = null,
+  bandName = '',
+  uploadUrl = '/api/admin/bands/photos',
+  fieldName = 'photo',
+  entityIdField = 'band_id',
+  entityId = null,
+  label = 'Band Photo',
+  helpText = 'Recommended: Square images work best for band profile photos. Minimum 400×400px for good quality.',
+  maxDimension = null,
+}) {
   const sanitizeImageSrc = value => {
     if (!value || typeof value !== 'string') return null
     const trimmed = value.trim()
@@ -79,23 +158,28 @@ export default function PhotoUpload({ currentPhoto, onPhotoChange, bandId = null
     setUploading(true)
 
     try {
+      // Downscale before preview/upload so the preview reflects exactly what
+      // gets sent (leanness budget, #616). No-op when maxDimension is unset.
+      const uploadFile = maxDimension ? await downscaleImage(file, maxDimension) : file
+
       // Create preview
       // eslint-disable-next-line no-undef
       const reader = new FileReader()
       reader.onloadend = () => {
         setPreview(reader.result)
       }
-      reader.readAsDataURL(file)
+      reader.readAsDataURL(uploadFile)
 
       // Upload to API
       // eslint-disable-next-line no-undef
       const formData = new FormData()
-      formData.append('photo', file)
-      if (bandId) {
-        formData.append('band_id', bandId.toString())
+      formData.append(fieldName, uploadFile)
+      const idValue = entityId ?? bandId
+      if (idValue) {
+        formData.append(entityIdField, idValue.toString())
       }
 
-      const response = await fetch('/api/admin/bands/photos', {
+      const response = await fetch(uploadUrl, {
         method: 'POST',
         headers: getAdminFormDataHeaders(),
         credentials: 'include',
@@ -171,7 +255,9 @@ export default function PhotoUpload({ currentPhoto, onPhotoChange, bandId = null
 
   return (
     <div className="space-y-3">
-      <label className="block text-white font-medium">Band Photo {bandName && `for ${bandName}`}</label>
+      <label className="block text-white font-medium">
+        {label} {bandName && `for ${bandName}`}
+      </label>
 
       {/* Upload area */}
       <div
@@ -266,9 +352,7 @@ export default function PhotoUpload({ currentPhoto, onPhotoChange, bandId = null
       )}
 
       {/* Help text */}
-      <p className="text-white/50 text-xs">
-        Recommended: Square images work best for band profile photos. Minimum 400×400px for good quality.
-      </p>
+      <p className="text-white/50 text-xs">{helpText}</p>
     </div>
   )
 }

--- a/frontend/src/admin/components/__tests__/PhotoUpload.test.jsx
+++ b/frontend/src/admin/components/__tests__/PhotoUpload.test.jsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import PhotoUpload from '../PhotoUpload.jsx'
+
+// #616: PhotoUpload gained an optional maxDimension prop that downscales
+// client-side via canvas before upload. jsdom implements neither
+// createImageBitmap nor a real 2D canvas context, so both are mocked here.
+// Band-photo usages (BandForm.jsx) pass no maxDimension and must be
+// byte-for-byte unaffected — that's the regression case these tests guard.
+
+function jpegFile(name = 'photo.jpg') {
+  // eslint-disable-next-line no-undef
+  return new File([new Uint8Array([0xff, 0xd8, 0xff, 0xe0])], name, { type: 'image/jpeg' })
+}
+
+function gifFile(name = 'anim.gif') {
+  // eslint-disable-next-line no-undef
+  return new File([new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61])], name, { type: 'image/gif' })
+}
+
+function selectFile(file) {
+  const input = document.querySelector('input[type="file"]')
+  fireEvent.change(input, { target: { files: [file] } })
+}
+
+describe('PhotoUpload', () => {
+  let fetchMock
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, url: 'https://example.test/uploaded.jpg' }),
+    })
+    global.fetch = fetchMock
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete global.createImageBitmap
+  })
+
+  it('band-photo usage (no maxDimension): uploads the original file unchanged to the default endpoint', async () => {
+    render(<PhotoUpload currentPhoto={null} onPhotoChange={vi.fn()} bandId={42} bandName="The Testers" />)
+
+    expect(screen.getByText(/Band Photo/)).toBeInTheDocument()
+    expect(screen.getByText(/for The Testers/)).toBeInTheDocument()
+
+    selectFile(jpegFile('band.jpg'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const [url, options] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/admin/bands/photos')
+
+    const formData = options.body
+    const uploaded = formData.get('photo')
+    expect(uploaded.name).toBe('band.jpg')
+    expect(uploaded.type).toBe('image/jpeg')
+    expect(formData.get('band_id')).toBe('42')
+  })
+
+  it('poster usage: downscales a large image via canvas before upload (longest edge clamped, JPEG q0.82)', async () => {
+    global.createImageBitmap = vi.fn().mockResolvedValue({ width: 3200, height: 2400, close: vi.fn() })
+    const drawImage = vi.fn()
+    // eslint-disable-next-line no-undef
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({ drawImage })
+    // eslint-disable-next-line no-undef
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(function (callback) {
+      // eslint-disable-next-line no-undef
+      callback(new Blob(['fake-jpeg-bytes'], { type: 'image/jpeg' }))
+    })
+
+    render(
+      <PhotoUpload
+        currentPhoto={null}
+        onPhotoChange={vi.fn()}
+        uploadUrl="/api/admin/events/posters"
+        fieldName="poster"
+        entityIdField="event_id"
+        entityId={7}
+        label="Event Poster"
+        maxDimension={1600}
+      />
+    )
+
+    selectFile(jpegFile('huge-poster.png'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 1600, 1200) // 3200x2400 -> 1600x1200
+
+    const [url, options] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/admin/events/posters')
+    const formData = options.body
+    const uploaded = formData.get('poster')
+    // Downscaled + re-encoded as JPEG, renamed with a .jpg extension.
+    expect(uploaded.type).toBe('image/jpeg')
+    expect(uploaded.name).toBe('huge-poster.jpg')
+    expect(formData.get('event_id')).toBe('7')
+  })
+
+  it('skips downscaling for GIFs even when maxDimension is set', async () => {
+    global.createImageBitmap = vi.fn().mockResolvedValue({ width: 3200, height: 2400, close: vi.fn() })
+    // eslint-disable-next-line no-undef
+    const toBlobSpy = vi.spyOn(HTMLCanvasElement.prototype, 'toBlob')
+
+    render(
+      <PhotoUpload
+        currentPhoto={null}
+        onPhotoChange={vi.fn()}
+        uploadUrl="/api/admin/events/posters"
+        fieldName="poster"
+        maxDimension={1600}
+      />
+    )
+
+    selectFile(gifFile('animated.gif'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(toBlobSpy).not.toHaveBeenCalled()
+    expect(global.createImageBitmap).not.toHaveBeenCalled()
+
+    const formData = fetchMock.mock.calls[0][1].body
+    const uploaded = formData.get('poster')
+    expect(uploaded.name).toBe('animated.gif')
+    expect(uploaded.type).toBe('image/gif')
+  })
+
+  it('already-small image (below maxDimension) is uploaded without re-encoding', async () => {
+    global.createImageBitmap = vi.fn().mockResolvedValue({ width: 800, height: 600, close: vi.fn() })
+    // eslint-disable-next-line no-undef
+    const toBlobSpy = vi.spyOn(HTMLCanvasElement.prototype, 'toBlob')
+
+    render(
+      <PhotoUpload
+        currentPhoto={null}
+        onPhotoChange={vi.fn()}
+        uploadUrl="/api/admin/events/posters"
+        fieldName="poster"
+        maxDimension={1600}
+      />
+    )
+
+    selectFile(jpegFile('small.jpg'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(toBlobSpy).not.toHaveBeenCalled()
+
+    const formData = fetchMock.mock.calls[0][1].body
+    expect(formData.get('poster').name).toBe('small.jpg')
+  })
+
+  it('falls back to the original file if downscaling throws', async () => {
+    global.createImageBitmap = vi.fn().mockRejectedValue(new Error('unsupported format'))
+
+    render(
+      <PhotoUpload
+        currentPhoto={null}
+        onPhotoChange={vi.fn()}
+        uploadUrl="/api/admin/events/posters"
+        fieldName="poster"
+        maxDimension={1600}
+      />
+    )
+
+    selectFile(jpegFile('weird.jpg'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const formData = fetchMock.mock.calls[0][1].body
+    expect(formData.get('poster').name).toBe('weird.jpg')
+  })
+})

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -177,6 +177,18 @@ export default function EventRecapPage() {
               </span>
               <span>Recap</span>
             </div>
+            {/* Poster is optional (#616) — the archive gets its art when one was
+                uploaded for this edition; omitted entirely otherwise. */}
+            {event.poster_url && (
+              <div className="mt-4 overflow-hidden rounded-xl border border-border bg-bg-navy/40">
+                <img
+                  src={event.poster_url}
+                  alt={`${event.name} poster`}
+                  loading="lazy"
+                  className="max-h-96 w-full object-contain"
+                />
+              </div>
+            )}
             <h1 className="mt-4 text-4xl font-bold text-text-primary">{event.name}</h1>
             <p className="mt-2 text-lg text-text-tertiary">{formattedDate}</p>
             <div className="mt-6 flex flex-wrap gap-3">

--- a/frontend/src/pages/__tests__/EventRecapPage.test.jsx
+++ b/frontend/src/pages/__tests__/EventRecapPage.test.jsx
@@ -141,6 +141,44 @@ describe('EventRecapPage — fully-scheduled event', () => {
   })
 })
 
+describe('EventRecapPage — poster (#616)', () => {
+  it('renders the poster, lazy-loaded, when poster_url is present', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      event: {
+        id: 4,
+        name: 'LWBC Vol16',
+        slug: 'lwbc16',
+        date: '2025-08-02',
+        poster_url: 'https://band-photos.settimes.ca/event-posters/1-vol16.jpg',
+      },
+      stats: { total_sets: 0, venue_count: 0, first_timers: 0, returning_acts: 0 },
+      bands: [],
+    })
+
+    renderPage('lwbc16')
+    expect(await screen.findByText('LWBC Vol16')).toBeInTheDocument()
+
+    const poster = screen.getByRole('img', { name: 'LWBC Vol16 poster' })
+    expect(poster).toHaveAttribute('src', 'https://band-photos.settimes.ca/event-posters/1-vol16.jpg')
+    expect(poster).toHaveAttribute('loading', 'lazy')
+  })
+
+  it('omits the poster entirely when poster_url is absent', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      event: { id: 5, name: 'LWBC Vol15', slug: 'lwbc15b', date: '2024-08-03', poster_url: null },
+      stats: { total_sets: 0, venue_count: 0, first_timers: 0, returning_acts: 0 },
+      bands: [],
+    })
+
+    renderPage('lwbc15b')
+    expect(await screen.findByText('LWBC Vol15')).toBeInTheDocument()
+
+    expect(screen.queryByRole('img', { name: /poster/i })).not.toBeInTheDocument()
+  })
+})
+
 describe('EventRecapPage — partially-scheduled event', () => {
   beforeEach(() => {
     fetchPublicJson.mockReset()

--- a/functions/__tests__/middleware.test.js
+++ b/functions/__tests__/middleware.test.js
@@ -18,9 +18,10 @@
 // limit outright.
 //
 // #495 fix: multipart is no longer exempt from the guard, only allowed a
-// higher ceiling (MULTIPART_MAX_BODY_BYTES), and only on the one route that
-// legitimately needs it (/api/admin/bands/photos, which enforces its own
-// precise 5MB-per-file limit downstream).
+// higher ceiling (MULTIPART_MAX_BODY_BYTES), and only on the routes that
+// legitimately need it (/api/admin/bands/photos, and /api/admin/events/posters
+// added in #616), each of which enforces its own precise 5MB-per-file limit
+// downstream.
 //
 // COUPLING NOTE: /api/metrics is now routed through the D1-backed fail-closed
 // rate limiter (#482/#494, already merged to main). Every request here sets
@@ -431,6 +432,73 @@ describe("body-size guard (#481, #495)", () => {
       `--${boundary}--\r\n`;
 
     const request = new Request("https://example.test/api/admin/bands/photos", {
+      method: "POST",
+      headers: {
+        ...LOOPBACK_HEADERS,
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+        "Content-Length": String(body.length),
+      },
+      body,
+    });
+    expect(Number(request.headers.get("Content-Length"))).toBeGreaterThan(6_000_000);
+
+    const response = await onRequest({
+      request,
+      env: minimalEnv(),
+      data: {},
+      next: neverCalledNext(),
+    });
+
+    expect(response.status).toBe(413);
+    const payload = await response.json();
+    expect(payload.error).toBe("Payload too large");
+  });
+
+  test("multipart POST to /api/admin/events/posters with Content-Length between 1MB and 6MB passes through (#616)", async () => {
+    // #616: the event poster upload route gets the same raised ceiling as
+    // band photos — 5MB is above the standard 1MB guard but under the 6MB
+    // coarse DoS ceiling, so this must reach next(), leaving the precise
+    // 5MB-per-file business rule to posters.js itself.
+    const boundary = "----test-boundary";
+    const fiveMbField = "x".repeat(5 * 1024 * 1024);
+    const body =
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="poster"; filename="event.jpg"\r\n\r\n` +
+      `${fiveMbField}\r\n` +
+      `--${boundary}--\r\n`;
+
+    const request = new Request("https://example.test/api/admin/events/posters", {
+      method: "POST",
+      headers: {
+        ...LOOPBACK_HEADERS,
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+        "Content-Length": String(body.length),
+      },
+      body,
+    });
+    expect(Number(request.headers.get("Content-Length"))).toBeGreaterThan(1_000_000);
+    expect(Number(request.headers.get("Content-Length"))).toBeLessThan(6_000_000);
+
+    const response = await onRequest({
+      request,
+      env: minimalEnv(),
+      data: {},
+      next: okNext(),
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  test("multipart POST to /api/admin/events/posters with Content-Length >6MB is rejected with 413 (#616)", async () => {
+    const boundary = "----test-boundary";
+    const sevenMbField = "x".repeat(7 * 1024 * 1024);
+    const body =
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="poster"; filename="event.jpg"\r\n\r\n` +
+      `${sevenMbField}\r\n` +
+      `--${boundary}--\r\n`;
+
+    const request = new Request("https://example.test/api/admin/events/posters", {
       method: "POST",
       headers: {
         ...LOOPBACK_HEADERS,

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -80,25 +80,27 @@ export async function onRequest(context) {
   // blanket multipart exemption solely off the client-supplied Content-Type,
   // so any client could set `Content-Type: multipart/form-data` on e.g.
   // /api/metrics and skip the 1MB limit entirely. Multipart now gets a raised
-  // ceiling instead of a bypass, and only on the one route that legitimately
-  // needs it.
+  // ceiling instead of a bypass, and only on the routes that legitimately
+  // need it (#616 added the event poster upload alongside band photos).
   if (["POST", "PUT", "PATCH"].includes(request.method)) {
     const contentType = request.headers.get("Content-Type") || "";
     const isMultipart = contentType.includes("multipart/form-data");
 
-    // The band photo upload (functions/api/admin/bands/photos.js) is the ONLY
-    // route that legitimately accepts multipart bodies, and it already
+    // The band photo (functions/api/admin/bands/photos.js) and event poster
+    // (functions/api/admin/events/posters.js, #616) uploads are the ONLY
+    // routes that legitimately accept multipart bodies, and each already
     // enforces its own precise 5MB-per-file limit after parsing formData.
-    // Pin the raised ceiling to that exact pathname — Cloudflare Pages
+    // Pin the raised ceiling to these exact pathnames — Cloudflare Pages
     // Functions match routes exactly, so this can't be satisfied by a
     // sub-path or a different handler.
-    const isPhotoUpload = isMultipart && url.pathname === "/api/admin/bands/photos";
+    const RAISED_LIMIT_UPLOAD_ROUTES = new Set(["/api/admin/bands/photos", "/api/admin/events/posters"]);
+    const isPhotoUpload = isMultipart && RAISED_LIMIT_UPLOAD_ROUTES.has(url.pathname);
 
     const MAX_BODY_BYTES = 1_000_000;
     // Coarse DoS ceiling, not the business rule: 5MB file + multipart
     // boundary/header overhead + other form fields. The precise 5MB-per-file
-    // limit stays enforced in photos.js; this guard only needs to reject
-    // bodies wildly larger than any real upload could be.
+    // limit stays enforced in photos.js/posters.js; this guard only needs to
+    // reject bodies wildly larger than any real upload could be.
     const MULTIPART_MAX_BODY_BYTES = 6_000_000;
     const maxBodyBytes = isPhotoUpload ? MULTIPART_MAX_BODY_BYTES : MAX_BODY_BYTES;
 

--- a/functions/api/admin/bands/photos.js
+++ b/functions/api/admin/bands/photos.js
@@ -7,70 +7,7 @@
  */
 
 import { checkPermission } from "../_middleware.js";
-
-// Maximum file size: 5MB
-const MAX_FILE_SIZE = 5 * 1024 * 1024;
-
-// Allowed MIME types
-const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
-
-/**
- * Detect the true MIME type from the file's magic bytes.
- * Rejects client-supplied Content-Type and validates the actual file header.
- * @param {File} file
- * @returns {Promise<string|null>} Detected MIME type or null if unrecognised.
- */
-async function detectMimeType(file) {
-  const header = new Uint8Array(await file.slice(0, 12).arrayBuffer());
-  const length = header.length;
-
-  // JPEG: FF D8 FF
-  if (length >= 3 && header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff) {
-    return "image/jpeg";
-  }
-  // PNG: 89 50 4E 47 0D 0A 1A 0A (full 8-byte signature)
-  if (
-    length >= 8 &&
-    header[0] === 0x89 &&
-    header[1] === 0x50 &&
-    header[2] === 0x4e &&
-    header[3] === 0x47 &&
-    header[4] === 0x0d &&
-    header[5] === 0x0a &&
-    header[6] === 0x1a &&
-    header[7] === 0x0a
-  ) {
-    return "image/png";
-  }
-  // GIF87a / GIF89a: 47 49 46 38 37|39 61 (full 6-byte signature)
-  if (
-    length >= 6 &&
-    header[0] === 0x47 &&
-    header[1] === 0x49 &&
-    header[2] === 0x46 &&
-    header[3] === 0x38 &&
-    (header[4] === 0x37 || header[4] === 0x39) &&
-    header[5] === 0x61
-  ) {
-    return "image/gif";
-  }
-  // WebP: RIFF (52 49 46 46) + 4-byte length + WEBP (57 45 42 50)
-  if (
-    length >= 12 &&
-    header[0] === 0x52 &&
-    header[1] === 0x49 &&
-    header[2] === 0x46 &&
-    header[3] === 0x46 &&
-    header[8] === 0x57 &&
-    header[9] === 0x45 &&
-    header[10] === 0x42 &&
-    header[11] === 0x50
-  ) {
-    return "image/webp";
-  }
-
-  return null;
-}
+import { detectImageMimeType, MAX_FILE_SIZE, ALLOWED_IMAGE_TYPES } from "../../../utils/imageUpload.js";
 
 export async function onRequestPost(context) {
   const { request, env } = context;
@@ -105,8 +42,8 @@ export async function onRequestPost(context) {
     }
 
     // Validate MIME type via magic bytes — ignores attacker-controlled file.type.
-    const detectedType = await detectMimeType(file);
-    if (!detectedType || !ALLOWED_TYPES.includes(detectedType)) {
+    const detectedType = await detectImageMimeType(file);
+    if (!detectedType || !ALLOWED_IMAGE_TYPES.includes(detectedType)) {
       return new Response(
         JSON.stringify({
           error: "Invalid file type. Allowed: JPEG, PNG, WebP, GIF",

--- a/functions/api/admin/events.js
+++ b/functions/api/admin/events.js
@@ -7,6 +7,7 @@ import {
   validateEntity,
   VALIDATION_SCHEMAS,
   validationErrorResponse,
+  normalizeHttpUrl,
   safeReflectSocialLinksString,
   sanitizeEventSocialLinks,
   sanitizeVenueInfo,
@@ -64,10 +65,12 @@ export async function onRequestGet(context) {
 
     // Read-path sanitize (#493): `e.*` pulls in the raw social_links column,
     // which may hold a pre-#483 (or otherwise legacy) value never routed
-    // through sanitizeEventSocialLinks on write.
+    // through sanitizeEventSocialLinks on write. poster_url gets the same
+    // #504-style treatment as ticket_url (#616).
     const events = (result.results || []).map((event) => ({
       ...event,
       social_links: safeReflectSocialLinksString(event.social_links, ["instagram", "x", "tiktok"]),
+      poster_url: normalizeHttpUrl(event.poster_url),
     }));
 
     return new Response(
@@ -131,6 +134,7 @@ export async function onRequestPost(context) {
       description,
       city,
       ticket_url,
+      poster_url,
       venue_info,
       social_links,
       theme_colors,
@@ -222,13 +226,14 @@ export async function onRequestPost(context) {
         description,
         city,
         ticket_url,
+        poster_url,
         venue_info,
         social_links,
         theme_colors,
         doors_json,
         created_by_user_id
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       RETURNING *
     `,
     )
@@ -242,6 +247,7 @@ export async function onRequestPost(context) {
         description,
         city,
         ticket_url,
+        normalizeHttpUrl(poster_url),
         sanitizedVenueInfo,
         sanitizedSocialLinks,
         theme_colors,
@@ -249,6 +255,10 @@ export async function onRequestPost(context) {
         currentUser.userId,
       )
       .first();
+
+    // Read-path sanitize (#504 convention): defense-in-depth alongside the
+    // write-path normalizeHttpUrl above.
+    result.poster_url = normalizeHttpUrl(result.poster_url);
 
     // Audit log
     await auditLog(

--- a/functions/api/admin/events/[id].js
+++ b/functions/api/admin/events/[id].js
@@ -8,6 +8,7 @@ import { checkPermission, auditLog } from "../_middleware.js";
 import {
   FIELD_LIMITS,
   isValidURL,
+  normalizeHttpUrl,
   safeReflectSocialLinksString,
   sanitizeEventSocialLinks,
   sanitizeString,
@@ -111,6 +112,7 @@ export async function onRequestPatch(context) {
       description,
       city,
       ticket_url,
+      poster_url,
       venue_info,
       social_links,
       theme_colors,
@@ -298,6 +300,42 @@ export async function onRequestPatch(context) {
       params.push(trimmed || null);
     }
 
+    if (poster_url !== undefined) {
+      if (poster_url !== null && typeof poster_url !== "string") {
+        return new Response(
+          JSON.stringify({
+            error: "Validation error",
+            message: "Poster image must be a string",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      const trimmed = poster_url ? poster_url.trim() : "";
+      if (trimmed && !isValidURL(trimmed)) {
+        return new Response(
+          JSON.stringify({
+            error: "Validation error",
+            message: "Poster image must be a valid URL",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (trimmed.length > FIELD_LIMITS.eventPosterUrl.max) {
+        return new Response(
+          JSON.stringify({
+            error: "Validation error",
+            message: `Poster image must be no more than ${FIELD_LIMITS.eventPosterUrl.max} characters`,
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      // #616: unlike ticket_url above, poster_url is normalized on write too
+      // (not just read-reflected) — the design spec calls for it explicitly,
+      // and it's cheap since normalizeHttpUrl(validURL) is a no-op reparse.
+      updates.push("poster_url = ?");
+      params.push(normalizeHttpUrl(trimmed) || null);
+    }
+
     if (venue_info !== undefined) {
       try {
         const sanitizedVenueInfo = sanitizeVenueInfo(venue_info);
@@ -420,8 +458,10 @@ export async function onRequestPatch(context) {
 
     // Read-path sanitize (#493): RETURNING * echoes the full row, so
     // social_links may reflect a pre-#483 (or otherwise legacy) value even
-    // when this request didn't touch social_links itself.
+    // when this request didn't touch social_links itself. poster_url gets
+    // the same #504-style read-reflect as ticket_url (#616).
     result.social_links = safeReflectSocialLinksString(result.social_links, ["instagram", "x", "tiktok"]);
+    result.poster_url = normalizeHttpUrl(result.poster_url);
 
     // Audit log
     await auditLog(
@@ -534,6 +574,7 @@ export async function onRequestPut(context) {
 
       // Read-path sanitize (#493): see the PATCH handler above.
       result.social_links = safeReflectSocialLinksString(result.social_links, ["instagram", "x", "tiktok"]);
+      result.poster_url = normalizeHttpUrl(result.poster_url);
 
       // Audit log
       await auditLog(

--- a/functions/api/admin/events/[id]/duplicate.js
+++ b/functions/api/admin/events/[id]/duplicate.js
@@ -69,8 +69,10 @@ export async function onRequestPost(context) {
     // NOT in this column list: the new event has a different date (and
     // possibly no end_date at all), so the source's date-keyed doors times
     // would no longer fall within the new event's festival-day span and
-    // would fail validateDoorsJson on the next edit anyway (#569). Leaving it
-    // out of INSERT defaults the column to NULL — start clean.
+    // would fail validateDoorsJson on the next edit anyway (#569). poster_url
+    // is excluded for the same "edition-specific" reasoning (#616) — a new
+    // edition gets its own poster, not the source event's. Leaving both out
+    // of INSERT defaults the columns to NULL — start clean.
     const newEvent = await DB.prepare(
       `INSERT INTO events (
          name, date, slug, status, is_published, description, city,
@@ -107,6 +109,9 @@ export async function onRequestPost(context) {
     // through this response.
     newEvent.social_links = safeReflectSocialLinksString(newEvent.social_links, ["instagram", "x", "tiktok"]);
     newEvent.ticket_url = normalizeHttpUrl(newEvent.ticket_url);
+    // Always NULL here (poster_url is excluded from INSERT above, #616) —
+    // sanitized anyway for consistency with every other admin read path.
+    newEvent.poster_url = normalizeHttpUrl(newEvent.poster_url);
 
     // Copy performances. If the copy fails, compensate by deleting the new event
     // so we never leave an empty orphan draft behind (D1 has no BEGIN/COMMIT).

--- a/functions/api/admin/events/__tests__/events.test.js
+++ b/functions/api/admin/events/__tests__/events.test.js
@@ -347,6 +347,116 @@ describe("Event API - handler integration", () => {
     expect(parsed.instagram).toBe("legit_handle");
   });
 
+  // ---------------------------------------------------------------------
+  // #616 — events.poster_url create/update/list wiring, mirroring the
+  // ticket_url #504 write-and-read-reflect convention end-to-end through the
+  // admin handlers.
+  // ---------------------------------------------------------------------
+  it("onRequestPost persists a valid poster_url", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const body = {
+      name: "Poster Event",
+      slug: "poster-event",
+      date: "2099-07-10",
+      poster_url: "https://band-photos.settimes.ca/event-posters/123-poster.jpg",
+    };
+    const request = new Request("https://example.test/api/admin/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify(body),
+    });
+
+    const res = await eventsHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.event.poster_url).toBe("https://band-photos.settimes.ca/event-posters/123-poster.jpg");
+
+    const stored = rawDb.prepare("SELECT poster_url FROM events WHERE id = ?").get(data.event.id);
+    expect(stored.poster_url).toBe("https://band-photos.settimes.ca/event-posters/123-poster.jpg");
+  });
+
+  it("onRequestPatch updates poster_url, normalized on write and read-reflected (#504 convention)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const ev = insertEvent(rawDb, { name: "Poster Patch Event", slug: "poster-patch-event" });
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ poster_url: "https://band-photos.settimes.ca/event-posters/456-poster.jpg" }),
+    });
+
+    const res = await eventIdHandler.onRequestPatch({ request, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.event.poster_url).toBe("https://band-photos.settimes.ca/event-posters/456-poster.jpg");
+
+    const stored = rawDb.prepare("SELECT poster_url FROM events WHERE id = ?").get(ev.id);
+    expect(stored.poster_url).toBe("https://band-photos.settimes.ca/event-posters/456-poster.jpg");
+  });
+
+  it("onRequestPatch clears poster_url when sent an empty string", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const ev = insertEvent(rawDb, { name: "Poster Clear Event", slug: "poster-clear-event" });
+    rawDb
+      .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
+      .run("https://band-photos.settimes.ca/event-posters/1-old.jpg", ev.id);
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ poster_url: "" }),
+    });
+
+    const res = await eventIdHandler.onRequestPatch({ request, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.event.poster_url).toBeNull();
+
+    const stored = rawDb.prepare("SELECT poster_url FROM events WHERE id = ?").get(ev.id);
+    expect(stored.poster_url).toBeNull();
+  });
+
+  it("onRequestPatch rejects a poster_url that isn't a valid URL", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const ev = insertEvent(rawDb, { name: "Poster Bad URL Event", slug: "poster-bad-url-event" });
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ poster_url: "not a url" }),
+    });
+
+    const res = await eventIdHandler.onRequestPatch({ request, env });
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /api/admin/events read-reflects a legacy javascript: poster_url across the list (#504 convention)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const ev = insertEvent(rawDb, { name: "Poster Scheme List Event", slug: "poster-scheme-list-event" });
+    // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #504-style read-path guard
+    rawDb.prepare("UPDATE events SET poster_url = ? WHERE id = ?").run("javascript:alert(1)", ev.id);
+
+    const request = new Request("https://example.test/api/admin/events", {
+      headers: { "x-test-role": "viewer" },
+    });
+    const res = await eventsHandler.onRequestGet({ request, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    const found = data.events.find((e) => e.id === ev.id);
+    expect(found).toBeDefined();
+    expect(found.poster_url).toBeNull();
+  });
+
   it("publish endpoint requires >=1 band and publishes event", async () => {
     const rawDb = createTestDB();
     const env = { DB: createDBEnv(rawDb) };
@@ -635,6 +745,35 @@ describe("Event API - handler integration", () => {
 
     const stored = rawDb.prepare("SELECT doors_json FROM events WHERE id = ?").get(data.event.id);
     expect(stored.doors_json).toBeNull();
+  });
+
+  it("duplicate endpoint does NOT copy poster_url to the new event (#616 — edition-specific, like doors_json)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+
+    const original = insertEvent(rawDb, { name: "Poster Source", slug: "poster-source" });
+    rawDb
+      .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
+      .run("https://band-photos.settimes.ca/event-posters/1-source.jpg", original.id);
+
+    const body = { name: "Poster Copy", date: "2100-07-09", slug: "poster-copy" };
+    const request = new Request(`https://example.test/api/admin/events/${original.id}/duplicate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify(body),
+    });
+
+    const res = await duplicateHandler.onRequestPost({
+      request,
+      env,
+      params: { id: String(original.id) },
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.event.poster_url).toBeNull();
+
+    const stored = rawDb.prepare("SELECT poster_url FROM events WHERE id = ?").get(data.event.id);
+    expect(stored.poster_url).toBeNull();
   });
 
   it("duplicate endpoint sanitizes a legacy javascript: social_links value at the write path (#499)", async () => {

--- a/functions/api/admin/events/__tests__/posters.test.js
+++ b/functions/api/admin/events/__tests__/posters.test.js
@@ -1,0 +1,182 @@
+// Tests for POST /api/admin/events/posters (#616).
+//
+// Mirrors functions/api/admin/bands/photos.js: same magic-byte validation
+// (functions/utils/imageUpload.js), same R2 bucket (env.BAND_PHOTOS) under an
+// event-posters/ key prefix. event_id is optional (a poster can be uploaded
+// while creating a brand-new event that has no id yet) but validated and
+// existence-checked when provided; providing it persists poster_url
+// immediately.
+
+import { describe, expect, test, vi } from "vitest";
+import { onRequestPost } from "../posters.js";
+import { createTestDB, createDBEnv, insertEvent } from "../../../test-utils.js";
+
+function jpegFile(name = "poster.jpg") {
+  const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01]);
+  return new File([bytes], name, { type: "image/jpeg" });
+}
+
+function textFile(name = "not-an-image.txt") {
+  return new File([new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f])], name, { type: "text/plain" });
+}
+
+function buildEnv() {
+  const rawDb = createTestDB();
+  const put = vi.fn().mockResolvedValue(undefined);
+  return {
+    rawDb,
+    env: {
+      DB: createDBEnv(rawDb),
+      BAND_PHOTOS: { put },
+      BAND_PHOTOS_PUBLIC_URL: "https://band-photos.settimes.ca",
+    },
+    put,
+  };
+}
+
+function requestWith(formData) {
+  return new Request("https://example.test/api/admin/events/posters", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+describe("POST /api/admin/events/posters", () => {
+  test("viewer role is forbidden (403)", async () => {
+    const { env } = buildEnv();
+    const formData = new FormData();
+    formData.append("poster", jpegFile());
+
+    const res = await onRequestPost({
+      request: requestWith(formData),
+      env,
+      data: { user: { role: "viewer", userId: 3, email: "viewer@test.local" } },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  test("editor role can upload a poster and gets a public URL back", async () => {
+    const { env, put } = buildEnv();
+    const formData = new FormData();
+    formData.append("poster", jpegFile());
+
+    const res = await onRequestPost({
+      request: requestWith(formData),
+      env,
+      data: { user: { role: "editor", userId: 2, email: "editor@test.local" } },
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.url).toMatch(/^https:\/\/band-photos\.settimes\.ca\/event-posters\/\d+-poster\.jpg$/);
+    expect(data.type).toBe("image/jpeg");
+
+    // R2 .put() called with the event-posters/ prefix (not band-photos/).
+    expect(put).toHaveBeenCalledTimes(1);
+    const [key] = put.mock.calls[0];
+    expect(key).toMatch(/^event-posters\//);
+  });
+
+  test("rejects a non-image file with 400 (magic-byte check, not just extension/Content-Type)", async () => {
+    const { env, put } = buildEnv();
+    const formData = new FormData();
+    formData.append("poster", textFile("poster.jpg")); // .jpg name, but text/plain bytes
+
+    const res = await onRequestPost({
+      request: requestWith(formData),
+      env,
+      data: { user: { role: "editor", userId: 2, email: "editor@test.local" } },
+    });
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/Invalid file type/);
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  test("rejects when no poster file is provided", async () => {
+    const { env } = buildEnv();
+    const formData = new FormData();
+
+    const res = await onRequestPost({
+      request: requestWith(formData),
+      env,
+      data: { user: { role: "editor", userId: 2, email: "editor@test.local" } },
+    });
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/No poster file provided/);
+  });
+
+  test("event_id omitted: upload succeeds without touching the events table", async () => {
+    const { env, rawDb } = buildEnv();
+    const event = insertEvent(rawDb, { name: "No Poster Yet", slug: "no-poster-yet" });
+    const formData = new FormData();
+    formData.append("poster", jpegFile());
+
+    const res = await onRequestPost({
+      request: requestWith(formData),
+      env,
+      data: { user: { role: "editor", userId: 2, email: "editor@test.local" } },
+    });
+
+    expect(res.status).toBe(200);
+    const stored = rawDb.prepare("SELECT poster_url FROM events WHERE id = ?").get(event.id);
+    expect(stored.poster_url).toBeNull();
+  });
+
+  test("event_id provided and valid: poster_url is persisted immediately", async () => {
+    const { env, rawDb } = buildEnv();
+    const event = insertEvent(rawDb, { name: "Gets A Poster", slug: "gets-a-poster" });
+    const formData = new FormData();
+    formData.append("poster", jpegFile());
+    formData.append("event_id", String(event.id));
+
+    const res = await onRequestPost({
+      request: requestWith(formData),
+      env,
+      data: { user: { role: "editor", userId: 2, email: "editor@test.local" } },
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    const stored = rawDb.prepare("SELECT poster_url FROM events WHERE id = ?").get(event.id);
+    expect(stored.poster_url).toBe(data.url);
+  });
+
+  test("event_id provided but malformed: 400, no upload attempted", async () => {
+    const { env, put } = buildEnv();
+    const formData = new FormData();
+    formData.append("poster", jpegFile());
+    formData.append("event_id", "not-a-number");
+
+    const res = await onRequestPost({
+      request: requestWith(formData),
+      env,
+      data: { user: { role: "editor", userId: 2, email: "editor@test.local" } },
+    });
+
+    expect(res.status).toBe(400);
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  test("event_id provided but references a non-existent event: 404, no upload attempted", async () => {
+    const { env, put } = buildEnv();
+    const formData = new FormData();
+    formData.append("poster", jpegFile());
+    formData.append("event_id", "999999");
+
+    const res = await onRequestPost({
+      request: requestWith(formData),
+      env,
+      data: { user: { role: "editor", userId: 2, email: "editor@test.local" } },
+    });
+
+    expect(res.status).toBe(404);
+    expect(put).not.toHaveBeenCalled();
+  });
+});

--- a/functions/api/admin/events/posters.js
+++ b/functions/api/admin/events/posters.js
@@ -1,0 +1,146 @@
+/**
+ * Event Poster Upload API
+ * POST /api/admin/events/posters
+ *
+ * Uploads an event poster image, mirroring functions/api/admin/bands/photos.js
+ * (#616 design comment): same magic-byte validation (functions/utils/imageUpload.js),
+ * same R2 bucket (BAND_PHOTOS) — a dedicated poster bucket would be pure
+ * operational overhead for the same storage need — under an event-posters/
+ * key prefix instead of band-photos/.
+ *
+ * event_id is optional (mirrors bandId in photos.js): a poster can be
+ * uploaded while creating a brand-new event that has no id yet, in which
+ * case the caller only gets the public URL back and includes it in the
+ * create payload. When event_id IS provided it is validated (validateId)
+ * and must reference a real event; on success the row is updated directly
+ * (same immediate-persistence convenience photos.js gives band_profiles),
+ * through the same normalizeHttpUrl write-path sanitization as the PATCH
+ * /api/admin/events/{id} endpoint (#504 convention).
+ */
+
+import { checkPermission } from "../_middleware.js";
+import { detectImageMimeType, MAX_FILE_SIZE, ALLOWED_IMAGE_TYPES } from "../../../utils/imageUpload.js";
+import { normalizeHttpUrl, validateId } from "../../../utils/validation.js";
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+
+  try {
+    const permCheck = await checkPermission(context, "editor");
+    if (permCheck.error) {
+      return permCheck.response;
+    }
+    const { user } = permCheck;
+
+    // Parse multipart form data
+    const formData = await request.formData();
+    const file = formData.get("poster");
+    const eventIdRaw = formData.get("event_id"); // Optional: associate with + persist to an event
+
+    if (!file || !(file instanceof File)) {
+      return new Response(JSON.stringify({ error: "No poster file provided" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Validate event_id when provided — an explicitly-supplied-but-invalid id
+    // is a client bug worth surfacing as 400, not silently ignored.
+    let eventId = null;
+    if (eventIdRaw !== null && eventIdRaw !== "") {
+      const { valid, value, error: idError } = validateId(eventIdRaw);
+      if (!valid) {
+        return new Response(JSON.stringify({ error: "Bad request", message: idError }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      const event = await env.DB.prepare("SELECT id FROM events WHERE id = ?").bind(value).first();
+      if (!event) {
+        return new Response(JSON.stringify({ error: "Not found", message: "Event not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      eventId = value;
+    }
+
+    // Validate file size
+    if (file.size > MAX_FILE_SIZE) {
+      return new Response(
+        JSON.stringify({
+          error: `File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`,
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Validate MIME type via magic bytes — ignores attacker-controlled file.type.
+    const detectedType = await detectImageMimeType(file);
+    if (!detectedType || !ALLOWED_IMAGE_TYPES.includes(detectedType)) {
+      return new Response(
+        JSON.stringify({
+          error: "Invalid file type. Allowed: JPEG, PNG, WebP, GIF",
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Generate unique filename with timestamp
+    const timestamp = Date.now();
+    const sanitizedName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_").toLowerCase();
+    const filename = `event-posters/${timestamp}-${sanitizedName}`;
+
+    // Upload to R2 bucket — use the server-verified type, not the client-supplied one.
+    await env.BAND_PHOTOS.put(filename, file.stream(), {
+      httpMetadata: {
+        contentType: detectedType,
+      },
+      customMetadata: {
+        uploadedBy: user.email,
+        uploadedAt: new Date().toISOString(),
+        originalName: file.name,
+        ...(eventId && { eventId: String(eventId) }),
+      },
+    });
+
+    // Generate the public URL for the stored object. Same base as band photos
+    // (BAND_PHOTOS_PUBLIC_URL) — the domain is bucket-level, not key-prefix-level.
+    const photoBaseUrl = env.BAND_PHOTOS_PUBLIC_URL || "https://band-photos.settimes.ca";
+    const publicUrl = `${photoBaseUrl}/${filename}`;
+
+    // If event_id provided, persist immediately (mirrors photos.js's optional
+    // bandId write). normalizeHttpUrl on write matches the PATCH endpoint's
+    // sanitization so this row can never diverge from that convention.
+    if (eventId) {
+      await env.DB.prepare("UPDATE events SET poster_url = ? WHERE id = ?")
+        .bind(normalizeHttpUrl(publicUrl), eventId)
+        .run();
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        url: publicUrl,
+        filename,
+        size: file.size,
+        type: detectedType,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  } catch (error) {
+    console.error("Poster upload error:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Poster upload failed",
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+}

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -1,4 +1,5 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
+import { normalizeHttpUrl } from "../../../utils/validation.js";
 import { sortableName } from "../../../utils/sortableName.js";
 
 // SQLite `ORDER BY` can't strip a leading article inline (#587); the SQL
@@ -38,10 +39,14 @@ export async function onRequestGet(context) {
 
   try {
     const event = isNumeric
-      ? await DB.prepare(`SELECT id, name, slug, date FROM events WHERE id = ? AND status = 'archived' LIMIT 1`)
+      ? await DB.prepare(
+          `SELECT id, name, slug, date, poster_url FROM events WHERE id = ? AND status = 'archived' LIMIT 1`,
+        )
           .bind(numericId)
           .first()
-      : await DB.prepare(`SELECT id, name, slug, date FROM events WHERE slug = ? AND status = 'archived' LIMIT 1`)
+      : await DB.prepare(
+          `SELECT id, name, slug, date, poster_url FROM events WHERE slug = ? AND status = 'archived' LIMIT 1`,
+        )
           .bind(rawId)
           .first();
 
@@ -51,6 +56,10 @@ export async function onRequestGet(context) {
         headers: { "Content-Type": "application/json" },
       });
     }
+
+    // Read-path sanitize (#504 convention, #616): never reflect a
+    // pre-validation legacy poster_url to public API consumers.
+    event.poster_url = normalizeHttpUrl(event.poster_url);
 
     const bandsResult = await DB.prepare(
       `

--- a/functions/api/events/__tests__/recap.test.js
+++ b/functions/api/events/__tests__/recap.test.js
@@ -368,6 +368,69 @@ describe("GET /api/events/:id/recap", () => {
     expect(res.status).toBe(500);
   });
 
+  // #616: the recap event payload exposes poster_url (sanitized), so the
+  // recap page can render the poster for the archived edition.
+  test("includes a sanitized poster_url when set", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Postered Recap",
+      slug: "postered-recap",
+      date: "2024-08-03",
+      status: "archived",
+    });
+    rawDb
+      .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
+      .run("https://band-photos.settimes.ca/event-posters/1-recap.jpg", event.id);
+
+    const request = new Request(`https://example.test/api/events/${event.slug}/recap`);
+    const response = await onRequestGet({ request, env, params: { id: event.slug } });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.event.poster_url).toBe("https://band-photos.settimes.ca/event-posters/1-recap.jpg");
+  });
+
+  test("poster_url is null when unset", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Posterless Recap",
+      slug: "posterless-recap",
+      date: "2024-08-03",
+      status: "archived",
+    });
+
+    const request = new Request(`https://example.test/api/events/${event.slug}/recap`);
+    const response = await onRequestGet({ request, env, params: { id: event.slug } });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.event.poster_url).toBeNull();
+  });
+
+  test("drops a legacy javascript: poster_url (#504-style read-path guard)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Unsafe Poster Recap",
+      slug: "unsafe-poster-recap",
+      date: "2024-08-03",
+      status: "archived",
+    });
+    rawDb
+      .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
+      // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #504-style read-path guard
+      .run("javascript:alert(1)", event.id);
+
+    const request = new Request(`https://example.test/api/events/${event.slug}/recap`);
+    const response = await onRequestGet({ request, env, params: { id: event.slug } });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.event.poster_url).toBeNull();
+  });
+
   test("returns 503 when PUBLIC_DATA_PUBLISH_ENABLED is not set", async () => {
     const { env, rawDb } = createTestEnv();
     // Do NOT set PUBLIC_DATA_PUBLISH_ENABLED

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -104,6 +104,7 @@ export function createTestDB() {
       description TEXT,
       city TEXT,
       ticket_url TEXT,
+      poster_url TEXT,
       venue_info TEXT,
       social_links TEXT,
       theme_colors TEXT,

--- a/functions/event/[slug].js
+++ b/functions/event/[slug].js
@@ -17,7 +17,7 @@ export async function onRequest(context) {
   let event;
   try {
     event = await env.DB.prepare(
-      `SELECT id, name, date, end_date, slug, description, city, ticket_url, created_at
+      `SELECT id, name, date, end_date, slug, description, city, ticket_url, poster_url, created_at
        FROM events
        WHERE slug = ? AND (is_published = 1 OR status = 'archived')`,
     )
@@ -72,17 +72,29 @@ export async function onRequest(context) {
   const description =
     plainDesc || `${event.name} — live music in ${where} on SetTimes.${event.date ? ` ${event.date}.` : ""}`;
 
+  // Read-path sanitize (#504 convention, #616): a pre-validation legacy
+  // poster_url must never be reflected into og:image/twitter:image or the
+  // MusicEvent JSON-LD image — normalizeHttpUrl returns null for anything
+  // that isn't a real http(s) URL, which omits the image entirely below.
+  const safePosterUrl = normalizeHttpUrl(event.poster_url);
+
   const metaTags = [
     `<meta name="description" content="${escapeAttr(description)}" />`,
     `<meta property="og:title" content="${escapeAttr(event.name)}" />`,
     `<meta property="og:description" content="${escapeAttr(description)}" />`,
     `<meta property="og:type" content="website" />`,
     `<meta property="og:url" content="${escapeAttr(url)}" />`,
-    `<meta name="twitter:card" content="summary" />`,
     `<meta name="twitter:title" content="${escapeAttr(event.name)}" />`,
     `<meta name="twitter:description" content="${escapeAttr(description)}" />`,
     `<link rel="canonical" href="${escapeAttr(url)}" />`,
   ];
+  if (safePosterUrl) {
+    metaTags.push(`<meta property="og:image" content="${escapeAttr(safePosterUrl)}" />`);
+    metaTags.push(`<meta name="twitter:image" content="${escapeAttr(safePosterUrl)}" />`);
+    metaTags.push(`<meta name="twitter:card" content="summary_large_image" />`);
+  } else {
+    metaTags.push(`<meta name="twitter:card" content="summary" />`);
+  }
 
   // Build MusicEvent location: use per-venue MusicVenue entries when available,
   // otherwise fall back to a generic Place for the Waterloo Region.
@@ -132,6 +144,7 @@ export async function onRequest(context) {
     ...(event.date ? { endDate: event.end_date || event.date } : {}),
     location,
     ...(plainDesc ? { description: plainDesc } : {}),
+    ...(safePosterUrl ? { image: [safePosterUrl] } : {}),
     organizer: {
       "@type": "Organization",
       name: "SetTimes",

--- a/functions/event/__tests__/slug.test.js
+++ b/functions/event/__tests__/slug.test.js
@@ -149,3 +149,82 @@ describe("SSR /event/[slug] — MusicEvent JSON-LD enrichment (#615)", () => {
     expect(musicEvent.offers).toBeUndefined();
   });
 });
+
+describe("SSR /event/[slug] — poster_url image + og:image/twitter:image (#616)", () => {
+  test("poster present: MusicEvent gets an image array and og:image/twitter:image are emitted", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Postered Event",
+      slug: "slug-616-poster",
+      date: "2026-08-02",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb
+      .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
+      .run("https://band-photos.settimes.ca/event-posters/1-vol17.jpg", event.id);
+
+    const response = await onRequest(makeContext({ env, slug: "slug-616-poster" }));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    expect(html).toContain(
+      '<meta property="og:image" content="https://band-photos.settimes.ca/event-posters/1-vol17.jpg" />',
+    );
+    expect(html).toContain(
+      '<meta name="twitter:image" content="https://band-photos.settimes.ca/event-posters/1-vol17.jpg" />',
+    );
+    expect(html).toContain('<meta name="twitter:card" content="summary_large_image" />');
+
+    const [musicEvent] = extractJsonLd(html);
+    expect(musicEvent.image).toEqual(["https://band-photos.settimes.ca/event-posters/1-vol17.jpg"]);
+  });
+
+  test("poster absent: no image field, no og:image/twitter:image, twitter:card falls back to summary", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Posterless Event",
+      slug: "slug-616-no-poster",
+      date: "2026-08-02",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const response = await onRequest(makeContext({ env, slug: "slug-616-no-poster" }));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    expect(html).not.toContain('property="og:image"');
+    expect(html).not.toContain('name="twitter:image"');
+    expect(html).toContain('<meta name="twitter:card" content="summary" />');
+
+    const [musicEvent] = extractJsonLd(html);
+    expect(musicEvent.image).toBeUndefined();
+  });
+
+  test("drops the image entirely for a legacy javascript: poster_url (#504-style read-path guard)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Unsafe Poster Event",
+      slug: "slug-616-unsafe-poster",
+      date: "2026-08-02",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb
+      .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
+      // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #504-style read-path guard
+      .run("javascript:alert(1)", event.id);
+
+    const response = await onRequest(makeContext({ env, slug: "slug-616-unsafe-poster" }));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    // eslint-disable-next-line no-script-url -- assertion text, not an executed scheme
+    expect(html).not.toContain("javascript:");
+    expect(html).not.toContain('property="og:image"');
+
+    const [musicEvent] = extractJsonLd(html);
+    expect(musicEvent.image).toBeUndefined();
+  });
+});

--- a/functions/utils/__tests__/imageUpload.test.js
+++ b/functions/utils/__tests__/imageUpload.test.js
@@ -1,0 +1,76 @@
+// Tests for functions/utils/imageUpload.js — the magic-byte MIME detector +
+// size cap extracted from functions/api/admin/bands/photos.js (#616) so
+// functions/api/admin/events/posters.js can reuse the exact same validation.
+
+import { describe, expect, test } from "vitest";
+import { ALLOWED_IMAGE_TYPES, detectImageMimeType, MAX_FILE_SIZE } from "../imageUpload.js";
+
+function fileFromBytes(bytes, name = "upload.bin") {
+  return new File([new Uint8Array(bytes)], name);
+}
+
+describe("imageUpload constants", () => {
+  test("MAX_FILE_SIZE is 5MB", () => {
+    expect(MAX_FILE_SIZE).toBe(5 * 1024 * 1024);
+  });
+
+  test("ALLOWED_IMAGE_TYPES covers JPEG, PNG, WebP, GIF", () => {
+    expect(ALLOWED_IMAGE_TYPES).toEqual(["image/jpeg", "image/png", "image/webp", "image/gif"]);
+  });
+});
+
+describe("detectImageMimeType", () => {
+  test("accepts a JPEG magic byte header (FF D8 FF)", async () => {
+    const file = fileFromBytes([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    await expect(detectImageMimeType(file)).resolves.toBe("image/jpeg");
+  });
+
+  test("accepts a full PNG 8-byte signature", async () => {
+    const file = fileFromBytes([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await expect(detectImageMimeType(file)).resolves.toBe("image/png");
+  });
+
+  test("accepts a GIF87a signature", async () => {
+    const file = fileFromBytes([0x47, 0x49, 0x46, 0x38, 0x37, 0x61]);
+    await expect(detectImageMimeType(file)).resolves.toBe("image/gif");
+  });
+
+  test("accepts a GIF89a signature", async () => {
+    const file = fileFromBytes([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+    await expect(detectImageMimeType(file)).resolves.toBe("image/gif");
+  });
+
+  test("accepts a WebP (RIFF....WEBP) signature", async () => {
+    const file = fileFromBytes([0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50]);
+    await expect(detectImageMimeType(file)).resolves.toBe("image/webp");
+  });
+
+  test("rejects an unrecognised header", async () => {
+    const file = fileFromBytes([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
+    await expect(detectImageMimeType(file)).resolves.toBeNull();
+  });
+
+  test("rejects a truncated PNG header (partial signature, e.g. spoofed via a short file)", async () => {
+    // Only the first 4 bytes of the 8-byte PNG signature — must not
+    // false-positive as PNG on a partial match.
+    const file = fileFromBytes([0x89, 0x50, 0x4e, 0x47]);
+    await expect(detectImageMimeType(file)).resolves.toBeNull();
+  });
+
+  test("rejects an empty file", async () => {
+    const file = fileFromBytes([]);
+    await expect(detectImageMimeType(file)).resolves.toBeNull();
+  });
+
+  test("rejects a RIFF header that isn't WEBP (e.g. a WAV file)", async () => {
+    const file = fileFromBytes([0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45]);
+    await expect(detectImageMimeType(file)).resolves.toBeNull();
+  });
+
+  test("does not trust a spoofed Content-Type — detection is purely magic-byte based", async () => {
+    // A file whose declared type claims image/png but whose bytes are JPEG's
+    // magic header must be detected as JPEG (or rejected), never PNG.
+    const file = new File([new Uint8Array([0xff, 0xd8, 0xff, 0xe0])], "fake.png", { type: "image/png" });
+    await expect(detectImageMimeType(file)).resolves.toBe("image/jpeg");
+  });
+});

--- a/functions/utils/imageUpload.js
+++ b/functions/utils/imageUpload.js
@@ -1,0 +1,74 @@
+/**
+ * Shared image upload validation
+ *
+ * Magic-byte MIME detection + size-cap logic, extracted from
+ * functions/api/admin/bands/photos.js (#616) so the event poster upload
+ * endpoint (functions/api/admin/events/posters.js) can reuse the exact same
+ * validation instead of duplicating it. Behaviour is unchanged from the
+ * original band-photo implementation.
+ */
+
+// Maximum file size: 5MB — shared backstop for band photos and event posters.
+export const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+// Allowed MIME types, verified via magic bytes below (never the
+// client-supplied Content-Type, which is attacker-controlled).
+export const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
+/**
+ * Detect the true MIME type from the file's magic bytes.
+ * Rejects client-supplied Content-Type and validates the actual file header.
+ * @param {File} file
+ * @returns {Promise<string|null>} Detected MIME type or null if unrecognised.
+ */
+export async function detectImageMimeType(file) {
+  const header = new Uint8Array(await file.slice(0, 12).arrayBuffer());
+  const length = header.length;
+
+  // JPEG: FF D8 FF
+  if (length >= 3 && header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff) {
+    return "image/jpeg";
+  }
+  // PNG: 89 50 4E 47 0D 0A 1A 0A (full 8-byte signature)
+  if (
+    length >= 8 &&
+    header[0] === 0x89 &&
+    header[1] === 0x50 &&
+    header[2] === 0x4e &&
+    header[3] === 0x47 &&
+    header[4] === 0x0d &&
+    header[5] === 0x0a &&
+    header[6] === 0x1a &&
+    header[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  // GIF87a / GIF89a: 47 49 46 38 37|39 61 (full 6-byte signature)
+  if (
+    length >= 6 &&
+    header[0] === 0x47 &&
+    header[1] === 0x49 &&
+    header[2] === 0x46 &&
+    header[3] === 0x38 &&
+    (header[4] === 0x37 || header[4] === 0x39) &&
+    header[5] === 0x61
+  ) {
+    return "image/gif";
+  }
+  // WebP: RIFF (52 49 46 46) + 4-byte length + WEBP (57 45 42 50)
+  if (
+    length >= 12 &&
+    header[0] === 0x52 &&
+    header[1] === 0x49 &&
+    header[2] === 0x46 &&
+    header[3] === 0x46 &&
+    header[8] === 0x57 &&
+    header[9] === 0x45 &&
+    header[10] === 0x42 &&
+    header[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+
+  return null;
+}

--- a/functions/utils/validation.js
+++ b/functions/utils/validation.js
@@ -90,6 +90,7 @@ export const FIELD_LIMITS = {
   eventName: { min: 3, max: 200 },
   eventSlug: { min: 3, max: 100 },
   ticketLink: { min: 0, max: 500 },
+  eventPosterUrl: { min: 0, max: 500 },
   eventDescription: { min: 0, max: 5000 },
   eventCity: { min: 0, max: 100 },
   eventVenueInfo: { min: 0, max: 5000 },
@@ -1302,6 +1303,12 @@ export const VALIDATION_SCHEMAS = {
       required: false,
       label: "Ticket link",
       max: FIELD_LIMITS.ticketLink.max,
+    },
+    poster_url: {
+      type: "url",
+      required: false,
+      label: "Poster image",
+      max: FIELD_LIMITS.eventPosterUrl.max,
     },
     venue_info: {
       type: "string",

--- a/migrations/0053_add_event_poster_url.sql
+++ b/migrations/0053_add_event_poster_url.sql
@@ -1,0 +1,9 @@
+-- Migration: 0053_add_event_poster_url
+-- Adds poster_url for the event's promotional poster image (#616), uploaded
+-- via the admin UI through the shared R2 photo pipeline (event-posters/
+-- prefix). NULL means "no poster" — surfaces (MusicEvent JSON-LD image,
+-- og:image/twitter:image, recap page) all no-op when this is absent.
+-- Edition-specific like doors_json (#569): event duplication deliberately
+-- does not copy it.
+
+ALTER TABLE events ADD COLUMN poster_url TEXT;


### PR DESCRIPTION
## Summary

Adds `events.poster_url`: an admin poster upload reusing the R2 photo pipeline, surfaced as MusicEvent structured-data `image` + `og:image`/`twitter:image` on event pages (closes Google's per-event "image" Events warning) and as the poster on recap pages — the archive gets its art back. Built to the leanness principle: `PhotoUpload` gains an optional `maxDimension` prop that canvas-downscales posters to a 1600px long edge (JPEG q0.82) **before** upload, so a print-res @hushpuppydesigns original never bloats R2 and zero bytes reach the fan bundle.

Closes #616

## What changed

| Area | Change |
|------|--------|
| Migration | `0053_add_event_poster_url.sql` (`events.poster_url TEXT`); setup-complete.sql regenerated, drift clean |
| Upload | `functions/utils/imageUpload.js` — magic-byte MIME + size validation extracted from bands/photos.js (byte-identical); new `functions/api/admin/events/posters.js` (editor RBAC, CSRF, R2 `event-posters/` prefix); `_middleware.js` raised-body allowlist extended to the route |
| Round-trip | `poster_url` sanitized via `normalizeHttpUrl` on read + write across admin event GET/PATCH/PUT; **event duplication excludes it** (edition-specific, like doors_json) |
| Admin UI | `EventFormModal` poster field via `PhotoUpload` with `maxDimension={1600}`; band-photo usages pass nothing → byte-for-byte unchanged |
| Surfaces | `event/[slug].js` MusicEvent `image` + OG/twitter meta when present; `EventRecapPage` renders it lazy, height-capped, theme-tokened, omitted when null |

## Security / correctness notes

Full `cloudflare-security-reviewer` pass — **clean, no findings**. Verified: editor RBAC short-circuits first; CSRF covered by the admin middleware before any mutation; R2 key can't escape the `event-posters/` prefix (filename sanitized, `event_id` via `validateId`, flat keyspace); MIME decided by magic bytes only (client Content-Type ignored); **SVG excluded** (XSS vector closed); the body-ceiling allowlist matches exact pathnames only and can't be widened by slash/case/encoding tricks; `poster_url` neutralized against `javascript:`/`data:`/protocol-relative at every sink (OG meta via `escapeAttr`, JSON-LD via `<`-escaped stringify, `<img src>`). Tests exercise the RBAC 403, magic-byte spoof, and `javascript:` reflection cases directly.

## Verification

- [x] Tests: backend 795 pass | 6 todo (76 files), frontend 535 pass (53 files) — via `make gate`
- [x] ESLint: 0 errors both stacks
- [x] Format check: clean both stacks
- [x] Build: green
- [x] Schema drift: clean (`make schema-check`)
- [x] `validate:openapi`: 73 route files, no drift — new endpoint documented
- [x] Manual smoke: pending post-deploy — upload a poster via the event form, confirm downscale + recap render + OG image (Rich Results Test on the event URL)

---
Built by Sonny · Reviewed by Cass (security) & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)