### PR TITLE
security: bump brace-expansion to 5.0.7, resolve tar/body-parser audit findings

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260714.1.tgz",
-      "integrity": "sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260721.1.tgz",
+      "integrity": "sha512-VivNMhiEdZIB4JBWxf1RMJGROErv53qmQ+dvhjA1evrCouvqRYW718VqDideU3PSV7Ythl5Df48NqZYWoaEHpQ==",
       "cpu": [
         "x64"
       ],
@@ -458,9 +458,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260714.1.tgz",
-      "integrity": "sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260721.1.tgz",
+      "integrity": "sha512-k7oye1ZiuwnnBBA2eTMduconr/ud5ZxFtRNTsYwMdmJeeeislw2+M72otrHxxvybCP7JWPPlJ38uhfajpcyhOA==",
       "cpu": [
         "arm64"
       ],
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260714.1.tgz",
-      "integrity": "sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260721.1.tgz",
+      "integrity": "sha512-hon0lW4ZQ4boAVgaw+0ZFTNS8v5MWPWvK0HZnt4tDpKYnDUviLZawtUW3KqvFmCQTipVHl1S34j3J8Eqb93hGQ==",
       "cpu": [
         "x64"
       ],
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260714.1.tgz",
-      "integrity": "sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260721.1.tgz",
+      "integrity": "sha512-nAl+HRQqpX5b7xVwWcvLPZmCk8NQ2yjI0yvJTWcHiRswbMEg1ZZckVmjJUAn0PHzZARbCSyIV7v3UjM+SPRmIQ==",
       "cpu": [
         "arm64"
       ],
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260714.1.tgz",
-      "integrity": "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260721.1.tgz",
+      "integrity": "sha512-9paFG5cMTKz/CRixnEEnZbe5uvFPBFSDthxJHANfCWhUtBj49GSL1FPIokIg+Q+H8DGJEExU0lL92LtxD0lTxQ==",
       "cpu": [
         "x64"
       ],
@@ -4508,9 +4508,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4550,9 +4550,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9231,16 +9231,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260714.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260714.0.tgz",
-      "integrity": "sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw==",
+      "version": "4.20260721.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260721.0.tgz",
+      "integrity": "sha512-fBLaCxZ2i/nPH8iyLzvza0C8/sSF4sjD1ma1Skf+pkZVK0TlaW5ujHJlUHwcwR66v2JZt+Q28d4DCX/oaLG0cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
         "undici": "7.28.0",
-        "workerd": "1.20260714.1",
+        "workerd": "1.20260721.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -11557,9 +11557,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -12547,9 +12547,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260714.1.tgz",
-      "integrity": "sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260721.1.tgz",
+      "integrity": "sha512-b/DWhpV0jTudzQpLhDovcOgBz233386q+3Hbari7CLCNT9UXxjQziSTZ9yCoKdT2K3TSx5jrwlOisq8hlLWXYg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -12560,17 +12560,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260714.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260714.1",
-        "@cloudflare/workerd-linux-64": "1.20260714.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260714.1",
-        "@cloudflare/workerd-windows-64": "1.20260714.1"
+        "@cloudflare/workerd-darwin-64": "1.20260721.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260721.1",
+        "@cloudflare/workerd-linux-64": "1.20260721.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260721.1",
+        "@cloudflare/workerd-windows-64": "1.20260721.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.112.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.112.0.tgz",
-      "integrity": "sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ==",
+      "version": "4.113.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.113.0.tgz",
+      "integrity": "sha512-ROGzSloJv0y21It6Oc9LaruNcu1tdiQ/XzL3Jc3YkFjzXEMXzTqVhA8vQaGMTdZHTjFP0PVcwAHNgaw3gXu4wA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -12578,10 +12578,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260714.0",
+        "miniflare": "4.20260721.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260714.1"
+        "workerd": "1.20260721.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -12595,7 +12595,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260714.1"
+        "@cloudflare/workers-types": "^5.20260721.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,7 +98,7 @@
     },
     "@babel/core": "7.29.6",
     "basic-ftp": "5.3.1",
-    "brace-expansion": "5.0.6",
+    "brace-expansion": "5.0.7",
     "esbuild": "0.28.1",
     "js-yaml": "4.2.0",
     "ajv": "^6.14.0"


### PR DESCRIPTION
## Summary

Closes GitHub security alert #67 (GHSA-3jxr-9vmj-r5cp / CVE-2026-13149, high): `brace-expansion` had exponential-time expansion of consecutive non-expanding `{}` groups (ReDoS-style DoS). The existing `overrides` pin (added for a prior CVE) was `5.0.6`, itself inside the newly-vulnerable range (`>= 3.0.0, < 5.0.7`). Bumped to `5.0.7`, the first patched version.

Running `npm audit fix` (non-breaking) to relockfile also resolved a **critical** `tar` finding (via `node-gyp`) and a **low** `body-parser` finding (via `@lhci/cli`'s bundled express) as a side effect.

## What changed

| File | Change |
|------|--------|
| `frontend/package.json` | `overrides.brace-expansion`: `5.0.6` → `5.0.7` |
| `frontend/package-lock.json` | Relockfiled via `npm install` + `npm audit fix` (non-force) |

## Security / correctness notes

All three resolved findings (`brace-expansion`, `tar`, `body-parser`) are dev-only dependency chains — `eslint`→`minimatch`, `node-gyp`, and `@lhci/cli`'s bundled `express` respectively. None are present in `functions/` (production Workers code) or the shipped frontend bundle.

**Not included:** 6 remaining high-severity findings (`miniflare`/`sharp` via `wrangler`; `js-yaml` via `@lhci/cli`) all require semver-major bumps. Confirmed `sharp` (image processing, inherited libvips CVEs) is pulled in only by wrangler's local Miniflare dev emulator — grepped `functions/` and confirmed zero references, so no production Workers exposure (native binaries can't run on Workers regardless, per CLAUDE.md). Deferred to #647 given the breaking-change risk to core dev tooling (local wrangler dev server, Lighthouse CI gates) — needs deliberate changelog review, not a blind `--force`.

## Verification

- [x] Tests: N/A (no application code changed)
- [x] ESLint: 0 errors, 2 pre-existing warnings unrelated to this change (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: green (`npm run build`)
- [x] `validate:openapi`: N/A
- [x] Manual smoke: N/A (dependency-only change, verified via lint/format/build)

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `brace-expansion` package version to improve dependency maintenance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->