### PR TITLE
chore: bring e2e specs under prettier + eslint scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,5 +97,5 @@ masks failures (this shipped a red lint to CI once). `make` propagates failures 
   Apple Silicon setups — CI covers it, note it and move on).
 - E2E requires a live wrangler server and env credentials (`ADMIN_EMAIL`/`ADMIN_PASSWORD`
   are required for ANY Playwright invocation, including `--list`). `make e2e` handles this.
-- E2E spec files are currently outside prettier/eslint scope (#622) — match their existing
-  single-quote style; don't reformat them piecemeal.
+- E2E spec files are under the same prettier/eslint scope as `functions/`/`scripts/` (#622) —
+  double quotes/semis, `eslint.config.js`'s `e2e/**` block covers Playwright + browser globals.

--- a/e2e/accessibility/admin-login.spec.js
+++ b/e2e/accessibility/admin-login.spec.js
@@ -9,93 +9,79 @@
  * - Focus management after failed login
  */
 
-import { test, expect } from '@playwright/test'
-import AxeBuilder from '@axe-core/playwright'
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
 
-test.use({ storageState: { cookies: [], origins: [] } })
+test.use({ storageState: { cookies: [], origins: [] } });
 
-test.describe('Admin Login - Accessibility', () => {
-  test('should not have automatically detectable WCAG violations', async ({
-    page,
-  }) => {
-    await page.goto('/admin/login')
-    await expect(
-      page.getByRole('heading', { name: /admin login/i }),
-    ).toBeVisible()
+test.describe("Admin Login - Accessibility", () => {
+  test("should not have automatically detectable WCAG violations", async ({ page }) => {
+    await page.goto("/admin/login");
+    await expect(page.getByRole("heading", { name: /admin login/i })).toBeVisible();
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze()
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"]).analyze();
 
-    expect(results.violations).toEqual([])
-  })
+    expect(results.violations).toEqual([]);
+  });
 
-  test('email and password inputs have associated labels', async ({ page }) => {
-    await page.goto('/admin/login')
+  test("email and password inputs have associated labels", async ({ page }) => {
+    await page.goto("/admin/login");
 
-    const emailInput = page.locator('#email')
-    const passwordInput = page.locator('#password')
+    const emailInput = page.locator("#email");
+    const passwordInput = page.locator("#password");
 
-    await expect(emailInput).toBeVisible()
-    await expect(passwordInput).toBeVisible()
+    await expect(emailInput).toBeVisible();
+    await expect(passwordInput).toBeVisible();
 
     // Verify label association via htmlFor/id pairing
-    await expect(page.locator('label[for="email"]')).toBeVisible()
-    await expect(page.locator('label[for="password"]')).toBeVisible()
-  })
+    await expect(page.locator('label[for="email"]')).toBeVisible();
+    await expect(page.locator('label[for="password"]')).toBeVisible();
+  });
 
-  test('error message uses role="alert" for screen reader announcement', async ({
-    page,
-  }) => {
-    await page.goto('/admin/login')
+  test('error message uses role="alert" for screen reader announcement', async ({ page }) => {
+    await page.goto("/admin/login");
 
-    await page.fill('#email', 'invalid@example.com')
-    await page.fill('#password', 'wrongpassword')
-    await page.click('button[type="submit"]')
+    await page.fill("#email", "invalid@example.com");
+    await page.fill("#password", "wrongpassword");
+    await page.click('button[type="submit"]');
 
     // role="alert" triggers assertive announcement in screen readers
-    const alert = page.locator('[role="alert"]')
-    await expect(alert).toBeVisible({ timeout: 5000 })
-    await expect(alert).not.toBeEmpty()
-  })
+    const alert = page.locator('[role="alert"]');
+    await expect(alert).toBeVisible({ timeout: 5000 });
+    await expect(alert).not.toBeEmpty();
+  });
 
-  test('can navigate the form with keyboard only', async ({ page }) => {
-    await page.goto('/admin/login')
+  test("can navigate the form with keyboard only", async ({ page }) => {
+    await page.goto("/admin/login");
 
-    const emailInput = page.locator('#email')
-    const passwordInput = page.locator('#password')
+    const emailInput = page.locator("#email");
+    const passwordInput = page.locator("#password");
     // Button text is "Login" (checked against AdminLogin.jsx)
-    const submitButton = page.getByRole('button', { name: 'Login' })
+    const submitButton = page.getByRole("button", { name: "Login" });
 
-    await expect(submitButton).toBeVisible()
+    await expect(submitButton).toBeVisible();
 
     // Focus email directly, then Tab through the rest of the form
-    await emailInput.focus()
-    await expect(emailInput).toBeFocused()
+    await emailInput.focus();
+    await expect(emailInput).toBeFocused();
 
-    await page.keyboard.press('Tab')
-    await expect(passwordInput).toBeFocused()
+    await page.keyboard.press("Tab");
+    await expect(passwordInput).toBeFocused();
 
-    await page.keyboard.press('Tab')
-    await expect(submitButton).toBeFocused()
-  })
+    await page.keyboard.press("Tab");
+    await expect(submitButton).toBeFocused();
+  });
 
-  test('submit button is reachable and operable with Enter key', async ({
-    page,
-  }) => {
-    await page.goto('/admin/login')
+  test("submit button is reachable and operable with Enter key", async ({ page }) => {
+    await page.goto("/admin/login");
 
-    await page.fill('#email', 'test@example.com')
-    await page.fill('#password', 'anypassword')
+    await page.fill("#email", "test@example.com");
+    await page.fill("#password", "anypassword");
 
     // Submit via Enter in the password field
-    await page.locator('#password').press('Enter')
+    await page.locator("#password").press("Enter");
 
     // Either an error or redirect should occur — form was submitted
-    await expect(
-      page
-        .locator('[role="alert"]')
-        .or(page.locator('#mfa-code')),
-    ).toBeVisible({ timeout: 5000 })
-  })
-})
+    await expect(page.locator('[role="alert"]').or(page.locator("#mfa-code"))).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/e2e/accessibility/design-system.spec.js
+++ b/e2e/accessibility/design-system.spec.js
@@ -14,8 +14,8 @@
  * - Focus management
  */
 
-import { test, expect } from '@playwright/test';
-import AxeBuilder from '@axe-core/playwright';
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
 
 // Helper to create a test page with component
 async function createComponentPage(page, componentHtml) {
@@ -38,126 +38,143 @@ async function createComponentPage(page, componentHtml) {
   `);
 }
 
-test.describe('Button Component - Accessibility', () => {
-  test('should not have automatically detectable WCAG violations - Primary variant', async ({ page }) => {
-    await createComponentPage(page, `
+test.describe("Button Component - Accessibility", () => {
+  test("should not have automatically detectable WCAG violations - Primary variant", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <button class="inline-flex items-center justify-center font-medium rounded-lg transition-all duration-base focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg-navy disabled:opacity-50 disabled:cursor-not-allowed bg-accent-500 text-white hover:bg-accent-600 focus:ring-accent-500 shadow-sm hover:shadow-md active:scale-95 px-4 py-2 text-base min-h-[44px]">
         Create Event
       </button>
-    `);
+    `,
+    );
 
     const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
       .analyze();
 
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 
-  test('should have sufficient color contrast for all variants', async ({ page }) => {
+  test("should have sufficient color contrast for all variants", async ({ page }) => {
     const variants = [
-      { name: 'primary', bg: '#0369a1', text: '#ffffff' }, // Updated to WCAG AA compliant (4.51:1)
-      { name: 'secondary', bg: '#f5f5f5', border: '#e5e5e5', text: '#171717' }, // Updated to match actual component colors (WCAG AA compliant)
-      { name: 'danger', bg: '#dc143c', text: '#ffffff' },
-      { name: 'success', bg: '#047857', text: '#ffffff' }, // Updated to WCAG AA compliant (5.48:1)
-      { name: 'warning', bg: '#b45309', text: '#ffffff' }, // Updated to WCAG AA compliant (5.02:1)
+      { name: "primary", bg: "#0369a1", text: "#ffffff" }, // Updated to WCAG AA compliant (4.51:1)
+      { name: "secondary", bg: "#f5f5f5", border: "#e5e5e5", text: "#171717" }, // Updated to match actual component colors (WCAG AA compliant)
+      { name: "danger", bg: "#dc143c", text: "#ffffff" },
+      { name: "success", bg: "#047857", text: "#ffffff" }, // Updated to WCAG AA compliant (5.48:1)
+      { name: "warning", bg: "#b45309", text: "#ffffff" }, // Updated to WCAG AA compliant (5.02:1)
     ];
 
     for (const variant of variants) {
-      await createComponentPage(page, `
-        <button style="background-color: ${variant.bg || 'transparent'}; color: ${variant.text}; ${variant.border ? `border: 2px solid ${variant.border};` : ''} padding: 12px 16px; min-height: 44px;">
+      await createComponentPage(
+        page,
+        `
+        <button style="background-color: ${variant.bg || "transparent"}; color: ${variant.text}; ${variant.border ? `border: 2px solid ${variant.border};` : ""} padding: 12px 16px; min-height: 44px;">
           ${variant.name} Button
         </button>
-      `);
+      `,
+      );
 
-      const results = await new AxeBuilder({ page })
-        .withTags(['wcag2aa'])
-        .include('button')
-        .analyze();
+      const results = await new AxeBuilder({ page }).withTags(["wcag2aa"]).include("button").analyze();
 
-      expect(results.violations.filter(v => v.id === 'color-contrast')).toEqual([]);
+      expect(results.violations.filter((v) => v.id === "color-contrast")).toEqual([]);
     }
   });
 
-  test('should meet touch target size requirements (44x44px)', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should meet touch target size requirements (44x44px)", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <button id="test-button" style="min-height: 44px; min-width: 44px; padding: 12px 16px;">
         Button
       </button>
-    `);
+    `,
+    );
 
-    const button = page.locator('#test-button');
+    const button = page.locator("#test-button");
     const boundingBox = await button.boundingBox();
 
     expect(boundingBox.height).toBeGreaterThanOrEqual(44);
     expect(boundingBox.width).toBeGreaterThanOrEqual(44);
   });
 
-  test('should be keyboard accessible with visible focus', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should be keyboard accessible with visible focus", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <button class="focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2" style="padding: 12px; min-height: 44px;">
         Test Button
       </button>
-    `);
+    `,
+    );
 
-    const button = page.locator('button');
+    const button = page.locator("button");
 
     // Tab to button
-    await page.keyboard.press('Tab');
+    await page.keyboard.press("Tab");
     await expect(button).toBeFocused();
 
     // Check focus indicator (ring should be visible)
-    const focusRing = await button.evaluate(el => {
-      const styles = window.getComputedStyle(el, ':focus');
+    const focusRing = await button.evaluate((el) => {
+      const styles = window.getComputedStyle(el, ":focus");
       return {
         outline: styles.outline,
         boxShadow: styles.boxShadow,
       };
     });
 
-    expect(focusRing.boxShadow).not.toBe('none');
+    expect(focusRing.boxShadow).not.toBe("none");
   });
 
-  test('should activate with keyboard (Enter and Space)', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should activate with keyboard (Enter and Space)", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <button onclick="this.setAttribute('data-clicked', 'true')">
         Test Button
       </button>
-    `);
+    `,
+    );
 
-    const button = page.locator('button');
+    const button = page.locator("button");
     await button.focus();
 
     // Test Enter key
-    await page.keyboard.press('Enter');
-    await expect(button).toHaveAttribute('data-clicked', 'true');
+    await page.keyboard.press("Enter");
+    await expect(button).toHaveAttribute("data-clicked", "true");
 
     // Reset
-    await button.evaluate(el => el.removeAttribute('data-clicked'));
+    await button.evaluate((el) => el.removeAttribute("data-clicked"));
 
     // Test Space key
-    await page.keyboard.press('Space');
-    await expect(button).toHaveAttribute('data-clicked', 'true');
+    await page.keyboard.press("Space");
+    await expect(button).toHaveAttribute("data-clicked", "true");
   });
 
-  test('should have proper disabled state ARIA', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should have proper disabled state ARIA", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <button disabled aria-disabled="true" style="opacity: 0.5; cursor: not-allowed;">
         Disabled Button
       </button>
-    `);
+    `,
+    );
 
     const results = await new AxeBuilder({ page }).analyze();
     expect(results.violations).toEqual([]);
 
-    const button = page.locator('button');
-    await expect(button).toHaveAttribute('disabled');
-    await expect(button).toHaveAttribute('aria-disabled', 'true');
+    const button = page.locator("button");
+    await expect(button).toHaveAttribute("disabled");
+    await expect(button).toHaveAttribute("aria-disabled", "true");
   });
 });
 
-test.describe('Input Component - Accessibility', () => {
-  test('should not have WCAG violations with proper label association', async ({ page }) => {
-    await createComponentPage(page, `
+test.describe("Input Component - Accessibility", () => {
+  test("should not have WCAG violations with proper label association", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div>
         <label for="email-input">Email Address</label>
         <input
@@ -168,17 +185,18 @@ test.describe('Input Component - Accessibility', () => {
         />
         <div id="email-hint">Enter your email address</div>
       </div>
-    `);
+    `,
+    );
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .analyze();
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
 
     expect(results.violations).toEqual([]);
   });
 
-  test('should have accessible error messaging', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should have accessible error messaging", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div>
         <label for="email-input">Email</label>
         <input
@@ -189,21 +207,24 @@ test.describe('Input Component - Accessibility', () => {
         />
         <div id="email-error" role="alert">Please enter a valid email address</div>
       </div>
-    `);
+    `,
+    );
 
     const results = await new AxeBuilder({ page }).analyze();
     expect(results.violations).toEqual([]);
 
-    const input = page.locator('#email-input');
-    await expect(input).toHaveAttribute('aria-invalid', 'true');
-    await expect(input).toHaveAttribute('aria-describedby', 'email-error');
+    const input = page.locator("#email-input");
+    await expect(input).toHaveAttribute("aria-invalid", "true");
+    await expect(input).toHaveAttribute("aria-describedby", "email-error");
 
-    const errorMessage = page.locator('#email-error');
-    await expect(errorMessage).toHaveAttribute('role', 'alert');
+    const errorMessage = page.locator("#email-error");
+    await expect(errorMessage).toHaveAttribute("role", "alert");
   });
 
-  test('should indicate required fields properly', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should indicate required fields properly", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div>
         <label for="required-input">
           Name <span aria-label="required">*</span>
@@ -215,20 +236,23 @@ test.describe('Input Component - Accessibility', () => {
           aria-required="true"
         />
       </div>
-    `);
+    `,
+    );
 
     const results = await new AxeBuilder({ page }).analyze();
     expect(results.violations).toEqual([]);
 
-    const input = page.locator('#required-input');
-    await expect(input).toHaveAttribute('required');
-    await expect(input).toHaveAttribute('aria-required', 'true');
+    const input = page.locator("#required-input");
+    await expect(input).toHaveAttribute("required");
+    await expect(input).toHaveAttribute("aria-required", "true");
   });
 });
 
-test.describe('Select Component - Accessibility', () => {
-  test('should not have WCAG violations', async ({ page }) => {
-    await createComponentPage(page, `
+test.describe("Select Component - Accessibility", () => {
+  test("should not have WCAG violations", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div>
         <label for="country-select">Country</label>
         <select id="country-select" name="country">
@@ -238,53 +262,58 @@ test.describe('Select Component - Accessibility', () => {
           <option value="uk">United Kingdom</option>
         </select>
       </div>
-    `);
+    `,
+    );
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .analyze();
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
 
     expect(results.violations).toEqual([]);
   });
 
-  test('should be keyboard navigable', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should be keyboard navigable", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <select>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
       </select>
-    `);
+    `,
+    );
 
-    const select = page.locator('select');
+    const select = page.locator("select");
     await select.focus();
     await expect(select).toBeFocused();
 
     // Arrow down should navigate options
-    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press("ArrowDown");
     const value = await select.inputValue();
-    expect(['1', '2']).toContain(value);
+    expect(["1", "2"]).toContain(value);
   });
 });
 
-test.describe('Checkbox Component - Accessibility', () => {
-  test('should not have WCAG violations', async ({ page }) => {
-    await createComponentPage(page, `
+test.describe("Checkbox Component - Accessibility", () => {
+  test("should not have WCAG violations", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div>
         <input type="checkbox" id="terms" name="terms" />
         <label for="terms">I agree to the terms and conditions</label>
       </div>
-    `);
+    `,
+    );
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .analyze();
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
 
     expect(results.violations).toEqual([]);
   });
 
-  test('should support indeterminate state with ARIA', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should support indeterminate state with ARIA", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div>
         <input
           type="checkbox"
@@ -293,47 +322,56 @@ test.describe('Checkbox Component - Accessibility', () => {
         />
         <label for="select-all">Select All</label>
       </div>
-    `);
+    `,
+    );
 
-    const checkbox = page.locator('#select-all');
-    await expect(checkbox).toHaveAttribute('aria-checked', 'mixed');
+    const checkbox = page.locator("#select-all");
+    await expect(checkbox).toHaveAttribute("aria-checked", "mixed");
   });
 
-  test('should be keyboard accessible (Space to toggle)', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should be keyboard accessible (Space to toggle)", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <input type="checkbox" id="test-checkbox" />
-    `);
+    `,
+    );
 
-    const checkbox = page.locator('#test-checkbox');
+    const checkbox = page.locator("#test-checkbox");
     await checkbox.focus();
     await expect(checkbox).toBeFocused();
 
     // Space should toggle
-    await page.keyboard.press('Space');
+    await page.keyboard.press("Space");
     await expect(checkbox).toBeChecked();
 
-    await page.keyboard.press('Space');
+    await page.keyboard.press("Space");
     await expect(checkbox).not.toBeChecked();
   });
 
-  test('should meet touch target size (44x44px)', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should meet touch target size (44x44px)", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <label style="display: inline-flex; align-items: center; min-height: 44px; min-width: 44px; cursor: pointer;">
         <input type="checkbox" style="width: 20px; height: 20px; margin: 12px;" />
         <span>Checkbox Label</span>
       </label>
-    `);
+    `,
+    );
 
-    const label = page.locator('label');
+    const label = page.locator("label");
     const boundingBox = await label.boundingBox();
 
     expect(boundingBox.height).toBeGreaterThanOrEqual(44);
   });
 });
 
-test.describe('Radio Component - Accessibility', () => {
-  test('should not have WCAG violations in radio group', async ({ page }) => {
-    await createComponentPage(page, `
+test.describe("Radio Component - Accessibility", () => {
+  test("should not have WCAG violations in radio group", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <fieldset>
         <legend>Choose a payment method</legend>
         <div>
@@ -349,17 +387,18 @@ test.describe('Radio Component - Accessibility', () => {
           <label for="paypal">PayPal</label>
         </div>
       </fieldset>
-    `);
+    `,
+    );
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .analyze();
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
 
     expect(results.violations).toEqual([]);
   });
 
-  test('should support keyboard navigation (arrow keys)', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should support keyboard navigation (arrow keys)", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <fieldset>
         <legend>Options</legend>
         <input type="radio" id="opt1" name="options" value="1" />
@@ -369,22 +408,25 @@ test.describe('Radio Component - Accessibility', () => {
         <input type="radio" id="opt3" name="options" value="3" />
         <label for="opt3">Option 3</label>
       </fieldset>
-    `);
+    `,
+    );
 
-    const radio1 = page.locator('#opt1');
+    const radio1 = page.locator("#opt1");
     await radio1.focus();
     await expect(radio1).toBeFocused();
 
     // Arrow down should move to next radio
-    await page.keyboard.press('ArrowDown');
-    const radio2 = page.locator('#opt2');
+    await page.keyboard.press("ArrowDown");
+    const radio2 = page.locator("#opt2");
     await expect(radio2).toBeFocused();
   });
 });
 
-test.describe('Toggle Component - Accessibility', () => {
-  test('should not have WCAG violations', async ({ page }) => {
-    await createComponentPage(page, `
+test.describe("Toggle Component - Accessibility", () => {
+  test("should not have WCAG violations", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div>
         <button
           role="switch"
@@ -395,48 +437,53 @@ test.describe('Toggle Component - Accessibility', () => {
         </button>
         <span id="notifications-label">Enable Notifications</span>
       </div>
-    `);
+    `,
+    );
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .analyze();
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
 
     expect(results.violations).toEqual([]);
   });
 
-  test('should have proper switch role and aria-checked', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should have proper switch role and aria-checked", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <button role="switch" aria-checked="true">
         <span class="sr-only">Toggle</span>
       </button>
-    `);
+    `,
+    );
 
     const toggle = page.locator('button[role="switch"]');
-    await expect(toggle).toHaveAttribute('role', 'switch');
-    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(toggle).toHaveAttribute("role", "switch");
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
   });
 });
 
-test.describe('Modal Component - Accessibility', () => {
-  test('should not have WCAG violations when open', async ({ page }) => {
-    await createComponentPage(page, `
+test.describe("Modal Component - Accessibility", () => {
+  test("should not have WCAG violations when open", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div role="dialog" aria-modal="true" aria-labelledby="modal-title">
         <h2 id="modal-title">Confirm Action</h2>
         <p>Are you sure you want to proceed?</p>
         <button>Cancel</button>
         <button>Confirm</button>
       </div>
-    `);
+    `,
+    );
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .analyze();
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
 
     expect(results.violations).toEqual([]);
   });
 
-  test('should trap focus within modal', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should trap focus within modal", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div role="dialog" aria-modal="true" aria-labelledby="modal-title">
         <button id="close-btn">Close</button>
         <h2 id="modal-title">Modal Title</h2>
@@ -445,20 +492,21 @@ test.describe('Modal Component - Accessibility', () => {
         <button id="cancel-btn">Cancel</button>
         <button id="confirm-btn">Confirm</button>
       </div>
-    `);
+    `,
+    );
 
     // Inject focus trap JavaScript to enable Tab wrapping behavior
     await page.evaluate(() => {
       const dialog = document.querySelector('[role="dialog"]');
       const focusableElements = dialog.querySelectorAll(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
       );
       const focusableArray = Array.from(focusableElements);
       const firstElement = focusableArray[0];
       const lastElement = focusableArray[focusableArray.length - 1];
 
-      document.addEventListener('keydown', (e) => {
-        if (e.key !== 'Tab') return;
+      document.addEventListener("keydown", (e) => {
+        if (e.key !== "Tab") return;
 
         if (e.shiftKey) {
           // Shift + Tab: if on first element, wrap to last
@@ -476,40 +524,45 @@ test.describe('Modal Component - Accessibility', () => {
       });
     });
 
-    const confirmBtn = page.locator('#confirm-btn');
-    const closeBtn = page.locator('#close-btn');
+    const confirmBtn = page.locator("#confirm-btn");
+    const closeBtn = page.locator("#close-btn");
 
     // Focus should start on first focusable element
     await closeBtn.focus();
 
     // Tab through all elements
-    await page.keyboard.press('Tab'); // input1
-    await page.keyboard.press('Tab'); // input2
-    await page.keyboard.press('Tab'); // cancel-btn
-    await page.keyboard.press('Tab'); // confirm-btn
-    await page.keyboard.press('Tab'); // should wrap to close-btn
+    await page.keyboard.press("Tab"); // input1
+    await page.keyboard.press("Tab"); // input2
+    await page.keyboard.press("Tab"); // cancel-btn
+    await page.keyboard.press("Tab"); // confirm-btn
+    await page.keyboard.press("Tab"); // should wrap to close-btn
 
     await expect(closeBtn).toBeFocused();
   });
 
-  test('should close on Escape key', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should close on Escape key", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div id="modal" role="dialog" aria-modal="true" style="display: block;">
         <h2>Modal</h2>
         <button onclick="document.getElementById('modal').style.display='none'">Close</button>
       </div>
-    `);
+    `,
+    );
 
-    const modal = page.locator('#modal');
+    const modal = page.locator("#modal");
     await expect(modal).toBeVisible();
 
     // Simulate Escape key close behavior
-    await page.keyboard.press('Escape');
+    await page.keyboard.press("Escape");
     // Note: actual close behavior would be in JS, this tests the pattern
   });
 
-  test('should have proper ARIA attributes', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should have proper ARIA attributes", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div
         role="dialog"
         aria-modal="true"
@@ -519,95 +572,105 @@ test.describe('Modal Component - Accessibility', () => {
         <h2 id="dialog-title">Delete Item</h2>
         <p id="dialog-desc">This action cannot be undone.</p>
       </div>
-    `);
+    `,
+    );
 
     const dialog = page.locator('[role="dialog"]');
-    await expect(dialog).toHaveAttribute('aria-modal', 'true');
-    await expect(dialog).toHaveAttribute('aria-labelledby', 'dialog-title');
-    await expect(dialog).toHaveAttribute('aria-describedby', 'dialog-desc');
+    await expect(dialog).toHaveAttribute("aria-modal", "true");
+    await expect(dialog).toHaveAttribute("aria-labelledby", "dialog-title");
+    await expect(dialog).toHaveAttribute("aria-describedby", "dialog-desc");
   });
 });
 
-test.describe('Alert Component - Accessibility', () => {
-  test('should not have WCAG violations - all variants', async ({ page }) => {
-    const variants = ['success', 'warning', 'error', 'info'];
+test.describe("Alert Component - Accessibility", () => {
+  test("should not have WCAG violations - all variants", async ({ page }) => {
+    const variants = ["success", "warning", "error", "info"];
 
     for (const variant of variants) {
-      await createComponentPage(page, `
+      await createComponentPage(
+        page,
+        `
         <div role="alert" class="${variant}">
           <strong>${variant.toUpperCase()}</strong>
           <p>This is a ${variant} message.</p>
         </div>
-      `);
+      `,
+      );
 
-      const results = await new AxeBuilder({ page })
-        .withTags(['wcag2a', 'wcag2aa'])
-        .analyze();
+      const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
 
       expect(results.violations).toEqual([]);
     }
   });
 
   test('should have role="alert" for screen readers', async ({ page }) => {
-    await createComponentPage(page, `
+    await createComponentPage(
+      page,
+      `
       <div role="alert">
         <strong>Success!</strong>
         <p>Your changes have been saved.</p>
       </div>
-    `);
+    `,
+    );
 
     const alert = page.locator('[role="alert"]');
-    await expect(alert).toHaveAttribute('role', 'alert');
+    await expect(alert).toHaveAttribute("role", "alert");
   });
 
-  test('should meet color contrast for all variants', async ({ page }) => {
+  test("should meet color contrast for all variants", async ({ page }) => {
     const variants = [
-      { name: 'success', bg: '#d4edda', border: '#228b22', text: '#0f5132' },
-      { name: 'warning', bg: '#fff3cd', border: '#b45309', text: '#8b4500' }, // Border updated to WCAG AA compliant
-      { name: 'error', bg: '#f8d7da', border: '#dc143c', text: '#8b0000' },
-      { name: 'info', bg: '#d1ecf1', border: '#1e90ff', text: '#004085' },
+      { name: "success", bg: "#d4edda", border: "#228b22", text: "#0f5132" },
+      { name: "warning", bg: "#fff3cd", border: "#b45309", text: "#8b4500" }, // Border updated to WCAG AA compliant
+      { name: "error", bg: "#f8d7da", border: "#dc143c", text: "#8b0000" },
+      { name: "info", bg: "#d1ecf1", border: "#1e90ff", text: "#004085" },
     ];
 
     for (const variant of variants) {
-      await createComponentPage(page, `
+      await createComponentPage(
+        page,
+        `
         <div
           role="alert"
           style="background-color: ${variant.bg}; border: 1px solid ${variant.border}; color: ${variant.text}; padding: 12px;"
         >
           ${variant.name} Alert
         </div>
-      `);
+      `,
+      );
 
-      const results = await new AxeBuilder({ page })
-        .withTags(['wcag2aa'])
-        .include('[role="alert"]')
-        .analyze();
+      const results = await new AxeBuilder({ page }).withTags(["wcag2aa"]).include('[role="alert"]').analyze();
 
-      const contrastViolations = results.violations.filter(v => v.id === 'color-contrast');
+      const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
       expect(contrastViolations).toEqual([]);
     }
   });
 
-  test('should be keyboard dismissible if dismissible', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should be keyboard dismissible if dismissible", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <div role="alert">
         <p>Alert message</p>
         <button aria-label="Dismiss alert">×</button>
       </div>
-    `);
+    `,
+    );
 
     const dismissBtn = page.locator('button[aria-label="Dismiss alert"]');
     await dismissBtn.focus();
     await expect(dismissBtn).toBeFocused();
 
-    await page.keyboard.press('Enter');
+    await page.keyboard.press("Enter");
     // Dismiss behavior would be tested with actual component
   });
 });
 
-test.describe('Card Component - Accessibility', () => {
-  test('should not have WCAG violations', async ({ page }) => {
-    await createComponentPage(page, `
+test.describe("Card Component - Accessibility", () => {
+  test("should not have WCAG violations", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <article>
         <header>
           <h2>Card Title</h2>
@@ -619,86 +682,95 @@ test.describe('Card Component - Accessibility', () => {
           <button>Action</button>
         </footer>
       </article>
-    `);
+    `,
+    );
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .analyze();
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
 
     expect(results.violations).toEqual([]);
   });
 
-  test('should use semantic HTML elements', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should use semantic HTML elements", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <article>
         <header><h3>Title</h3></header>
         <div><p>Content</p></div>
         <footer><button>Action</button></footer>
       </article>
-    `);
+    `,
+    );
 
-    await expect(page.locator('article')).toBeVisible();
-    await expect(page.locator('header')).toBeVisible();
-    await expect(page.locator('footer')).toBeVisible();
+    await expect(page.locator("article")).toBeVisible();
+    await expect(page.locator("header")).toBeVisible();
+    await expect(page.locator("footer")).toBeVisible();
   });
 });
 
-test.describe('Badge Component - Accessibility', () => {
-  test('should not have WCAG violations', async ({ page }) => {
-    await createComponentPage(page, `
+test.describe("Badge Component - Accessibility", () => {
+  test("should not have WCAG violations", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <span role="status" aria-label="Status: Active">
         Active
       </span>
-    `);
+    `,
+    );
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .analyze();
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
 
     expect(results.violations).toEqual([]);
   });
 
-  test('should meet color contrast requirements', async ({ page }) => {
+  test("should meet color contrast requirements", async ({ page }) => {
     const badges = [
-      { name: 'primary', bg: '#1e40af', text: '#ffffff' },
-      { name: 'success', bg: '#047857', text: '#ffffff' }, // Updated to WCAG AA compliant (5.48:1)
-      { name: 'warning', bg: '#b45309', text: '#ffffff' }, // Updated to WCAG AA compliant (5.02:1)
-      { name: 'error', bg: '#dc143c', text: '#ffffff' },
+      { name: "primary", bg: "#1e40af", text: "#ffffff" },
+      { name: "success", bg: "#047857", text: "#ffffff" }, // Updated to WCAG AA compliant (5.48:1)
+      { name: "warning", bg: "#b45309", text: "#ffffff" }, // Updated to WCAG AA compliant (5.02:1)
+      { name: "error", bg: "#dc143c", text: "#ffffff" },
     ];
 
     for (const badge of badges) {
-      await createComponentPage(page, `
+      await createComponentPage(
+        page,
+        `
         <span style="background-color: ${badge.bg}; color: ${badge.text}; padding: 4px 8px; border-radius: 4px;">
           ${badge.name}
         </span>
-      `);
+      `,
+      );
 
-      const results = await new AxeBuilder({ page })
-        .withTags(['wcag2aa'])
-        .analyze();
+      const results = await new AxeBuilder({ page }).withTags(["wcag2aa"]).analyze();
 
-      const contrastViolations = results.violations.filter(v => v.id === 'color-contrast');
+      const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
       expect(contrastViolations).toEqual([]);
     }
   });
 
-  test('should have proper ARIA label for context', async ({ page }) => {
-    await createComponentPage(page, `
+  test("should have proper ARIA label for context", async ({ page }) => {
+    await createComponentPage(
+      page,
+      `
       <span role="status" aria-label="5 unread notifications">
         5
       </span>
-    `);
+    `,
+    );
 
     const badge = page.locator('[role="status"]');
-    await expect(badge).toHaveAttribute('aria-label', '5 unread notifications');
+    await expect(badge).toHaveAttribute("aria-label", "5 unread notifications");
   });
 });
 
-test.describe('Reduced Motion Preference - Accessibility', () => {
-  test('should respect prefers-reduced-motion', async ({ page }) => {
-    await page.emulateMedia({ reducedMotion: 'reduce' });
+test.describe("Reduced Motion Preference - Accessibility", () => {
+  test("should respect prefers-reduced-motion", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
 
-    await createComponentPage(page, `
+    await createComponentPage(
+      page,
+      `
       <style>
         @media (prefers-reduced-motion: reduce) {
           .animated {
@@ -710,31 +782,35 @@ test.describe('Reduced Motion Preference - Accessibility', () => {
       <button class="animated" style="transition: all 0.3s;">
         Button
       </button>
-    `);
+    `,
+    );
 
-    const button = page.locator('button');
-    const transition = await button.evaluate(el => {
+    const button = page.locator("button");
+    const transition = await button.evaluate((el) => {
       return window.getComputedStyle(el).transition;
     });
 
     // With reduced motion, transitions should be disabled
-    expect(transition).toBe('none');
+    expect(transition).toBe("none");
   });
 });
 
-test.describe('High Contrast Mode - Accessibility', () => {
-  test('should be visible in high contrast mode', async ({ page }) => {
+test.describe("High Contrast Mode - Accessibility", () => {
+  test("should be visible in high contrast mode", async ({ page }) => {
     // Emulate high contrast mode (Windows High Contrast)
-    await page.emulateMedia({ colorScheme: 'dark', forcedColors: 'active' });
+    await page.emulateMedia({ colorScheme: "dark", forcedColors: "active" });
 
-    await createComponentPage(page, `
+    await createComponentPage(
+      page,
+      `
       <button style="border: 2px solid; padding: 12px;">
         High Contrast Button
       </button>
-    `);
+    `,
+    );
 
-    const button = page.locator('button');
-    const styles = await button.evaluate(el => {
+    const button = page.locator("button");
+    const styles = await button.evaluate((el) => {
       const computed = window.getComputedStyle(el);
       return {
         border: computed.border,
@@ -743,6 +819,6 @@ test.describe('High Contrast Mode - Accessibility', () => {
     });
 
     // Border should be defined for visibility in high contrast
-    expect(styles.border).not.toBe('none');
+    expect(styles.border).not.toBe("none");
   });
 });

--- a/e2e/accessibility/theme-contrast.spec.js
+++ b/e2e/accessibility/theme-contrast.spec.js
@@ -13,13 +13,13 @@
  * instead of shipping as a mobile-screenshot bug report (this was at least the
  * third instance of the bug class).
  */
-import { test, expect } from '@playwright/test';
-import AxeBuilder from '@axe-core/playwright';
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
 
 // Mirrors frontend/src/components/ThemeProvider.jsx exactly — THEME_KEY and
 // VALID_THEMES. Do not let these drift from that file without updating both.
-const THEME_STORAGE_KEY = 'settimes-theme';
-const THEMES = ['midnight-ember', 'arctic-night', 'daybreak', 'silver-lining'];
+const THEME_STORAGE_KEY = "settimes-theme";
+const THEMES = ["midnight-ember", "arctic-night", "daybreak", "silver-lining"];
 
 /**
  * Seeds localStorage with the target theme before any page script runs, via
@@ -38,7 +38,7 @@ async function primeTheme(page, theme) {
         // default theme (midnight-ember), which is exercised by that run anyway.
       }
     },
-    { key: THEME_STORAGE_KEY, value: theme }
+    { key: THEME_STORAGE_KEY, value: theme },
   );
 }
 
@@ -46,29 +46,28 @@ async function primeTheme(page, theme) {
  * into a readable block for the assertion message, so a CI failure names the
  * offending element instead of just "1 violation". */
 function formatViolations(violations) {
-  if (violations.length === 0) return '';
+  if (violations.length === 0) return "";
   return violations
-    .map(violation =>
+    .map((violation) =>
       violation.nodes
-        .map(node => {
-          const check = node.any?.find(c => c.id === 'color-contrast') || node.any?.[0];
+        .map((node) => {
+          const check = node.any?.find((c) => c.id === "color-contrast") || node.any?.[0];
           const data = check?.data;
           const detail = data
             ? `fg=${data.fgColor} bg=${data.bgColor} ratio=${data.contrastRatio} (needs ${data.expectedContrastRatio})`
-            : node.failureSummary || check?.message || 'no contrast data available';
-          return `  [${violation.id}] ${node.target.join(' ')} — ${detail}`;
+            : node.failureSummary || check?.message || "no contrast data available";
+          return `  [${violation.id}] ${node.target.join(" ")} — ${detail}`;
         })
-        .join('\n')
+        .join("\n"),
     )
-    .join('\n');
+    .join("\n");
 }
 
 async function assertNoColorContrastViolations(page, label) {
-  const results = await new AxeBuilder({ page }).withRules(['color-contrast']).analyze();
-  expect(
-    results.violations,
-    `Color-contrast violations on ${label}:\n${formatViolations(results.violations)}`
-  ).toEqual([]);
+  const results = await new AxeBuilder({ page }).withRules(["color-contrast"]).analyze();
+  expect(results.violations, `Color-contrast violations on ${label}:\n${formatViolations(results.violations)}`).toEqual(
+    [],
+  );
 }
 
 /**
@@ -83,17 +82,17 @@ async function assertNoColorContrastViolations(page, label) {
  * page's primary content wait on any page that renders PrivacyBanner.
  */
 async function waitForPrivacyBannerSettled(page) {
-  await expect(page.getByRole('button', { name: 'Got it' })).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole("button", { name: "Got it" })).toBeVisible({ timeout: 10000 });
 }
 
 /** Resolves the seeded upcoming event's slug from the homepage event card —
  * the same [data-testid="event-card"] locator public-timeline.spec.js uses. */
 async function resolveEventSlug(page) {
-  await page.goto('/');
+  await page.goto("/");
   const card = page.locator('[data-testid="event-card"]').first();
   await expect(card).toBeVisible();
-  const href = await card.locator('h3 a').first().getAttribute('href');
-  return href ? href.replace(/^\/event\//, '') : null;
+  const href = await card.locator("h3 a").first().getAttribute("href");
+  return href ? href.replace(/^\/event\//, "") : null;
 }
 
 /** Resolves a seeded band profile link from the homepage's collapsed
@@ -101,12 +100,12 @@ async function resolveEventSlug(page) {
  * band-profile-viewing.spec.js uses. Returns null if the seed provides none,
  * so the caller can skip gracefully instead of failing. */
 async function resolveBandProfileHref(page) {
-  await page.goto('/');
+  await page.goto("/");
   await expect(page.locator('[data-testid="event-card"]').first()).toBeVisible();
   const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
   const visible = await bandLink.isVisible().catch(() => false);
   if (!visible) return null;
-  return bandLink.getAttribute('href');
+  return bandLink.getAttribute("href");
 }
 
 for (const theme of THEMES) {
@@ -115,48 +114,48 @@ for (const theme of THEMES) {
       await primeTheme(page, theme);
     });
 
-    test('events list (/)', async ({ page }) => {
-      await page.goto('/');
+    test("events list (/)", async ({ page }) => {
+      await page.goto("/");
       // Use exact:true to avoid matching both "Events" h1 and "Past Events" h2.
-      await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Events", exact: true })).toBeVisible();
       await expect(page.locator('[data-testid="event-card"]').first()).toBeVisible();
       await waitForPrivacyBannerSettled(page);
 
       await assertNoColorContrastViolations(page, `${theme} — events list (/)`);
     });
 
-    test('event schedule page', async ({ page }) => {
+    test("event schedule page", async ({ page }) => {
       const slug = await resolveEventSlug(page);
-      test.skip(!slug, 'No seeded event slug found on the homepage event card');
+      test.skip(!slug, "No seeded event slug found on the homepage event card");
 
       await page.goto(`/event/${slug}`);
       // "Full Lineup" is ScheduleView's unconditional heading — waiting for it
       // guarantees the schedule has rendered past the loading skeleton.
-      await expect(page.getByRole('heading', { name: 'Full Lineup' })).toBeVisible({ timeout: 15000 });
+      await expect(page.getByRole("heading", { name: "Full Lineup" })).toBeVisible({ timeout: 15000 });
       await waitForPrivacyBannerSettled(page);
 
       await assertNoColorContrastViolations(page, `${theme} — event schedule (/event/${slug})`);
     });
 
-    test('subscribe page (/subscribe)', async ({ page }) => {
-      await page.goto('/subscribe');
-      await expect(page.getByRole('heading', { name: 'Never Miss a Show' })).toBeVisible();
+    test("subscribe page (/subscribe)", async ({ page }) => {
+      await page.goto("/subscribe");
+      await expect(page.getByRole("heading", { name: "Never Miss a Show" })).toBeVisible();
 
       await assertNoColorContrastViolations(page, `${theme} — subscribe (/subscribe)`);
     });
 
-    test('band profile page', async ({ page }) => {
+    test("band profile page", async ({ page }) => {
       const href = await resolveBandProfileHref(page);
-      test.skip(!href, 'Seed data provides no band profile link on the homepage');
+      test.skip(!href, "Seed data provides no band profile link on the homepage");
 
       await page.goto(href);
-      await expect(page.locator('main h1')).toBeVisible({ timeout: 15000 });
+      await expect(page.locator("main h1")).toBeVisible({ timeout: 15000 });
 
       const notFound = await page
-        .getByRole('heading', { name: /band not found/i })
+        .getByRole("heading", { name: /band not found/i })
         .isVisible()
         .catch(() => false);
-      test.skip(notFound, 'Resolved band link led to a not-found page');
+      test.skip(notFound, "Resolved band link led to a not-found page");
 
       await waitForPrivacyBannerSettled(page);
       await assertNoColorContrastViolations(page, `${theme} — band profile (${href})`);

--- a/e2e/auth.setup.js
+++ b/e2e/auth.setup.js
@@ -1,13 +1,13 @@
-import fs from 'fs';
-import { test, expect } from '@playwright/test';
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from './credentials';
+import fs from "fs";
+import { test, expect } from "@playwright/test";
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
 
-const storageStatePath = 'e2e/.auth/admin.json';
+const storageStatePath = "e2e/.auth/admin.json";
 
-test('authenticate admin and save storage state', async ({ page }) => {
-  fs.mkdirSync('e2e/.auth', { recursive: true });
+test("authenticate admin and save storage state", async ({ page }) => {
+  fs.mkdirSync("e2e/.auth", { recursive: true });
 
-  await page.goto('/admin/login');
+  await page.goto("/admin/login");
   await page.fill('input[type="email"]', ADMIN_EMAIL);
   await page.fill('input[type="password"]', ADMIN_PASSWORD);
   await page.click('button[type="submit"]');

--- a/e2e/band-management.spec.js
+++ b/e2e/band-management.spec.js
@@ -1,15 +1,15 @@
-import { test, expect } from '@playwright/test';
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from './credentials';
+import { test, expect } from "@playwright/test";
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
 
 const loginAsAdmin = async (page) => {
-  await page.goto('/admin');
+  await page.goto("/admin");
   // Wait for either admin tab buttons (valid session) or login form (session expired/invalidated)
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: 'visible', timeout: 15000 });
+  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
   if (await page.locator('input[type="email"]').isVisible()) {
     await page.fill('input[type="email"]', ADMIN_EMAIL);
     await page.fill('input[type="password"]', ADMIN_PASSWORD);
     await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: 'visible', timeout: 15000 });
+    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
   }
 };
 
@@ -17,44 +17,44 @@ const openRosterTab = async (page) => {
   await page.click('button:has-text("Roster")');
 };
 
-test.describe('Band Management', () => {
+test.describe("Band Management", () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
   });
 
-  test('should allow admin to create a new artist', async ({ page }) => {
+  test("should allow admin to create a new artist", async ({ page }) => {
     const suffix = Date.now();
     const bandName = `Test Band ${suffix}`;
     await openRosterTab(page);
 
     await page.click('button:has-text("New Artist")');
-    await expect(page.getByRole('heading', { name: 'New Artist' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "New Artist" })).toBeVisible();
 
     await page.fill('input[name="name"]', bandName);
-    await page.fill('input[name="genre"]', 'Rock');
-    await page.locator('.ProseMirror').first().fill('A test band with great music');
-    await page.fill('input[name="website"]', 'https://testband.com');
-    await page.fill('input[name="instagram"]', '@testband');
-    await page.fill('input[name="bandcamp"]', 'https://bandcamp.com/testband');
+    await page.fill('input[name="genre"]', "Rock");
+    await page.locator(".ProseMirror").first().fill("A test band with great music");
+    await page.fill('input[name="website"]', "https://testband.com");
+    await page.fill('input[name="instagram"]', "@testband");
+    await page.fill('input[name="bandcamp"]', "https://bandcamp.com/testband");
 
     await page.click('button[type="submit"]:has-text("Add Artist")');
 
-    const row = page.locator('table tbody tr', { hasText: bandName }).first();
+    const row = page.locator("table tbody tr", { hasText: bandName }).first();
     await expect(row).toBeVisible();
-    await expect(row).toContainText('Rock');
+    await expect(row).toContainText("Rock");
   });
 
-  test('should validate required artist name', async ({ page }) => {
+  test("should validate required artist name", async ({ page }) => {
     await openRosterTab(page);
 
     await page.click('button:has-text("New Artist")');
     await page.click('button[type="submit"]:has-text("Add Artist")');
 
-    const nameMissing = await page.locator('input[name="name"]').evaluate(input => input.validity.valueMissing);
+    const nameMissing = await page.locator('input[name="name"]').evaluate((input) => input.validity.valueMissing);
     expect(nameMissing).toBe(true);
   });
 
-  test('should allow admin to edit artist profile', async ({ page }) => {
+  test("should allow admin to edit artist profile", async ({ page }) => {
     const suffix = Date.now();
     const originalName = `Editable Band ${suffix}`;
     const updatedName = `Updated Band ${suffix}`;
@@ -62,57 +62,57 @@ test.describe('Band Management', () => {
 
     await page.click('button:has-text("New Artist")');
     await page.fill('input[name="name"]', originalName);
-    await page.fill('input[name="genre"]', 'Jazz');
-    await page.locator('.ProseMirror').first().fill('Original bio');
+    await page.fill('input[name="genre"]', "Jazz");
+    await page.locator(".ProseMirror").first().fill("Original bio");
     await page.click('button[type="submit"]:has-text("Add Artist")');
 
-    await page.locator('tr', { hasText: originalName }).getByRole('button', { name: 'Edit' }).click();
-    await expect(page.getByRole('heading', { name: 'Edit Artist' })).toBeVisible();
+    await page.locator("tr", { hasText: originalName }).getByRole("button", { name: "Edit" }).click();
+    await expect(page.getByRole("heading", { name: "Edit Artist" })).toBeVisible();
 
     await page.fill('input[name="name"]', updatedName);
-    await page.locator('.ProseMirror').first().fill('Updated bio with new information');
+    await page.locator(".ProseMirror").first().fill("Updated bio with new information");
 
     await page.click('button[type="submit"]:has-text("Update Artist")');
 
-    const updatedRow = page.locator('table tbody tr', { hasText: updatedName }).first();
+    const updatedRow = page.locator("table tbody tr", { hasText: updatedName }).first();
     await expect(updatedRow).toBeVisible();
-    await expect(page.getByText('Artist updated')).toBeVisible();
+    await expect(page.getByText("Artist updated")).toBeVisible();
   });
 
-  test('should allow admin to delete an artist', async ({ page }) => {
+  test("should allow admin to delete an artist", async ({ page }) => {
     const suffix = Date.now();
     const bandName = `Deletable Band ${suffix}`;
     await openRosterTab(page);
 
     await page.click('button:has-text("New Artist")');
     await page.fill('input[name="name"]', bandName);
-    await page.fill('input[name="genre"]', 'Pop');
-    await page.locator('.ProseMirror').first().fill('This band will be deleted');
+    await page.fill('input[name="genre"]', "Pop");
+    await page.locator(".ProseMirror").first().fill("This band will be deleted");
     await page.click('button[type="submit"]:has-text("Add Artist")');
 
-    page.once('dialog', dialog => dialog.accept());
-    await page.locator('tr', { hasText: bandName }).getByRole('button', { name: 'Delete' }).click();
+    page.once("dialog", (dialog) => dialog.accept());
+    await page.locator("tr", { hasText: bandName }).getByRole("button", { name: "Delete" }).click();
 
-    await expect(page.getByText('Artist deleted')).toBeVisible();
+    await expect(page.getByText("Artist deleted")).toBeVisible();
   });
 
-  test('should allow admin to upload band photo', async ({ page }) => {
+  test("should allow admin to upload band photo", async ({ page }) => {
     const suffix = Date.now();
     const bandName = `Photo Band ${suffix}`;
     await openRosterTab(page);
 
     await page.click('button:has-text("New Artist")');
     await page.fill('input[name="name"]', bandName);
-    await page.fill('input[name="genre"]', 'Electronic');
+    await page.fill('input[name="genre"]', "Electronic");
     await page.click('button[type="submit"]:has-text("Add Artist")');
 
-    await page.locator('tr', { hasText: bandName }).getByRole('button', { name: 'Edit' }).click();
+    await page.locator("tr", { hasText: bandName }).getByRole("button", { name: "Edit" }).click();
 
     const fileInput = page.locator('input[type="file"]');
     if (await fileInput.isVisible()) {
       await fileInput.setInputFiles({
-        name: 'test.jpg',
-        mimeType: 'image/jpeg',
+        name: "test.jpg",
+        mimeType: "image/jpeg",
         buffer: Buffer.from([0xff, 0xd8, 0xff, 0xd9]),
       });
 
@@ -124,17 +124,17 @@ test.describe('Band Management', () => {
     }
   });
 
-  test.skip('should show band profile with social media links', async ({ page }) => {
+  test.skip("should show band profile with social media links", async ({ page }) => {
     // Roster view does not expose public profile links; covered in public tests instead.
     await openRosterTab(page);
   });
 
-  test.skip('should search for bands by name', async ({ page }) => {
+  test.skip("should search for bands by name", async ({ page }) => {
     // Roster view does not currently include search.
     await openRosterTab(page);
   });
 
-  test.skip('should filter bands by genre', async ({ page }) => {
+  test.skip("should filter bands by genre", async ({ page }) => {
     // Roster view does not currently include genre filtering.
     await openRosterTab(page);
   });

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -1,9 +1,9 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test.describe('Band Profile Viewing', () => {
-  test('should display band profile without authentication', async ({ page }) => {
+test.describe("Band Profile Viewing", () => {
+  test("should display band profile without authentication", async ({ page }) => {
     // Navigate to public homepage first to get a band
-    await page.goto('/');
+    await page.goto("/");
 
     // Click on first band link (may be in event card or band list)
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -13,7 +13,7 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Verify band profile page loads
-      await expect(page.getByRole('heading', { name: new RegExp(bandName || '', 'i') })).toBeVisible();
+      await expect(page.getByRole("heading", { name: new RegExp(bandName || "", "i") })).toBeVisible();
 
       // Should NOT redirect to login
       await expect(page).not.toHaveURL(/\/admin\/login/);
@@ -21,8 +21,8 @@ test.describe('Band Profile Viewing', () => {
     }
   });
 
-  test('should display band biography and details', async ({ page }) => {
-    await page.goto('/');
+  test("should display band biography and details", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -30,11 +30,9 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Verify bio/description is displayed
-      const bioText = page.locator('[data-testid="band-bio"]').or(
-        page.locator('[class*="bio"]').or(
-          page.locator('p, div').filter({ hasText: /\w{20,}/ })
-        )
-      );
+      const bioText = page
+        .locator('[data-testid="band-bio"]')
+        .or(page.locator('[class*="bio"]').or(page.locator("p, div").filter({ hasText: /\w{20,}/ })));
 
       if (await bioText.first().isVisible()) {
         await expect(bioText.first()).toBeVisible();
@@ -48,8 +46,8 @@ test.describe('Band Profile Viewing', () => {
     }
   });
 
-  test('should show social media links', async ({ page }) => {
-    await page.goto('/');
+  test("should show social media links", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -57,7 +55,9 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Check for social media links
-      const socialLinks = page.locator('a[href*="instagram.com"], a[href*="facebook.com"], a[href*="spotify.com"], a[href*="youtube.com"], a[href*="bandcamp.com"], a[href*="soundcloud.com"]');
+      const socialLinks = page.locator(
+        'a[href*="instagram.com"], a[href*="facebook.com"], a[href*="spotify.com"], a[href*="youtube.com"], a[href*="bandcamp.com"], a[href*="soundcloud.com"]',
+      );
 
       const linkCount = await socialLinks.count();
       if (linkCount > 0) {
@@ -66,16 +66,16 @@ test.describe('Band Profile Viewing', () => {
 
         // Verify links open in new tab (external links)
         const firstLink = socialLinks.first();
-        const target = await firstLink.getAttribute('target');
+        const target = await firstLink.getAttribute("target");
         if (target) {
-          expect(target).toBe('_blank');
+          expect(target).toBe("_blank");
         }
       }
     }
   });
 
-  test('should display band website link', async ({ page }) => {
-    await page.goto('/');
+  test("should display band website link", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -83,24 +83,22 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Look for official website link
-      const websiteLink = page.locator('a[data-testid="band-website"]').or(
-        page.locator('a:has-text("Website")').or(
-          page.locator('a[class*="website"]')
-        )
-      );
+      const websiteLink = page
+        .locator('a[data-testid="band-website"]')
+        .or(page.locator('a:has-text("Website")').or(page.locator('a[class*="website"]')));
 
       if (await websiteLink.isVisible()) {
         await expect(websiteLink).toBeVisible();
 
         // Verify link has valid URL
-        const href = await websiteLink.getAttribute('href');
+        const href = await websiteLink.getAttribute("href");
         expect(href).toMatch(/^https?:\/\//);
       }
     }
   });
 
-  test('should list upcoming band events', async ({ page }) => {
-    await page.goto('/');
+  test("should list upcoming band events", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -108,15 +106,15 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Look for upcoming events section
-      const upcomingSection = page.locator('[data-testid="upcoming-events"]').or(
-        page.getByRole('heading', { name: /upcoming|shows|events|performances/i })
-      );
+      const upcomingSection = page
+        .locator('[data-testid="upcoming-events"]')
+        .or(page.getByRole("heading", { name: /upcoming|shows|events|performances/i }));
 
       if (await upcomingSection.isVisible()) {
         await expect(upcomingSection).toBeVisible();
 
         // Verify event listings
-        const eventList = page.locator('[data-testid="event-card"]').or(page.locator('.event-card'));
+        const eventList = page.locator('[data-testid="event-card"]').or(page.locator(".event-card"));
         const eventCount = await eventList.count();
 
         if (eventCount > 0) {
@@ -125,7 +123,7 @@ test.describe('Band Profile Viewing', () => {
           await expect(firstEvent).toBeVisible();
 
           // Check for date information
-          const dateInfo = firstEvent.locator('text=/\\d{1,2}|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/i');
+          const dateInfo = firstEvent.locator("text=/\\d{1,2}|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/i");
           if (await dateInfo.isVisible()) {
             await expect(dateInfo).toBeVisible();
           }
@@ -134,8 +132,8 @@ test.describe('Band Profile Viewing', () => {
     }
   });
 
-  test('should show past performance history', async ({ page }) => {
-    await page.goto('/');
+  test("should show past performance history", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -143,9 +141,9 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Look for past performances section
-      const pastSection = page.locator('[data-testid="past-events"]').or(
-        page.getByRole('heading', { name: /past|previous|history/i })
-      );
+      const pastSection = page
+        .locator('[data-testid="past-events"]')
+        .or(page.getByRole("heading", { name: /past|previous|history/i }));
 
       if (await pastSection.isVisible()) {
         await expect(pastSection).toBeVisible();
@@ -153,8 +151,8 @@ test.describe('Band Profile Viewing', () => {
     }
   });
 
-  test('should display band photos', async ({ page }) => {
-    await page.goto('/');
+  test("should display band photos", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -162,17 +160,15 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Look for band photo/image
-      const bandPhoto = page.locator('[data-testid="band-photo"]').or(
-        page.locator('img[alt*="band"]').or(
-          page.locator('[class*="photo"], [class*="image"]').locator('img')
-        )
-      );
+      const bandPhoto = page
+        .locator('[data-testid="band-photo"]')
+        .or(page.locator('img[alt*="band"]').or(page.locator('[class*="photo"], [class*="image"]').locator("img")));
 
       if (await bandPhoto.first().isVisible()) {
         await expect(bandPhoto.first()).toBeVisible();
 
         // Verify image has proper alt text for accessibility
-        const altText = await bandPhoto.first().getAttribute('alt');
+        const altText = await bandPhoto.first().getAttribute("alt");
         if (altText) {
           expect(altText.length).toBeGreaterThan(0);
         }
@@ -180,15 +176,15 @@ test.describe('Band Profile Viewing', () => {
     }
   });
 
-  test('should be responsive on mobile viewport', async ({ page }) => {
+  test("should be responsive on mobile viewport", async ({ page }) => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
-    await page.goto('/');
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
     if (await bandLink.isVisible()) {
-      const bandName = (await bandLink.textContent())?.trim() || '';
+      const bandName = (await bandLink.textContent())?.trim() || "";
       await bandLink.click();
       await page.waitForURL(/\/band(s)?\//);
 
@@ -196,10 +192,8 @@ test.describe('Band Profile Viewing', () => {
       // profile route is lazy-loaded and fetches its data, which can exceed the
       // default 5s timeout on a cold CI mobile run. Match the band name robustly
       // (regex-escaped), and allow multiple headings via .first().
-      const headingName = bandName
-        ? new RegExp(bandName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i')
-        : /.+/;
-      await expect(page.getByRole('heading', { name: headingName }).first()).toBeVisible({
+      const headingName = bandName ? new RegExp(bandName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i") : /.+/;
+      await expect(page.getByRole("heading", { name: headingName }).first()).toBeVisible({
         timeout: 15000,
       });
 
@@ -211,8 +205,8 @@ test.describe('Band Profile Viewing', () => {
     }
   });
 
-  test('should navigate back to timeline from band profile', async ({ page }) => {
-    await page.goto('/');
+  test("should navigate back to timeline from band profile", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -220,44 +214,42 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Look for back button or home link
-      const backButton = page.locator('button:has-text("Back")').or(
-        page.locator('a[href="/"]').or(
-          page.locator('a:has-text("Home")').or(
-            page.locator('a:has-text("Schedule")')
-          )
-        )
-      );
+      const backButton = page
+        .locator('button:has-text("Back")')
+        .or(
+          page.locator('a[href="/"]').or(page.locator('a:has-text("Home")').or(page.locator('a:has-text("Schedule")'))),
+        );
 
       if (await backButton.first().isVisible()) {
         await backButton.first().click();
 
         // Verify we're back on timeline
-        await expect(page.getByRole('heading', { name: /schedule/i })).toBeVisible();
+        await expect(page.getByRole("heading", { name: /schedule/i })).toBeVisible();
       }
     }
   });
 
-  test('should handle band profile not found gracefully', async ({ page }) => {
+  test("should handle band profile not found gracefully", async ({ page }) => {
     // Navigate to non-existent band profile
-    await page.goto('/band/nonexistent-band-12345');
+    await page.goto("/band/nonexistent-band-12345");
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState("networkidle");
 
     // Should show 404 or error message, not crash
-    const errorMessage = page.getByRole('heading', { name: /band not found/i }).or(
-      page.locator('text=/not found|404|doesn\'t exist/i')
-    );
+    const errorMessage = page
+      .getByRole("heading", { name: /band not found/i })
+      .or(page.locator("text=/not found|404|doesn't exist/i"));
     const homeLink = page.locator('a[href="/"]').or(page.locator('a:has-text("Home")'));
 
     // Either error message OR redirect to home should happen
-    const isOnHome = page.url().includes('/#') || page.url().endsWith('/');
+    const isOnHome = page.url().includes("/#") || page.url().endsWith("/");
     if (!isOnHome) {
       await expect(errorMessage.or(homeLink).first()).toBeVisible({ timeout: 10000 });
     }
   });
 
-  test('should display band contact information if available', async ({ page }) => {
-    await page.goto('/');
+  test("should display band contact information if available", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -265,9 +257,9 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Look for contact information
-      const contactInfo = page.locator('[data-testid="band-contact"]').or(
-        page.locator('text=/contact|booking|management|email/i')
-      );
+      const contactInfo = page
+        .locator('[data-testid="band-contact"]')
+        .or(page.locator("text=/contact|booking|management|email/i"));
 
       if (await contactInfo.first().isVisible()) {
         await expect(contactInfo.first()).toBeVisible();
@@ -275,8 +267,8 @@ test.describe('Band Profile Viewing', () => {
     }
   });
 
-  test('should show band formation year or history', async ({ page }) => {
-    await page.goto('/');
+  test("should show band formation year or history", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -284,9 +276,9 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Look for formation year or history information
-      const historyInfo = page.locator('[data-testid="band-formed"]').or(
-        page.locator('text=/formed|since|est\\.|established|\\d{4}/i')
-      );
+      const historyInfo = page
+        .locator('[data-testid="band-formed"]')
+        .or(page.locator("text=/formed|since|est\\.|established|\\d{4}/i"));
 
       if (await historyInfo.first().isVisible()) {
         await expect(historyInfo.first()).toBeVisible();
@@ -294,8 +286,8 @@ test.describe('Band Profile Viewing', () => {
     }
   });
 
-  test('should allow clicking event from band profile to event details', async ({ page }) => {
-    await page.goto('/');
+  test("should allow clicking event from band profile to event details", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -303,20 +295,20 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Look for event listings in band profile
-      const eventCard = page.locator('[data-testid="event-card"]').or(page.locator('.event-card')).first();
+      const eventCard = page.locator('[data-testid="event-card"]').or(page.locator(".event-card")).first();
 
       if (await eventCard.isVisible()) {
         const eventTitle = await eventCard.locator('h3, h2, [class*="title"]').first().textContent();
         await eventCard.click();
 
         // Verify event details page/modal opens
-        await expect(page.getByRole('heading', { name: new RegExp(eventTitle || '', 'i') })).toBeVisible();
+        await expect(page.getByRole("heading", { name: new RegExp(eventTitle || "", "i") })).toBeVisible();
       }
     }
   });
 
-  test('should display band member information if available', async ({ page }) => {
-    await page.goto('/');
+  test("should display band member information if available", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -324,9 +316,9 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Look for band members section
-      const membersSection = page.locator('[data-testid="band-members"]').or(
-        page.getByRole('heading', { name: /members|lineup|artists/i })
-      );
+      const membersSection = page
+        .locator('[data-testid="band-members"]')
+        .or(page.getByRole("heading", { name: /members|lineup|artists/i }));
 
       if (await membersSection.isVisible()) {
         await expect(membersSection).toBeVisible();
@@ -334,8 +326,8 @@ test.describe('Band Profile Viewing', () => {
     }
   });
 
-  test('should load band profile with proper metadata', async ({ page }) => {
-    await page.goto('/');
+  test("should load band profile with proper metadata", async ({ page }) => {
+    await page.goto("/");
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
@@ -344,7 +336,7 @@ test.describe('Band Profile Viewing', () => {
       await bandLink.click();
 
       // Wait for page to fully load
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState("networkidle");
 
       // Verify page title includes band name (SEO)
       const title = await page.title();

--- a/e2e/credentials.js
+++ b/e2e/credentials.js
@@ -1,13 +1,9 @@
-const ADMIN_EMAIL =
-  process.env.E2E_ADMIN_EMAIL ||
-  process.env.ADMIN_EMAIL ||
-  'admin@settimes.ca'
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || process.env.ADMIN_EMAIL || "admin@settimes.ca";
 
-const ADMIN_PASSWORD =
-  process.env.E2E_ADMIN_PASSWORD || process.env.ADMIN_PASSWORD
+const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD || process.env.ADMIN_PASSWORD;
 
 if (!ADMIN_PASSWORD) {
-  throw new Error('E2E_ADMIN_PASSWORD (or ADMIN_PASSWORD) must be set')
+  throw new Error("E2E_ADMIN_PASSWORD (or ADMIN_PASSWORD) must be set");
 }
 
-export { ADMIN_EMAIL, ADMIN_PASSWORD }
+export { ADMIN_EMAIL, ADMIN_PASSWORD };

--- a/e2e/event-creation.spec.js
+++ b/e2e/event-creation.spec.js
@@ -1,15 +1,15 @@
-import { test, expect } from '@playwright/test';
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from './credentials';
+import { test, expect } from "@playwright/test";
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
 
 const loginAsAdmin = async (page) => {
-  await page.goto('/admin');
+  await page.goto("/admin");
   // Wait for either admin tab buttons (valid session) or login form (session expired/invalidated)
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: 'visible', timeout: 15000 });
+  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
   if (await page.locator('input[type="email"]').isVisible()) {
     await page.fill('input[type="email"]', ADMIN_EMAIL);
     await page.fill('input[type="password"]', ADMIN_PASSWORD);
     await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: 'visible', timeout: 15000 });
+    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
   }
 };
 
@@ -19,13 +19,13 @@ const openEventsTab = async (page) => {
 
 const openCreateEventModal = async (page) => {
   await page.click('button:has-text("Create New Event")');
-  await expect(page.getByRole('heading', { name: 'Create New Event' })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Create New Event" })).toBeVisible();
 };
 
 const uniqueSuffix = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
 const getCsrfToken = async (page) => {
   const cookies = await page.context().cookies();
-  const csrfCookie = cookies.find(cookie => cookie.name === 'csrf_token');
+  const csrfCookie = cookies.find((cookie) => cookie.name === "csrf_token");
   return csrfCookie?.value;
 };
 
@@ -37,18 +37,18 @@ const apiGet = async (page, url) => {
 
 const apiPost = async (page, url, data) => {
   const csrfToken = await getCsrfToken(page);
-  const headers = csrfToken ? { 'X-CSRF-Token': csrfToken } : {};
+  const headers = csrfToken ? { "X-CSRF-Token": csrfToken } : {};
   const response = await page.request.post(url, { data, headers });
   expect(response.ok()).toBeTruthy();
   return response.json();
 };
 
-test.describe('Event Creation', () => {
+test.describe("Event Creation", () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
   });
 
-  test('should allow admin to create a new event', async ({ page }) => {
+  test("should allow admin to create a new event", async ({ page }) => {
     const suffix = uniqueSuffix();
     const eventName = `Test Event ${suffix}`;
     const eventSlug = `test-event-${suffix}`;
@@ -57,26 +57,26 @@ test.describe('Event Creation', () => {
 
     await page.fill('input[name="name"]', eventName);
     await page.fill('input[name="slug"]', eventSlug);
-    await page.fill('input[name="date"]', '2026-10-15');
+    await page.fill('input[name="date"]', "2026-10-15");
 
     await page.click('button[type="submit"]:has-text("Create Event")');
-    await expect(page.getByRole('heading', { name: 'Create New Event' })).not.toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("heading", { name: "Create New Event" })).not.toBeVisible({ timeout: 15000 });
 
-    const row = page.locator('table tbody tr', { hasText: eventName }).first();
+    const row = page.locator("table tbody tr", { hasText: eventName }).first();
     await expect(row).toBeVisible({ timeout: 15000 });
   });
 
-  test('should validate required fields', async ({ page }) => {
+  test("should validate required fields", async ({ page }) => {
     await openEventsTab(page);
     await openCreateEventModal(page);
 
     await page.click('button[type="submit"]:has-text("Create Event")');
 
-    const nameMissing = await page.locator('input[name="name"]').evaluate(input => input.validity.valueMissing);
+    const nameMissing = await page.locator('input[name="name"]').evaluate((input) => input.validity.valueMissing);
     expect(nameMissing).toBe(true);
   });
 
-  test('should allow admin to publish an event', async ({ page }) => {
+  test("should allow admin to publish an event", async ({ page }) => {
     const suffix = uniqueSuffix();
     const eventName = `Published Event ${suffix}`;
     const eventSlug = `published-event-${suffix}`;
@@ -85,53 +85,53 @@ test.describe('Event Creation', () => {
 
     await page.fill('input[name="name"]', eventName);
     await page.fill('input[name="slug"]', eventSlug);
-    await page.fill('input[name="date"]', '2026-10-20');
+    await page.fill('input[name="date"]', "2026-10-20");
     await page.click('button[type="submit"]:has-text("Create Event")');
-    await expect(page.getByRole('heading', { name: 'Create New Event' })).not.toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("heading", { name: "Create New Event" })).not.toBeVisible({ timeout: 15000 });
 
-    const eventsData = await apiGet(page, '/api/admin/events');
-    const createdEvent = eventsData.events?.find(event => event.name === eventName);
+    const eventsData = await apiGet(page, "/api/admin/events");
+    const createdEvent = eventsData.events?.find((event) => event.name === eventName);
     expect(createdEvent).toBeTruthy();
 
-    const venuesData = await apiGet(page, '/api/admin/venues');
+    const venuesData = await apiGet(page, "/api/admin/venues");
     const venue = venuesData.venues?.[0];
     expect(venue).toBeTruthy();
 
-    await apiPost(page, '/api/admin/bands', {
+    await apiPost(page, "/api/admin/bands", {
       eventId: createdEvent.id,
       venueId: venue.id,
       name: `Publish Band ${suffix}`,
-      startTime: '19:00',
-      endTime: '19:30',
+      startTime: "19:00",
+      endTime: "19:30",
     });
 
-    page.once('dialog', dialog => dialog.accept());
-    const publishRow = page.locator('table tbody tr', { hasText: eventName }).first();
-    await publishRow.locator('button', { hasText: /^Publish$/ }).click();
+    page.once("dialog", (dialog) => dialog.accept());
+    const publishRow = page.locator("table tbody tr", { hasText: eventName }).first();
+    await publishRow.locator("button", { hasText: /^Publish$/ }).click();
 
-    await expect(publishRow.locator('button', { hasText: /^Unpublish$/ })).toBeVisible({ timeout: 15000 });
+    await expect(publishRow.locator("button", { hasText: /^Unpublish$/ })).toBeVisible({ timeout: 15000 });
   });
 
-  test('should show error when creating event with past date', async ({ page }) => {
+  test("should show error when creating event with past date", async ({ page }) => {
     const suffix = uniqueSuffix();
     await openEventsTab(page);
     await openCreateEventModal(page);
 
     await page.fill('input[name="name"]', `Past Event ${suffix}`);
     await page.fill('input[name="slug"]', `past-event-${suffix}`);
-    await page.fill('input[name="date"]', '2020-01-01');
+    await page.fill('input[name="date"]', "2020-01-01");
 
     await page.click('button[type="submit"]:has-text("Create Event")');
 
     // EventFormModal sets min=today on the date input; HTML5 rangeUnderflow blocks
     // submission before React's validateForm() can run, so the custom error text
     // never appears. Verify the form was rejected: modal still open, input invalid.
-    await expect(page.getByRole('heading', { name: 'Create New Event' })).toBeVisible();
-    const isInvalid = await page.locator('input[name="date"]').evaluate(input => !input.validity.valid);
+    await expect(page.getByRole("heading", { name: "Create New Event" })).toBeVisible();
+    const isInvalid = await page.locator('input[name="date"]').evaluate((input) => !input.validity.valid);
     expect(isInvalid).toBe(true);
   });
 
-  test('should allow admin to edit an event', async ({ page }) => {
+  test("should allow admin to edit an event", async ({ page }) => {
     const suffix = uniqueSuffix();
     const eventName = `Editable Event ${suffix}`;
     const eventSlug = `editable-event-${suffix}`;
@@ -141,22 +141,22 @@ test.describe('Event Creation', () => {
 
     await page.fill('input[name="name"]', eventName);
     await page.fill('input[name="slug"]', eventSlug);
-    await page.fill('input[name="date"]', '2026-10-25');
+    await page.fill('input[name="date"]', "2026-10-25");
     await page.click('button[type="submit"]:has-text("Create Event")');
-    await expect(page.getByRole('heading', { name: 'Create New Event' })).not.toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("heading", { name: "Create New Event" })).not.toBeVisible({ timeout: 15000 });
 
-    const editRow = page.locator('table tbody tr', { hasText: eventName }).first();
-    await editRow.locator('button', { hasText: /^Edit$/ }).click();
-    await expect(page.getByRole('heading', { name: 'Edit Event' })).toBeVisible();
+    const editRow = page.locator("table tbody tr", { hasText: eventName }).first();
+    await editRow.locator("button", { hasText: /^Edit$/ }).click();
+    await expect(page.getByRole("heading", { name: "Edit Event" })).toBeVisible();
 
     await page.fill('input[name="name"]', updatedName);
     await page.click('button[type="submit"]:has-text("Update Event")');
 
-    const updatedRow = page.locator('table tbody tr', { hasText: updatedName }).first();
+    const updatedRow = page.locator("table tbody tr", { hasText: updatedName }).first();
     await expect(updatedRow).toBeVisible({ timeout: 15000 });
   });
 
-  test('should allow admin to delete an event', async ({ page }) => {
+  test("should allow admin to delete an event", async ({ page }) => {
     const suffix = uniqueSuffix();
     const eventName = `Delete Event ${suffix}`;
     const eventSlug = `delete-event-${suffix}`;
@@ -165,14 +165,14 @@ test.describe('Event Creation', () => {
 
     await page.fill('input[name="name"]', eventName);
     await page.fill('input[name="slug"]', eventSlug);
-    await page.fill('input[name="date"]', '2026-10-30');
+    await page.fill('input[name="date"]', "2026-10-30");
     await page.click('button[type="submit"]:has-text("Create Event")');
-    await expect(page.getByRole('heading', { name: 'Create New Event' })).not.toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("heading", { name: "Create New Event" })).not.toBeVisible({ timeout: 15000 });
 
-    page.once('dialog', dialog => dialog.accept());
-    const deleteRow = page.locator('table tbody tr', { hasText: eventName }).first();
-    await deleteRow.locator('button', { hasText: /^Delete$/ }).click();
+    page.once("dialog", (dialog) => dialog.accept());
+    const deleteRow = page.locator("table tbody tr", { hasText: eventName }).first();
+    await deleteRow.locator("button", { hasText: /^Delete$/ }).click();
 
-    await expect(page.locator('table tbody tr', { hasText: eventName })).toHaveCount(0, { timeout: 15000 });
+    await expect(page.locator("table tbody tr", { hasText: eventName })).toHaveCount(0, { timeout: 15000 });
   });
 });

--- a/e2e/event-wizard.spec.js
+++ b/e2e/event-wizard.spec.js
@@ -1,5 +1,5 @@
-import { test, expect } from '@playwright/test';
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from './credentials';
+import { test, expect } from "@playwright/test";
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
 
 const uniqueSuffix = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
 
@@ -11,142 +11,140 @@ const futureDate = () => {
 };
 
 const loginAsAdmin = async (page) => {
-  await page.goto('/admin');
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: 'visible', timeout: 15000 });
+  await page.goto("/admin");
+  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
   if (await page.locator('input[type="email"]').isVisible()) {
     await page.fill('input[type="email"]', ADMIN_EMAIL);
     await page.fill('input[type="password"]', ADMIN_PASSWORD);
     await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: 'visible', timeout: 15000 });
+    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
   }
 };
 
 const getCsrfToken = async (page) => {
   const cookies = await page.context().cookies();
-  return cookies.find((c) => c.name === 'csrf_token')?.value;
+  return cookies.find((c) => c.name === "csrf_token")?.value;
 };
 
 const deleteEvent = async (page, eventName) => {
   const csrfToken = await getCsrfToken(page);
-  const { events } = await (await page.request.get('/api/admin/events?limit=100')).json();
+  const { events } = await (await page.request.get("/api/admin/events?limit=100")).json();
   const event = events?.find((e) => e.name === eventName);
   if (event) {
     await page.request.delete(`/api/admin/events/${event.id}?confirmCascade=true`, {
-      headers: { 'X-CSRF-Token': csrfToken },
+      headers: { "X-CSRF-Token": csrfToken },
     });
   }
 };
 
-test.describe('Event Wizard', () => {
+test.describe("Event Wizard", () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
   });
 
-  test('creates event with venue and band through full wizard flow', async ({ page }) => {
+  test("creates event with venue and band through full wizard flow", async ({ page }) => {
     const suffix = uniqueSuffix();
     const eventName = `Wizard Fest ${suffix}`;
-    const dialog = page.getByRole('dialog', { name: 'Create Event' });
+    const dialog = page.getByRole("dialog", { name: "Create Event" });
 
     // Open wizard from header button
-    await page.getByRole('button', { name: 'Create Event' }).click();
+    await page.getByRole("button", { name: "Create Event" }).click();
     await expect(dialog).toBeVisible();
 
     // Step 1: Event Basics
-    await expect(dialog.getByRole('heading', { name: 'Event Basics' })).toBeVisible();
-    await dialog.getByRole('textbox', { name: 'Event Name *' }).fill(eventName);
-    await dialog.getByRole('textbox', { name: 'Event Date *' }).fill(futureDate());
+    await expect(dialog.getByRole("heading", { name: "Event Basics" })).toBeVisible();
+    await dialog.getByRole("textbox", { name: "Event Name *" }).fill(eventName);
+    await dialog.getByRole("textbox", { name: "Event Date *" }).fill(futureDate());
     // Slug auto-populates from name — Next enables once all required fields are set
-    await expect(dialog.getByRole('button', { name: 'Next' })).toBeEnabled();
-    await dialog.getByRole('button', { name: 'Next' }).click();
+    await expect(dialog.getByRole("button", { name: "Next" })).toBeEnabled();
+    await dialog.getByRole("button", { name: "Next" }).click();
 
     // Step 2: Venues — Next is disabled until at least one venue is added
-    await expect(dialog.getByRole('heading', { name: 'Venues' })).toBeVisible();
-    await expect(dialog.getByRole('button', { name: 'Next' })).toBeDisabled();
-    await dialog.getByRole('textbox', { name: 'Venue name' }).fill('The Playwright Lounge');
-    await dialog.getByRole('textbox', { name: 'Address (optional)' }).fill('123 Test Ave');
-    await dialog.getByRole('button', { name: 'Add Venue' }).click();
-    await expect(dialog.getByText('The Playwright Lounge')).toBeVisible();
-    await dialog.getByRole('button', { name: 'Next' }).click();
+    await expect(dialog.getByRole("heading", { name: "Venues" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Next" })).toBeDisabled();
+    await dialog.getByRole("textbox", { name: "Venue name" }).fill("The Playwright Lounge");
+    await dialog.getByRole("textbox", { name: "Address (optional)" }).fill("123 Test Ave");
+    await dialog.getByRole("button", { name: "Add Venue" }).click();
+    await expect(dialog.getByText("The Playwright Lounge")).toBeVisible();
+    await dialog.getByRole("button", { name: "Next" }).click();
 
     // Step 3: Bands
-    await expect(dialog.getByRole('heading', { name: 'Bands' })).toBeVisible();
-    await dialog.getByRole('textbox', { name: 'Band name' }).fill('The Test Subjects');
-    await dialog.getByRole('combobox').selectOption('The Playwright Lounge');
-    await dialog.getByPlaceholder('Start time').fill('20:00');
-    await dialog.getByPlaceholder('End time').fill('21:30');
-    await dialog.getByRole('button', { name: 'Add Band' }).click();
-    await expect(dialog.getByText('The Test Subjects')).toBeVisible();
-    await dialog.getByRole('button', { name: 'Next' }).click();
+    await expect(dialog.getByRole("heading", { name: "Bands" })).toBeVisible();
+    await dialog.getByRole("textbox", { name: "Band name" }).fill("The Test Subjects");
+    await dialog.getByRole("combobox").selectOption("The Playwright Lounge");
+    await dialog.getByPlaceholder("Start time").fill("20:00");
+    await dialog.getByPlaceholder("End time").fill("21:30");
+    await dialog.getByRole("button", { name: "Add Band" }).click();
+    await expect(dialog.getByText("The Test Subjects")).toBeVisible();
+    await dialog.getByRole("button", { name: "Next" }).click();
 
     // Step 4: Review & Publish
-    await expect(dialog.getByRole('heading', { name: 'Review & Publish' })).toBeVisible();
+    await expect(dialog.getByRole("heading", { name: "Review & Publish" })).toBeVisible();
     await expect(dialog.getByText(eventName)).toBeVisible();
-    await expect(dialog.getByText('1 venue(s)')).toBeVisible();
-    await expect(dialog.getByText('1 band(s)')).toBeVisible();
-    await dialog.getByRole('button', { name: 'Publish Event' }).click();
+    await expect(dialog.getByText("1 venue(s)")).toBeVisible();
+    await expect(dialog.getByText("1 band(s)")).toBeVisible();
+    await dialog.getByRole("button", { name: "Publish Event" }).click();
 
     // Wizard closes and global success toast appears
     await expect(dialog).not.toBeVisible({ timeout: 10000 });
-    await expect(page.getByRole('alert')).toContainText(`Event "${eventName}" created successfully!`);
+    await expect(page.getByRole("alert")).toContainText(`Event "${eventName}" created successfully!`);
 
     // App auto-navigates to the new event's Lineup tab — verify band is there
-    await expect(page.getByRole('cell', { name: 'The Test Subjects' })).toBeVisible();
-    await expect(page.getByRole('cell', { name: 'The Playwright Lounge' })).toBeVisible();
-    await expect(page.getByRole('cell', { name: '8:00 PM – 9:30 PM' })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "The Test Subjects" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "The Playwright Lounge" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "8:00 PM – 9:30 PM" })).toBeVisible();
 
     await deleteEvent(page, eventName);
   });
 
-  test('disables Next on venues step until a venue is added', async ({ page }) => {
+  test("disables Next on venues step until a venue is added", async ({ page }) => {
     const suffix = uniqueSuffix();
-    const dialog = page.getByRole('dialog', { name: 'Create Event' });
+    const dialog = page.getByRole("dialog", { name: "Create Event" });
 
-    await page.getByRole('button', { name: 'Create Event' }).click();
+    await page.getByRole("button", { name: "Create Event" }).click();
     await expect(dialog).toBeVisible();
 
-    await dialog.getByRole('textbox', { name: 'Event Name *' }).fill(`Wizard Fest ${suffix}`);
-    await dialog.getByRole('textbox', { name: 'Event Date *' }).fill(futureDate());
-    await dialog.getByRole('button', { name: 'Next' }).click();
+    await dialog.getByRole("textbox", { name: "Event Name *" }).fill(`Wizard Fest ${suffix}`);
+    await dialog.getByRole("textbox", { name: "Event Date *" }).fill(futureDate());
+    await dialog.getByRole("button", { name: "Next" }).click();
 
-    await expect(dialog.getByRole('heading', { name: 'Venues' })).toBeVisible();
-    await expect(dialog.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(dialog.getByRole("heading", { name: "Venues" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Next" })).toBeDisabled();
   });
 
-  test('shows error in dialog when slug already exists', async ({ page }) => {
+  test("shows error in dialog when slug already exists", async ({ page }) => {
     const suffix = uniqueSuffix();
-    const dialog = page.getByRole('dialog', { name: 'Create Event' });
+    const dialog = page.getByRole("dialog", { name: "Create Event" });
 
-    await page.getByRole('button', { name: 'Create Event' }).click();
+    await page.getByRole("button", { name: "Create Event" }).click();
     await expect(dialog).toBeVisible();
 
     // Fill name first (auto-populates slug), then override slug with a known-taken value
-    await dialog.getByRole('textbox', { name: 'Event Name *' }).fill(`Duplicate Slug ${suffix}`);
-    await dialog.getByRole('textbox', { name: 'Event Date *' }).fill(futureDate());
-    await dialog.getByRole('textbox', { name: 'URL Slug *' }).fill('winter-warm-up-2024');
-    await dialog.getByRole('button', { name: 'Next' }).click();
+    await dialog.getByRole("textbox", { name: "Event Name *" }).fill(`Duplicate Slug ${suffix}`);
+    await dialog.getByRole("textbox", { name: "Event Date *" }).fill(futureDate());
+    await dialog.getByRole("textbox", { name: "URL Slug *" }).fill("winter-warm-up-2024");
+    await dialog.getByRole("button", { name: "Next" }).click();
 
-    await dialog.getByRole('textbox', { name: 'Venue name' }).fill('Any Venue');
-    await dialog.getByRole('button', { name: 'Add Venue' }).click();
-    await dialog.getByRole('button', { name: 'Next' }).click();
+    await dialog.getByRole("textbox", { name: "Venue name" }).fill("Any Venue");
+    await dialog.getByRole("button", { name: "Add Venue" }).click();
+    await dialog.getByRole("button", { name: "Next" }).click();
 
-    await dialog.getByRole('textbox', { name: 'Band name' }).fill('Any Band');
-    await dialog.getByRole('combobox').selectOption('Any Venue');
-    await dialog.getByPlaceholder('Start time').fill('19:00');
-    await dialog.getByPlaceholder('End time').fill('20:00');
-    await dialog.getByRole('button', { name: 'Add Band' }).click();
-    await dialog.getByRole('button', { name: 'Next' }).click();
+    await dialog.getByRole("textbox", { name: "Band name" }).fill("Any Band");
+    await dialog.getByRole("combobox").selectOption("Any Venue");
+    await dialog.getByPlaceholder("Start time").fill("19:00");
+    await dialog.getByPlaceholder("End time").fill("20:00");
+    await dialog.getByRole("button", { name: "Add Band" }).click();
+    await dialog.getByRole("button", { name: "Next" }).click();
 
     // Wait for the API response before asserting the error alert — on a cold CI runner
     // the slug-conflict response can be slow, causing a first-attempt flake.
     await Promise.all([
-      page.waitForResponse(resp =>
-        resp.url().includes('/api/admin/events') && !resp.ok()
-      ),
-      dialog.getByRole('button', { name: 'Publish Event' }).click(),
+      page.waitForResponse((resp) => resp.url().includes("/api/admin/events") && !resp.ok()),
+      dialog.getByRole("button", { name: "Publish Event" }).click(),
     ]);
 
     // Error renders inside the dialog (not the global toast)
-    await expect(dialog.getByRole('alert')).toContainText('slug already exists');
+    await expect(dialog.getByRole("alert")).toContainText("slug already exists");
     await expect(dialog).toBeVisible();
   });
 });

--- a/e2e/login.spec.js
+++ b/e2e/login.spec.js
@@ -1,15 +1,15 @@
-import { test, expect } from '@playwright/test';
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from './credentials';
+import { test, expect } from "@playwright/test";
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
 
 test.use({ storageState: { cookies: [], origins: [] } });
 
-test.describe('Admin Login', () => {
-  test('should allow admin to login', async ({ page }) => {
+test.describe("Admin Login", () => {
+  test("should allow admin to login", async ({ page }) => {
     // Go to admin login page
-    await page.goto('/admin/login');
+    await page.goto("/admin/login");
 
     // Check if we are on the login page
-    await expect(page.getByRole('heading', { name: 'Admin Login' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Admin Login" })).toBeVisible();
 
     // Fill in credentials (from environment)
     await page.fill('input[type="email"]', ADMIN_EMAIL);
@@ -20,20 +20,20 @@ test.describe('Admin Login', () => {
 
     // Should redirect to admin panel
     await expect(page).toHaveURL(/\/admin$/);
-    
+
     // Should see the admin header
-    await expect(page.getByText('SetTimes')).toBeVisible();
-    await expect(page.getByText('Admin')).toBeVisible();
+    await expect(page.getByText("SetTimes")).toBeVisible();
+    await expect(page.getByText("Admin")).toBeVisible();
   });
 
-  test('should show error for invalid credentials', async ({ page }) => {
-    await page.goto('/admin/login');
+  test("should show error for invalid credentials", async ({ page }) => {
+    await page.goto("/admin/login");
 
     await page.fill('input[type="email"]', ADMIN_EMAIL);
-    await page.fill('input[type="password"]', 'wrongpassword');
+    await page.fill('input[type="password"]', "wrongpassword");
     await page.click('button[type="submit"]');
 
     // Should show error message
-    await expect(page.getByText('Invalid email or password')).toBeVisible();
+    await expect(page.getByText("Invalid email or password")).toBeVisible();
   });
 });

--- a/e2e/offline-experience.spec.js
+++ b/e2e/offline-experience.spec.js
@@ -1,8 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
 
-/* global navigator -- referenced inside a page.waitForFunction browser callback */
-
 // Re-establish the admin session in THIS context. The shared storageState
 // session (from auth.setup) is invalidated whenever another spec logs in —
 // lucia.invalidateUserSessions() kills all other sessions on re-auth — so

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
 // During show hours, EventTimeline.jsx auto-expands a live event
 // (`useState(isLive)`), so its "View Details" toggle already reads "Hide
@@ -17,75 +17,75 @@ import { test, expect } from '@playwright/test';
 // card's position regardless of its later expanded/collapsed state.
 async function collapsedEventCard(page) {
   const allCards = page.locator('[data-testid="event-card"]');
-  const collapsed = allCards.filter({ has: page.getByRole('button', { name: /view details/i }) }).first();
-  const index = await collapsed.evaluate((el, testid) =>
-    Array.from(document.querySelectorAll(`[data-testid="${testid}"]`)).indexOf(el),
-    'event-card'
+  const collapsed = allCards.filter({ has: page.getByRole("button", { name: /view details/i }) }).first();
+  const index = await collapsed.evaluate(
+    (el, testid) => Array.from(document.querySelectorAll(`[data-testid="${testid}"]`)).indexOf(el),
+    "event-card",
   );
   return allCards.nth(index);
 }
 
-test.describe('Public Timeline Viewing', () => {
-  test('should display upcoming events without authentication', async ({ page }) => {
-    await page.goto('/');
+test.describe("Public Timeline Viewing", () => {
+  test("should display upcoming events without authentication", async ({ page }) => {
+    await page.goto("/");
 
     // Use exact:true to avoid matching both "Events" h1 and "Past Events" h2
-    await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Events", exact: true })).toBeVisible();
 
     const eventCards = page.locator('[data-testid="event-card"]');
     await expect(eventCards.first()).toBeVisible();
   });
 
-  test('should show event details when clicked', async ({ page }) => {
-    await page.goto('/');
+  test("should show event details when clicked", async ({ page }) => {
+    await page.goto("/");
 
     const firstEvent = await collapsedEventCard(page);
-    await firstEvent.getByRole('button', { name: /view details/i }).click();
+    await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Verify the card expanded (button flips to Hide Details)
-    await expect(firstEvent.getByRole('button', { name: /hide details/i })).toBeVisible();
+    await expect(firstEvent.getByRole("button", { name: /hide details/i })).toBeVisible();
 
     // Seed data guarantees the upcoming event has venues
-    await expect(firstEvent.getByRole('heading', { name: /venues/i })).toBeVisible();
+    await expect(firstEvent.getByRole("heading", { name: /venues/i })).toBeVisible();
   });
 
-  test('should allow filtering controls', async ({ page }) => {
-    await page.goto('/');
+  test("should allow filtering controls", async ({ page }) => {
+    await page.goto("/");
 
-    const filtersButton = page.getByRole('button', { name: /show filters/i });
+    const filtersButton = page.getByRole("button", { name: /show filters/i });
     if (await filtersButton.isVisible()) {
       await filtersButton.click();
-      await expect(page.getByRole('button', { name: /hide filters/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /hide filters/i })).toBeVisible();
     }
   });
 
-  test('should display event venue information', async ({ page }) => {
-    await page.goto('/');
+  test("should display event venue information", async ({ page }) => {
+    await page.goto("/");
 
     const firstEvent = await collapsedEventCard(page);
-    await firstEvent.getByRole('button', { name: /view details/i }).click();
+    await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Seed data guarantees the upcoming event has venues
-    await expect(firstEvent.getByRole('button', { name: /hide details/i })).toBeVisible();
-    await expect(firstEvent.getByRole('heading', { name: /venues/i })).toBeVisible();
+    await expect(firstEvent.getByRole("button", { name: /hide details/i })).toBeVisible();
+    await expect(firstEvent.getByRole("heading", { name: /venues/i })).toBeVisible();
   });
 
-  test('should show band/performer information in events', async ({ page }) => {
-    await page.goto('/');
+  test("should show band/performer information in events", async ({ page }) => {
+    await page.goto("/");
 
     const firstEvent = await collapsedEventCard(page);
-    await firstEvent.getByRole('button', { name: /view details/i }).click();
+    await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Seed data guarantees the upcoming event has performers
-    await expect(firstEvent.getByRole('button', { name: /hide details/i })).toBeVisible();
-    await expect(firstEvent.getByRole('heading', { name: /all performers/i })).toBeVisible();
+    await expect(firstEvent.getByRole("button", { name: /hide details/i })).toBeVisible();
+    await expect(firstEvent.getByRole("heading", { name: /all performers/i })).toBeVisible();
   });
 
-  test('should navigate to band profile from event', async ({ page }) => {
-    await page.goto('/');
+  test("should navigate to band profile from event", async ({ page }) => {
+    await page.goto("/");
 
     const firstEvent = await collapsedEventCard(page);
-    await firstEvent.getByRole('button', { name: /view details/i }).click();
+    await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     const bandLink = firstEvent.locator('a[href*="/band/"]').first();
     if (await bandLink.isVisible()) {
@@ -95,40 +95,40 @@ test.describe('Public Timeline Viewing', () => {
       // toHaveTitle waits for the useEffect title update; only then is the page settled.
       // Scoping to main h1 avoids the Header's "SetTimes" h1 (strict mode violation).
       await expect(page).toHaveTitle(/- Band Profile \| SetTimes$/);
-      await expect(page.locator('main h1')).toBeVisible();
+      await expect(page.locator("main h1")).toBeVisible();
     }
   });
 
-  test('should display timeline content', async ({ page }) => {
-    await page.goto('/');
+  test("should display timeline content", async ({ page }) => {
+    await page.goto("/");
 
     const eventCards = page.locator('[data-testid="event-card"]');
     await expect(eventCards.first()).toBeVisible();
   });
 
-  test('should be responsive on mobile viewport', async ({ page }) => {
+  test("should be responsive on mobile viewport", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
-    await page.goto('/');
+    await page.goto("/");
 
     // Use exact:true to avoid matching both "Events" h1 and "Past Events" h2
-    await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Events", exact: true })).toBeVisible();
 
     const eventCards = page.locator('[data-testid="event-card"]');
     await expect(eventCards.first()).toBeVisible();
 
     const mobileCard = await collapsedEventCard(page);
-    await mobileCard.getByRole('button', { name: /view details/i }).click();
+    await mobileCard.getByRole("button", { name: /view details/i }).click();
     await page.waitForTimeout(500);
   });
 
-  test('should show empty state when no events available', async ({ page }) => {
-    await page.goto('/');
+  test("should show empty state when no events available", async ({ page }) => {
+    await page.goto("/");
 
-    const historyButton = page.getByRole('button', { name: /show history|hide history/i });
+    const historyButton = page.getByRole("button", { name: /show history|hide history/i });
     if (await historyButton.isVisible()) {
       await historyButton.click();
 
-      const emptyMessage = page.locator('text=/no events|no performances|nothing scheduled/i');
+      const emptyMessage = page.locator("text=/no events|no performances|nothing scheduled/i");
       const eventCards = page.locator('[data-testid="event-card"]');
 
       const hasEvents = (await eventCards.count()) > 0;
@@ -138,39 +138,39 @@ test.describe('Public Timeline Viewing', () => {
     }
   });
 
-  test('should display event duration and time details', async ({ page }) => {
-    await page.goto('/');
+  test("should display event duration and time details", async ({ page }) => {
+    await page.goto("/");
 
     const firstEvent = await collapsedEventCard(page);
-    await firstEvent.getByRole('button', { name: /view details/i }).click();
+    await firstEvent.getByRole("button", { name: /view details/i }).click();
 
-    const timeRange = firstEvent.locator('text=/\\d{2}:\\d{2}\\s*-\\s*\\d{2}:\\d{2}/');
+    const timeRange = firstEvent.locator("text=/\\d{2}:\\d{2}\\s*-\\s*\\d{2}:\\d{2}/");
     if (await timeRange.first().isVisible()) {
       await expect(timeRange.first()).toBeVisible();
     }
   });
 
-  test('should allow visitors to access timeline without login', async ({ page }) => {
-    await page.goto('/');
+  test("should allow visitors to access timeline without login", async ({ page }) => {
+    await page.goto("/");
 
     await expect(page).not.toHaveURL(/\/admin\/login/);
     await expect(page).not.toHaveURL(/\/login/);
 
     // Use exact:true to avoid matching both "Events" h1 and "Past Events" h2
-    await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Events", exact: true })).toBeVisible();
 
     const eventCards = page.locator('[data-testid="event-card"]');
     await expect(eventCards.first()).toBeVisible();
   });
 
-  test('should show venue location details in event view', async ({ page }) => {
-    await page.goto('/');
+  test("should show venue location details in event view", async ({ page }) => {
+    await page.goto("/");
 
     const firstEvent = await collapsedEventCard(page);
-    await firstEvent.getByRole('button', { name: /view details/i }).click();
+    await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Seed data guarantees the upcoming event has venues
-    await expect(firstEvent.getByRole('button', { name: /hide details/i })).toBeVisible();
-    await expect(firstEvent.getByRole('heading', { name: /venues/i })).toBeVisible();
+    await expect(firstEvent.getByRole("button", { name: /hide details/i })).toBeVisible();
+    await expect(firstEvent.getByRole("heading", { name: /venues/i })).toBeVisible();
   });
 });

--- a/e2e/user-management.spec.js
+++ b/e2e/user-management.spec.js
@@ -1,21 +1,21 @@
-import { test, expect } from '@playwright/test';
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from './credentials';
+import { test, expect } from "@playwright/test";
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
 
 const loginAsAdmin = async (page) => {
-  await page.goto('/admin');
+  await page.goto("/admin");
   // Wait for either admin tab buttons (valid session) or login form (session expired/invalidated)
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: 'visible', timeout: 15000 });
+  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
   if (await page.locator('input[type="email"]').isVisible()) {
     await page.fill('input[type="email"]', ADMIN_EMAIL);
     await page.fill('input[type="password"]', ADMIN_PASSWORD);
     await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: 'visible', timeout: 15000 });
+    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
   }
 };
 
 const openUsersTab = async (page) => {
   await page.click('button:has-text("Users")');
-  await expect(page.getByRole('heading', { name: 'User Management' })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "User Management" })).toBeVisible();
 };
 
 const uniqueSuffix = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
@@ -23,37 +23,37 @@ const uniqueSuffix = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
 // with a URL-copy view (email delivery failed). Both cases are handled here.
 const clickAndWaitForToast = async (page, selector, matcher) => {
   await page.click(selector);
-  await expect(page.locator('body')).toContainText(matcher, { timeout: 10000 });
+  await expect(page.locator("body")).toContainText(matcher, { timeout: 10000 });
   // If email delivery failed the modal stays open showing the invite URL.
   // Close it so subsequent test steps are not blocked by the overlay.
-  const inviteCreatedHeading = page.getByRole('heading', { name: 'Invite Created' });
+  const inviteCreatedHeading = page.getByRole("heading", { name: "Invite Created" });
   if (await inviteCreatedHeading.isVisible()) {
-    await page.getByRole('button', { name: 'Close' }).click();
+    await page.getByRole("button", { name: "Close" }).click();
     await expect(inviteCreatedHeading).not.toBeVisible();
   }
 };
 const waitForCreateUserForm = async (page) => {
-  await expect(page.getByRole('heading', { name: 'Create New User' })).toBeVisible();
-  await expect(page.locator('#email')).toHaveValue('');
+  await expect(page.getByRole("heading", { name: "Create New User" })).toBeVisible();
+  await expect(page.locator("#email")).toHaveValue("");
   await page.waitForTimeout(50);
 };
 const waitForEditUserForm = async (page, email) => {
-  await expect(page.getByRole('heading', { name: 'Edit User' })).toBeVisible();
-  await expect(page.locator('#email')).toHaveValue(email);
+  await expect(page.getByRole("heading", { name: "Edit User" })).toBeVisible();
+  await expect(page.locator("#email")).toHaveValue(email);
   await page.waitForTimeout(50);
 };
 
-test.describe('User Management', () => {
+test.describe("User Management", () => {
   // Tests mutate shared seeded accounts — serialize to prevent parallel races
-  test.describe.configure({ mode: 'serial' })
+  test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
   });
 
-  test('should allow admin to create a new user', async ({ page }) => {
+  test("should allow admin to create a new user", async ({ page }) => {
     const suffix = uniqueSuffix();
-    const firstName = 'Test';
+    const firstName = "Test";
     const lastName = `User ${suffix}`;
     const email = `testuser${suffix}@example.com`;
     await openUsersTab(page);
@@ -61,33 +61,33 @@ test.describe('User Management', () => {
 
     await waitForCreateUserForm(page);
 
-    await page.fill('#firstName', firstName);
-    await page.fill('#lastName', lastName);
-    await page.fill('#email', email);
-    await page.selectOption('#role', 'editor');
+    await page.fill("#firstName", firstName);
+    await page.fill("#lastName", lastName);
+    await page.fill("#email", email);
+    await page.selectOption("#role", "editor");
 
     // Invite flow: creates an invite code, not a user row.
     // The user appears in the table only after they complete signup via the invite link.
     await clickAndWaitForToast(page, 'button[type="submit"]:has-text("Send Invite")', /invite (sent|created)/i);
   });
 
-  test('should validate required user fields', async ({ page }) => {
+  test("should validate required user fields", async ({ page }) => {
     await openUsersTab(page);
     await page.click('button:has-text("Invite User")');
 
     await page.click('button[type="submit"]:has-text("Send Invite")');
 
-    await expect(page.getByText('Email is required')).toBeVisible();
-    await expect(page.getByText('First name is required')).toBeVisible();
-    await expect(page.getByText('Last name is required')).toBeVisible();
+    await expect(page.getByText("Email is required")).toBeVisible();
+    await expect(page.getByText("First name is required")).toBeVisible();
+    await expect(page.getByText("Last name is required")).toBeVisible();
   });
 
-  test.skip('should validate password confirmation match', async ({ page }) => {
+  test.skip("should validate password confirmation match", async ({ page }) => {
     // Password confirmation is no longer part of the user form.
     await openUsersTab(page);
   });
 
-  test('should allow admin to assign different user roles', async ({ page }) => {
+  test("should allow admin to assign different user roles", async ({ page }) => {
     const adminSuffix = uniqueSuffix();
     const adminEmail = `adminuser${adminSuffix}@example.com`;
     const viewerSuffix = uniqueSuffix();
@@ -97,73 +97,73 @@ test.describe('User Management', () => {
     // Invite admin-role user
     await page.click('button:has-text("Invite User")');
     await waitForCreateUserForm(page);
-    await page.fill('#firstName', 'Admin');
-    await page.fill('#lastName', `User ${adminSuffix}`);
-    await page.fill('#email', adminEmail);
-    await page.selectOption('#role', 'admin');
+    await page.fill("#firstName", "Admin");
+    await page.fill("#lastName", `User ${adminSuffix}`);
+    await page.fill("#email", adminEmail);
+    await page.selectOption("#role", "admin");
     await clickAndWaitForToast(page, 'button[type="submit"]:has-text("Send Invite")', /invite (sent|created)/i);
 
     // Invite viewer-role user
     await page.click('button:has-text("Invite User")');
     await waitForCreateUserForm(page);
-    await page.fill('#firstName', 'Viewer');
-    await page.fill('#lastName', `User ${viewerSuffix}`);
-    await page.fill('#email', viewerEmail);
-    await page.selectOption('#role', 'viewer');
+    await page.fill("#firstName", "Viewer");
+    await page.fill("#lastName", `User ${viewerSuffix}`);
+    await page.fill("#email", viewerEmail);
+    await page.selectOption("#role", "viewer");
     await clickAndWaitForToast(page, 'button[type="submit"]:has-text("Send Invite")', /invite (sent|created)/i);
   });
 
-  test('should allow admin to edit user details', async ({ page }) => {
+  test("should allow admin to edit user details", async ({ page }) => {
     // Use the seeded viewer user — invite flow does not create a user row until
     // the invitee completes signup, so we edit an already-existing account.
-    const email = 'viewer@settimes.ca';
-    const updatedFirstName = 'Updated';
-    const updatedLastName = 'ViewUser';
+    const email = "viewer@settimes.ca";
+    const updatedFirstName = "Updated";
+    const updatedLastName = "ViewUser";
     await openUsersTab(page);
 
-    const editRow = page.locator('table tbody tr', { hasText: email }).first();
+    const editRow = page.locator("table tbody tr", { hasText: email }).first();
     await expect(editRow).toBeVisible({ timeout: 15000 });
     await editRow.locator('button[aria-label^="Edit"]').click();
     await waitForEditUserForm(page, email);
 
-    await page.fill('#firstName', updatedFirstName);
-    await page.fill('#lastName', updatedLastName);
+    await page.fill("#firstName", updatedFirstName);
+    await page.fill("#lastName", updatedLastName);
     await clickAndWaitForToast(page, 'button[type="submit"]:has-text("Update User")', /updated successfully/i);
 
-    const updatedRow = page.locator('table tbody tr', { hasText: email }).first();
+    const updatedRow = page.locator("table tbody tr", { hasText: email }).first();
     await expect(updatedRow).toContainText(`${updatedFirstName} ${updatedLastName}`);
   });
 
-  test('should show delete confirm dialog and allow cancellation', async ({ page }) => {
-    const email = 'viewer@settimes.ca';
+  test("should show delete confirm dialog and allow cancellation", async ({ page }) => {
+    const email = "viewer@settimes.ca";
     await openUsersTab(page);
 
-    const row = page.locator('table tbody tr', { hasText: email }).first();
+    const row = page.locator("table tbody tr", { hasText: email }).first();
     await expect(row).toBeVisible({ timeout: 15000 });
 
     await row.locator('button[aria-label^="Delete"]').click();
-    await expect(page.getByRole('dialog')).toBeVisible();
-    await expect(page.getByRole('dialog')).toContainText('Delete User');
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByRole("dialog")).toContainText("Delete User");
 
     // Cancel — user should still be in the table
-    await page.getByRole('dialog').getByRole('button', { name: 'Cancel' }).click();
-    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await page.getByRole("dialog").getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
     await expect(row).toBeVisible();
   });
 
-  test('should show toggle confirm dialog and complete deactivate/reactivate cycle', async ({ page }) => {
-    const email = 'viewer@settimes.ca';
+  test("should show toggle confirm dialog and complete deactivate/reactivate cycle", async ({ page }) => {
+    const email = "viewer@settimes.ca";
     await openUsersTab(page);
 
-    const row = page.locator('table tbody tr', { hasText: email }).first();
+    const row = page.locator("table tbody tr", { hasText: email }).first();
     await expect(row).toBeVisible({ timeout: 15000 });
 
     // Deactivate
     await row.locator('button[aria-label^="Deactivate"]').click();
-    await expect(page.getByRole('dialog')).toBeVisible();
-    await expect(page.getByRole('dialog')).toContainText('Deactivate User');
-    await page.getByRole('dialog').getByRole('button', { name: 'Deactivate' }).click();
-    await expect(page.locator('body')).toContainText(/deactivated/i, { timeout: 10000 });
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByRole("dialog")).toContainText("Deactivate User");
+    await page.getByRole("dialog").getByRole("button", { name: "Deactivate" }).click();
+    await expect(page.locator("body")).toContainText(/deactivated/i, { timeout: 10000 });
 
     // Full page reload flushes wrangler D1 local write-through and guarantees fresh DB state.
     // Fast tab navigation (previous approach) races the miniflare SQLite commit.
@@ -171,12 +171,12 @@ test.describe('User Management', () => {
     await openUsersTab(page);
 
     // DB-backed state: user is now inactive — Activate button is deterministically present.
-    const deactivatedRow = page.locator('table tbody tr', { hasText: email }).first();
+    const deactivatedRow = page.locator("table tbody tr", { hasText: email }).first();
     await expect(deactivatedRow).toBeVisible({ timeout: 15000 });
     await deactivatedRow.locator('button[aria-label^="Activate"]').click();
-    await expect(page.getByRole('dialog')).toBeVisible();
-    await expect(page.getByRole('dialog')).toContainText('Activate User');
-    await page.getByRole('dialog').getByRole('button', { name: 'Activate' }).click();
-    await expect(page.locator('body')).toContainText(/activated/i, { timeout: 10000 });
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByRole("dialog")).toContainText("Activate User");
+    await page.getByRole("dialog").getByRole("button", { name: "Activate" }).click();
+    await expect(page.locator("body")).toContainText(/activated/i, { timeout: 10000 });
   });
 });

--- a/e2e/visual-regression.spec.js
+++ b/e2e/visual-regression.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
 test.use({ storageState: { cookies: [], origins: [] } });
 
@@ -28,22 +28,22 @@ const createComponentPage = async (page, componentHtml) => {
   `);
 };
 
-test.describe('Visual Regression', () => {
+test.describe("Visual Regression", () => {
   test.beforeEach(async ({}, testInfo) => {
     testInfo.skip(
-      process.env.PLAYWRIGHT_SKIP_A11Y_VISUAL === 'true',
-      'Visual regression tests skipped in main e2e workflow'
+      process.env.PLAYWRIGHT_SKIP_A11Y_VISUAL === "true",
+      "Visual regression tests skipped in main e2e workflow",
     );
   });
 
-  test('admin login page', async ({ page }) => {
-    await page.goto('/admin/login');
-    await expect(page.getByRole('heading', { name: 'Admin Login' })).toBeVisible();
+  test("admin login page", async ({ page }) => {
+    await page.goto("/admin/login");
+    await expect(page.getByRole("heading", { name: "Admin Login" })).toBeVisible();
     await waitForFonts(page);
-    await expect(page).toHaveScreenshot('admin-login.png', { fullPage: true });
+    await expect(page).toHaveScreenshot("admin-login.png", { fullPage: true });
   });
 
-  test('design system snapshot', async ({ page }) => {
+  test("design system snapshot", async ({ page }) => {
     await createComponentPage(
       page,
       `
@@ -56,10 +56,10 @@ test.describe('Visual Regression', () => {
           <p class="text-sm text-gray-300">Stable snapshot content for visual regression.</p>
         </div>
       </div>
-      `
+      `,
     );
 
     await waitForFonts(page);
-    await expect(page).toHaveScreenshot('design-system.png', { fullPage: true });
+    await expect(page).toHaveScreenshot("design-system.png", { fullPage: true });
   });
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -101,6 +101,38 @@ export default [
     },
   },
 
+  // --- E2E tests (Playwright, e2e/) ---
+  {
+    files: ["e2e/**/*.js", "e2e/**/*.mjs"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        // Specs run under Node (Playwright test runner: process, Buffer for
+        // multipart fixtures), but also embed browser-context callbacks
+        // (page.evaluate/waitForFunction) that reference DOM/window globals
+        // like navigator/document directly — both sets are needed for no-undef.
+        ...globals.node,
+        ...globals.browser,
+      },
+    },
+    rules: {
+      "no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
+      "no-console": "off",
+
+      // Playwright's `async ({}, testInfo) => {}` idiom deliberately destructures
+      // no fixtures (only testInfo is needed) — not a mistake to flag.
+      "no-empty-pattern": "off",
+    },
+  },
+
   // --- Test files: add Vitest + Node globals on top of the above ---
   {
     files: [

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "format": "prettier --write \"functions/**/*.{js,json}\" \"scripts/**/*.{js,mjs,json}\"",
-    "format:check": "prettier --check \"functions/**/*.{js,json}\" \"scripts/**/*.{js,mjs,json}\"",
-    "lint": "eslint functions/ scripts/"
+    "format": "prettier --write \"functions/**/*.{js,json}\" \"scripts/**/*.{js,mjs,json}\" \"e2e/**/*.{js,mjs}\"",
+    "format:check": "prettier --check \"functions/**/*.{js,json}\" \"scripts/**/*.{js,mjs,json}\" \"e2e/**/*.{js,mjs}\"",
+    "lint": "eslint functions/ scripts/ e2e/"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",


### PR DESCRIPTION
## Summary

The `format`/`format:check`/`lint` npm scripts globbed only `functions/**` and `scripts/**`, so the 14 `e2e/*.spec.js` files drifted from repo style (single quotes vs the config's doubles) and nothing enforced consistency — found while fixing #602. This extends the scope to `e2e/**`, adds an eslint override for e2e (Playwright + browser globals for the `page.evaluate`/`waitForFunction` callbacks), and one-time reformats every spec to repo prettier style.

Closes #622

## What changed

| Area | Change |
|------|--------|
| `package.json` | `format`/`format:check` prettier globs + `lint` eslint target extended to `e2e/**` |
| `eslint.config.js` | New `e2e/**` block — `globals.node` + `globals.browser`, `no-empty-pattern: off` (Playwright's `async ({}, testInfo) =>` idiom), warn-severity `no-unused-vars` matching the repo convention |
| `AGENTS.md` | The note documenting this gap updated — it's now closed |
| 12 e2e specs | Prettier reformat (quote/semi/arrow-paren churn); 1 was already compliant, 1 needed a stale `/* global */` pragma removed (conflicts with the new shared globals) |
| `Makefile` | No change needed — its targets delegate to the npm scripts |

**Zero test logic changed** — verified by AST-comparing every reformatted file against its pre-reformat version (acorn parse, position/quote-style normalized): all 14 structurally identical. Stronger than spot-checking, and it covers the largest diff (`design-system.spec.js`, 552 lines).

## Security / correctness notes

None — tooling config + mechanical reformat of test files. No runtime code touched.

## Verification

- [x] `make format:check` — clean, e2e now included (both stacks exit 0)
- [x] `make lint` — 0 errors with `e2e/` in scope (1 pre-existing warn: unused `confirmBtn` in `design-system.spec.js`, warn-severity per repo convention, dead test code left as-is)
- [x] Tests/build: unaffected (e2e reformat doesn't touch unit tests or the build); AST-identity proves specs still parse+behave identically
- [x] CI: no YAML change — `quality.yml`/`cloudflare-pages.yml` invoke the bare npm scripts, so scoping is picked up automatically
- [x] `validate:openapi`: n/a

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)