### PR TITLE
feat(events): show poster thumbnails on every main-page event listing

### DIFF
--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -3202,6 +3202,9 @@ components:
         ticket_url:
           type: string
           nullable: true
+        poster_url:
+          type: string
+          nullable: true
         is_upcoming:
           type: integer
         band_count:
@@ -3258,6 +3261,9 @@ components:
           type: string
           nullable: true
         ticket_url:
+          type: string
+          nullable: true
+        poster_url:
           type: string
           nullable: true
         band_count:

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -612,54 +612,67 @@ function EventCard({
       {/* Event Header */}
       <div className="p-6">
         <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4 mb-4">
-          <div className="flex-1">
-            <div className="flex flex-wrap items-start gap-2 mb-2">
-              {event.slug ? (
-                <h3 className="text-2xl font-bold text-accent-500 flex-1">
-                  <Link
-                    to={`/event/${event.slug}`}
-                    className="hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500/70 rounded-xs"
-                  >
-                    {event.name}
-                  </Link>
-                </h3>
-              ) : (
-                <h3 className="text-2xl font-bold text-accent-500 flex-1">{event.name}</h3>
-              )}
-              {isLive && (
-                <Badge variant="error" size="md">
-                  LIVE NOW
-                </Badge>
-              )}
-              {event.status === 'archived' && (
-                <Badge variant="default" size="md">
-                  <Archive size={12} className="mr-1" aria-hidden="true" />
-                  Archived
-                </Badge>
-              )}
-              {event.is_published === false && <Badge variant="warning">Draft</Badge>}
-            </div>
-
-            <p className="text-text-secondary text-sm mb-4 flex items-center gap-2">
-              <CalendarDays size={12} />
-              {formatDate(event.date)}
-            </p>
-
-            {/* Event Stats */}
-            <div className="flex flex-wrap gap-6 text-sm">
-              <div className="flex items-center gap-2">
-                <span className="font-bold text-text-primary">{allBandCount}</span>
-                <span className="text-text-tertiary">{allBandCount === 1 ? 'Band' : 'Bands'}</span>
+          <div className="flex flex-1 gap-4 min-w-0">
+            {/* Poster thumbnail (#658) — decorative on the listing: the card's
+                Link/title already names the event, and the full-size lightbox
+                lives on the event page (#656), not here. Fixed-size container
+                + object-contain so varying poster aspect ratios (roughly 3:4
+                to 4:5 in production) never distort the card or its text
+                alignment; omitted entirely (no placeholder box) when absent. */}
+            {event.poster_url && (
+              <div className="w-20 sm:w-24 aspect-[3/4] shrink-0 overflow-hidden rounded-lg border border-border bg-surface">
+                <img src={event.poster_url} alt="" loading="lazy" className="h-full w-full object-contain" />
               </div>
-              {/* Historical volumes have roster-only lineups with no venue
+            )}
+            <div className="flex-1 min-w-0">
+              <div className="flex flex-wrap items-start gap-2 mb-2">
+                {event.slug ? (
+                  <h3 className="text-2xl font-bold text-accent-500 flex-1">
+                    <Link
+                      to={`/event/${event.slug}`}
+                      className="hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500/70 rounded-xs"
+                    >
+                      {event.name}
+                    </Link>
+                  </h3>
+                ) : (
+                  <h3 className="text-2xl font-bold text-accent-500 flex-1">{event.name}</h3>
+                )}
+                {isLive && (
+                  <Badge variant="error" size="md">
+                    LIVE NOW
+                  </Badge>
+                )}
+                {event.status === 'archived' && (
+                  <Badge variant="default" size="md">
+                    <Archive size={12} className="mr-1" aria-hidden="true" />
+                    Archived
+                  </Badge>
+                )}
+                {event.is_published === false && <Badge variant="warning">Draft</Badge>}
+              </div>
+
+              <p className="text-text-secondary text-sm mb-4 flex items-center gap-2">
+                <CalendarDays size={12} />
+                {formatDate(event.date)}
+              </p>
+
+              {/* Event Stats */}
+              <div className="flex flex-wrap gap-6 text-sm">
+                <div className="flex items-center gap-2">
+                  <span className="font-bold text-text-primary">{allBandCount}</span>
+                  <span className="text-text-tertiary">{allBandCount === 1 ? 'Band' : 'Bands'}</span>
+                </div>
+                {/* Historical volumes have roster-only lineups with no venue
                   assignments — "0 Venues" reads as missing data, so omit the
                   stat entirely rather than showing a zero. */}
-              {allVenueCount > 0 && (
-                <div className="flex items-center gap-2">
-                  <span className="font-bold text-text-primary">{allVenueCount}</span>
-                  <span className="text-text-tertiary">{allVenueCount === 1 ? 'Venue' : 'Venues'}</span>
-                </div>
-              )}
+                {allVenueCount > 0 && (
+                  <div className="flex items-center gap-2">
+                    <span className="font-bold text-text-primary">{allVenueCount}</span>
+                    <span className="text-text-tertiary">{allVenueCount === 1 ? 'Venue' : 'Venues'}</span>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
 

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -613,23 +613,13 @@ function EventCard({
       <div className="p-6">
         <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4 mb-4">
           <div className="flex flex-1 gap-4 min-w-0">
-            {/* Poster thumbnail (#658) — decorative on the listing: the card's
-                Link/title already names the event, and the full-size lightbox
-                lives on the event page (#656), not here. Renders in all three
-                timeline sections (now/upcoming/past) since this same EventCard
-                is reused for each. Fixed-size container + object-contain so
-                varying poster aspect ratios (roughly 3:4 to 4:5 in production)
-                never distort the card or its text alignment, and reserve
-                layout space up front to avoid CLS when the image loads;
-                omitted entirely (no placeholder box) when absent.
-                Performance (17 past-event posters, 240KB-663KB originals):
-                loading="lazy" defers the fetch until near-viewport, and
-                decoding="async" keeps decode off the main thread. The past
-                section itself is conditionally rendered on showPast further
-                down — these poster img elements are not in the DOM at all
-                until "Show History" is clicked, so collapsed history costs
-                nothing. No CDN/resize transform yet; a proper thumbnail
-                pipeline is tracked as a follow-up (see PR description). */}
+            {/* Decorative: alt="" because the card's link text already names
+                the event. Do not make this open a lightbox — that would nest
+                a <button> inside the card's <a>, which is invalid and breaks
+                keyboard nav; the full-size view lives on the event page.
+                The fixed-size container is load-bearing, not styling: poster
+                aspect ratios vary, so it prevents card distortion and reserves
+                layout space against CLS. */}
             {event.poster_url && (
               <div className="w-20 sm:w-24 aspect-[3/4] shrink-0 overflow-hidden rounded-lg border border-border bg-surface">
                 <img

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -615,13 +615,30 @@ function EventCard({
           <div className="flex flex-1 gap-4 min-w-0">
             {/* Poster thumbnail (#658) — decorative on the listing: the card's
                 Link/title already names the event, and the full-size lightbox
-                lives on the event page (#656), not here. Fixed-size container
-                + object-contain so varying poster aspect ratios (roughly 3:4
-                to 4:5 in production) never distort the card or its text
-                alignment; omitted entirely (no placeholder box) when absent. */}
+                lives on the event page (#656), not here. Renders in all three
+                timeline sections (now/upcoming/past) since this same EventCard
+                is reused for each. Fixed-size container + object-contain so
+                varying poster aspect ratios (roughly 3:4 to 4:5 in production)
+                never distort the card or its text alignment, and reserve
+                layout space up front to avoid CLS when the image loads;
+                omitted entirely (no placeholder box) when absent.
+                Performance (17 past-event posters, 240KB-663KB originals):
+                loading="lazy" defers the fetch until near-viewport, and
+                decoding="async" keeps decode off the main thread. The past
+                section itself is conditionally rendered on showPast further
+                down — these poster img elements are not in the DOM at all
+                until "Show History" is clicked, so collapsed history costs
+                nothing. No CDN/resize transform yet; a proper thumbnail
+                pipeline is tracked as a follow-up (see PR description). */}
             {event.poster_url && (
               <div className="w-20 sm:w-24 aspect-[3/4] shrink-0 overflow-hidden rounded-lg border border-border bg-surface">
-                <img src={event.poster_url} alt="" loading="lazy" className="h-full w-full object-contain" />
+                <img
+                  src={event.poster_url}
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                  className="h-full w-full object-contain"
+                />
               </div>
             )}
             <div className="flex-1 min-w-0">

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -317,3 +317,97 @@ describe('EventTimeline collapsed performer chips ordering', () => {
     expect(chips).toEqual(['The Anti-Queens', 'Mango Static', 'Zebra Mussels'])
   })
 })
+
+// Poster thumbnails on the listing (#658): the card is decorative-only (no
+// lightbox — that lives on the event page, #656) and must render nothing
+// when poster_url is absent, which is still the common case for events that
+// haven't had a poster uploaded yet.
+describe('EventTimeline poster thumbnails (#658)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders a decorative poster image when poster_url is present', async () => {
+    const timelineData = {
+      now: [],
+      upcoming: [
+        {
+          id: 1,
+          name: 'Poster Fest',
+          slug: 'poster-fest',
+          date: '2026-08-02',
+          status: 'published',
+          is_published: true,
+          venues: [],
+          bands: [],
+          band_count: 0,
+          venue_count: 0,
+          ticket_url: null,
+          poster_url: 'https://cdn.example.com/posters/poster-fest.jpg',
+        },
+      ],
+      past: [],
+    }
+
+    global.fetch = vi.fn(url => {
+      if (url.startsWith('/api/events/timeline')) {
+        return Promise.resolve(jsonResponse(timelineData))
+      }
+      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+    })
+
+    const { container } = render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Poster Fest')).toBeInTheDocument()
+
+    const posterImg = container.querySelector('img[src="https://cdn.example.com/posters/poster-fest.jpg"]')
+    expect(posterImg).toBeInTheDocument()
+    expect(posterImg).toHaveAttribute('alt', '')
+    expect(posterImg).toHaveAttribute('loading', 'lazy')
+    // Decorative only — must not be wrapped in a button/lightbox trigger.
+    expect(posterImg.closest('button')).toBeNull()
+  })
+
+  it('renders no poster element when poster_url is null', async () => {
+    const timelineData = {
+      now: [],
+      upcoming: [
+        {
+          id: 2,
+          name: 'No Poster Fest',
+          slug: 'no-poster-fest',
+          date: '2026-08-07',
+          status: 'published',
+          is_published: true,
+          venues: [],
+          bands: [],
+          band_count: 0,
+          venue_count: 0,
+          ticket_url: null,
+          poster_url: null,
+        },
+      ],
+      past: [],
+    }
+
+    global.fetch = vi.fn(url => {
+      if (url.startsWith('/api/events/timeline')) {
+        return Promise.resolve(jsonResponse(timelineData))
+      }
+      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+    })
+
+    const { container } = render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('No Poster Fest')).toBeInTheDocument()
+    expect(container.querySelector('img')).toBeNull()
+  })
+})

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -368,6 +368,7 @@ describe('EventTimeline poster thumbnails (#658)', () => {
     expect(posterImg).toBeInTheDocument()
     expect(posterImg).toHaveAttribute('alt', '')
     expect(posterImg).toHaveAttribute('loading', 'lazy')
+    expect(posterImg).toHaveAttribute('decoding', 'async')
     // Decorative only — must not be wrapped in a button/lightbox trigger.
     expect(posterImg.closest('button')).toBeNull()
   })
@@ -409,5 +410,73 @@ describe('EventTimeline poster thumbnails (#658)', () => {
 
     expect(await screen.findByText('No Poster Fest')).toBeInTheDocument()
     expect(container.querySelector('img')).toBeNull()
+  })
+})
+
+// Past-section poster performance (#658 follow-up): every past event now has
+// a poster (240KB-663KB originals). Rendering all of them unconditionally
+// would ship multiple megabytes on every homepage load even though the past
+// list starts collapsed. The past cards — and therefore their <img> tags —
+// must be conditionally rendered (not just CSS-hidden), so the browser never
+// fetches a single past poster until "Show History" is clicked.
+describe('EventTimeline past-section poster lazy mounting (#658)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not mount past poster <img> elements until History is expanded, then mounts them all', async () => {
+    const pastEvent = (id, name) => ({
+      id,
+      name,
+      slug: name.toLowerCase().replace(/\s+/g, '-'),
+      date: '2020-05-10',
+      status: 'archived',
+      is_published: true,
+      venues: [],
+      bands: [],
+      band_count: 0,
+      venue_count: 0,
+      ticket_url: null,
+      poster_url: `https://cdn.example.com/posters/${id}.jpg`,
+    })
+
+    const timelineData = {
+      now: [],
+      upcoming: [],
+      past: [pastEvent(1, 'Past Fest One'), pastEvent(2, 'Past Fest Two'), pastEvent(3, 'Past Fest Three')],
+    }
+
+    global.fetch = vi.fn(url => {
+      if (url.startsWith('/api/events/timeline')) {
+        return Promise.resolve(jsonResponse(timelineData))
+      }
+      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+    })
+
+    const { container } = render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    const toggle = await screen.findByRole('button', { name: /show history/i })
+
+    // Collapsed: none of the past posters are in the DOM at all — a
+    // display:none/hidden approach would still leave <img> tags present
+    // (and the browser would still fetch them), so this asserts the
+    // stronger conditional-render requirement.
+    expect(container.querySelector('img')).toBeNull()
+    expect(screen.queryByText('Past Fest One')).not.toBeInTheDocument()
+
+    fireEvent.click(toggle)
+
+    expect(await screen.findByText('Past Fest One')).toBeInTheDocument()
+    const posterImgs = container.querySelectorAll('img')
+    expect(posterImgs).toHaveLength(3)
+    posterImgs.forEach(img => {
+      expect(img).toHaveAttribute('loading', 'lazy')
+      expect(img).toHaveAttribute('decoding', 'async')
+      expect(img).toHaveAttribute('alt', '')
+    })
   })
 })

--- a/functions/api/events/__tests__/public.test.js
+++ b/functions/api/events/__tests__/public.test.js
@@ -358,4 +358,58 @@ describe("GET /api/events/public", () => {
       expect(data.events[0].ticket_url).toBe("https://tickets.example.com/summer-fest");
     });
   });
+
+  describe("poster_url (#658)", () => {
+    it("returns poster_url when present", async () => {
+      const event = createMockEvent({ poster_url: "https://cdn.example.com/posters/summer-fest.jpg" });
+      const venue = createMockVenue();
+      const band = createMockBand();
+
+      seedMockData(mockDB, [event], [venue], [band]);
+
+      const request = new Request("http://localhost/api/events/public");
+      const context = { request, env: mockEnv };
+
+      const response = await onRequestGet(context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.events[0].poster_url).toBe("https://cdn.example.com/posters/summer-fest.jpg");
+    });
+
+    it("returns null when poster_url is absent", async () => {
+      const event = createMockEvent();
+      const venue = createMockVenue();
+      const band = createMockBand();
+
+      seedMockData(mockDB, [event], [venue], [band]);
+
+      const request = new Request("http://localhost/api/events/public");
+      const context = { request, env: mockEnv };
+
+      const response = await onRequestGet(context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.events[0].poster_url).toBeNull();
+    });
+
+    it("nulls out a legacy javascript: poster_url value", async () => {
+      // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #658 read-path guard
+      const event = createMockEvent({ poster_url: "javascript:alert(1)" });
+      const venue = createMockVenue();
+      const band = createMockBand();
+
+      seedMockData(mockDB, [event], [venue], [band]);
+
+      const request = new Request("http://localhost/api/events/public");
+      const context = { request, env: mockEnv };
+
+      const response = await onRequestGet(context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.events[0].poster_url).toBeNull();
+    });
+  });
 });

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -963,6 +963,97 @@ describe("Timeline real-DB — event ticket_url is scheme-validated (#504)", () 
 });
 
 // ---------------------------------------------------------------------------
+// Real-DB regression — the event-level `poster_url` reflection must never
+// carry an unsafe scheme, and must be present when set (#658: the main-page
+// listing — powered by THIS endpoint via EventTimeline.jsx, not
+// functions/api/events/public.js — never selected or returned poster_url, so
+// event cards had no poster to render). Seeded via a direct SQL UPDATE
+// (bypassing write-path validation) to simulate a pre-#616 legacy row, same
+// pattern as the #504 ticket_url tests above.
+// ---------------------------------------------------------------------------
+describe("Timeline real-DB — event poster_url is present and scheme-validated (#658)", () => {
+  test("an event with a normal https poster_url passes through unchanged", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const today = eventLocalToday();
+
+    const event = insertEvent(rawDb, {
+      name: "Poster Event",
+      slug: "timeline-realdb-658-safe",
+      date: today,
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb
+      .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
+      .run("https://cdn.example.com/posters/poster-event.jpg", event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const found = data.now.find((e) => e.id === event.id);
+    expect(found).toBeDefined();
+    expect(found.poster_url).toBe("https://cdn.example.com/posters/poster-event.jpg");
+  });
+
+  test("an event with no poster_url resolves to null", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const today = eventLocalToday();
+
+    const event = insertEvent(rawDb, {
+      name: "No Poster Event",
+      slug: "timeline-realdb-658-absent",
+      date: today,
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const found = data.now.find((e) => e.id === event.id);
+    expect(found).toBeDefined();
+    expect(found.poster_url).toBeNull();
+  });
+
+  test("an event with a javascript: poster_url resolves to poster_url: null", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const today = eventLocalToday();
+
+    const event = insertEvent(rawDb, {
+      name: "Unsafe Poster Event",
+      slug: "timeline-realdb-658-unsafe",
+      date: today,
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #658 read-path guard
+    rawDb.prepare("UPDATE events SET poster_url = ? WHERE id = ?").run("javascript:alert(1)", event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const found = data.now.find((e) => e.id === event.id);
+    expect(found).toBeDefined();
+    expect(found.poster_url).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Real-DB — start-edge gate (#569). An event's FIRST day isn't "Happening
 // Now" at local midnight; it's held in "upcoming" (moved to the front) until
 // its start edge, which is in precedence order: that day's doors/gates time →

--- a/functions/api/events/public.js
+++ b/functions/api/events/public.js
@@ -32,6 +32,7 @@ export async function onRequestGet(context) {
         e.description,
         e.city,
         e.ticket_url,
+        e.poster_url,
         CASE WHEN COALESCE(e.end_date, e.date) >= date('now', '-6 hours') THEN 1 ELSE 0 END as is_upcoming,
         COUNT(DISTINCT p.band_profile_id) as band_count,
         COUNT(DISTINCT p.venue_id) as venue_count
@@ -84,9 +85,13 @@ export async function onRequestGet(context) {
     // javascript: scheme) must not be reflected to this public, unauthenticated
     // endpoint — normalizeHttpUrl returns null for anything that isn't a real
     // http(s) URL.
+    // poster_url gets the same treatment (#658, matches the ticket_url
+    // precedent above): pre-#616 rows were never write-validated, so a legacy
+    // unsafe scheme must never reach this response.
     const sanitizedEvents = filteredEvents.map((event) => ({
       ...event,
       ticket_url: normalizeHttpUrl(event.ticket_url),
+      poster_url: normalizeHttpUrl(event.poster_url),
     }));
 
     // Return JSON

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -140,6 +140,12 @@ export async function onRequestGet(context) {
             end_date: row.event_end_date || null,
             status: row.event_status || null,
             ticket_url: normalizeHttpUrl(row.ticket_url),
+            // Read-path sanitize (#658, matches the ticket_url precedent
+            // above): a pre-#616 legacy poster_url (e.g. a javascript:
+            // scheme) must never be reflected to this public, unauthenticated
+            // endpoint. Functionally dependent on event_id (one value per
+            // event), so any row carries the same value.
+            poster_url: normalizeHttpUrl(row.poster_url),
             bands: includeBands ? [] : null,
             bandIds: new Set(),
             venues: new Map(),
@@ -225,6 +231,7 @@ export async function onRequestGet(context) {
         end_date: event.end_date,
         status: event.status,
         ticket_url: normalizeHttpUrl(event.ticket_url),
+        poster_url: normalizeHttpUrl(event.poster_url),
         band_count: event.bandIds.size,
         venue_count: event.venues.size,
         bands: includeBands ? event.bands : undefined,
@@ -258,6 +265,7 @@ export async function onRequestGet(context) {
           e.end_date as event_end_date,
           e.doors_json as doors_json,
           e.ticket_url as ticket_url,
+          e.poster_url as poster_url,
           p.band_profile_id as band_id,
           b.name as band_name,
           p.start_time,
@@ -308,6 +316,7 @@ export async function onRequestGet(context) {
           e.date as event_date,
           e.end_date as event_end_date,
           e.ticket_url as ticket_url,
+          e.poster_url as poster_url,
           p.band_profile_id as band_id,
           b.name as band_name,
           p.start_time,
@@ -363,6 +372,7 @@ export async function onRequestGet(context) {
           e.end_date as event_end_date,
           e.status as event_status,
           e.ticket_url as ticket_url,
+          e.poster_url as poster_url,
           p.band_profile_id as band_id,
           b.name as band_name,
           p.start_time,

--- a/functions/api/subscriptions/__tests__/mocks/d1.js
+++ b/functions/api/subscriptions/__tests__/mocks/d1.js
@@ -219,7 +219,16 @@ export class MockD1Database {
     // Returning it unconditionally would let a test assert on poster_url and
     // still pass after someone drops `e.poster_url` from the query — the
     // assertion would be reading this mock, not the projection (#658).
-    const projectsPosterUrl = queryLower.includes("poster_url");
+    //
+    // Scoped to the projection list so a mention in WHERE/ORDER BY doesn't
+    // count as selecting the column. Slicing to the first FROM is deliberately
+    // naive: no query routed here puts a subquery in its projection, and a
+    // real SQL parser inside a test mock would be more fragile than the bug
+    // it prevents. Wildcards (* / e.*) project everything, so they count;
+    // COUNT(*) does not, since the trailing ")" fails the boundary check.
+    const fromIndex = queryLower.indexOf(" from ");
+    const selectList = fromIndex === -1 ? queryLower : queryLower.slice(0, fromIndex);
+    const projectsPosterUrl = /\bposter_url\b/.test(selectList) || /(^|[\s,])(\*|[a-z_]+\.\*)(\s|,|$)/.test(selectList);
 
     // This is a complex query with JOINs - return aggregated data
     let results = this.data.events.map((event) => {

--- a/functions/api/subscriptions/__tests__/mocks/d1.js
+++ b/functions/api/subscriptions/__tests__/mocks/d1.js
@@ -230,6 +230,7 @@ export class MockD1Database {
         description: event.description,
         city: event.city,
         ticket_url: event.ticket_url,
+        poster_url: event.poster_url ?? null,
         band_count: uniqueBandIds.size,
         venue_count: uniqueVenueIds.size,
         is_published: event.is_published,

--- a/functions/api/subscriptions/__tests__/mocks/d1.js
+++ b/functions/api/subscriptions/__tests__/mocks/d1.js
@@ -215,6 +215,12 @@ export class MockD1Database {
   }
 
   _handleEventsQuery(queryLower, params) {
+    // Honor the SELECT projection for poster_url the way the real DB would.
+    // Returning it unconditionally would let a test assert on poster_url and
+    // still pass after someone drops `e.poster_url` from the query — the
+    // assertion would be reading this mock, not the projection (#658).
+    const projectsPosterUrl = queryLower.includes("poster_url");
+
     // This is a complex query with JOINs - return aggregated data
     let results = this.data.events.map((event) => {
       const eventPerformances = this.data.performances.filter((p) => p.event_id === event.id);
@@ -230,7 +236,7 @@ export class MockD1Database {
         description: event.description,
         city: event.city,
         ticket_url: event.ticket_url,
-        poster_url: event.poster_url ?? null,
+        ...(projectsPosterUrl ? { poster_url: event.poster_url ?? null } : {}),
         band_count: uniqueBandIds.size,
         venue_count: uniqueVenueIds.size,
         is_published: event.is_published,


### PR DESCRIPTION
## Summary

Event posters were visible on individual event pages and archived recap pages (#655/#656), but not on the main page. This adds a poster thumbnail to every event card in the timeline — **now, upcoming, and past** — so the artwork accompanies each listing.

Closes #658

## What changed

| File | Change |
|------|--------|
| `functions/api/events/timeline.js` | `poster_url` added to all three period queries (now/upcoming/past) and threaded through `groupEventData`, sanitized via `normalizeHttpUrl` on read |
| `functions/api/events/public.js` | Same addition — standalone JSON feed, kept consistent |
| `frontend/src/components/EventTimeline.jsx` | `EventCard` renders a decorative poster thumbnail; omitted entirely when absent |
| `functions/api/subscriptions/__tests__/mocks/d1.js` | Mock D1 hand-maps fields; `poster_url` was missing |
| `docs/api-spec.yaml` | `poster_url` documented on `PublicEventSummary` and `TimelineEvent` |
| tests (3 files) | See Verification |

## Scope correction worth recording

The issue named `functions/api/events/public.js` as "the listing endpoint behind the main page." **It isn't.** The real path is `/` → `EventsPage` → `<EventTimeline />` → `GET /api/events/timeline`. `public.js` is a standalone JSON feed linked only from the Subscribe page; nothing in the UI fetches it.

Implementing only what the issue literally specified would have compiled, tested green, and produced **zero visible change** on the site. `timeline.js` is the fix; `public.js` is updated too for consistency.

## Performance

Every one of the 17 past events now has a poster, with source images between 240KB and 663KB. Three properties keep that from costing anything:

1. **Collapsed history downloads nothing.** The past section is conditionally rendered on `showPast`, so those `<img>` elements are not in the DOM until "Show History" is clicked. This was already the existing pattern — this PR verifies it and adds a regression test, because switching to CSS hiding (`hidden` / `display:none`) for an animation would look identical while quietly fetching all 17 on page load.
2. **`loading="lazy"`** — expanding history doesn't pull every poster at once, only those near the viewport.
3. **Fixed `w-20 sm:w-24 aspect-[3/4]` container** reserves layout space up front, so images popping in can't cascade layout shifts. Production posters vary (960×1280, 1440×1800, 1440×1920, 1159×1441, 791×1021), so intrinsic sizing isn't reliable.

Plus `decoding="async"` to keep decode off the main thread.

**Not included:** a CDN/resize thumbnail pipeline. Full-size originals are served scaled to ~96px. Tracked as #659.

## Accessibility

The poster is **decorative on the listing** — `alt=""`, no lightbox. Each card is a `<Link>`, and nesting a `<button>` inside an `<a>` is invalid HTML that breaks keyboard navigation and AT semantics. The card's link text already names the event, so a described image would double-announce. The full-size lightbox lives on the event page (#656), one tap away.

## Security / correctness notes

- `poster_url` passes through `normalizeHttpUrl()` on the read path in both endpoints, matching the `ticket_url` precedent (#504 convention). Rows written before #616 were never write-validated, so a `javascript:` value must never reach an `<img src>`. Covered by tests in both endpoints.
- No schema change, no migration. Read-only column addition to existing SELECTs.
- No auth, CSRF, or session surface touched.
- A bug was caught pre-merge by the test suite: `poster_url` was set at object-init in `groupEventData` but the function's final `return ... .map()` whitelists fields explicitly, so the value never reached the JSON response. Tests failed with `undefined`; fixed and re-run green.

## Verification

- [x] Tests: 589 frontend pass, 820 backend pass (+6 pre-existing todos), 0 failures
- [x] ESLint: 0 errors (2 pre-existing frontend warnings, 1 backend — all unrelated and untouched)
- [x] Format check: clean, both suites
- [x] Build: green (`npm run build --prefix frontend`)
- [x] `validate:openapi`: no drift — 72 documented + 1 internal = 73 route files
- [ ] Manual smoke: **pending preview deploy.** Worth checking the mixed-row case specifically — `blr3` has no poster while surrounding events do, so it's the one card rendering without a thumbnail. Tests confirm it omits cleanly; whether it *sits* well beside poster-bearing cards is a judgment only a real render answers.

All gates re-run after rebasing onto `origin/main`.

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event listings and timelines now expose an optional `poster_url` field for event poster images.
  * Event cards render a decorative poster thumbnail when `poster_url` is present, including after expanding past history.
* **Bug Fixes**
  * Poster URLs are sanitized, with unsafe schemes returned as `null`.
  * Missing poster images consistently return as `null`.
* **Tests**
  * Added UI tests for poster rendering attributes and lazy mounting (not mounted while history is collapsed).
  * Added API tests ensuring `poster_url` behavior and scheme safety for public and timeline responses.
* **Documentation**
  * Updated the API spec to include `poster_url` in the relevant response schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->