### PR TITLE
fix(seo): gate event JSON-LD venues query on reveal_mode

### DIFF
--- a/functions/event/[slug].js
+++ b/functions/event/[slug].js
@@ -125,12 +125,13 @@ export async function onRequest(context) {
   // start_time; the flat `bands` performer list is deduped from these rows
   // in JS instead.
   //
-  // Reveal-mode gate (#542 PR-4, folded pre-existing bug): mirrors the
-  // `(e.reveal_mode = 0 OR p.is_announced = 1)` filter already applied in
-  // schedule.js/ical.js/timeline.js. Without it, an unannounced band on a
-  // reveal-mode event would leak into crawler-facing JSON-LD before the
-  // admin ever announces it. No reveal-mode event exists in prod today, so
-  // this was latent, not active.
+  // Reveal-mode gate (#542 PR-4, folded pre-existing bug; extended to venues
+  // in #635): mirrors the `(e.reveal_mode = 0 OR p.is_announced = 1)` filter
+  // already applied in schedule.js/ical.js/timeline.js. Both queries below
+  // apply it independently — a venue whose ONLY performance is unannounced
+  // must not leak into crawler-facing JSON-LD `location` any more than an
+  // unannounced band leaks into `performer`. No reveal-mode event exists in
+  // prod today, so this was latent, not active.
   let performanceRows = [];
   let venues = [];
   try {
@@ -150,9 +151,10 @@ export async function onRequest(context) {
          FROM performances p
          JOIN venues v ON p.venue_id = v.id
          WHERE p.event_id = ?
+           AND (? = 0 OR p.is_announced = 1)
          ORDER BY v.name`,
       )
-        .bind(event.id)
+        .bind(event.id, event.reveal_mode ?? 0)
         .all(),
     ]);
     performanceRows = performancesResult.results ?? [];

--- a/functions/event/__tests__/slug.test.js
+++ b/functions/event/__tests__/slug.test.js
@@ -419,3 +419,38 @@ describe("SSR /event/[slug] — per-day subEvent JSON-LD (#542 PR-4)", () => {
     expect(winterMusicEvent.startDate).toBe("2026-02-14T18:45:00-05:00");
   });
 });
+
+describe("SSR /event/[slug] — MusicEvent JSON-LD venue reveal_mode gate (#635)", () => {
+  test("reveal-mode event: a venue whose ONLY performance is unannounced is absent from JSON-LD location", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Reveal Mode Venue Fest",
+      slug: "slug-635-reveal-venue",
+      date: "2026-08-01",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+
+    const visibleVenue = insertVenue(rawDb, { name: "Visible Venue" });
+    const hiddenVenue = insertVenue(rawDb, { name: "Hidden Venue" });
+
+    const announced = insertBand(rawDb, { name: "Announced Band", event_id: event.id, venue_id: visibleVenue.id });
+    rawDb.prepare("UPDATE performances SET is_announced=1 WHERE id=?").run(announced.id);
+
+    // Hidden Venue's ONLY performance is unannounced — the venue itself must
+    // not leak into JSON-LD location, mirroring the bands-query gate (#634).
+    const hidden = insertBand(rawDb, { name: "Hidden Band", event_id: event.id, venue_id: hiddenVenue.id });
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(hidden.id);
+
+    const response = await onRequest(makeContext({ env, slug: "slug-635-reveal-venue" }));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    const [musicEvent] = extractJsonLd(html);
+
+    expect(Array.isArray(musicEvent.location)).toBe(true);
+    const venueNames = musicEvent.location.map((v) => v.name);
+    expect(venueNames).toContain("Visible Venue");
+    expect(venueNames).not.toContain("Hidden Venue");
+    expect(html).not.toContain("Hidden Venue");
+  });
+});


### PR DESCRIPTION
## Summary

`functions/event/[slug].js` builds SSR JSON-LD (MusicEvent structured data) for event pages from two parallel D1 queries. The bands query was gated on `reveal_mode`/`is_announced` in #634; the venues query was not — so on a reveal-mode event, a venue whose *only* performance was unannounced would still appear in the MusicEvent `location` array, leaking part of an unannounced lineup to crawlers. Latent only: no reveal-mode event exists in prod today.

Closes #635

## What changed

| File | Change |
|------|--------|
| `functions/event/[slug].js` | Added `AND (? = 0 OR p.is_announced = 1)` + `.bind(event.id, event.reveal_mode ?? 0)` to the venues query, mirroring the bands query's existing gate. Updated the explanatory comment to reflect both queries are now gated. |
| `functions/event/__tests__/slug.test.js` | New regression test: reveal-mode event with two venues (one visible, one whose only performance is unannounced) asserts the hidden venue is absent from JSON-LD `location`. |

## Security / correctness notes

Closes a latent info-disclosure gap in crawler-facing structured data (unannounced lineup leaking before an admin publishes it). No effect on non-reveal-mode events — `(reveal_mode = 0 OR ...)` is a no-op when `reveal_mode` is 0, confirmed by the unchanged golden JSON-LD snapshot.

## Verification

- [x] Tests: 804 pass, 0 failures (`npm test`); regression test independently confirmed to fail pre-fix (`expected [...] to not include 'Hidden Venue'`) and pass post-fix
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: N/A (backend-only change, no frontend touched)
- [x] `validate:openapi`: N/A (no `docs/api-spec.yaml` change)
- [x] Manual smoke: N/A (no reveal-mode event exists in prod; verified via SSR route's unit/golden-snapshot tests)

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event structured data so venues linked only to unannounced performances are excluded when reveal mode is active.
  * Prevented hidden venue names from appearing in crawler-facing event information.

* **Tests**
  * Added coverage confirming visible venues remain included while hidden venues are excluded from event metadata and rendered pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->