### PR TITLE
perf(images): serve a right-sized poster derivative on the live event page

### DIFF
--- a/frontend/src/components/EventPosterThumbnail.jsx
+++ b/frontend/src/components/EventPosterThumbnail.jsx
@@ -17,11 +17,11 @@ import PosterImage from './PosterImage'
  * push it down. Renders nothing when posterUrl is absent/null, which is the
  * common case (most events have no poster yet).
  *
- * Uses PosterImage (#664) rather than a raw <img> so this thumbnail requests
- * a right-sized Cloudflare transform derivative instead of the full-size
- * original — a 180px-tall render has no business downloading a 1440x1800
- * poster. `width={200}` covers the tallest breakpoint's ~150px-wide render
- * at 1x, with PosterImage's 2x srcset candidate covering retina.
+ * Must request a right-sized Cloudflare derivative, never the full-size
+ * original. `width={200}` is tied to the `md:h-[180px]` cap below: a 3:4
+ * portrait poster renders ~150px wide there, so the 200-wide 1x derivative
+ * covers it and PosterImage's 400-wide 2x candidate covers retina. Resize the
+ * thumbnail and this width has to move with it.
  */
 function EventPosterThumbnail({ posterUrl, eventName, onOpen }) {
   if (!posterUrl) return null

--- a/frontend/src/components/EventPosterThumbnail.jsx
+++ b/frontend/src/components/EventPosterThumbnail.jsx
@@ -1,3 +1,5 @@
+import PosterImage from './PosterImage'
+
 /**
  * EventPosterThumbnail — compact, click-to-enlarge poster thumbnail for the
  * live event page header (#655).
@@ -6,13 +8,20 @@
  * events' recap pages — an uploaded poster silently did nothing on a
  * published/upcoming event's own page. This renders a small thumbnail near
  * the top of the event page; `onOpen` is expected to open an ImageLightbox
- * with the full-size poster.
+ * with the full-size poster (the untransformed `posterUrl` — the lightbox
+ * intentionally bypasses PosterImage so the enlarged view isn't downscaled).
  *
  * Deliberately compact (~140-180px tall) rather than the recap page's larger
  * treatment: posters are portrait (3:4 or taller) and the live schedule must
  * stay above the fold on mobile — a full-width portrait poster here would
  * push it down. Renders nothing when posterUrl is absent/null, which is the
  * common case (most events have no poster yet).
+ *
+ * Uses PosterImage (#664) rather than a raw <img> so this thumbnail requests
+ * a right-sized Cloudflare transform derivative instead of the full-size
+ * original — a 180px-tall render has no business downloading a 1440x1800
+ * poster. `width={200}` covers the tallest breakpoint's ~150px-wide render
+ * at 1x, with PosterImage's 2x srcset candidate covering retina.
  */
 function EventPosterThumbnail({ posterUrl, eventName, onOpen }) {
   if (!posterUrl) return null
@@ -27,9 +36,10 @@ function EventPosterThumbnail({ posterUrl, eventName, onOpen }) {
         aria-label={`View ${label}`}
         className="overflow-hidden rounded-lg border border-border bg-surface transition-opacity hover:opacity-90 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
       >
-        <img
+        <PosterImage
           src={posterUrl}
           alt={label}
+          width={200}
           loading="lazy"
           className="h-[140px] w-auto object-contain sm:h-[160px] md:h-[180px]"
         />

--- a/frontend/src/components/__tests__/EventPosterThumbnail.test.jsx
+++ b/frontend/src/components/__tests__/EventPosterThumbnail.test.jsx
@@ -2,6 +2,9 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { describe, expect, it, vi } from 'vitest'
 import EventPosterThumbnail from '../EventPosterThumbnail'
+import { POSTER_IMAGE_HOST } from '../../utils/posterImage'
+
+const POSTER_URL = `https://${POSTER_IMAGE_HOST}/event-posters/36-buddiesfest2.jpg`
 
 // #655: the poster thumbnail on the live event page must render nothing when
 // poster_url is absent (the common case — most events have no poster yet).
@@ -17,20 +20,32 @@ describe('EventPosterThumbnail', () => {
   })
 
   it('renders a real button with a lazy-loaded image and correct alt text when posterUrl is present', () => {
-    render(
-      <EventPosterThumbnail
-        posterUrl="https://band-photos.settimes.ca/event-posters/36-buddiesfest2.jpg"
-        eventName="Buddies Fest 2"
-        onOpen={vi.fn()}
-      />
-    )
+    render(<EventPosterThumbnail posterUrl={POSTER_URL} eventName="Buddies Fest 2" onOpen={vi.fn()} />)
 
     const button = screen.getByRole('button', { name: 'View Buddies Fest 2 poster' })
     expect(button.tagName).toBe('BUTTON')
 
     const image = screen.getByRole('img', { name: 'Buddies Fest 2 poster' })
-    expect(image).toHaveAttribute('src', 'https://band-photos.settimes.ca/event-posters/36-buddiesfest2.jpg')
     expect(image).toHaveAttribute('loading', 'lazy')
+  })
+
+  // #664: the thumbnail must request a right-sized Cloudflare transform
+  // derivative (200-wide 1x, 400-wide 2x) instead of the full-size poster
+  // original — this is the whole point of routing through PosterImage rather
+  // than a raw <img src={posterUrl}>.
+  it('requests a Cloudflare image-transform derivative rather than the full-size original', () => {
+    render(<EventPosterThumbnail posterUrl={POSTER_URL} eventName="Buddies Fest 2" onOpen={vi.fn()} />)
+
+    const image = screen.getByRole('img', { name: 'Buddies Fest 2 poster' })
+    expect(image).toHaveAttribute(
+      'src',
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/36-buddiesfest2.jpg`
+    )
+    expect(image).toHaveAttribute(
+      'srcset',
+      `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=200,format=auto/event-posters/36-buddiesfest2.jpg 1x, ` +
+        `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=400,format=auto/event-posters/36-buddiesfest2.jpg 2x`
+    )
   })
 
   it('calls onOpen when clicked', () => {

--- a/frontend/src/components/__tests__/EventPosterThumbnail.test.jsx
+++ b/frontend/src/components/__tests__/EventPosterThumbnail.test.jsx
@@ -29,10 +29,8 @@ describe('EventPosterThumbnail', () => {
     expect(image).toHaveAttribute('loading', 'lazy')
   })
 
-  // #664: the thumbnail must request a right-sized Cloudflare transform
-  // derivative (200-wide 1x, 400-wide 2x) instead of the full-size poster
-  // original — this is the whole point of routing through PosterImage rather
-  // than a raw <img src={posterUrl}>.
+  // #664: the thumbnail must request a right-sized Cloudflare derivative —
+  // a 200-wide 1x src and a 400-wide 2x srcset candidate.
   it('requests a Cloudflare image-transform derivative rather than the full-size original', () => {
     render(<EventPosterThumbnail posterUrl={POSTER_URL} eventName="Buddies Fest 2" onOpen={vi.fn()} />)
 


### PR DESCRIPTION
## Summary

`EventPosterThumbnail` — the poster on the **live** event page (#655) — rendered a raw `<img src={posterUrl}>`, bypassing the Cloudflare image-transform pipeline added in #661. The page therefore downloaded the full-size 1440x1800 original (363,590 bytes) to paint a 114x142 thumbnail, a ~12x linear oversample on the surface every fan opens. `EventRecapPage` was migrated to `PosterImage` in #661; this call site was missed. Found while capturing promo screenshots of https://settimes.ca/event/lwbc17.

Closes #664

## What changed

| File | Change |
|------|--------|
| `frontend/src/components/EventPosterThumbnail.jsx` | Raw `<img>` → `<PosterImage width={200}>`; docblock notes why the lightbox stays untransformed |
| `frontend/src/components/__tests__/EventPosterThumbnail.test.jsx` | New case asserting the `/cdn-cgi/image/` src + 1x/2x srcset; existing src assertion folded into it (it asserted the now-incorrect untransformed URL) |

Measured against production:

| Variant | Bytes | Format | Saving |
|---|---:|---|---:|
| Original (shipped before this PR) | 363,590 | image/jpeg | — |
| `width=200,format=auto` (1x) | 21,785 | image/avif | **94%** |
| `width=400,format=auto` (2x) | 61,584 | image/avif | **83%** |

`width={200}` covers the tallest breakpoint (`md:h-[180px]`, ~135px wide at 3:4 portrait) at 1x, with the 2x candidate covering retina.

## Security / correctness notes

None. No auth, data, or user-input path is touched.

Two correctness details worth a reviewer's eye:

- **The lightbox is deliberately NOT changed.** `App.jsx` still passes the untransformed `poster_url` to `ImageLightbox`, so click-to-enlarge keeps showing the full-resolution poster. Downscaling it would have been a regression.
- **Transform failures degrade safely.** `PosterImage`'s `onError` falls back to the untransformed original exactly once, so if image transforms were ever disabled on the zone this thumbnail degrades to today's behaviour rather than breaking.

## Verification

- [x] Tests: 617 pass, 0 failures (`cd frontend && npm test -- --run`, 58 files)
- [x] ESLint: 0 errors (`npm run lint` — 2 pre-existing `react-hooks/exhaustive-deps` warnings in `admin/`, untouched by this PR)
- [x] Format check: clean (`cd frontend && npm run format:check`)
- [x] Build: green (`npm run build`)
- [ ] `validate:openapi`: N/A — no API spec change
- [x] Manual smoke: confirmed against production that the live page currently serves the untransformed R2 URL at `naturalWidth=1440` rendered into 114x142, and that both derivative URLs return HTTP 200 as `image/avif`

## Notes

Vol. 17 is **2026-08-02**, ~5 days out. This is the largest avoidable payload on the primary fan page — worth landing before the crawl.

Follow-ups filed from the same investigation: #665 (sticky header occupies 39% of the mobile viewport) and #666 (poster thumbnail leaves 68% of its row empty).

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Event poster thumbnails now load right-sized image versions for improved efficiency.
  * Added responsive image loading for standard and high-resolution displays.

* **Accessibility**
  * Maintained descriptive alternative text and accessible controls for poster thumbnails.

* **Tests**
  * Updated thumbnail tests to validate right-sized derivative image requests and lazy-loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->