### PR TITLE
fix(time): restore Toronto-local metrics date key and canonical after-midnight constant

### DIFF
--- a/frontend/src/admin/EventsTab.jsx
+++ b/frontend/src/admin/EventsTab.jsx
@@ -17,6 +17,7 @@ import {
   confirmArchivedEventDelete,
 } from '../utils/eventLifecycle'
 import { safeExternalHref } from '../utils/urlSafety'
+import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from '../utils/festivalDays'
 
 const isEventLockedAsArchived = event => event?.status === 'archived' || isEventArchived(event?.date)
 const getAdminEventState = event => (event?.status === 'archived' ? 'archived' : getEventState(event?.date))
@@ -28,7 +29,6 @@ const inputFocusClass =
   'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-purple'
 
 const MINUTES_IN_DAY = 24 * 60
-const EARLY_MORNING_CUTOFF_HOUR = 6
 const EVENING_START_HOUR = 18
 
 const parseTimeToMinutes = time => {
@@ -42,7 +42,7 @@ const getSortableTimeMinutes = time => {
   const totalMinutes = parseTimeToMinutes(time)
   if (totalMinutes === null) return Number.POSITIVE_INFINITY
   const hours = Math.floor(totalMinutes / 60)
-  return hours < EARLY_MORNING_CUTOFF_HOUR ? totalMinutes + MINUTES_IN_DAY : totalMinutes
+  return hours < AFTER_MIDNIGHT_THRESHOLD_HOUR ? totalMinutes + MINUTES_IN_DAY : totalMinutes
 }
 
 const getDurationMinutes = (startTime, endTime) => {
@@ -73,7 +73,7 @@ const calculateEventTotals = eventBands => {
     if (startMinutes === null) return
     const hour = Math.floor(startMinutes / 60)
     if (hour >= EVENING_START_HOUR) hasEveningShows = true
-    if (hour < EARLY_MORNING_CUTOFF_HOUR) hasEarlyMorningShows = true
+    if (hour < AFTER_MIDNIGHT_THRESHOLD_HOUR) hasEarlyMorningShows = true
   })
 
   const isMidnightCrossing = hasEveningShows && hasEarlyMorningShows
@@ -94,10 +94,10 @@ const calculateEventTotals = eventBands => {
     if (isMidnightCrossing) {
       const startHour = Math.floor(startMinutes / 60)
       const endHour = Math.floor(endMinutes / 60)
-      if (startHour < EARLY_MORNING_CUTOFF_HOUR) {
+      if (startHour < AFTER_MIDNIGHT_THRESHOLD_HOUR) {
         adjustedStart += MINUTES_IN_DAY
       }
-      if (endHour < EARLY_MORNING_CUTOFF_HOUR) {
+      if (endHour < AFTER_MIDNIGHT_THRESHOLD_HOUR) {
         adjustedEnd += MINUTES_IN_DAY
       }
     } else if (endMinutes < startMinutes) {

--- a/frontend/src/utils/__tests__/invariants.test.js
+++ b/frontend/src/utils/__tests__/invariants.test.js
@@ -46,4 +46,23 @@ describe('after-midnight threshold invariant (#550, CLAUDE.md "After-midnight ba
     // defeat the import assertion above while still "importing" the name.
     expect(source).not.toMatch(/(?:const|let|var)\s+AFTER_MIDNIGHT_THRESHOLD_HOUR\s*=\s*6\b/)
   })
+
+  it('EventsTab.jsx imports the threshold from festivalDays.js rather than re-encoding a literal 6 (#669)', () => {
+    // #669: EventsTab.jsx had re-encoded the canonical threshold as its own
+    // `EARLY_MORNING_CUTOFF_HOUR = 6` local constant instead of importing
+    // AFTER_MIDNIGHT_THRESHOLD_HOUR from festivalDays.js — exactly the drift
+    // this guard exists to catch, and it didn't (no guard covered this file
+    // before this test). Same source-read technique as the bandUtils.js
+    // check above, extended to this file.
+    const currentFile = fileURLToPath(import.meta.url)
+    const eventsTabPath = path.join(path.dirname(currentFile), '../../admin/EventsTab.jsx')
+    const source = readFileSync(eventsTabPath, 'utf8')
+
+    expect(source).toMatch(/import\s*{[^}]*AFTER_MIDNIGHT_THRESHOLD_HOUR[^}]*}\s*from\s*['"][^'"]*festivalDays['"]/)
+    // Guards against a locally re-encoded cutoff constant under any name
+    // (e.g. the original `EARLY_MORNING_CUTOFF_HOUR = 6`) reappearing
+    // alongside or instead of the import.
+    expect(source).not.toMatch(/(?:const|let|var)\s+\w*CUTOFF\w*\s*=\s*6\b/i)
+    expect(source).not.toMatch(/(?:const|let|var)\s+AFTER_MIDNIGHT_THRESHOLD_HOUR\s*=\s*6\b/)
+  })
 })

--- a/frontend/src/utils/__tests__/invariants.test.js
+++ b/frontend/src/utils/__tests__/invariants.test.js
@@ -64,5 +64,12 @@ describe('after-midnight threshold invariant (#550, CLAUDE.md "After-midnight ba
     // alongside or instead of the import.
     expect(source).not.toMatch(/(?:const|let|var)\s+\w*CUTOFF\w*\s*=\s*6\b/i)
     expect(source).not.toMatch(/(?:const|let|var)\s+AFTER_MIDNIGHT_THRESHOLD_HOUR\s*=\s*6\b/)
+    // A re-encoding needn't be named *CUTOFF* — `EARLY_MORNING_HOUR = 6` is the
+    // same drift under a name the guard above misses.
+    expect(source).not.toMatch(/(?:const|let|var)\s+\w*HOUR\w*\s*=\s*6\b/i)
+    // Nor need it be a named constant at all: inlining the threshold directly
+    // into the comparison (`hours < 6`) defeats every declaration guard above
+    // while re-encoding the exact value the invariant protects.
+    expect(source).not.toMatch(/\b\w*hours?\w*\s*[<>]=?\s*6\b/i)
   })
 })

--- a/functions/api/__tests__/metrics.test.js
+++ b/functions/api/__tests__/metrics.test.js
@@ -5,7 +5,7 @@
 import { describe, expect, test, vi, afterEach } from "vitest";
 import { onRequestPost } from "../metrics.js";
 import * as loggerModule from "../../utils/logger.js";
-import { createTestEnv } from "../test-utils.js";
+import { createTestEnv, insertBand } from "../test-utils.js";
 
 function makeRequest(events) {
   return new Request("https://example.test/api/metrics", {
@@ -95,5 +95,45 @@ describe("POST /api/metrics", () => {
       expect.stringContaining("page_views_daily"),
       expect.objectContaining({ statementCount: expect.any(Number) }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Toronto-local date key, not UTC-sliced (#668, CLAUDE.md "Server-side
+// 'today'/'now' is Toronto-local — never UTC-sliced"). The date key written
+// into artist_daily_stats/page_views_daily used to come from
+// `new Date().toISOString().split("T")[0]`, which flips to the next UTC day
+// at 8 PM Eastern — evening traffic was silently misattributed to tomorrow's
+// date. Regression for the metrics.js fix restoring eventLocalToday().
+// ---------------------------------------------------------------------------
+describe("POST /api/metrics — date key is Toronto-local, not UTC (#668)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("evening Toronto traffic is written under the Toronto date, not the UTC date", async () => {
+    const { env, rawDb } = createTestEnv();
+    const band = insertBand(rawDb, { name: "Cool Band" });
+
+    // 2026-08-02T23:30:00-04:00 is 11:30 PM EDT on Aug 2 in Toronto, but
+    // 2026-08-03T03:30:00Z in UTC — the exact drift window the bug hit.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T23:30:00-04:00"));
+
+    const events = [
+      { event: "artist_profile_view", props: { band_profile_id: band.band_profile_id } },
+      { event: "page_view", props: { page: "/bands/cool-band" } },
+    ];
+
+    const res = await onRequestPost({ request: makeRequest(events), env });
+    expect(res.status).toBe(200);
+
+    const statsRow = rawDb
+      .prepare("SELECT date FROM artist_daily_stats WHERE band_profile_id = ?")
+      .get(band.band_profile_id);
+    expect(statsRow.date).toBe("2026-08-02");
+
+    const pvRow = rawDb.prepare("SELECT date FROM page_views_daily WHERE page = ?").get("/bands/cool-band");
+    expect(pvRow.date).toBe("2026-08-02");
   });
 });

--- a/functions/api/metrics.js
+++ b/functions/api/metrics.js
@@ -3,6 +3,7 @@
 // Privacy-first: no PII, aggregated only
 
 import { logger } from "../utils/logger.js";
+import { eventLocalToday } from "../utils/eventDay.js";
 
 const MAX_BATCH_STATEMENTS = 20;
 
@@ -83,7 +84,11 @@ export async function onRequestPost(context) {
     }
 
     if (env.DB) {
-      const today = new Date().toISOString().split("T")[0];
+      // Toronto-local, not UTC-sliced: new Date().toISOString() flips to the
+      // next day at 8 PM Eastern, which misattributed evening traffic to
+      // tomorrow's date key (CLAUDE.md "Server-side 'today'/'now' is
+      // Toronto-local", #668).
+      const today = eventLocalToday();
       const bandViewCounts = new Map();
       const socialClickCounts = new Map();
       const pageCounts = new Map(); // page path → count


### PR DESCRIPTION
## Summary

Restores two documented invariants that had drifted back into the codebase. Both were found by a full-codebase audit and both are pre-Vol-17 because they affect event night directly.

Closes #668
Closes #669

## Changes

### `functions/api/metrics.js` — Toronto-local date key (#668)

`new Date().toISOString().split("T")[0]` was the date key bound into both `artist_daily_stats` and `page_views_daily`. `toISOString()` flips to the next day at **8:00 PM Eastern**.

Vol. 17 runs doors 6:30 PM past midnight, so **the majority of event-night traffic was being attributed to Aug 3 instead of Aug 2**. Now uses `eventLocalToday()` from `functions/utils/eventDay.js`, matching the five other correct usages already in the tree.

Violated the CLAUDE.md invariant "Server-side 'today'/'now' is Toronto-local — never UTC-sliced" (the PR #568 bug class).

### `frontend/src/admin/EventsTab.jsx` — canonical after-midnight constant (#669)

`EARLY_MORNING_CUTOFF_HOUR = 6` re-encoded the canonical `AFTER_MIDNIGHT_THRESHOLD_HOUR` from `frontend/src/utils/festivalDays.js`, which states every consumer must import it rather than re-encode `6`. Every other consumer complied; this was the sole holdout.

Four use sites updated (two in `getSortableTimeMinutes`/`calculateEventTotals`, two more in the midnight-crossing branch). Behaviour is identical — both values are 6. Vol. 17 has 3 after-midnight sets, so this is the live admin sort path on event night.

## Test plan

Both regression tests were **verified to fail against the pre-fix code**, not just asserted to:

- `functions/api/__tests__/metrics.test.js` — pins the clock to `2026-08-02T23:30:00-04:00` (Aug 2 in Toronto, Aug 3 in UTC) and asserts both daily tables record `2026-08-02`. Fails with the old UTC slice.
- `frontend/src/utils/__tests__/invariants.test.js` — extends the existing source-read guard (which proved `bandUtils.js` imports rather than re-hardcodes) to also cover `EventsTab.jsx`. **This guard existed but didn't scan the one file that violated the invariant** — closing that hole is the more valuable half of this PR.

## Verification

- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm test` — 821 passed, 6 todo (was 820)
- [x] `cd frontend && npm run lint` — 0 errors
- [x] `cd frontend && npm run format:check` — clean
- [x] `cd frontend && npm test -- --run` — 618 passed (was 616)
- [x] `cd frontend && npm run build` — green
- [x] Both new tests confirmed red against pre-fix code

## Risk

Low. 11 production lines, no schema change, no API contract change, no behaviour change beyond the two bug corrections.

## Notes

Neither open Dependabot high alert is addressed here — both were assessed as non-exploitable (`react-router` RSC advisory doesn't apply to this SPA; `js-yaml` is a dev-only transitive). Deliberately deferred until after Aug 2.

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event schedule sorting and duration calculations for performances occurring after midnight.
  - Corrected early-morning event handling so times spanning midnight are displayed and calculated consistently.
  - Fixed daily metrics dates to use the event’s Toronto-local date, preventing activity from being assigned to the wrong day.
  - Preserved existing event management and analytics behaviour outside these date and time corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->