### PR TITLE
perf(images): serve right-sized poster derivatives via Cloudflare transforms

### DIFF
--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -10,6 +10,7 @@ import { getSelectedBands, saveSelectedBands } from '../utils/scheduleStorage'
 import { sortableName } from '../utils/sortableName'
 import { Alert, Badge, Button, Card, Loading } from './ui'
 import EventsPageSkeleton from './EventsPageSkeleton'
+import PosterImage from './PosterImage'
 
 /**
  * EventTimeline - Main timeline showing Now, Upcoming, and Past events
@@ -617,17 +618,29 @@ function EventCard({
                 the event. Do not make this open a lightbox — that would nest
                 a <button> inside the card's <a>, which is invalid and breaks
                 keyboard nav; the full-size view lives on the event page.
-                The fixed-size container is load-bearing, not styling: poster
-                aspect ratios vary, so it prevents card distortion and reserves
-                layout space against CLS. */}
+                `self-start` stops the flex row's default align-items:stretch
+                from stretching this box to the height of the text column
+                beside it — without it, the box was taller than the poster's
+                real aspect ratio and the image (object-contain) letterboxed
+                inside the extra space, reading as "artificially and doubly
+                constrained" (#659 follow-up). No fixed aspect ratio either:
+                production posters range ~0.75-0.80 (3:4 to 4:5), so any
+                single ratio letterboxes most of them — `h-auto` lets the
+                image set its own height and letterboxes none. Trade-off:
+                this gives up the reserved layout space that guarded against
+                CLS; accepted because the image is loading="lazy" and the
+                past-section cards are additionally gated behind a collapsed
+                "Show History" toggle, so neither mounts until near-viewport
+                or explicitly expanded. */}
             {event.poster_url && (
-              <div className="w-20 sm:w-24 aspect-[3/4] shrink-0 overflow-hidden rounded-lg border border-border bg-surface">
-                <img
+              <div className="w-28 sm:w-36 shrink-0 self-start overflow-hidden rounded-lg border border-border">
+                <PosterImage
                   src={event.poster_url}
+                  width={200}
                   alt=""
                   loading="lazy"
                   decoding="async"
-                  className="h-full w-full object-contain"
+                  className="h-auto w-full"
                 />
               </div>
             )}

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -640,7 +640,15 @@ function EventCard({
                   alt=""
                   loading="lazy"
                   decoding="async"
-                  className="h-auto w-full"
+                  /* aspect-[auto_3/4] is the TWO-VALUE aspect-ratio syntax:
+                     reserve a 3:4 box while the lazy image has no intrinsic
+                     dimensions, then let the real ratio take over once it
+                     loads. This is NOT the fixed-ratio box that caused
+                     letterboxing — that was a stretched container plus
+                     object-contain, which pinned the wrong ratio permanently.
+                     Nothing letterboxes after load here, and the reserved box
+                     stops expanding History from cascading layout shifts. */
+                  className="aspect-[auto_3/4] h-auto w-full"
                 />
               </div>
             )}

--- a/frontend/src/components/PosterImage.jsx
+++ b/frontend/src/components/PosterImage.jsx
@@ -1,0 +1,66 @@
+import { useCallback, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+import { posterImageUrl, posterImageSrcSet } from '../utils/posterImage'
+
+/**
+ * PosterImage — <img> wrapper that requests a right-sized Cloudflare image
+ * transform derivative instead of the full-size poster original (#659).
+ * Centralizes the transform + srcset logic so the listing thumbnail, the
+ * recap poster, and the lightbox stay simple call sites with consistent
+ * behaviour.
+ *
+ * `onError` falls back to the untransformed original, exactly once. If
+ * image transforms are ever disabled on the zone, every `/cdn-cgi/image/`
+ * URL on the site would 404 simultaneously — this makes that failure mode
+ * invisible (degrades to the full-size original) instead of breaking every
+ * poster on the site at once. The `fellBack` ref (not just state) guards
+ * against looping if the fallback *also* fails to load: once tripped, the
+ * handler is a no-op regardless of how many further error events fire for
+ * this element, and the srcset is cleared alongside src so the browser
+ * can't re-trigger a transform request via a listed candidate.
+ */
+export default function PosterImage({
+  src,
+  alt = '',
+  width,
+  className,
+  loading = 'lazy',
+  decoding = 'async',
+  ...rest
+}) {
+  const [fellBack, setFellBack] = useState(false)
+  const fellBackRef = useRef(false)
+
+  const handleError = useCallback(() => {
+    if (fellBackRef.current) return
+    fellBackRef.current = true
+    setFellBack(true)
+  }, [])
+
+  const resolvedSrc = fellBack ? src : posterImageUrl(src, width)
+  const resolvedSrcSet = fellBack ? undefined : posterImageSrcSet(src, width)
+
+  return (
+    <img
+      {...rest}
+      src={resolvedSrc}
+      srcSet={resolvedSrcSet}
+      alt={alt}
+      loading={loading}
+      decoding={decoding}
+      className={className}
+      onError={handleError}
+    />
+  )
+}
+
+PosterImage.propTypes = {
+  /** Original (untransformed) poster URL. */
+  src: PropTypes.string,
+  alt: PropTypes.string,
+  /** Target render width in CSS pixels — used to pick the transform width and the 2x srcset candidate. */
+  width: PropTypes.number,
+  className: PropTypes.string,
+  loading: PropTypes.string,
+  decoding: PropTypes.string,
+}

--- a/frontend/src/components/PosterImage.jsx
+++ b/frontend/src/components/PosterImage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { posterImageUrl, posterImageSrcSet } from '../utils/posterImage'
 
@@ -26,16 +26,35 @@ export default function PosterImage({
   className,
   loading = 'lazy',
   decoding = 'async',
+  onError,
   ...rest
 }) {
   const [fellBack, setFellBack] = useState(false)
   const fellBackRef = useRef(false)
 
-  const handleError = useCallback(() => {
-    if (fellBackRef.current) return
-    fellBackRef.current = true
-    setFellBack(true)
-  }, [])
+  // A fallback belongs to the URL that failed, not to the component instance.
+  // Without this reset, a PosterImage reused for a different poster (the same
+  // element re-rendered with a new src rather than remounted) would stay
+  // pinned to untransformed originals for the rest of its life because of one
+  // earlier failure.
+  useEffect(() => {
+    fellBackRef.current = false
+    setFellBack(false)
+  }, [src])
+
+  const handleError = useCallback(
+    event => {
+      // Compose rather than replace: a caller's own onError must still fire.
+      // This runs first so the caller sees the error even if its handler
+      // throws, and the ref guard below only suppresses OUR fallback
+      // transition, never the caller's callback.
+      onError?.(event)
+      if (fellBackRef.current) return
+      fellBackRef.current = true
+      setFellBack(true)
+    },
+    [onError]
+  )
 
   const resolvedSrc = fellBack ? src : posterImageUrl(src, width)
   const resolvedSrcSet = fellBack ? undefined : posterImageSrcSet(src, width)
@@ -63,4 +82,6 @@ PosterImage.propTypes = {
   className: PropTypes.string,
   loading: PropTypes.string,
   decoding: PropTypes.string,
+  /** Optional caller error handler. Composed with the internal fallback, not replaced by it. */
+  onError: PropTypes.func,
 }

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import EventTimeline from '../EventTimeline'
+import { POSTER_IMAGE_HOST } from '../../utils/posterImage'
 
 function jsonResponse(data) {
   return {
@@ -327,7 +328,14 @@ describe('EventTimeline poster thumbnails (#658)', () => {
     vi.restoreAllMocks()
   })
 
-  it('renders a decorative poster image when poster_url is present', async () => {
+  // #659: the listing thumbnail renders through PosterImage, which requests
+  // a Cloudflare image-transform derivative (width=200,format=auto, plus a
+  // 200/400 1x/2x srcset) rather than the full-size original — the poster
+  // URL here deliberately uses the real poster host so the transform
+  // actually applies; a foreign host would silently pass through unchanged
+  // and this test would stop proving anything.
+  it('renders a decorative, transformed poster image when poster_url is present', async () => {
+    const originalUrl = `https://${POSTER_IMAGE_HOST}/event-posters/1-poster-fest.jpg`
     const timelineData = {
       now: [],
       upcoming: [
@@ -343,7 +351,7 @@ describe('EventTimeline poster thumbnails (#658)', () => {
           band_count: 0,
           venue_count: 0,
           ticket_url: null,
-          poster_url: 'https://cdn.example.com/posters/poster-fest.jpg',
+          poster_url: originalUrl,
         },
       ],
       past: [],
@@ -364,8 +372,14 @@ describe('EventTimeline poster thumbnails (#658)', () => {
 
     expect(await screen.findByText('Poster Fest')).toBeInTheDocument()
 
-    const posterImg = container.querySelector('img[src="https://cdn.example.com/posters/poster-fest.jpg"]')
+    const transformedSrc = `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/1-poster-fest.jpg`
+    const posterImg = container.querySelector(`img[src="${transformedSrc}"]`)
     expect(posterImg).toBeInTheDocument()
+    expect(posterImg).toHaveAttribute(
+      'srcset',
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/1-poster-fest.jpg 1x, ` +
+        `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=400,format=auto/event-posters/1-poster-fest.jpg 2x`
+    )
     expect(posterImg).toHaveAttribute('alt', '')
     expect(posterImg).toHaveAttribute('loading', 'lazy')
     expect(posterImg).toHaveAttribute('decoding', 'async')

--- a/frontend/src/components/__tests__/PosterImage.test.jsx
+++ b/frontend/src/components/__tests__/PosterImage.test.jsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import PosterImage from '../PosterImage'
 import { POSTER_IMAGE_HOST } from '../../utils/posterImage'
 
@@ -63,5 +63,53 @@ describe('PosterImage', () => {
     render(<PosterImage src={POSTER_URL} alt="poster" width={200} className="max-h-96 w-full" />)
     const img = screen.getByRole('img', { name: 'poster' })
     expect(img).toHaveClass('max-h-96', 'w-full')
+  })
+
+  // The fallback belongs to the URL that failed, not to the component
+  // instance. A PosterImage re-rendered with a new src (rather than
+  // remounted) must start that URL fresh on the optimized path.
+  it('resets the fallback when src changes, so a new poster retries the transform', () => {
+    const OTHER_URL = `https://${POSTER_IMAGE_HOST}/event-posters/2-vol16.jpg`
+    const { rerender } = render(<PosterImage src={POSTER_URL} alt="poster" width={200} />)
+
+    const img = screen.getByRole('img', { name: 'poster' })
+    fireEvent.error(img)
+    expect(img).toHaveAttribute('src', POSTER_URL)
+    expect(img).not.toHaveAttribute('srcset')
+
+    rerender(<PosterImage src={OTHER_URL} alt="poster" width={200} />)
+
+    const next = screen.getByRole('img', { name: 'poster' })
+    expect(next).toHaveAttribute(
+      'src',
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/2-vol16.jpg`
+    )
+    expect(next).toHaveAttribute('srcset')
+  })
+
+  it("invokes a caller's onError as well as falling back", () => {
+    const onError = vi.fn()
+    render(<PosterImage src={POSTER_URL} alt="poster" width={200} onError={onError} />)
+
+    const img = screen.getByRole('img', { name: 'poster' })
+    fireEvent.error(img)
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    // The caller's handler must not suppress the fallback, nor vice versa.
+    expect(img).toHaveAttribute('src', POSTER_URL)
+    expect(img).not.toHaveAttribute('srcset')
+  })
+
+  it("keeps calling the caller's onError after the fallback guard has tripped", () => {
+    const onError = vi.fn()
+    render(<PosterImage src={POSTER_URL} alt="poster" width={200} onError={onError} />)
+
+    const img = screen.getByRole('img', { name: 'poster' })
+    fireEvent.error(img)
+    fireEvent.error(img)
+
+    // The ref guard suppresses only the duplicate fallback transition — the
+    // caller still hears about every failure.
+    expect(onError).toHaveBeenCalledTimes(2)
   })
 })

--- a/frontend/src/components/__tests__/PosterImage.test.jsx
+++ b/frontend/src/components/__tests__/PosterImage.test.jsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { describe, expect, it } from 'vitest'
+import PosterImage from '../PosterImage'
+import { POSTER_IMAGE_HOST } from '../../utils/posterImage'
+
+const POSTER_URL = `https://${POSTER_IMAGE_HOST}/event-posters/1-vol17.jpg`
+
+describe('PosterImage', () => {
+  it('renders the transformed src and a matching 1x/2x srcset', () => {
+    render(<PosterImage src={POSTER_URL} alt="LWBC Vol17 poster" width={200} />)
+
+    const img = screen.getByRole('img', { name: 'LWBC Vol17 poster' })
+    expect(img).toHaveAttribute(
+      'src',
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/1-vol17.jpg`
+    )
+    expect(img).toHaveAttribute(
+      'srcset',
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/1-vol17.jpg 1x, ` +
+        `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=400,format=auto/event-posters/1-vol17.jpg 2x`
+    )
+  })
+
+  it('defaults to loading="lazy" and decoding="async"', () => {
+    render(<PosterImage src={POSTER_URL} alt="poster" width={200} />)
+    const img = screen.getByRole('img', { name: 'poster' })
+    expect(img).toHaveAttribute('loading', 'lazy')
+    expect(img).toHaveAttribute('decoding', 'async')
+  })
+
+  it('passes through unchanged for a foreign-host URL (no srcset)', () => {
+    const foreignUrl = 'https://cdn.example.com/posters/poster-fest.jpg'
+    render(<PosterImage src={foreignUrl} alt="poster" width={200} />)
+    const img = screen.getByRole('img', { name: 'poster' })
+    expect(img).toHaveAttribute('src', foreignUrl)
+    expect(img).not.toHaveAttribute('srcset')
+  })
+
+  it('falls back to the untransformed original src on error, exactly once', () => {
+    render(<PosterImage src={POSTER_URL} alt="LWBC Vol17 poster" width={200} />)
+    const img = screen.getByRole('img', { name: 'LWBC Vol17 poster' })
+
+    expect(img).toHaveAttribute(
+      'src',
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/1-vol17.jpg`
+    )
+
+    fireEvent.error(img)
+
+    expect(img).toHaveAttribute('src', POSTER_URL)
+    expect(img).not.toHaveAttribute('srcset')
+
+    // A second error (e.g. the untransformed original also fails to load)
+    // must not loop back to re-request the transform URL — the guard trips
+    // once and stays tripped.
+    fireEvent.error(img)
+    expect(img).toHaveAttribute('src', POSTER_URL)
+    expect(img).not.toHaveAttribute('srcset')
+  })
+
+  it('passes through extra props (e.g. className) to the underlying <img>', () => {
+    render(<PosterImage src={POSTER_URL} alt="poster" width={200} className="max-h-96 w-full" />)
+    const img = screen.getByRole('img', { name: 'poster' })
+    expect(img).toHaveClass('max-h-96', 'w-full')
+  })
+})

--- a/frontend/src/components/ui/ImageLightbox.jsx
+++ b/frontend/src/components/ui/ImageLightbox.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { X } from 'lucide-react'
+import PosterImage from '../PosterImage'
 
 /**
  * ImageLightbox — full-viewport click-to-enlarge image viewer (#655).
@@ -22,8 +23,17 @@ import { X } from 'lucide-react'
  * The close button uses `text-white` deliberately — it sits over a fixed
  * dark scrim (bg-black/90), one of the documented theme-token exceptions
  * (CLAUDE.md "Theming"), not a public-surface violation.
+ *
+ * The image renders through `PosterImage` (#659) rather than a bare `<img>`,
+ * so a full-viewport view requests a right-sized Cloudflare image-transform
+ * derivative instead of the full-size original — `width` defaults to 1600,
+ * chosen so a poster stays readable when someone opens it specifically to
+ * read the lineup. Both current callers (the live event page and the
+ * archived recap page) pass a poster URL on the same R2-backed host, so
+ * baking the transform in here (rather than at each call site) keeps them
+ * simple and automatically covers any future caller of this component.
  */
-export default function ImageLightbox({ src, alt, isOpen, onClose }) {
+export default function ImageLightbox({ src, alt, isOpen, onClose, width = 1600 }) {
   const dialogRef = useRef(null)
   const previousActiveElement = useRef(null)
 
@@ -146,9 +156,11 @@ export default function ImageLightbox({ src, alt, isOpen, onClose }) {
             failure. Never let this render with no alt attribute at all:
             React omits the attribute entirely for `undefined`, and AT then
             falls back to announcing the URL. */}
-        <img
+        <PosterImage
           src={src}
+          width={width}
           alt={alt || 'Enlarged image'}
+          loading="eager"
           className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
         />
       </div>
@@ -166,4 +178,6 @@ ImageLightbox.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   /** Callback when the lightbox should close. */
   onClose: PropTypes.func.isRequired,
+  /** Target render width in CSS pixels for the Cloudflare image transform (#659). Defaults to 1600 — full-viewport, so the poster stays readable. */
+  width: PropTypes.number,
 }

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -196,7 +196,13 @@ export default function EventRecapPage() {
                     width={800}
                     alt={`${event.name} poster`}
                     loading="lazy"
-                    className="max-h-96 w-full object-contain"
+                    /* Two-value aspect-ratio (#659 review): reserves a 3:4 box
+                       while the lazy image has no intrinsic dimensions, then
+                       yields to the real ratio on load. object-contain stays
+                       harmless — once `auto` resolves to the intrinsic ratio
+                       the box matches the image, so there is nothing left to
+                       letterbox. */
+                    className="aspect-[auto_3/4] max-h-96 w-full object-contain"
                   />
                 </button>
               </div>

--- a/frontend/src/pages/EventRecapPage.jsx
+++ b/frontend/src/pages/EventRecapPage.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { Link, useParams } from 'react-router-dom'
 import { Alert, ImageLightbox, Loading } from '../components/ui'
+import PosterImage from '../components/PosterImage'
 import { buildBandProfileHref } from '../utils/bandProfileLink'
 import { fetchPublicJson } from '../utils/publicApi'
 import { parseLocalDate } from '../utils/timeFormat'
@@ -190,8 +191,9 @@ export default function EventRecapPage() {
                   aria-label={`View ${event.name} poster`}
                   className="block w-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-400"
                 >
-                  <img
+                  <PosterImage
                     src={event.poster_url}
+                    width={800}
                     alt={`${event.name} poster`}
                     loading="lazy"
                     className="max-h-96 w-full object-contain"

--- a/frontend/src/pages/__tests__/EventRecapPage.test.jsx
+++ b/frontend/src/pages/__tests__/EventRecapPage.test.jsx
@@ -160,7 +160,20 @@ describe('EventRecapPage — poster (#616)', () => {
     expect(await screen.findByText('LWBC Vol16')).toBeInTheDocument()
 
     const poster = screen.getByRole('img', { name: 'LWBC Vol16 poster' })
-    expect(poster).toHaveAttribute('src', 'https://band-photos.settimes.ca/event-posters/1-vol16.jpg')
+    // #659: the recap poster renders through a Cloudflare image transform at
+    // the width it actually displays (max-h-96), not the full-size original.
+    // Asserting the concrete transformed URL — rather than loosening this to a
+    // substring match — is what would catch the width silently reverting or the
+    // rewrite being dropped entirely.
+    expect(poster).toHaveAttribute(
+      'src',
+      'https://band-photos.settimes.ca/cdn-cgi/image/width=800,format=auto/event-posters/1-vol16.jpg'
+    )
+    expect(poster).toHaveAttribute(
+      'srcset',
+      'https://band-photos.settimes.ca/cdn-cgi/image/width=800,format=auto/event-posters/1-vol16.jpg 1x, ' +
+        'https://band-photos.settimes.ca/cdn-cgi/image/width=1600,format=auto/event-posters/1-vol16.jpg 2x'
+    )
     expect(poster).toHaveAttribute('loading', 'lazy')
   })
 

--- a/frontend/src/utils/__tests__/posterImage.test.js
+++ b/frontend/src/utils/__tests__/posterImage.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { POSTER_IMAGE_HOST, posterImageSrcSet, posterImageUrl } from '../posterImage'
+
+const POSTER_URL = `https://${POSTER_IMAGE_HOST}/event-posters/1785199290009-lwbc-vol-17-poster.jpg`
+
+describe('posterImageUrl', () => {
+  it('rewrites a poster-host URL to a width/format=auto transform, preserving the path', () => {
+    expect(posterImageUrl(POSTER_URL, 200)).toBe(
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/1785199290009-lwbc-vol-17-poster.jpg`
+    )
+  })
+
+  it('rounds a fractional width', () => {
+    expect(posterImageUrl(POSTER_URL, 199.6)).toBe(
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/1785199290009-lwbc-vol-17-poster.jpg`
+    )
+  })
+
+  it('preserves query string and hash on the original URL', () => {
+    const url = `https://${POSTER_IMAGE_HOST}/event-posters/poster.jpg?v=2#frag`
+    expect(posterImageUrl(url, 400)).toBe(
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=400,format=auto/event-posters/poster.jpg?v=2#frag`
+    )
+  })
+
+  it.each([[null], [undefined], ['']])('passes through %p unchanged', value => {
+    expect(posterImageUrl(value, 200)).toBe(value)
+  })
+
+  it('passes through a foreign-host URL unchanged', () => {
+    const url = 'https://cdn.example.com/posters/poster-fest.jpg'
+    expect(posterImageUrl(url, 200)).toBe(url)
+  })
+
+  it('passes through a URL that is already a transform URL unchanged', () => {
+    const url = `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/poster.jpg`
+    expect(posterImageUrl(url, 800)).toBe(url)
+  })
+
+  it('passes through unchanged when width is missing, zero, negative, or non-finite', () => {
+    expect(posterImageUrl(POSTER_URL, undefined)).toBe(POSTER_URL)
+    expect(posterImageUrl(POSTER_URL, 0)).toBe(POSTER_URL)
+    expect(posterImageUrl(POSTER_URL, -200)).toBe(POSTER_URL)
+    expect(posterImageUrl(POSTER_URL, NaN)).toBe(POSTER_URL)
+    expect(posterImageUrl(POSTER_URL, Infinity)).toBe(POSTER_URL)
+  })
+
+  it('never throws on a malformed URL string — passes it through unchanged', () => {
+    expect(posterImageUrl('not a url', 200)).toBe('not a url')
+  })
+})
+
+describe('posterImageSrcSet', () => {
+  it('formats a 1x/2x srcset from the given base width', () => {
+    expect(posterImageSrcSet(POSTER_URL, 200)).toBe(
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/1785199290009-lwbc-vol-17-poster.jpg 1x, ` +
+        `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=400,format=auto/event-posters/1785199290009-lwbc-vol-17-poster.jpg 2x`
+    )
+  })
+
+  it('returns undefined for a foreign-host URL rather than a repeated-URL srcset', () => {
+    expect(posterImageSrcSet('https://cdn.example.com/posters/poster-fest.jpg', 200)).toBeUndefined()
+  })
+
+  it('returns undefined for null/undefined/empty input', () => {
+    expect(posterImageSrcSet(null, 200)).toBeUndefined()
+    expect(posterImageSrcSet(undefined, 200)).toBeUndefined()
+    expect(posterImageSrcSet('', 200)).toBeUndefined()
+  })
+
+  it('returns undefined for an already-transformed URL', () => {
+    const url = `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/poster.jpg`
+    expect(posterImageSrcSet(url, 800)).toBeUndefined()
+  })
+})

--- a/frontend/src/utils/__tests__/posterImage.test.js
+++ b/frontend/src/utils/__tests__/posterImage.test.js
@@ -73,3 +73,27 @@ describe('posterImageSrcSet', () => {
     expect(posterImageSrcSet(url, 800)).toBeUndefined()
   })
 })
+
+// A positive width below 0.5 satisfies `width > 0` but rounds to 0, which
+// would emit `width=0,format=auto` — a meaningless transform. The guard runs
+// on the rounded value so the check and the emitted URL agree.
+describe('sub-unit widths', () => {
+  const url = `https://${POSTER_IMAGE_HOST}/event-posters/poster.jpg`
+
+  it.each([0.1, 0.49, 0.0001])('passes through unchanged for width %p', width => {
+    expect(posterImageUrl(url, width)).toBe(url)
+    expect(posterImageSrcSet(url, width)).toBeUndefined()
+  })
+
+  it('still rewrites at the 0.5 rounding boundary, where width becomes 1', () => {
+    expect(posterImageUrl(url, 0.5)).toBe(
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=1,format=auto/event-posters/poster.jpg`
+    )
+  })
+
+  it('never emits width=0', () => {
+    for (const width of [0, 0.1, 0.4, -5, Number.NaN]) {
+      expect(posterImageUrl(url, width)).not.toContain('width=0')
+    }
+  })
+})

--- a/frontend/src/utils/posterImage.js
+++ b/frontend/src/utils/posterImage.js
@@ -37,7 +37,11 @@ function isRewritable(parsed, width) {
   if (!parsed) return false
   if (parsed.hostname !== POSTER_IMAGE_HOST) return false
   if (parsed.pathname.includes(TRANSFORM_MARKER)) return false
-  return Number.isFinite(width) && width > 0
+  // Guard on the ROUNDED width, not the raw one: a positive sub-unit width
+  // like 0.1 passes `> 0` but rounds to 0, which would emit `width=0` — a
+  // meaningless transform. Rounding first keeps the guard and the emitted
+  // value in agreement.
+  return Number.isFinite(width) && Math.round(width) >= 1
 }
 
 /**

--- a/frontend/src/utils/posterImage.js
+++ b/frontend/src/utils/posterImage.js
@@ -1,0 +1,72 @@
+/**
+ * posterImage.js — Cloudflare image-transform URL helper for R2-hosted event
+ * posters (#659).
+ *
+ * Cloudflare image resizing is already enabled on the poster host
+ * (`band-photos.settimes.ca`) via `/cdn-cgi/image/<options>/<original-path>`.
+ * Full-size posters run 240KB-663KB; a ~96px-wide listing thumbnail has no
+ * business downloading a 1440x1920 original. This rewrites a poster URL into
+ * a right-sized, WebP-negotiated (`format=auto`) derivative so each call site
+ * downloads roughly what it renders.
+ *
+ * Only URLs on the poster host are ever rewritten. Everything else — a
+ * missing URL, a foreign host, or a URL that's already been through the
+ * transform — passes through UNCHANGED. A malformed transform URL is worse
+ * than a large original, so this never guesses at a rewrite it can't be sure
+ * of.
+ */
+
+// Mirrors the production fallback default in
+// functions/api/admin/events/posters.js and functions/api/admin/bands/photos.js
+// (`env.BAND_PHOTOS_PUBLIC_URL || "https://band-photos.settimes.ca"`). Kept as
+// a single exported constant so it's never re-typed as a literal elsewhere.
+export const POSTER_IMAGE_HOST = 'band-photos.settimes.ca'
+
+const TRANSFORM_MARKER = '/cdn-cgi/image/'
+
+function parseUrl(url) {
+  if (!url) return null
+  try {
+    return new URL(url)
+  } catch {
+    return null
+  }
+}
+
+function isRewritable(parsed, width) {
+  if (!parsed) return false
+  if (parsed.hostname !== POSTER_IMAGE_HOST) return false
+  if (parsed.pathname.includes(TRANSFORM_MARKER)) return false
+  return Number.isFinite(width) && width > 0
+}
+
+/**
+ * Rewrites a poster URL to a Cloudflare image-transform derivative at the
+ * given pixel width, negotiating format (WebP where the client supports it)
+ * via `format=auto`. Returns the input completely unchanged — never a
+ * best-effort rewrite — when it isn't a poster-host URL, is already a
+ * transform URL, or `width` isn't a positive finite number.
+ */
+export function posterImageUrl(url, width) {
+  const parsed = parseUrl(url)
+  if (!isRewritable(parsed, width)) return url
+
+  const roundedWidth = Math.round(width)
+  return `${parsed.origin}${TRANSFORM_MARKER}width=${roundedWidth},format=auto${parsed.pathname}${parsed.search}${parsed.hash}`
+}
+
+/**
+ * Builds a 1x/2x `srcset` string for a poster URL, e.g.
+ * `".../width=200,format=auto/... 1x, .../width=400,format=auto/... 2x"`.
+ * Returns `undefined` when the base URL isn't rewritable — callers should
+ * fall back to a plain `src` rather than emit a srcset that just repeats the
+ * same URL at both densities.
+ */
+export function posterImageSrcSet(url, width) {
+  const parsed = parseUrl(url)
+  if (!isRewritable(parsed, width)) return undefined
+
+  const oneX = posterImageUrl(url, width)
+  const twoX = posterImageUrl(url, width * 2)
+  return `${oneX} 1x, ${twoX} 2x`
+}


### PR DESCRIPTION
## Summary

Posters were served as full-size originals (240KB–663KB) and scaled down in CSS — a ~96px listing thumbnail downloaded a 1440×1920 JPEG. Every poster now routes through Cloudflare image transforms (already enabled on the poster host) at the width its call site actually renders.

Also fixes the listing thumbnail layout, which was rendering the poster letterboxed inside a stretched box.

Closes #659

## Measured impact

Against the real Vol. 17 poster (363,590 bytes original), fetched live:

| Variant | Bytes | vs. original |
|---|---|---|
| Original | 363,590 | — |
| `width=200,format=auto` (listing) | **22,766** webp | **−94%** |
| `width=400` (2× DPR) | 65,922 webp | −82% |
| `width=800` (recap) | 175,848 webp | −52% |
| 663KB PNG source @ 200 | **25,692** webp | **−96%** |

Expanding "Show History" pulled up to ~6MB of posters across 17 past events. At `width=200` that's roughly **425KB**.

## What changed

| File | Change |
|------|--------|
| `frontend/src/utils/posterImage.js` | New. Rewrites poster-host URLs to `/cdn-cgi/image/width=N,format=auto/<path>`; 1×/2× srcset builder |
| `frontend/src/components/PosterImage.jsx` | New. `<img>` wrapper applying transform + srcset, with `onError` fallback |
| `frontend/src/components/EventTimeline.jsx` | Listing thumbnail → width 200; **layout fix** (below) |
| `frontend/src/pages/EventRecapPage.jsx` | Recap poster → width 800 |
| `frontend/src/components/ui/ImageLightbox.jsx` | Lightbox → width 1600 |
| tests (4 files) | Helper, component, and updated call-site assertions |

**No backend files changed.** Nothing under `functions/` or `migrations/`.

## Layout fix

The listing thumbnail was **doubly constrained**, and one of the two was a bug:

```jsx
<div className="flex flex-1 gap-4 min-w-0">          {/* align-items: stretch */}
  <div className="w-20 sm:w-24 aspect-[3/4] ...">    {/* ratio silently overridden */}
    <img className="h-full w-full object-contain" /> {/* letterboxed in the gap */}
```

The flex row's default `align-items: stretch` overrode the container's `aspect-[3/4]`, so the box rendered far taller than 3:4 and `object-contain` letterboxed the image inside it — visible dead bars **even on Vol. 17's poster, which is exactly 3:4 (1440×1920)** and should have filled the box edge to edge.

Now `self-start` with no fixed ratio and `h-auto`, so the poster sets its own height and nothing letterboxes. Production posters range 0.75–0.80 aspect (3:4, 4:5, 1159×1441, 791×1021), so *any* fixed ratio letterboxed most of them. Width raised from 80/96px to 112/144px.

## Safety / correctness notes

- **`onError` falls back to the untransformed original, exactly once.** If transforms were ever disabled on the zone, every `/cdn-cgi/image/` URL would 404 *simultaneously* — every poster on the site at once. This degrades to full-size originals instead. A ref (not just state) guards against looping if the fallback also fails, and the srcset is cleared alongside src so the browser can't re-trigger a transform via a listed candidate.
- **The helper never guesses.** Passes through completely unchanged for a missing URL, a foreign host, an already-transformed URL, or a non-positive width. A malformed transform URL is worse than a large original.
- **`og:image` / `twitter:image` deliberately keep the ORIGINAL URL** (`functions/event/[slug].js`, untouched). Social crawlers want a large image and some handle transform URLs poorly.
- Removing the fixed aspect box gives up reserved layout space. Accepted deliberately: these images are `loading="lazy"` and the past section is below the fold. Reintroducing a fixed ratio would restore the bug.

## Verification

- [x] Tests: **608 frontend pass** (58 files), **820 backend pass** (+6 pre-existing todos), 0 failures
- [x] ESLint: 0 errors (2 pre-existing frontend warnings, 1 backend — unrelated, untouched)
- [x] Format check: clean, both suites
- [x] Build: green
- [x] Transform URLs verified live against production R2 — all variants returned HTTP 200 with `image/webp`
- [ ] Manual smoke: **pending preview deploy.** Two things worth eyeing: whether `w-28 sm:w-36` is large enough (the reporter felt the previous size was too small), and the mixed-row case where `blr3` has no poster.

Rebased on `main` before push.

## Cost note

Cloudflare image transforms may bill per request depending on plan, and this puts them on a hot path. Bandwidth savings almost certainly justify it, but worth confirming against the account's plan before merge.

---
Built by Sonny · Finished & reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved event poster rendering with responsive sizing and optimized delivery.
  * Added adaptive image variants (1x/2x) for faster poster thumbnails, recap images, and lightbox views.
  * Lightbox now supports a configurable target width for enlarged images.
* **Bug Fixes**
  * Improved poster layout/alignment in event cards, reducing unwanted letterboxing.
  * Enhanced fallback to the original poster when optimized images fail to load.
* **Tests**
  * Updated and expanded coverage for poster optimization and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->