### PR TITLE
feat: probe tries name+music / name+band bandcamp slug variants

### DIFF
--- a/scripts/probe-band-links.mjs
+++ b/scripts/probe-band-links.mjs
@@ -66,7 +66,12 @@ function candidateSlugs(name) {
     .trim()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");
-  return [...new Set([concat, noThe, hyphen])].filter((s) => s.length >= 3);
+  // Common bandcamp subdomain suffixes when the plain slug is taken or the
+  // artist brands with one (Avalon Stone → avalonstonemusic; many use
+  // "band"/"music"). Canonical forms are tried first so exact matches still
+  // win and suffix variants only fire when the plain slug isn't a live page.
+  const suffixed = [concat, noThe].flatMap((base) => [`${base}music`, `${base}band`]);
+  return [...new Set([concat, noThe, hyphen, ...suffixed])].filter((s) => s.length >= 3);
 }
 
 const normalize = (s) => (s || "").toLowerCase().replace(/[^a-z0-9]/g, "");


### PR DESCRIPTION
## Summary

Follow-up to the link-probe tooling: many bands brand their bandcamp subdomain with a suffix — Avalon Stone lives at `avalonstonemusic`, and `<name>band`/`<name>music` are common when the plain slug is taken. The probe only tried three canonical slug shapes (concat, article-stripped, hyphenated) and put such bands in NONE. `candidateSlugs()` now also appends `music`/`band` to the concat and article-stripped forms, **after** the canonical slugs so exact matches still win and the extra requests only fire when the plain slug isn't a live page.

Validated: re-sweeping the prior 17-band NONE bucket recovered **Avalon Stone → AUTO** via `avalonstonemusic` (the exact case Dre surfaced), and turned up Colorsfade (correctly REVIEW — its page is Gatineau, QC, not Ontario).

## What changed

| File | Change |
|------|--------|
| `scripts/probe-band-links.mjs` | `candidateSlugs()` appends `music`/`band` suffix variants after the canonical forms |

## Security / correctness notes

None — operator script, read-only outbound HTTP, no app code.

## Verification

- [x] Tests: n/a — operator script; canary asserts `candidateSlugs("Avalon Stone")` now includes `avalonstonemusic`; full re-sweep run recovered it as AUTO
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build/openapi: n/a

---
Built by Theo · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)