### PR TITLE
chore: export toSqliteDateTime() for direct unit testing

### DIFF
--- a/functions/utils/__tests__/authAttempts.test.js
+++ b/functions/utils/__tests__/authAttempts.test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { createDBEnv, createTestDB } from "../../api/test-utils.js";
-import { AUTH_ATTEMPT_TYPES, checkAuthRateLimit, writeAuthAttempt } from "../authAttempts.js";
+import { AUTH_ATTEMPT_TYPES, checkAuthRateLimit, toSqliteDateTime, writeAuthAttempt } from "../authAttempts.js";
 
 describe("authAttempts", () => {
   let rawDb;
@@ -159,5 +159,20 @@ describe("authAttempts", () => {
     });
 
     expect(rateCheck.allowed).toBe(true);
+  });
+});
+
+describe("toSqliteDateTime", () => {
+  it("formats a Date as SQLite's space-separated YYYY-MM-DD HH:MM:SS", () => {
+    const result = toSqliteDateTime(new Date("2026-07-23T14:30:05.123Z"));
+
+    expect(result).toBe("2026-07-23 14:30:05");
+  });
+
+  it("never produces the ISO 8601 T-separator or Z suffix that breaks D1 string comparisons", () => {
+    const result = toSqliteDateTime(new Date("2026-07-23T14:30:05.123Z"));
+
+    expect(result).not.toContain("T");
+    expect(result).not.toContain("Z");
   });
 });

--- a/functions/utils/__tests__/invariants.test.js
+++ b/functions/utils/__tests__/invariants.test.js
@@ -5,13 +5,12 @@
 import { describe, expect, it } from "vitest";
 import { checkAuthRateLimit } from "../authAttempts.js";
 
-// toSqliteDateTime() is NOT exported from authAttempts.js — it's a private
-// helper only reachable through checkAuthRateLimit's `windowStart` binding.
-// Rather than exporting it solely for this test (a production-code change
-// outside this task's scope) or reimplementing its logic in the test (which
-// would test the copy, not the real code), this stub captures the exact
-// value the real, unexported toSqliteDateTime() produces when
-// checkAuthRateLimit binds it into the rate-limit query.
+// toSqliteDateTime() is exported from authAttempts.js and has its own direct
+// unit tests in authAttempts.test.js (format + no-T/Z assertions). This stub
+// exists for a different purpose: it captures the exact value the real
+// toSqliteDateTime() produces when checkAuthRateLimit binds it into the
+// rate-limit query, proving the *binding path* itself is wired correctly —
+// not just that the helper's output format is right in isolation.
 function createCapturingDB(queryResult = { count: 0, earliest_attempt: null }) {
   let boundArgs = null;
   const DB = {

--- a/functions/utils/authAttempts.js
+++ b/functions/utils/authAttempts.js
@@ -52,7 +52,7 @@ function getRateLimitQuery(scope) {
   throw new Error(`Unsupported auth rate-limit scope: ${scope}`);
 }
 
-function toSqliteDateTime(date) {
+export function toSqliteDateTime(date) {
   return date.toISOString().replace("T", " ").slice(0, 19);
 }
 


### PR DESCRIPTION
## Summary

`toSqliteDateTime()` in `functions/utils/authAttempts.js` is CLAUDE.md's documented canonical normalizer for the SEC-F1 datetime bug class (D1's `datetime('now')` is space-separated; JS `toISOString()` is T-separated — comparing the two silently fails). It was previously private, only reachable indirectly through `checkAuthRateLimit`'s `windowStart` binding. This exports it and adds a direct unit test.

Closes #637

## What changed

| File | Change |
|------|--------|
| `functions/utils/authAttempts.js` | `function toSqliteDateTime` → `export function toSqliteDateTime` (behavior unchanged) |
| `functions/utils/__tests__/authAttempts.test.js` | New direct tests: format assertion + negative case (no `T`/`Z` in output) |
| `functions/utils/__tests__/invariants.test.js` | Corrected a comment that claimed the helper was "NOT exported" — no longer true after this change (caught in review) |

## Security / correctness notes

None. Pure export of an existing private helper; no behavior change. The new tests are additive regression guards for a previously-fixed production bug class (SEC-F1).

## Verification

- [x] Tests: 805 pass, 0 failures (`npm test`)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: N/A (backend-only change, no frontend touched)
- [x] `validate:openapi`: N/A (no `docs/api-spec.yaml` change)
- [x] Manual smoke: N/A (no user-facing behavior; verified via unit tests directly)

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date and time formatting for database comparisons by using SQLite-compatible values without ISO separators or timezone suffixes.

* **Tests**
  * Added coverage to verify consistent date formatting and correct rate-limit query parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->