### PR TITLE
feat: day-tab filter for multi-day event schedules (#542 PR-3)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,7 @@ import { getTimeFilterOptions } from './utils/timeFilter'
 import { computeNextMove } from './utils/nextMove'
 import { validateBandsData } from './utils/validation'
 import { prepareBands } from './utils/bandUtils'
+import { orderedFestivalDays } from './utils/festivalDays'
 import { saveSelectedBands } from './utils/scheduleStorage'
 
 const HINT_DISMISSED_KEY = 'scheduleHintDismissed'
@@ -589,6 +590,12 @@ function App() {
   const isArchived = Boolean(eventData?.is_archived)
   const myBands = bands.filter(band => selectedBands.includes(band.id))
   const selectedVenues = useMemo(() => [...new Set(myBands.map(b => b.venue).filter(Boolean))], [myBands])
+  // The FULL event's festival-day list (#542 PR-3), not derived from `myBands`
+  // — MySchedule needs this so a fan whose selections only touch Day 1 of a
+  // multi-day event still sees a Day 2 tab (see the `festivalDays` prop
+  // comment in MySchedule.jsx for why deriving it from a selected-bands
+  // subset would be wrong).
+  const eventFestivalDays = useMemo(() => orderedFestivalDays(bands), [bands])
   const sharedBandsAlreadySelectedCount = pendingSharedBands.filter(id => selectedBands.includes(id)).length
   const sharedBandsNewCount = pendingSharedBands.length - sharedBandsAlreadySelectedCount
   const toggleShowPast = () => setShowPast(prev => !prev)
@@ -836,6 +843,8 @@ function App() {
             showVenueFilter={false}
             eventSlug={slug || eventData?.slug}
             doorsJson={eventData?.doors_json}
+            eventStartDate={eventData?.date}
+            eventEndDate={eventData?.end_date}
           />
         ) : (
           <Suspense
@@ -856,6 +865,9 @@ function App() {
               eventSlug={slug || eventData?.slug}
               eventId={eventData?.id}
               doorsJson={eventData?.doors_json}
+              festivalDays={eventFestivalDays}
+              eventStartDate={eventData?.date}
+              eventEndDate={eventData?.end_date}
             />
           </Suspense>
         )}

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -22,11 +22,12 @@ import {
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { HIGHLIGHTED_BANDS, getHighlightMessage } from '../config/highlights.jsx'
 import { copyToClipboard } from '../utils/clipboard'
-import { dayNumberByDate, isMultiDay } from '../utils/festivalDays'
+import { dayNumberMapFromDays, formatFestivalDate, orderedFestivalDays } from '../utils/festivalDays'
 import { formatTimeRange } from '../utils/timeFormat'
+import { useFestivalDayFilter } from '../hooks/useFestivalDayFilter'
 import BandCard from './BandCard'
 import LockInLineupPanel from './LockInLineupPanel'
-import { DayDivider } from './ui'
+import { DayDivider, DayTabs } from './ui'
 import { walkMinutesBetween } from '../utils/walkTime'
 
 // Label a break between two sets at the same venue.
@@ -97,6 +98,9 @@ function MySchedule({
   eventSlug,
   eventId,
   doorsJson = null,
+  festivalDays: festivalDaysProp = null,
+  eventStartDate = null,
+  eventEndDate = null,
 }) {
   const [currentTime, setCurrentTime] = useState(() => (nowOverride ? new Date(nowOverride) : new Date()))
   const [copyButtonLabel, setCopyButtonLabel] = useState('Copy Schedule')
@@ -120,11 +124,46 @@ function MySchedule({
   const effectiveNow = useMemo(() => {
     return nowOverride ? new Date(nowOverride) : currentTime
   }, [currentTime, nowOverride])
+
+  // Day-tab filter (#542 PR-3): `festivalDays` is normally supplied by the
+  // parent from the FULL event lineup, not derived from `bands` (the fan's
+  // currently *selected* bands) — a selection that only touches Day 1 of a
+  // 2-day event must still show a Day 2 tab, and label Day-2 picks "Day 2"
+  // rather than mislabeling them "Day 1" because that's the only date the
+  // subset happens to contain. Falls back to deriving from `bands` when the
+  // prop is omitted (e.g. a standalone/test render) so the component stays
+  // self-sufficient.
+  const ownFestivalDays = useMemo(() => orderedFestivalDays(bands), [bands])
+  const festivalDays = useMemo(
+    () => (festivalDaysProp && festivalDaysProp.length > 0 ? festivalDaysProp : ownFestivalDays),
+    [festivalDaysProp, ownFestivalDays]
+  )
+  const dayNumberByDateMap = useMemo(() => dayNumberMapFromDays(festivalDays), [festivalDays])
+  const hasDayTabs = festivalDays.length > 1
+
+  const { activeDayNumber, activeDate, setActiveDayNumber } = useFestivalDayFilter(festivalDays, {
+    currentTime: effectiveNow,
+    startDate: eventStartDate,
+    endDate: eventEndDate,
+  })
+
+  // Filter (not scroll-anchor, locked product decision): once a day tab is
+  // active, everything below — conflict/overlap detection, the countdown
+  // list, the "longest break" reminder — operates on just that day's
+  // selections. Share Schedule / Lock-In deliberately read the RAW `bands`
+  // prop instead (see handleShareSchedule/performanceIds below), not this
+  // filtered set, so sharing/locking in always covers the fan's whole
+  // multi-day route regardless of which day tab they're looking at.
+  const dayFilteredBands = useMemo(
+    () => (hasDayTabs && activeDate ? bands.filter(band => band.date === activeDate) : bands),
+    [bands, hasDayTabs, activeDate]
+  )
+
   const highlightedBandIds = useMemo(() => new Set(HIGHLIGHTED_BANDS), [])
   const normalizedBands = useMemo(() => {
     const oneDayMs = 24 * 60 * 60 * 1000
 
-    return bands.map(band => {
+    return dayFilteredBands.map(band => {
       const parsedStartMs = Date.parse(`${band.date}T${band.startTime}:00`)
       const parsedEndMs = Date.parse(`${band.date}T${band.endTime}:00`)
       const startMs =
@@ -147,7 +186,7 @@ function MySchedule({
         endMs,
       }
     })
-  }, [bands])
+  }, [dayFilteredBands])
 
   // Calculate time until/since a band
   const getTimeStatus = band => {
@@ -228,12 +267,9 @@ function MySchedule({
 
   // Day-divider support (#541): a flat time-sorted list, so day boundaries are
   // detected by comparing each rendered band's `.date` to the previous one
-  // (see the render loop below). Numbering + the multi-day gate use the full
-  // `sortedBands` (not the `showPast`-filtered `visibleBands`) so a day's number
-  // never shifts when past sets are hidden — keeping it consistent with
-  // ScheduleView. Single-day schedules render zero dividers, byte-identical.
-  const dayNumberByDateMap = useMemo(() => dayNumberByDate(sortedBands), [sortedBands])
-  const multiDayEvent = useMemo(() => isMultiDay(sortedBands), [sortedBands])
+  // (see the render loop below). `dayNumberByDateMap`/`hasDayTabs` are
+  // computed above from the authoritative `festivalDays` (#542 PR-3), not
+  // re-derived from `sortedBands` here — see the comment there for why.
 
   // Find first highlighted band ID (only show reminder for the first one)
   const firstHighlightedBandId = useMemo(() => {
@@ -288,7 +324,15 @@ function MySchedule({
     return { conflicts, overlaps, overlapCount }
   }, [visibleBands])
 
-  if (sortedBands.length === 0) {
+  // Rendered whenever tabs are showing so a fan can switch days from any of
+  // the empty-state branches below, not just the main return.
+  const dayTabsControl = hasDayTabs ? (
+    <div className="max-w-5xl mx-auto mb-4 flex justify-center">
+      <DayTabs days={festivalDays} activeDayNumber={activeDayNumber} onSelectDay={setActiveDayNumber} />
+    </div>
+  ) : null
+
+  if (bands.length === 0) {
     return (
       <div className="py-16 text-center space-y-4">
         <div className="text-text-disabled mb-2">
@@ -308,9 +352,36 @@ function MySchedule({
     )
   }
 
+  // The fan has a route, but nothing on the currently active day tab (e.g.
+  // they've only picked Day 1 bands so far and switched to the Day 2 tab).
+  // Distinct from the "no bands selected yet" state above — the CTA here is
+  // "switch days or add more", not "get started".
+  if (hasDayTabs && sortedBands.length === 0) {
+    const activeDayLabel = activeDate ? formatFestivalDate(activeDate, 'short') : 'this day'
+    return (
+      <div className="py-16 text-center space-y-4">
+        {dayTabsControl}
+        <div className="text-text-disabled mb-2">
+          <CalendarPlus size={60} aria-hidden="true" />
+        </div>
+        <p className="text-text-primary text-xl font-semibold">No bands in your route for {activeDayLabel}</p>
+        <p className="text-accent-400 text-sm">Switch days above, or browse the lineup to add more.</p>
+        {onBrowseAll && (
+          <button
+            onClick={onBrowseAll}
+            className="mt-2 px-6 py-3 min-h-[44px] rounded-lg bg-accent-500/20 border border-accent-500/50 text-accent-400 font-semibold hover:bg-accent-500/30 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500"
+          >
+            Browse Lineup
+          </button>
+        )}
+      </div>
+    )
+  }
+
   if (!showPast && visibleBands.length === 0 && hiddenFinishedCount > 0) {
     return (
       <div className="py-12 text-center">
+        {dayTabsControl}
         <p className="text-text-primary text-xl mb-2">All your selected bands have wrapped up</p>
         <p className="text-accent-400">Tap &ldquo;Show finished sets&rdquo; to revisit what you already caught.</p>
         <div className="mt-4">
@@ -461,6 +532,9 @@ function MySchedule({
             </p>
           </div>
         </div>
+
+        {dayTabsControl}
+
         {sortedBands.length > 0 && (
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-center gap-3 sm:gap-4 mt-3">
             {hasFinishedBands && (
@@ -576,7 +650,7 @@ function MySchedule({
           // Day-divider: render above this band when its festival day differs
           // from the previously-rendered band's day (#541).
           const previousDate = idx > 0 ? visibleBands[idx - 1].date : undefined
-          const showDayDivider = multiDayEvent && band.date !== previousDate
+          const showDayDivider = hasDayTabs && band.date !== previousDate
 
           // Walk + buffer from the previous set — the crawl's "can I make it?" math.
           let transition = null

--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -2,11 +2,12 @@ import { Check, Copy, Music } from 'lucide-react'
 import { Fragment, memo, useMemo, useState } from 'react'
 import { copyToClipboard } from '../utils/clipboard'
 import { compareByName } from '../utils/sortableName'
-import { dayNumberByDate, isMultiDay } from '../utils/festivalDays'
+import { dayNumberByDate, orderedFestivalDays } from '../utils/festivalDays'
 import { formatTime, formatTimeRange } from '../utils/timeFormat'
 import { filterPerformancesByTime } from '../utils/timeFilter'
+import { useFestivalDayFilter } from '../hooks/useFestivalDayFilter'
 import BandCard from './BandCard'
-import { DayDivider } from './ui'
+import { DayDivider, DayTabs } from './ui'
 
 const UNSCHEDULED = Symbol('unscheduled')
 const UNSCHEDULED_FILTER_VALUE = '__unscheduled__'
@@ -53,6 +54,8 @@ function ScheduleView({
   showVenueFilter = true,
   eventSlug,
   doorsJson = null,
+  eventStartDate = null,
+  eventEndDate = null,
 }) {
   const [copyAllLabel, setCopyAllLabel] = useState('Copy Visible Schedule')
   const [isCopyingAll, setIsCopyingAll] = useState(false)
@@ -69,14 +72,40 @@ function ScheduleView({
   // `bands` set (not the filtered/split subsets below) so day numbers stay
   // consistent across the Upcoming and Past sections and across filter changes.
   const dayNumberByDateMap = useMemo(() => dayNumberByDate(bands), [bands])
-  const multiDayEvent = useMemo(() => isMultiDay(bands), [bands])
+  const festivalDays = useMemo(() => orderedFestivalDays(bands), [bands])
 
-  const uniqueVenues = useMemo(() => [...new Set(bands.map(b => b.venue).filter(Boolean))].sort(), [bands])
-  const hasUnscheduled = useMemo(() => bands.some(b => !b.venue), [bands])
-  const uniqueGenres = useMemo(() => [...new Set(bands.filter(b => b.genre).map(b => b.genre))].sort(), [bands])
+  // Day-tab filter (#542 PR-3): a hard FILTER, not a scroll-anchor — exactly
+  // one festival day's performances render at a time once an event spans
+  // more than one day. `hasDayTabs`/`activeDate` derive from the full
+  // `bands` (same array as the divider numbering above) so both stay in
+  // sync as the day-tab selection changes.
+  const {
+    isMultiDay: hasDayTabs,
+    activeDayNumber,
+    activeDate,
+    setActiveDayNumber,
+  } = useFestivalDayFilter(festivalDays, { currentTime, startDate: eventStartDate, endDate: eventEndDate })
+
+  const dayFilteredBands = useMemo(
+    () => (hasDayTabs && activeDate ? bands.filter(band => band.date === activeDate) : bands),
+    [bands, hasDayTabs, activeDate]
+  )
+
+  const uniqueVenues = useMemo(
+    () => [...new Set(dayFilteredBands.map(b => b.venue).filter(Boolean))].sort(),
+    [dayFilteredBands]
+  )
+  const hasUnscheduled = useMemo(() => dayFilteredBands.some(b => !b.venue), [dayFilteredBands])
+  const uniqueGenres = useMemo(
+    () => [...new Set(dayFilteredBands.filter(b => b.genre).map(b => b.genre))].sort(),
+    [dayFilteredBands]
+  )
 
   // Apply time filter first, then venue/genre filter (before showPast so finishedCount is accurate)
-  const timeFilteredBands = useMemo(() => filterPerformancesByTime(bands, timeFilter), [bands, timeFilter])
+  const timeFilteredBands = useMemo(
+    () => filterPerformancesByTime(dayFilteredBands, timeFilter),
+    [dayFilteredBands, timeFilter]
+  )
 
   const venueGenreFilteredBands = useMemo(
     () =>
@@ -311,6 +340,16 @@ function ScheduleView({
         </div>
       </div>
 
+      {/* Day-tab filter (#542 PR-3): a hard FILTER — selecting a day renders
+          ONLY that day's performances, never "all days" merged. Gated on
+          hasDayTabs so single-day events render nothing here (repo
+          invariant: no lone "Day 1" control). */}
+      {hasDayTabs && (
+        <div className="flex justify-center sm:justify-start">
+          <DayTabs days={festivalDays} activeDayNumber={activeDayNumber} onSelectDay={setActiveDayNumber} />
+        </div>
+      )}
+
       {/* Filter pills */}
       {(showVenueFilter || uniqueGenres.length > 0) &&
         (uniqueVenues.length > 1 || uniqueGenres.length > 0 || hasUnscheduled) && (
@@ -502,7 +541,7 @@ function ScheduleView({
               </div>
               {upcomingByTime.map(({ time, date, bands: timeBands }, idx) => {
                 const previousDate = idx > 0 ? upcomingByTime[idx - 1].date : undefined
-                const showDayDivider = multiDayEvent && date !== previousDate
+                const showDayDivider = hasDayTabs && date !== previousDate
                 return (
                   <Fragment key={`${date ?? ''}-${time}`}>
                     {showDayDivider && (
@@ -548,7 +587,7 @@ function ScheduleView({
               </div>
               {pastByTime.map(({ time, date, bands: timeBands }, idx) => {
                 const previousDate = idx > 0 ? pastByTime[idx - 1].date : undefined
-                const showDayDivider = multiDayEvent && date !== previousDate
+                const showDayDivider = hasDayTabs && date !== previousDate
                 return (
                   <Fragment key={`${date ?? ''}-${time}`}>
                     {showDayDivider && (

--- a/frontend/src/components/__tests__/ScheduleView.test.jsx
+++ b/frontend/src/components/__tests__/ScheduleView.test.jsx
@@ -39,9 +39,9 @@ const defaultProps = {
   timeFilter: 'all',
 }
 
-const renderView = props =>
+const renderView = (props, { route = '/' } = {}) =>
   render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[route]}>
       <ScheduleView {...defaultProps} {...props} />
     </MemoryRouter>
   )
@@ -270,7 +270,7 @@ describe('ScheduleView — P2: copy action respects visible filters', () => {
   })
 })
 
-describe('ScheduleView — #541: multi-day day dividers', () => {
+describe('ScheduleView — #541: day dividers', () => {
   it('renders no day dividers for a single-day lineup', () => {
     const bands = [
       makeBand({
@@ -296,36 +296,9 @@ describe('ScheduleView — #541: multi-day day dividers', () => {
     expect(screen.queryByText(/^Day 1/)).not.toBeInTheDocument()
   })
 
-  it('renders one day-divider per festival day, in ascending order, for a multi-day lineup', () => {
-    const bands = [
-      makeBand({
-        id: '1',
-        name: 'Alpha',
-        date: '2024-06-01',
-        startTime: '21:00',
-        startMs: Date.parse('2024-06-01T21:00:00'),
-        endMs: Date.parse('2024-06-01T22:00:00'),
-      }),
-      makeBand({
-        id: '2',
-        name: 'Beta',
-        date: '2024-06-02',
-        startTime: '21:00',
-        startMs: Date.parse('2024-06-02T21:00:00'),
-        endMs: Date.parse('2024-06-02T22:00:00'),
-      }),
-    ]
-    renderView({ bands, currentTime: new Date('2024-05-31T12:00:00') })
-
-    const dividers = screen.getAllByRole('separator')
-    expect(dividers).toHaveLength(2)
-    expect(dividers[0]).toHaveTextContent('Day 1')
-    expect(dividers[0]).toHaveTextContent('Saturday, June 1')
-    expect(dividers[1]).toHaveTextContent('Day 2')
-    expect(dividers[1]).toHaveTextContent('Sunday, June 2')
-  })
-
-  it('renders a divider once per day even with multiple time slots on the same day', () => {
+  it('renders exactly one divider for the active day, labeled with its true day number, even with multiple time slots that day', () => {
+    // Deep-links straight to Day 2 (?day=2) so the divider's numbering can be
+    // checked without depending on the smart-default resolution tested below.
     const bands = [
       makeBand({
         id: '1',
@@ -338,23 +311,110 @@ describe('ScheduleView — #541: multi-day day dividers', () => {
       makeBand({
         id: '2',
         name: 'Beta',
-        date: '2024-06-01',
-        startTime: '21:30',
-        startMs: Date.parse('2024-06-01T21:30:00'),
-        endMs: Date.parse('2024-06-01T22:30:00'),
-      }),
-      makeBand({
-        id: '3',
-        name: 'Gamma',
         date: '2024-06-02',
         startTime: '20:00',
         startMs: Date.parse('2024-06-02T20:00:00'),
         endMs: Date.parse('2024-06-02T21:00:00'),
       }),
+      makeBand({
+        id: '3',
+        name: 'Gamma',
+        date: '2024-06-02',
+        startTime: '21:30',
+        startMs: Date.parse('2024-06-02T21:30:00'),
+        endMs: Date.parse('2024-06-02T22:30:00'),
+      }),
     ]
-    renderView({ bands, currentTime: new Date('2024-05-31T12:00:00') })
+    renderView({ bands, currentTime: new Date('2024-05-31T12:00:00') }, { route: '/?day=2' })
 
-    expect(screen.getAllByRole('separator')).toHaveLength(2)
+    const dividers = screen.getAllByRole('separator')
+    expect(dividers).toHaveLength(1)
+    expect(dividers[0]).toHaveTextContent('Day 2')
+    expect(dividers[0]).toHaveTextContent('Sunday, June 2')
+  })
+})
+
+describe('ScheduleView — #542 PR-3: day-tab filter', () => {
+  const twoDayBands = [
+    makeBand({
+      id: '1',
+      name: 'Alpha',
+      date: '2024-06-01',
+      startTime: '21:00',
+      startMs: Date.parse('2024-06-01T21:00:00'),
+      endMs: Date.parse('2024-06-01T22:00:00'),
+    }),
+    makeBand({
+      id: '2',
+      name: 'Beta',
+      date: '2024-06-02',
+      startTime: '21:00',
+      startMs: Date.parse('2024-06-02T21:00:00'),
+      endMs: Date.parse('2024-06-02T22:00:00'),
+    }),
+  ]
+
+  it('renders one tab per festival day and filters the list to the selected day', () => {
+    renderView({ bands: twoDayBands, currentTime: new Date('2024-05-31T12:00:00') })
+
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(2)
+
+    // No ?day= and the event hasn't started (currentTime is before Day 1) — defaults to Day 1.
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.queryByText('Beta')).not.toBeInTheDocument()
+  })
+
+  it('renders NO tabs for a single-day event (repo invariant: never a lone "Day 1" control)', () => {
+    const bands = [makeBand({ id: '1', name: 'Alpha' }), makeBand({ id: '2', name: 'Beta' })]
+    renderView({ bands })
+
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('tab')).toHaveLength(0)
+    // Both bands (same day) render unfiltered.
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+  })
+
+  it('?day=2 activates day 2 on load', () => {
+    renderView({ bands: twoDayBands, currentTime: new Date('2024-05-31T12:00:00') }, { route: '/?day=2' })
+
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+
+    const activeTab = screen.getAllByRole('tab').find(tab => tab.getAttribute('aria-selected') === 'true')
+    expect(activeTab).toHaveTextContent('Sun Jun 2')
+  })
+
+  it('an out-of-range ?day= falls back to the default day instead of blanking the view', () => {
+    renderView({ bands: twoDayBands, currentTime: new Date('2024-05-31T12:00:00') }, { route: '/?day=99' })
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.queryByText('Beta')).not.toBeInTheDocument()
+  })
+
+  it('switching tabs updates the rendered list', () => {
+    renderView({ bands: twoDayBands, currentTime: new Date('2024-05-31T12:00:00') })
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.queryByText('Beta')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Sun Jun 2' }))
+
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+  })
+
+  it('defaults to today’s festival day when the event is in progress', () => {
+    renderView({
+      bands: twoDayBands,
+      currentTime: new Date('2024-06-02T12:00:00'),
+      eventStartDate: '2024-06-01',
+      eventEndDate: '2024-06-02',
+    })
+
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/ui/DayTabs.jsx
+++ b/frontend/src/components/ui/DayTabs.jsx
@@ -1,0 +1,85 @@
+import { memo, useCallback, useRef } from 'react'
+import PropTypes from 'prop-types'
+import { formatFestivalDate } from '../../utils/festivalDays'
+
+/**
+ * Segmented day-tab filter for multi-day events (#542 PR-3). Selecting a tab
+ * is the single source of truth for which day's performances render — a
+ * FILTER, not a scroll-anchor (locked product decision) — wired to the
+ * shared `?day=N` URL param by `useFestivalDayFilter`.
+ *
+ * A proper tablist: `role="tablist"`/`"tab"`, `aria-selected`, roving
+ * tabindex, and Left/Right/Home/End arrow-key navigation with visible focus.
+ * Public / theme-following surface — semantic tokens only, no hardcoded
+ * white. Each tab is a ≥44px tap target.
+ *
+ * Callers must gate rendering on `days.length > 1` themselves (never render
+ * for a single-day event — repo invariant, no lone "Day 1" control).
+ */
+const DayTabs = memo(function DayTabs({ days, activeDayNumber, onSelectDay, className = '' }) {
+  const tabRefs = useRef([])
+
+  const handleKeyDown = useCallback(
+    (event, index) => {
+      let nextIndex
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        nextIndex = (index + 1) % days.length
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        nextIndex = (index - 1 + days.length) % days.length
+      } else if (event.key === 'Home') {
+        nextIndex = 0
+      } else if (event.key === 'End') {
+        nextIndex = days.length - 1
+      } else {
+        return
+      }
+      event.preventDefault()
+      onSelectDay(nextIndex + 1)
+      tabRefs.current[nextIndex]?.focus()
+    },
+    [days.length, onSelectDay]
+  )
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Festival day"
+      className={`inline-flex items-center gap-1 overflow-x-auto rounded-full border border-border bg-surface p-1 ${className}`.trim()}
+    >
+      {days.map((date, index) => {
+        const dayNumber = index + 1
+        const isActive = dayNumber === activeDayNumber
+        return (
+          <button
+            key={date}
+            ref={el => {
+              tabRefs.current[index] = el
+            }}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => onSelectDay(dayNumber)}
+            onKeyDown={event => handleKeyDown(event, index)}
+            className={`min-h-[44px] min-w-[44px] whitespace-nowrap rounded-full px-4 py-1.5 text-sm font-semibold transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 ${
+              isActive
+                ? 'bg-accent-500 text-bg-navy'
+                : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary'
+            }`}
+          >
+            {formatFestivalDate(date, 'short')}
+          </button>
+        )
+      })}
+    </div>
+  )
+})
+
+DayTabs.propTypes = {
+  days: PropTypes.arrayOf(PropTypes.string).isRequired,
+  activeDayNumber: PropTypes.number,
+  onSelectDay: PropTypes.func.isRequired,
+  className: PropTypes.string,
+}
+
+export default DayTabs

--- a/frontend/src/components/ui/index.js
+++ b/frontend/src/components/ui/index.js
@@ -17,6 +17,7 @@ export { default as Loading } from './Loading'
 export { default as Tooltip } from './Tooltip'
 export { default as ConfirmDialog } from './ConfirmDialog'
 export { default as DayDivider } from './DayDivider'
+export { default as DayTabs } from './DayTabs'
 export {
   BandCardSkeleton,
   BandCardSkeletonGrid,

--- a/frontend/src/hooks/useFestivalDayFilter.js
+++ b/frontend/src/hooks/useFestivalDayFilter.js
@@ -1,0 +1,65 @@
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { resolveActiveFestivalDay } from '../utils/festivalDays'
+
+/**
+ * Sticky day-tab filter state for multi-day events (#542 PR-3): resolves
+ * which festival day is active — `?day=N` URL param (1-indexed) > today's
+ * festival day if the event is in progress > day 1, via
+ * `resolveActiveFestivalDay` — and exposes a setter that updates the URL via
+ * history *replace* (shareable at any time, but a run of tab clicks doesn't
+ * spam the back-button stack with one stop per click).
+ *
+ * `days` must be the FULL ordered list of the event's festival days (e.g.
+ * `orderedFestivalDays(fullEventBands)`) — not a possibly-partial subset.
+ * `ScheduleView` and `MySchedule` both call this hook so a shared `?day=N`
+ * keeps them showing the same day when the fan toggles between "Full
+ * Lineup" and "My Route"; if `days` diverged between the two calls (e.g.
+ * MySchedule deriving it from only the fan's *selected* bands) the same URL
+ * would resolve to a different day number in each — hence
+ * MySchedule accepts an authoritative `festivalDays` prop from the parent
+ * instead of re-deriving it from its own possibly-partial `bands`.
+ *
+ * Single-day events (`days.length <= 1`) resolve to `isMultiDay: false` and
+ * `activeDate: null` — callers must gate all day-tab UI and filtering on
+ * `isMultiDay` and never render for a single day (repo invariant: no lone
+ * "Day 1" label/selector).
+ */
+export function useFestivalDayFilter(days, { currentTime, startDate = null, endDate = null } = {}) {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const isMultiDay = days.length > 1
+  const dayParam = searchParams.get('day')
+
+  // Toronto-local "today" per CLAUDE.md convention — derived from the same
+  // `currentTime`/`effectiveNow` prop the caller already uses for every
+  // other "now" calculation (Now Playing, countdowns, debug-time override),
+  // so the smart default reacts to the same clock QA already drives via
+  // `?debugTime=`.
+  const todayStr = useMemo(() => {
+    const date = currentTime instanceof Date ? currentTime : new Date(currentTime)
+    return Number.isNaN(date.getTime()) ? '' : date.toLocaleDateString('en-CA')
+  }, [currentTime])
+
+  const activeDayNumber = useMemo(() => {
+    if (!isMultiDay) return null
+    return resolveActiveFestivalDay({ days, dayParam, todayStr, startDate, endDate })
+  }, [isMultiDay, days, dayParam, todayStr, startDate, endDate])
+
+  const activeDate = isMultiDay && activeDayNumber ? days[activeDayNumber - 1] : null
+
+  const setActiveDayNumber = useCallback(
+    nextDayNumber => {
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          next.set('day', String(nextDayNumber))
+          return next
+        },
+        { replace: true }
+      )
+    },
+    [setSearchParams]
+  )
+
+  return { isMultiDay, activeDayNumber, activeDate, setActiveDayNumber }
+}

--- a/frontend/src/test/MySchedule.test.jsx
+++ b/frontend/src/test/MySchedule.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import '@testing-library/jest-dom'
 import MySchedule from '../components/MySchedule'
@@ -29,6 +29,13 @@ const defaultProps = {
   onToggleShowPast: vi.fn(),
   nowOverride: null,
 }
+
+const renderSchedule = (props, { route = '/' } = {}) =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <MySchedule {...defaultProps} {...props} />
+    </MemoryRouter>
+  )
 
 describe('MySchedule — conflict vs overlap severity', () => {
   it('shows red warning for two bands at the exact same start time', () => {
@@ -155,62 +162,113 @@ describe('MySchedule — conflict vs overlap severity', () => {
   })
 })
 
-describe('MySchedule — #541: multi-day day dividers', () => {
+describe('MySchedule — #541: day dividers', () => {
   it('renders no day dividers for a single-day schedule', () => {
     const bands = [
       makeBand(1, 'Band Alpha', 'Stage A', '20:00', '20:30'),
       makeBand(2, 'Band Beta', 'Stage B', '21:00', '21:30'),
     ]
-    render(
-      <MemoryRouter>
-        <MySchedule {...defaultProps} bands={bands} />
-      </MemoryRouter>
-    )
+    renderSchedule({ bands })
 
     expect(screen.queryByRole('separator')).not.toBeInTheDocument()
   })
 
-  it('inserts a day-divider before Day 1 and again before the first Day 2 band, none for the second Day 1 band', () => {
-    const bands = [
-      makeBand(1, 'Band Alpha', 'Stage A', '20:00', '20:30', '2026-05-17'),
-      makeBand(2, 'Band Beta', 'Stage B', '21:00', '21:30', '2026-05-17'),
-      makeBand(3, 'Band Gamma', 'Stage A', '20:00', '20:30', '2026-05-18'),
-    ]
-    const { container } = render(
-      <MemoryRouter>
-        <MySchedule {...defaultProps} bands={bands} />
-      </MemoryRouter>
-    )
-
-    // One divider before the very first band (Day 1) and one before the first
-    // Day 2 band (Gamma); Band Beta (2nd Day 1 band) gets none since its date
-    // matches the previous rendered band's date.
-    const dividers = screen.getAllByRole('separator')
-    expect(dividers).toHaveLength(2)
-    expect(dividers[0]).toHaveTextContent('Day 1')
-    expect(dividers[1]).toHaveTextContent('Day 2')
-
-    // The Day 2 divider must appear before Band Gamma (the first Day 2 band) in DOM order.
-    const text = container.textContent
-    expect(text.indexOf('Day 2')).toBeLessThan(text.indexOf('Band Gamma'))
-  })
-
-  it('inserts a divider for each subsequent day change across a 3-day schedule', () => {
+  it('renders exactly one divider for the active day, labeled with its true day number, across a 3-day route', () => {
     const bands = [
       makeBand(1, 'Band Alpha', 'Stage A', '20:00', '20:30', '2026-05-17'),
       makeBand(2, 'Band Beta', 'Stage A', '20:00', '20:30', '2026-05-18'),
       makeBand(3, 'Band Gamma', 'Stage A', '20:00', '20:30', '2026-05-19'),
     ]
-    render(
-      <MemoryRouter>
-        <MySchedule {...defaultProps} bands={bands} />
-      </MemoryRouter>
-    )
+    // Deep-links to Day 3 (?day=3) so the divider's numbering can be checked
+    // independent of the smart-default resolution (covered separately below).
+    renderSchedule({ bands }, { route: '/?day=3' })
 
     const dividers = screen.getAllByRole('separator')
-    expect(dividers).toHaveLength(3)
-    expect(dividers[0]).toHaveTextContent('Day 1')
-    expect(dividers[1]).toHaveTextContent('Day 2')
-    expect(dividers[2]).toHaveTextContent('Day 3')
+    expect(dividers).toHaveLength(1)
+    expect(dividers[0]).toHaveTextContent('Day 3')
+    expect(screen.getByText('Band Gamma')).toBeInTheDocument()
+    expect(screen.queryByText('Band Alpha')).not.toBeInTheDocument()
+    expect(screen.queryByText('Band Beta')).not.toBeInTheDocument()
+  })
+})
+
+describe('MySchedule — #542 PR-3: day-tab filter', () => {
+  const twoDayBands = [
+    makeBand(1, 'Band Alpha', 'Stage A', '20:00', '20:30', '2026-05-17'),
+    makeBand(2, 'Band Beta', 'Stage A', '20:00', '20:30', '2026-05-18'),
+  ]
+
+  it('renders one tab per festival day and filters the route to the selected day (default Day 1)', () => {
+    renderSchedule({ bands: twoDayBands })
+
+    expect(screen.getAllByRole('tab')).toHaveLength(2)
+    expect(screen.getByText('Band Alpha')).toBeInTheDocument()
+    expect(screen.queryByText('Band Beta')).not.toBeInTheDocument()
+  })
+
+  it('renders NO tabs for a single-day route (repo invariant)', () => {
+    const bands = [
+      makeBand(1, 'Band Alpha', 'Stage A', '20:00', '20:30'),
+      makeBand(2, 'Band Beta', 'Stage B', '21:00', '21:30'),
+    ]
+    renderSchedule({ bands })
+
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+    expect(screen.getByText('Band Alpha')).toBeInTheDocument()
+    expect(screen.getByText('Band Beta')).toBeInTheDocument()
+  })
+
+  it('?day=2 activates day 2 on load', () => {
+    renderSchedule({ bands: twoDayBands }, { route: '/?day=2' })
+
+    expect(screen.queryByText('Band Alpha')).not.toBeInTheDocument()
+    expect(screen.getByText('Band Beta')).toBeInTheDocument()
+  })
+
+  it('switching tabs updates the rendered route', () => {
+    renderSchedule({ bands: twoDayBands })
+
+    expect(screen.getByText('Band Alpha')).toBeInTheDocument()
+    expect(screen.queryByText('Band Beta')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByRole('tab')[1])
+
+    expect(screen.queryByText('Band Alpha')).not.toBeInTheDocument()
+    expect(screen.getByText('Band Beta')).toBeInTheDocument()
+  })
+
+  it('defaults to today’s festival day when the event is in progress', () => {
+    renderSchedule({
+      bands: twoDayBands,
+      nowOverride: '2026-05-18T12:00:00',
+      eventStartDate: '2026-05-17',
+      eventEndDate: '2026-05-18',
+    })
+
+    expect(screen.queryByText('Band Alpha')).not.toBeInTheDocument()
+    expect(screen.getByText('Band Beta')).toBeInTheDocument()
+  })
+
+  it('shows a Day-2 tab and correctly labels a Day-2-only selection when the full event days are supplied', () => {
+    // The fan has only picked Day 2 bands so far. Without the authoritative
+    // `festivalDays` prop, deriving days from `bands` alone would see just
+    // one date and mislabel it "Day 1" — this is the exact bug the prop
+    // fixes (see MySchedule.jsx's `festivalDays` prop comment).
+    const day2OnlyBands = [makeBand(1, 'Band Gamma', 'Stage A', '20:00', '20:30', '2026-05-18')]
+
+    renderSchedule({
+      bands: day2OnlyBands,
+      festivalDays: ['2026-05-17', '2026-05-18'],
+    })
+
+    expect(screen.getAllByRole('tab')).toHaveLength(2)
+    // ?day= isn't set and the route isn't "in progress" (no nowOverride
+    // matching), so it defaults to Day 1 — which has zero of the fan's picks.
+    expect(screen.getByText(/No bands in your route for/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByRole('tab')[1])
+
+    expect(screen.getByText('Band Gamma')).toBeInTheDocument()
+    expect(screen.getByRole('separator')).toHaveTextContent('Day 2')
   })
 })

--- a/frontend/src/utils/__tests__/festivalDays.test.js
+++ b/frontend/src/utils/__tests__/festivalDays.test.js
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { dayNumberByDate, formatFestivalDate, isMultiDay, orderedFestivalDays } from '../festivalDays'
+import {
+  dayNumberByDate,
+  dayNumberMapFromDays,
+  formatFestivalDate,
+  isMultiDay,
+  orderedFestivalDays,
+  resolveActiveFestivalDay,
+} from '../festivalDays'
 
 describe('formatFestivalDate', () => {
   it('formats the short style as "Sun Aug 2" (no comma)', () => {
@@ -81,6 +88,114 @@ describe('dayNumberByDate', () => {
     const map = dayNumberByDate(items)
     expect(map.size).toBe(1)
     expect(map.get('2026-08-02')).toBe(1)
+  })
+})
+
+describe('dayNumberMapFromDays', () => {
+  it('assigns 1..N in the given order, trusting the caller-supplied list', () => {
+    const map = dayNumberMapFromDays(['2026-08-02', '2026-08-03', '2026-08-04'])
+    expect(map.get('2026-08-02')).toBe(1)
+    expect(map.get('2026-08-03')).toBe(2)
+    expect(map.get('2026-08-04')).toBe(3)
+  })
+
+  it('numbers a date correctly even when it is the only one present in a caller-supplied subset day list', () => {
+    // Simulates MySchedule deriving from a fan's Day-2-only selection while
+    // still being told the full event's days start on 2026-08-02 (#542 PR-3).
+    const map = dayNumberMapFromDays(['2026-08-02', '2026-08-03'])
+    expect(map.get('2026-08-03')).toBe(2)
+  })
+
+  it('returns an empty map for an empty list', () => {
+    expect(dayNumberMapFromDays([]).size).toBe(0)
+  })
+})
+
+describe('resolveActiveFestivalDay', () => {
+  const days = ['2026-08-07', '2026-08-08', '2026-08-09']
+
+  it('returns null when there are no festival days', () => {
+    expect(resolveActiveFestivalDay({ days: [], dayParam: '1', todayStr: '2026-08-07' })).toBeNull()
+  })
+
+  it('honors a valid ?day=N param over the smart default', () => {
+    expect(resolveActiveFestivalDay({ days, dayParam: '3', todayStr: '2026-08-07' })).toBe(3)
+  })
+
+  it('falls back to the smart default for a non-numeric dayParam', () => {
+    expect(resolveActiveFestivalDay({ days, dayParam: 'abc', todayStr: '2026-08-09' })).toBe(3)
+  })
+
+  it('falls back to the smart default for a dayParam of 0', () => {
+    expect(resolveActiveFestivalDay({ days, dayParam: '0', todayStr: '2026-08-07' })).toBe(1)
+  })
+
+  it('falls back to the smart default for a dayParam beyond the day count', () => {
+    expect(resolveActiveFestivalDay({ days, dayParam: '99', todayStr: '2026-08-07' })).toBe(1)
+  })
+
+  it('falls back to the smart default for a dayParam with trailing garbage', () => {
+    expect(resolveActiveFestivalDay({ days, dayParam: '2abc', todayStr: '2026-08-07' })).toBe(1)
+  })
+
+  it('falls back to the smart default when dayParam is missing', () => {
+    expect(resolveActiveFestivalDay({ days, dayParam: null, todayStr: '2026-08-07' })).toBe(1)
+  })
+
+  it('defaults to today’s festival day when in progress (within [startDate, endDate])', () => {
+    expect(
+      resolveActiveFestivalDay({
+        days,
+        dayParam: null,
+        todayStr: '2026-08-08',
+        startDate: '2026-08-07',
+        endDate: '2026-08-09',
+      })
+    ).toBe(2)
+  })
+
+  it('defaults to day 1 when today is before the event start, even if bounds are given', () => {
+    expect(
+      resolveActiveFestivalDay({
+        days,
+        dayParam: null,
+        todayStr: '2026-08-01',
+        startDate: '2026-08-07',
+        endDate: '2026-08-09',
+      })
+    ).toBe(1)
+  })
+
+  it('defaults to day 1 when today is after the event ends', () => {
+    expect(
+      resolveActiveFestivalDay({
+        days,
+        dayParam: null,
+        todayStr: '2026-08-15',
+        startDate: '2026-08-07',
+        endDate: '2026-08-09',
+      })
+    ).toBe(1)
+  })
+
+  it('defaults to day 1 when today is in progress but is not itself a festival day (dark day)', () => {
+    expect(
+      resolveActiveFestivalDay({
+        days: ['2026-08-07', '2026-08-09'],
+        dayParam: null,
+        todayStr: '2026-08-08',
+        startDate: '2026-08-07',
+        endDate: '2026-08-09',
+      })
+    ).toBe(1)
+  })
+
+  it('without startDate/endDate, approximates "in progress" as direct membership in days', () => {
+    expect(resolveActiveFestivalDay({ days, dayParam: null, todayStr: '2026-08-09' })).toBe(3)
+  })
+
+  it('without startDate/endDate, defaults to day 1 when today matches no festival day', () => {
+    expect(resolveActiveFestivalDay({ days, dayParam: null, todayStr: '2026-05-01' })).toBe(1)
   })
 })
 

--- a/frontend/src/utils/festivalDays.js
+++ b/frontend/src/utils/festivalDays.js
@@ -86,14 +86,65 @@ export const orderedFestivalDays = items => {
 }
 
 /**
+ * Maps each entry in an already-ordered `days` array (e.g. the output of
+ * `orderedFestivalDays`) to its 1-based day number. Split out from
+ * `dayNumberByDate` so a caller holding the *authoritative* full-event day
+ * list doesn't have to round-trip back through a possibly-partial `items`
+ * array to get the same numbering (see MySchedule's `festivalDays` prop,
+ * #542 PR-3 — a fan's selected-bands subset can span fewer days than the
+ * event itself, e.g. Day-2-only selections, which would otherwise mislabel
+ * Day 2 as "Day 1").
+ */
+export const dayNumberMapFromDays = days => new Map(days.map((date, index) => [date, index + 1]))
+
+/**
  * Maps each distinct festival date to its 1-based day number (earliest = Day 1).
  */
-export const dayNumberByDate = items => {
-  const days = orderedFestivalDays(items)
-  return new Map(days.map((date, index) => [date, index + 1]))
-}
+export const dayNumberByDate = items => dayNumberMapFromDays(orderedFestivalDays(items))
 
 /**
  * True when `items` span more than one distinct festival day.
  */
 export const isMultiDay = items => orderedFestivalDays(items).length > 1
+
+/**
+ * Resolves which 1-based festival day should be active for the day-tab
+ * filter (#542 PR-3). Day tabs are a hard FILTER — exactly one day's
+ * performances render at a time, there is no "all days" tab — so this is
+ * the single source of truth both `ScheduleView` and `MySchedule` call
+ * through `useFestivalDayFilter` to agree on the same day.
+ *
+ * Precedence:
+ *  1. `dayParam` (the `?day=N` URL value, 1-indexed) when it parses as a
+ *     plain positive integer within `[1, days.length]`. Anything else
+ *     (missing, non-numeric, out-of-range, a stale link after the lineup
+ *     shrank) falls through to the default — an invalid `?day=` must never
+ *     blank the view.
+ *  2. Smart default: if `todayStr` (YYYY-MM-DD, Toronto-local per CLAUDE.md)
+ *     falls within `[startDate, endDate]` (the event's official run) AND
+ *     matches one of the festival `days` exactly, default to that day.
+ *     `startDate`/`endDate` are optional — surfaces without the event
+ *     record (e.g. the embed view) omit them and "in progress" degrades to
+ *     direct membership in `days`.
+ *  3. Otherwise day 1.
+ *
+ * Pure and synchronous — unit-testable without mounting a component or a
+ * Router.
+ */
+export function resolveActiveFestivalDay({ days, dayParam, todayStr, startDate = null, endDate = null }) {
+  if (!days || days.length === 0) return null
+
+  const trimmed = typeof dayParam === 'string' ? dayParam.trim() : ''
+  if (/^\d+$/.test(trimmed)) {
+    const parsed = Number(trimmed)
+    if (parsed >= 1 && parsed <= days.length) return parsed
+  }
+
+  const inProgress = startDate && endDate ? todayStr >= startDate && todayStr <= endDate : days.includes(todayStr)
+  if (inProgress) {
+    const idx = days.indexOf(todayStr)
+    if (idx >= 0) return idx + 1
+  }
+
+  return 1
+}


### PR DESCRIPTION
## Summary

Multi-day events get a day-tab segmented control on both the full schedule (`ScheduleView`) and the fan's personal schedule (`MySchedule`). Selecting a day **filters** the list to that day's sets (Dre's confirmed choice over scroll-anchor), and `?day=N` deep-links straight to a day's lineup — shareable, back-button-sane. Directly serves **Buddies Fest 2** (Aug 7–9), the upcoming multi-day event.

Closes #542 (final sibling PR — PR-1 staleness #604, PR-2 day-aware ICS, PR-4 subEvent JSON-LD #634)

## What changed

| File | Change |
|------|--------|
| `frontend/src/utils/festivalDays.js` | `resolveActiveFestivalDay()` — precedence `?day=N` → today's festival day if in-progress → day 1, using the existing 6 AM after-midnight convention (untouched) |
| `frontend/src/hooks/useFestivalDayFilter.js` (new) | Wraps `useSearchParams` + the resolver; syncs the active day to the URL |
| `frontend/src/components/ui/DayTabs.jsx` (new) | Shared tablist: roving tabindex, arrow/Home/End keys, `aria-selected`, ≥44px targets, theme tokens only |
| `frontend/src/components/{ScheduleView,MySchedule}.jsx` | Pre-filter bands to the active day before their existing pipelines (venue/genre/time filters, conflict detection, Copy all operate on the active day); render `DayTabs` only when `festivalDays.length > 1` |
| `frontend/src/App.jsx` | Threads an authoritative `festivalDays` (from the full lineup) into MySchedule so a Day-2-only selection isn't mislabelled "Day 1" |

**Deliberate scope calls** (flagged, not oversights): Share Schedule + Lock-In Lineup read the **unfiltered** band list so a shared route covers the whole festival regardless of active tab; the existing `DayDivider` (carries #569 doors time) is kept alongside the tabs; single-day events render **no tabs** (never-show-"Day 1" rule, byte-unchanged).

## Security / correctness notes

None — client-side view filtering + a URL param. Schedule storage logic untouched; the filter is layered on top.

## Verification

- [x] Tests: frontend 561 pass (53 files), incl. new coverage across festivalDays / ScheduleView / MySchedule
- [x] ESLint: 0 errors · Format check: clean · Build: green
- [x] Single-day regression: no tabs rendered (gated on `festivalDays.length > 1` at both call sites — verified)
- [x] `validate:openapi`: n/a — frontend only
- [ ] Manual smoke: recommend a click-through on Buddies Fest 2 post-deploy (tab filter, `?day=2` deep-link, keyboard nav)

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)