### PR TITLE
ux(mobile): collapse sticky event header, inline the poster, drop weekday from dates

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -720,6 +720,8 @@ function App() {
           onVenueFilterChange={setVenueFilter}
           timeFilter={timeFilter}
           onTimeFilterChange={setTimeFilter}
+          posterUrl={eventData?.poster_url}
+          onPosterOpen={() => setPosterLightboxOpen(true)}
         />
       )}
       <main
@@ -733,11 +735,20 @@ function App() {
         <div className="hidden sm:block">
           <Breadcrumbs items={breadcrumbs} />
         </div>
-        <EventPosterThumbnail
-          posterUrl={eventData?.poster_url}
-          eventName={eventData?.name}
-          onOpen={() => setPosterLightboxOpen(true)}
-        />
+        {/* Archived events skip LiveContextBar entirely (no sticky bar, no
+            Tabs) so this stays the ONLY poster placement and must render at
+            every width. Live (non-archived) events hide it below `sm:` —
+            LiveContextBar renders the poster itself there
+            (`variant="inline"`, beside the title/stats, #666) as part of
+            its mobile identity block, so showing it here too would
+            duplicate it. */}
+        <div className={isArchived ? undefined : 'hidden sm:block'}>
+          <EventPosterThumbnail
+            posterUrl={eventData?.poster_url}
+            eventName={eventData?.name}
+            onOpen={() => setPosterLightboxOpen(true)}
+          />
+        </div>
 
         {/* Archived event banner */}
         {isArchived && (

--- a/frontend/src/admin/utils/__tests__/dayOptions.test.js
+++ b/frontend/src/admin/utils/__tests__/dayOptions.test.js
@@ -47,26 +47,26 @@ describe('enumerateFestivalDays', () => {
 })
 
 describe('buildDayOptions', () => {
-  it('produces correct labels/values for a 2-day span', () => {
+  it('produces correct labels/values for a 2-day span (no weekday, #681)', () => {
     const options = buildDayOptions('2026-08-02', '2026-08-03')
     expect(options).toEqual([
-      { value: '2026-08-02', label: 'Day 1 (Sun Aug 2)' },
-      { value: '2026-08-03', label: 'Day 2 (Mon Aug 3)' },
+      { value: '2026-08-02', label: 'Day 1 (Aug 2)' },
+      { value: '2026-08-03', label: 'Day 2 (Aug 3)' },
     ])
   })
 
-  it('produces correct labels/values for a 3-day span', () => {
+  it('produces correct labels/values for a 3-day span (no weekday, #681)', () => {
     const options = buildDayOptions('2026-08-02', '2026-08-04')
     expect(options).toEqual([
-      { value: '2026-08-02', label: 'Day 1 (Sun Aug 2)' },
-      { value: '2026-08-03', label: 'Day 2 (Mon Aug 3)' },
-      { value: '2026-08-04', label: 'Day 3 (Tue Aug 4)' },
+      { value: '2026-08-02', label: 'Day 1 (Aug 2)' },
+      { value: '2026-08-03', label: 'Day 2 (Aug 3)' },
+      { value: '2026-08-04', label: 'Day 3 (Aug 4)' },
     ])
   })
 
   it('produces a single Day 1 option for a single-day event', () => {
     const options = buildDayOptions('2026-08-02', null)
-    expect(options).toEqual([{ value: '2026-08-02', label: 'Day 1 (Sun Aug 2)' }])
+    expect(options).toEqual([{ value: '2026-08-02', label: 'Day 1 (Aug 2)' }])
   })
 
   it('option values round-trip through enumerateFestivalDays', () => {

--- a/frontend/src/admin/utils/dayOptions.js
+++ b/frontend/src/admin/utils/dayOptions.js
@@ -58,7 +58,11 @@ export const enumerateFestivalDays = (startDate, endDate) => {
 
 /**
  * Builds <select> options for an event's festival days:
- * [{ value: 'YYYY-MM-DD', label: 'Day 1 (Sat Aug 2)' }, ...]
+ * [{ value: 'YYYY-MM-DD', label: 'Day 1 (Aug 2)' }, ...]
+ *
+ * No weekday in the label (#681) — `formatFestivalDate`'s docblock explains
+ * why (an after-midnight set's calendar weekday can mismatch the festival
+ * day it belongs to).
  */
 export const buildDayOptions = (startDate, endDate) =>
   enumerateFestivalDays(startDate, endDate).map((value, index) => ({

--- a/frontend/src/components/EventPosterThumbnail.jsx
+++ b/frontend/src/components/EventPosterThumbnail.jsx
@@ -65,7 +65,10 @@ function EventPosterThumbnail({ posterUrl, eventName, onOpen, variant = 'standal
           src={posterUrl}
           alt={label}
           width={isInline ? 80 : 200}
-          loading="lazy"
+          // The inline variant renders in the sticky bar, above the fold — lazy
+          // loading it would delay LCP and pop in. Standalone stays lazy.
+          loading={isInline ? 'eager' : 'lazy'}
+          fetchPriority={isInline ? 'high' : undefined}
           className={
             isInline ? 'h-[100px] w-auto object-contain' : 'h-[140px] w-auto object-contain sm:h-[160px] md:h-[180px]'
           }

--- a/frontend/src/components/EventPosterThumbnail.jsx
+++ b/frontend/src/components/EventPosterThumbnail.jsx
@@ -2,34 +2,59 @@ import PosterImage from './PosterImage'
 
 /**
  * EventPosterThumbnail — compact, click-to-enlarge poster thumbnail for the
- * live event page header (#655).
+ * live event page (#655).
  *
  * `poster_url` (added in #616) was previously only ever visible on archived
  * events' recap pages — an uploaded poster silently did nothing on a
- * published/upcoming event's own page. This renders a small thumbnail near
- * the top of the event page; `onOpen` is expected to open an ImageLightbox
- * with the full-size poster (the untransformed `posterUrl` — the lightbox
- * intentionally bypasses PosterImage so the enlarged view isn't downscaled).
+ * published/upcoming event's own page. `onOpen` is expected to open an
+ * ImageLightbox with the full-size poster (the untransformed `posterUrl` —
+ * the lightbox intentionally bypasses PosterImage so the enlarged view
+ * isn't downscaled). Renders nothing when posterUrl is absent/null, which is
+ * the common case (most events have no poster yet).
  *
- * Deliberately compact (~140-180px tall) rather than the recap page's larger
- * treatment: posters are portrait (3:4 or taller) and the live schedule must
- * stay above the fold on mobile — a full-width portrait poster here would
- * push it down. Renders nothing when posterUrl is absent/null, which is the
- * common case (most events have no poster yet).
+ * Two layout variants, both rendered by `App.jsx` (desktop) and
+ * `LiveContextBar` (mobile) rather than one responsive shape, because the
+ * two surfaces have genuinely different jobs (#666):
+ *
+ * - `variant="standalone"` (default): a full-width row below the
+ *   breadcrumbs — unchanged from the original #655 shape, sizing included.
+ *   `App.jsx` wraps it in `hidden sm:block` for LIVE events only, because
+ *   `LiveContextBar` (mobile-only `variant="inline"`) takes over there;
+ *   ARCHIVED events skip `LiveContextBar` entirely, so `standalone` stays
+ *   the only poster placement and must keep rendering at every width there.
+ * - `variant="inline"`: sits beside the event title/stats inside
+ *   `LiveContextBar`'s mobile-only identity block, `sm:hidden`. Mobile
+ *   previously rendered `standalone` alone on its own row — 114x142px in a
+ *   361px-wide container, 68% of the row empty — while still costing a full
+ *   ~142px of vertical space. `inline` reclaims that dead width AND removes
+ *   the extra row: the poster sits in the same row as the title/stats it
+ *   used to sit above, at roughly that column's natural height instead of
+ *   adding to it. It also participates in the identity block's
+ *   scroll-collapse (#665) — a sticky-pinned poster after the fan starts
+ *   scrolling the lineup would just be trading one wasted-space problem for
+ *   another.
  *
  * Must request a right-sized Cloudflare derivative, never the full-size
- * original. `width={200}` is tied to the `md:h-[180px]` cap below: a 3:4
- * portrait poster renders ~150px wide there, so the 200-wide 1x derivative
- * covers it and PosterImage's 400-wide 2x candidate covers retina. Resize the
- * thumbnail and this width has to move with it.
+ * original — the `width` passed to `PosterImage` must track whichever
+ * variant's rendered height is in play:
+ * - `standalone`'s `width={200}` is tied to its `md:h-[180px]` cap: a 3:4
+ *   portrait poster renders ~150px wide there, so the 200-wide 1x
+ *   derivative covers it and PosterImage's 400-wide 2x candidate covers
+ *   retina.
+ * - `inline`'s `width={80}` is tied to its `h-[100px]` cap: a 3:4 portrait
+ *   poster renders ~75px wide there, so 80 covers the 1x case with a small
+ *   margin for posters slightly wider than 3:4.
+ *
+ * Resize either variant and its `width` has to move with it.
  */
-function EventPosterThumbnail({ posterUrl, eventName, onOpen }) {
+function EventPosterThumbnail({ posterUrl, eventName, onOpen, variant = 'standalone' }) {
   if (!posterUrl) return null
 
   const label = eventName ? `${eventName} poster` : 'Event poster'
+  const isInline = variant === 'inline'
 
   return (
-    <div className="flex justify-start">
+    <div className={isInline ? 'shrink-0' : 'flex justify-start'}>
       <button
         type="button"
         onClick={onOpen}
@@ -39,9 +64,11 @@ function EventPosterThumbnail({ posterUrl, eventName, onOpen }) {
         <PosterImage
           src={posterUrl}
           alt={label}
-          width={200}
+          width={isInline ? 80 : 200}
           loading="lazy"
-          className="h-[140px] w-auto object-contain sm:h-[160px] md:h-[180px]"
+          className={
+            isInline ? 'h-[100px] w-auto object-contain' : 'h-[140px] w-auto object-contain sm:h-[160px] md:h-[180px]'
+          }
         />
       </button>
     </div>

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -567,10 +567,13 @@ function EventCard({
   const [expanded, setExpanded] = useState(isLive) // Auto-expand live events
   const ticketHref = safeExternalHref(event.ticket_url)
 
+  // No `weekday` (#681): a festival day runs 6 AM -> 6 AM, so an
+  // after-midnight set's calendar weekday can mismatch the festival day a
+  // fan actually experienced — month/day/year carries the same information
+  // without that ambiguity.
   const formatDate = dateStr => {
     const date = parseLocalDate(dateStr) || new Date(dateStr)
     return date.toLocaleDateString('en-US', {
-      weekday: 'long',
       year: 'numeric',
       month: 'long',
       day: 'numeric',

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,39 +1,21 @@
-import { memo, useEffect, useState } from 'react'
+import { memo } from 'react'
 import { Link } from 'react-router-dom'
+import { useScrollCollapse } from '../hooks/useScrollCollapse.js'
 import ThemeToggle from './ThemeToggle.jsx'
 import VenueStrip from './VenueStrip.jsx'
 
 function Header({ eventName, eventDate, selectedVenues }) {
+  // No `weekday` (#681): a festival day runs 6 AM -> 6 AM, so an
+  // after-midnight set's calendar weekday can mismatch the festival day a
+  // fan is standing in — the month/day alone carries the same information
+  // without that ambiguity.
   const formattedDate = eventDate
     ? new Date(`${eventDate}T12:00:00`).toLocaleDateString('en-US', {
-        weekday: 'long',
         month: 'long',
         day: 'numeric',
       })
     : null
-  const [scrollProgress, setScrollProgress] = useState(0)
-
-  useEffect(() => {
-    let frame = null
-    const update = () => {
-      frame = null
-      const y = window.scrollY || 0
-      const start = 20
-      const end = 140
-      const next = Math.min(Math.max((y - start) / (end - start), 0), 1)
-      setScrollProgress(prev => (Math.abs(prev - next) < 0.01 ? prev : next))
-    }
-    const onScroll = () => {
-      if (frame) return
-      frame = requestAnimationFrame(update)
-    }
-    update()
-    window.addEventListener('scroll', onScroll, { passive: true })
-    return () => {
-      window.removeEventListener('scroll', onScroll)
-      if (frame) cancelAnimationFrame(frame)
-    }
-  }, [])
+  const scrollProgress = useScrollCollapse(20, 140)
 
   const headerPadding = Math.round(12 - 4 * scrollProgress)
   const headerStyle = {

--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -85,12 +85,17 @@ function LiveContextBar({
   // collapsed well before `scrollY` reaches the ~600px this was measured at.
   const scrollProgress = useScrollCollapse(48, 240)
   const identityFadeProgress = Math.min(1, scrollProgress * 1.75)
+  // Past this point the identity block is visually gone. `pointerEvents: none`
+  // alone would still leave its focusable children (the status badge) in the
+  // tab order, so a keyboard user could focus an invisible zero-height
+  // control; `inert` removes them from focus and the a11y tree too.
+  const isIdentityCollapsed = scrollProgress > 0.7
   const identityCollapseStyle = {
     opacity: 1 - identityFadeProgress,
     transform: `translateY(${scrollProgress * -6}px)`,
     maxHeight: `${Math.round(200 * (1 - scrollProgress))}px`,
     overflow: 'hidden',
-    pointerEvents: scrollProgress > 0.7 ? 'none' : 'auto',
+    pointerEvents: isIdentityCollapsed ? 'none' : 'auto',
   }
   const tapCountRef = useRef(0)
   const firstTapTimeRef = useRef(0)
@@ -177,7 +182,7 @@ function LiveContextBar({
               a fan needs once they're scrolling the lineup (Tabs, filter
               toggle) lives in the always-visible block below, outside this
               wrapper. */}
-          <div style={identityCollapseStyle}>
+          <div style={identityCollapseStyle} inert={isIdentityCollapsed}>
             <div className="flex items-center justify-between gap-3">
               <span
                 role="button"

--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -1,9 +1,11 @@
 import { CalendarDays, ChevronDown, Clock, DoorOpen, Route, Warehouse } from 'lucide-react'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
+import { useScrollCollapse } from '../hooks/useScrollCollapse.js'
 import { getDaysAwayAriaLabel, getDaysAwayLabel } from '../utils/daysAway'
 import { getDoorsTimeForDate } from '../utils/doorsTime'
 import { getLifecycleLabel } from '../utils/liveLabel'
 import { formatTime } from '../utils/timeFormat'
+import EventPosterThumbnail from './EventPosterThumbnail'
 import EventSocialLinks from './EventSocialLinks'
 import GhostEasterEgg from './GhostEasterEgg'
 import TimeFilter from './TimeFilter'
@@ -38,6 +40,8 @@ function LiveContextBar({
   onVenueFilterChange,
   timeFilter = 'all',
   onTimeFilterChange,
+  posterUrl = null,
+  onPosterOpen,
 }) {
   const venueOptions = useMemo(() => [...new Set(bands.map(band => band.venue).filter(Boolean))].sort(), [bands])
   const hasVenueFilter = venueOptions.length > 1
@@ -62,8 +66,32 @@ function LiveContextBar({
     () => getDoorsTimeForDate(eventData?.doors_json, eventData?.date),
     [eventData?.doors_json, eventData?.date]
   )
-  const [isFiltersOpen, setIsFiltersOpen] = useState(true)
+  // Filters (venue/time selects) default OPEN on tablet/desktop, where the
+  // extra vertical space costs nothing, and default CLOSED on phone-width
+  // viewports (#665) — expanded-by-default was the single biggest
+  // contributor to this bar's mobile height, since it renders before the fan
+  // has scrolled (or even interacted) at all. Computed once at mount against
+  // the `sm` breakpoint (640px) rather than tracked on resize — a phone
+  // doesn't get wider mid-session. The Tabs below stay reachable regardless
+  // of this state; only the venue/time selects are gated by it.
+  const [isFiltersOpen, setIsFiltersOpen] = useState(() => typeof window === 'undefined' || window.innerWidth >= 640)
   const [showGhost, setShowGhost] = useState(false)
+
+  // Collapses the mobile-only identity block (status badge, clock, title,
+  // poster, stats line) once the fan scrolls past it — #665. The Tabs and
+  // filter toggle below are NOT part of this collapse; they render in their
+  // own always-visible block further down. Thresholds are wider than the
+  // site header's (20-140) because this block starts taller: fully
+  // collapsed well before `scrollY` reaches the ~600px this was measured at.
+  const scrollProgress = useScrollCollapse(48, 240)
+  const identityFadeProgress = Math.min(1, scrollProgress * 1.75)
+  const identityCollapseStyle = {
+    opacity: 1 - identityFadeProgress,
+    transform: `translateY(${scrollProgress * -6}px)`,
+    maxHeight: `${Math.round(200 * (1 - scrollProgress))}px`,
+    overflow: 'hidden',
+    pointerEvents: scrollProgress > 0.7 ? 'none' : 'auto',
+  }
   const tapCountRef = useRef(0)
   const firstTapTimeRef = useRef(0)
 
@@ -144,53 +172,65 @@ function LiveContextBar({
     <section className="sticky top-[57px] z-40 border-b border-border bg-bg-navy/92 backdrop-blur-xs">
       <div className="container mx-auto px-4 max-w-(--breakpoint-2xl) py-2.5 sm:py-3">
         <div className="sm:hidden">
-          <div className="flex items-center justify-between gap-3">
-            <span
-              role="button"
-              tabIndex={0}
-              className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${lifecycle.classes}`}
-              aria-label={`Event status: ${lifecycle.label}`}
-              onClick={handleLifecycleTap}
-              onKeyDown={e => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  handleLifecycleTap()
-                }
-              }}
-            >
-              {lifecycle.label}
-            </span>
+          {/* Identity block: status badge, clock, poster, title, stats.
+              Collapses on scroll (#665, style computed above) — everything
+              a fan needs once they're scrolling the lineup (Tabs, filter
+              toggle) lives in the always-visible block below, outside this
+              wrapper. */}
+          <div style={identityCollapseStyle}>
+            <div className="flex items-center justify-between gap-3">
+              <span
+                role="button"
+                tabIndex={0}
+                className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${lifecycle.classes}`}
+                aria-label={`Event status: ${lifecycle.label}`}
+                onClick={handleLifecycleTap}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    handleLifecycleTap()
+                  }
+                }}
+              >
+                {lifecycle.label}
+              </span>
 
-            <div className="inline-flex min-h-[36px] shrink-0 items-center gap-2 rounded-full border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-secondary">
-              <Clock size={14} aria-hidden="true" className="text-accent-400" />
-              <span className="tabular-nums">{formatCurrentTime(currentTime)}</span>
+              <div className="inline-flex min-h-[36px] shrink-0 items-center gap-2 rounded-full border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-secondary">
+                <Clock size={14} aria-hidden="true" className="text-accent-400" />
+                <span className="tabular-nums">{formatCurrentTime(currentTime)}</span>
+              </div>
             </div>
-          </div>
 
-          <h2
-            className="mt-2 overflow-hidden text-base font-semibold leading-snug text-text-primary"
-            style={{ display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}
-          >
-            {eventData.name}
-          </h2>
-          <EventSocialLinks socialLinks={eventData.social_links} eventName={eventData.name} className="-ml-2 mt-0.5" />
-
-          <div className="mt-1 flex items-center justify-between gap-2">
-            <p className="truncate text-xs text-text-tertiary">{mobileSummary}</p>
-            <button
-              type="button"
-              onClick={() => setIsFiltersOpen(v => !v)}
-              aria-label={isFiltersOpen ? 'Hide filters' : 'Show filters'}
-              aria-expanded={isFiltersOpen}
-              aria-controls="live-filter-panel"
-              className="shrink-0 flex min-h-[44px] min-w-[44px] items-center justify-center gap-1 px-2 text-xs text-text-tertiary hover:text-text-secondary transition-colors"
-            >
-              <ChevronDown
-                size={14}
-                aria-hidden="true"
-                className={`transition-transform duration-200 ${isFiltersOpen ? 'rotate-180' : ''}`}
-              />
-            </button>
+            {/* Poster beside the title/stats rather than stacked above them
+                (#666) — reclaims the dead width a poster-alone row left
+                empty and drops a whole ~142px row from the mobile vertical
+                budget. Absent posterUrl (the common case) just leaves this
+                column at full width; nothing here depends on the poster
+                being present. */}
+            <div className="mt-2 flex gap-3">
+              {posterUrl && (
+                <EventPosterThumbnail
+                  posterUrl={posterUrl}
+                  eventName={eventData.name}
+                  onOpen={onPosterOpen}
+                  variant="inline"
+                />
+              )}
+              <div className="min-w-0 flex-1">
+                <h2
+                  className="overflow-hidden text-base font-semibold leading-snug text-text-primary"
+                  style={{ display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}
+                >
+                  {eventData.name}
+                </h2>
+                <EventSocialLinks
+                  socialLinks={eventData.social_links}
+                  eventName={eventData.name}
+                  className="-ml-2 mt-0.5"
+                />
+                <p className="mt-1 truncate text-xs text-text-tertiary">{mobileSummary}</p>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -282,9 +322,14 @@ function LiveContextBar({
           </button>
         </div>
 
-        {isFiltersOpen && (
-          <div id="live-filter-panel" className="mt-3 border-t border-border pt-3">
-            <div className="grid gap-2 sm:flex sm:flex-wrap sm:items-center">
+        {/* Tabs (Live Lineup / My Route) and the mobile filters toggle are
+            deliberately OUTSIDE the `isFiltersOpen` gate below (#665) — they
+            are the functional navigation controls and must stay reachable
+            at all times, unlike the venue/time selects, which are genuinely
+            optional filtering and are fine to default-collapse on mobile. */}
+        <div className="mt-3 border-t border-border pt-3">
+          <div className="grid gap-2 sm:flex sm:flex-wrap sm:items-center">
+            <div className="flex items-center gap-2">
               <div className="grid grid-cols-2 items-center rounded-full border border-border bg-surface p-1">
                 <button
                   type="button"
@@ -313,7 +358,30 @@ function LiveContextBar({
                 </button>
               </div>
 
+              {/* Desktop already has its own "Filters" toggle in the stat
+                  chip row above (`ml-auto` button, unaffected by this
+                  change); this compact mobile-only twin keeps the toggle
+                  reachable next to the Tabs once the identity block above
+                  has scroll-collapsed away. */}
+              <button
+                type="button"
+                onClick={() => setIsFiltersOpen(v => !v)}
+                aria-label={isFiltersOpen ? 'Hide filters' : 'Show filters'}
+                aria-expanded={isFiltersOpen}
+                aria-controls="live-filter-panel"
+                className="ml-auto flex min-h-[44px] min-w-[44px] shrink-0 items-center justify-center gap-1 px-2 text-xs text-text-tertiary transition-colors hover:text-text-secondary sm:hidden"
+              >
+                <ChevronDown
+                  size={14}
+                  aria-hidden="true"
+                  className={`transition-transform duration-200 ${isFiltersOpen ? 'rotate-180' : ''}`}
+                />
+              </button>
+            </div>
+
+            {isFiltersOpen && (
               <div
+                id="live-filter-panel"
                 className={`grid gap-2 ${hasVenueFilter ? 'grid-cols-2' : 'grid-cols-1'} sm:flex sm:flex-wrap sm:items-center`}
               >
                 {hasVenueFilter && (
@@ -348,9 +416,9 @@ function LiveContextBar({
                   className="min-w-0 sm:min-w-[180px]"
                 />
               </div>
-            </div>
+            )}
           </div>
-        )}
+        </div>
       </div>
       {showGhost && <GhostEasterEgg onDismiss={() => setShowGhost(false)} />}
     </section>

--- a/frontend/src/components/__tests__/EventPosterThumbnail.test.jsx
+++ b/frontend/src/components/__tests__/EventPosterThumbnail.test.jsx
@@ -60,4 +60,45 @@ describe('EventPosterThumbnail', () => {
     render(<EventPosterThumbnail posterUrl="https://example.test/poster.jpg" onOpen={vi.fn()} />)
     expect(screen.getByRole('button', { name: 'View Event poster' })).toBeInTheDocument()
   })
+
+  // #666: `variant="inline"` is the mobile, beside-the-title-and-stats
+  // layout used inside LiveContextBar — a smaller derivative than the
+  // desktop `standalone` row, and no outer `flex justify-start` wrapper
+  // since its parent flex row now supplies the layout.
+  describe('variant="inline"', () => {
+    it('renders nothing when posterUrl is null', () => {
+      const { container } = render(
+        <EventPosterThumbnail posterUrl={null} eventName="Buddies Fest 2" onOpen={vi.fn()} variant="inline" />
+      )
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it('requests a smaller derivative than the standalone variant', () => {
+      render(
+        <EventPosterThumbnail posterUrl={POSTER_URL} eventName="Buddies Fest 2" onOpen={vi.fn()} variant="inline" />
+      )
+
+      const image = screen.getByRole('img', { name: 'Buddies Fest 2 poster' })
+      expect(image).toHaveAttribute(
+        'src',
+        `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=80,format=auto/event-posters/36-buddiesfest2.jpg`
+      )
+      expect(image).toHaveAttribute(
+        'srcset',
+        `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=80,format=auto/event-posters/36-buddiesfest2.jpg 1x, ` +
+          `https://${POSTER_IMAGE_HOST}/cdn-cgi/image/width=160,format=auto/event-posters/36-buddiesfest2.jpg 2x`
+      )
+    })
+
+    it('still opens the lightbox and keeps a real button tap target', () => {
+      const onOpen = vi.fn()
+      render(
+        <EventPosterThumbnail posterUrl={POSTER_URL} eventName="Buddies Fest 2" onOpen={onOpen} variant="inline" />
+      )
+
+      const button = screen.getByRole('button', { name: 'View Buddies Fest 2 poster' })
+      fireEvent.click(button)
+      expect(onOpen).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/frontend/src/components/__tests__/LiveContextBar.test.jsx
+++ b/frontend/src/components/__tests__/LiveContextBar.test.jsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import LiveContextBar from '../LiveContextBar'
 
 const eventData = {
@@ -11,6 +11,10 @@ const bands = [
   { id: '1', venue: 'Stage A' },
   { id: '2', venue: 'Stage B' },
 ]
+
+function setViewportWidth(width) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width })
+}
 
 describe('LiveContextBar', () => {
   it('surfaces route, venue, and time controls in the sticky bar', () => {
@@ -139,5 +143,151 @@ describe('LiveContextBar', () => {
 
     expect(screen.getAllByText('Tonight').length).toBeGreaterThan(0)
     expect(screen.queryByText(/0 days away/)).not.toBeInTheDocument()
+  })
+
+  // #665: Tabs and the filters toggle are the functional controls and must
+  // stay reachable regardless of the venue/time filter panel's open state —
+  // previously they were rendered INSIDE the same `isFiltersOpen` gate as
+  // the selects, so closing filters also hid the Live Lineup/My Route tabs.
+  describe('Tabs stay reachable independent of the filter panel (#665)', () => {
+    afterEach(() => {
+      setViewportWidth(1024)
+    })
+
+    it('keeps the Tabs visible after collapsing the venue/time filters', () => {
+      render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T19:30:00')}
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+
+      const toggles = screen.getAllByRole('button', { name: /hide filters/i })
+      fireEvent.click(toggles[0])
+
+      expect(screen.queryByLabelText(/Time filter/i)).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Live Lineup/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /My Route/i })).toBeInTheDocument()
+      // The toggle itself must also stay reachable once collapsed.
+      expect(screen.getAllByRole('button', { name: /show filters/i }).length).toBeGreaterThan(0)
+    })
+
+    it('defaults the filter panel open on a desktop-width viewport', () => {
+      setViewportWidth(1024)
+      render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T19:30:00')}
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+
+      expect(screen.getByLabelText(/Time filter/i)).toBeInTheDocument()
+    })
+
+    it('defaults the filter panel collapsed on a phone-width viewport, Tabs still present', () => {
+      setViewportWidth(375)
+      render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T19:30:00')}
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByLabelText(/Time filter/i)).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Live Lineup/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /My Route/i })).toBeInTheDocument()
+    })
+  })
+
+  // #666: the poster is rendered inline (beside the title/stats) inside
+  // LiveContextBar's mobile identity block rather than as its own row.
+  describe('inline poster (#666)', () => {
+    it('renders the poster button when posterUrl is provided', () => {
+      render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T19:30:00')}
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+          posterUrl="https://band-photos.settimes.ca/event-posters/1-test.jpg"
+          onPosterOpen={vi.fn()}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: /View .*poster/i })).toBeInTheDocument()
+    })
+
+    it('renders no poster button when posterUrl is absent — the meta column stays unaffected', () => {
+      render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T19:30:00')}
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: /View .*poster/i })).not.toBeInTheDocument()
+      expect(screen.getAllByText(eventData.name).length).toBeGreaterThan(0)
+    })
+
+    it('calls onPosterOpen when the inline poster is clicked', () => {
+      const onPosterOpen = vi.fn()
+      render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T19:30:00')}
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+          posterUrl="https://band-photos.settimes.ca/event-posters/1-test.jpg"
+          onPosterOpen={onPosterOpen}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /View .*poster/i }))
+      expect(onPosterOpen).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/frontend/src/components/__tests__/ScheduleView.test.jsx
+++ b/frontend/src/components/__tests__/ScheduleView.test.jsx
@@ -330,7 +330,7 @@ describe('ScheduleView — #541: day dividers', () => {
     const dividers = screen.getAllByRole('separator')
     expect(dividers).toHaveLength(1)
     expect(dividers[0]).toHaveTextContent('Day 2')
-    expect(dividers[0]).toHaveTextContent('Sunday, June 2')
+    expect(dividers[0]).toHaveTextContent('June 2')
   })
 })
 
@@ -383,7 +383,7 @@ describe('ScheduleView — #542 PR-3: day-tab filter', () => {
     expect(screen.getByText('Beta')).toBeInTheDocument()
 
     const activeTab = screen.getAllByRole('tab').find(tab => tab.getAttribute('aria-selected') === 'true')
-    expect(activeTab).toHaveTextContent('Sun Jun 2')
+    expect(activeTab).toHaveTextContent('Jun 2')
   })
 
   it('an out-of-range ?day= falls back to the default day instead of blanking the view', () => {
@@ -399,7 +399,7 @@ describe('ScheduleView — #542 PR-3: day-tab filter', () => {
     expect(screen.getByText('Alpha')).toBeInTheDocument()
     expect(screen.queryByText('Beta')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Sun Jun 2' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Jun 2' }))
 
     expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
     expect(screen.getByText('Beta')).toBeInTheDocument()

--- a/frontend/src/components/ui/DayDivider.jsx
+++ b/frontend/src/components/ui/DayDivider.jsx
@@ -9,7 +9,8 @@ import { formatTime } from '../../utils/timeFormat'
  * DayDivider - Design System v1.0
  *
  * Festival-day header shown between sets on different days of a multi-day
- * event (#541): "DAY N · Saturday, August 2". Public / theme-following
+ * event (#541): "DAY N · August 2" (no weekday, #681 — see
+ * `formatFestivalDate`'s docblock for why). Public / theme-following
  * surface — semantic tokens only, never hardcoded white.
  *
  * When `doorsJson` (the event's `doors_json`) has a time for this day's

--- a/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
+++ b/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
@@ -1,0 +1,68 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useScrollCollapse } from '../useScrollCollapse'
+
+function Harness({ start, end }) {
+  const progress = useScrollCollapse(start, end)
+  return <span data-testid="progress">{progress}</span>
+}
+
+function setScrollY(y) {
+  Object.defineProperty(window, 'scrollY', { writable: true, configurable: true, value: y })
+}
+
+function fireScroll() {
+  act(() => {
+    window.dispatchEvent(new Event('scroll'))
+  })
+}
+
+describe('useScrollCollapse', () => {
+  afterEach(() => {
+    setScrollY(0)
+  })
+
+  it('reports 0 before scrolling starts', () => {
+    setScrollY(0)
+    render(<Harness start={40} end={140} />)
+    expect(screen.getByTestId('progress')).toHaveTextContent('0')
+  })
+
+  it('clamps to 0 below the start threshold', () => {
+    setScrollY(20)
+    render(<Harness start={40} end={140} />)
+    fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('0')
+  })
+
+  it('ramps linearly between start and end', () => {
+    setScrollY(90) // halfway between 40 and 140
+    render(<Harness start={40} end={140} />)
+    fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('0.5')
+  })
+
+  it('clamps to 1 at and beyond the end threshold', () => {
+    setScrollY(500)
+    render(<Harness start={40} end={140} />)
+    fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('1')
+  })
+
+  // The anti-jitter guarantee this hook exists for (#665): progress is a
+  // pure function of `window.scrollY` alone, never of anything the
+  // collapsing element itself renders — so a caller re-rendering in
+  // response to a progress change can't feed back into another scroll
+  // measurement and oscillate.
+  it('is driven only by scrollY, not by re-renders with no scroll event', () => {
+    setScrollY(90)
+    const { rerender } = render(<Harness start={40} end={140} />)
+    fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('0.5')
+
+    // A prop change causing a re-render without a new scroll event must not
+    // change the reported progress.
+    rerender(<Harness start={40} end={140} />)
+    expect(screen.getByTestId('progress')).toHaveTextContent('0.5')
+  })
+})

--- a/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
+++ b/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
@@ -11,9 +11,13 @@ function setScrollY(y) {
   Object.defineProperty(window, 'scrollY', { writable: true, configurable: true, value: y })
 }
 
-function fireScroll() {
-  act(() => {
+// The hook batches its measurement into a requestAnimationFrame, so dispatching
+// the event synchronously is not enough — the frame has to be flushed before the
+// committed progress can be asserted.
+async function fireScroll() {
+  await act(async () => {
     window.dispatchEvent(new Event('scroll'))
+    await new Promise(resolve => requestAnimationFrame(resolve))
   })
 }
 
@@ -28,24 +32,34 @@ describe('useScrollCollapse', () => {
     expect(screen.getByTestId('progress')).toHaveTextContent('0')
   })
 
-  it('clamps to 0 below the start threshold', () => {
+  it('clamps to 0 below the start threshold', async () => {
     setScrollY(20)
     render(<Harness start={40} end={140} />)
-    fireScroll()
+    await fireScroll()
     expect(screen.getByTestId('progress')).toHaveTextContent('0')
   })
 
-  it('ramps linearly between start and end', () => {
-    setScrollY(90) // halfway between 40 and 140
+  // These two mount at scrollY 0 and only then scroll, so the asserted value
+  // can ONLY have come from the scroll listener — mounting with the target
+  // scrollY already set would pass on the mount-time update alone and prove
+  // nothing about the listener.
+  it('ramps linearly between start and end', async () => {
+    setScrollY(0)
     render(<Harness start={40} end={140} />)
-    fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('0')
+
+    setScrollY(90) // halfway between 40 and 140
+    await fireScroll()
     expect(screen.getByTestId('progress')).toHaveTextContent('0.5')
   })
 
-  it('clamps to 1 at and beyond the end threshold', () => {
-    setScrollY(500)
+  it('clamps to 1 at and beyond the end threshold', async () => {
+    setScrollY(0)
     render(<Harness start={40} end={140} />)
-    fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('0')
+
+    setScrollY(500)
+    await fireScroll()
     expect(screen.getByTestId('progress')).toHaveTextContent('1')
   })
 

--- a/frontend/src/hooks/useScrollCollapse.js
+++ b/frontend/src/hooks/useScrollCollapse.js
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Tracks `window.scrollY` and returns a 0..1 progress value for a
+ * shrink-on-scroll transition — e.g. the site header's padding/shadow
+ * collapse, or the live-event sticky bar's identity-block collapse (#665).
+ *
+ * `start`/`end` are `window.scrollY` pixel thresholds: progress is 0 below
+ * `start`, ramps linearly to 1 at `end`, and clamps at 1 beyond it.
+ *
+ * Driven purely by `window.scrollY` — never by the collapsing element's own
+ * measured height — so it can't feed back into itself and jitter. That
+ * feedback loop is the classic sticky-collapse bug: if collapsing content
+ * shortens the page, `scrollY` effectively shifts under the user, which
+ * re-triggers the same collapse calculation and the layout oscillates.
+ * Reading only the global scroll position keeps the function monotonic in
+ * a value the collapse itself never changes.
+ *
+ * `requestAnimationFrame`-batched (one measurement per paint, not per
+ * `scroll` event) and only commits a state update when the value moves by
+ * more than 0.01, so repeated paints with no real change don't re-render.
+ *
+ * Callers should apply the returned progress via a CSS `transition-*`
+ * utility (not a JS-timed animation) so the transition inherits the
+ * sitewide `prefers-reduced-motion` rule in `index.css`, which collapses
+ * every transition/animation duration to ~0 for users who request less
+ * motion — there is nothing further this hook needs to do for that.
+ */
+export function useScrollCollapse(start, end) {
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    let frame = null
+    const update = () => {
+      frame = null
+      const y = window.scrollY || 0
+      const next = Math.min(Math.max((y - start) / (end - start), 0), 1)
+      setProgress(prev => (Math.abs(prev - next) < 0.01 ? prev : next))
+    }
+    const onScroll = () => {
+      if (frame) return
+      frame = requestAnimationFrame(update)
+    }
+    update()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      if (frame) cancelAnimationFrame(frame)
+    }
+  }, [start, end])
+
+  return progress
+}

--- a/frontend/src/utils/__tests__/festivalDays.test.js
+++ b/frontend/src/utils/__tests__/festivalDays.test.js
@@ -9,27 +9,27 @@ import {
 } from '../festivalDays'
 
 describe('formatFestivalDate', () => {
-  it('formats the short style as "Sun Aug 2" (no comma)', () => {
-    expect(formatFestivalDate('2026-08-02', 'short')).toBe('Sun Aug 2')
+  it('formats the short style as "Aug 2" (no weekday, #681)', () => {
+    expect(formatFestivalDate('2026-08-02', 'short')).toBe('Aug 2')
   })
 
-  it('formats the long style as "Sunday, August 2"', () => {
-    expect(formatFestivalDate('2026-08-02', 'long')).toBe('Sunday, August 2')
+  it('formats the long style as "August 2" (no weekday, #681)', () => {
+    expect(formatFestivalDate('2026-08-02', 'long')).toBe('August 2')
   })
 
   it('defaults to the long style when no style is passed', () => {
-    expect(formatFestivalDate('2026-08-02')).toBe('Sunday, August 2')
+    expect(formatFestivalDate('2026-08-02')).toBe('August 2')
   })
 
   it('does not drift a day near a month boundary (short style)', () => {
     // July 31 2026 is a Friday; a UTC-parsing bug (`new Date('2026-07-31')`) would
-    // render as "Thu Jul 30" or "Fri Jul 31" depending on timezone offset direction —
+    // render as "Jul 30" or "Jul 31" depending on timezone offset direction —
     // the local-timezone numeric constructor must keep this pinned to Jul 31.
-    expect(formatFestivalDate('2026-07-31', 'short')).toBe('Fri Jul 31')
+    expect(formatFestivalDate('2026-07-31', 'short')).toBe('Jul 31')
   })
 
   it('does not drift a day near a month boundary (long style)', () => {
-    expect(formatFestivalDate('2026-08-01', 'long')).toBe('Saturday, August 1')
+    expect(formatFestivalDate('2026-08-01', 'long')).toBe('August 1')
   })
 
   it('returns an empty string for a missing/empty date', () => {

--- a/frontend/src/utils/festivalDays.js
+++ b/frontend/src/utils/festivalDays.js
@@ -43,8 +43,18 @@ const parseDateParts = dateStr => {
 /**
  * Formats a YYYY-MM-DD string for display.
  *
- * `style: 'short'` -> "Sat Aug 2"
- * `style: 'long'`  -> "Saturday, August 2"
+ * `style: 'short'` -> "Aug 2"
+ * `style: 'long'`  -> "August 2"
+ *
+ * No weekday (#681): a festival day runs 6 AM -> 6 AM
+ * (`AFTER_MIDNIGHT_THRESHOLD_HOUR`), so an after-midnight set belongs to the
+ * *previous evening's* lineup even though its calendar weekday has already
+ * ticked over. A fan at a venue at 1 AM would see their phone say Monday
+ * while a weekday label here said Sunday — both correct, but the mismatch
+ * reads as the app being wrong. Month/day carries the same information
+ * without that ambiguity, and is redundant with the day-number label on
+ * single-day events regardless (see CLAUDE.md "Single-day events: never
+ * show 'Day 1'").
  *
  * Uses the local-timezone numeric `new Date(year, month - 1, day)`
  * constructor (parsed by splitting on `-`) — NEVER `new Date('YYYY-MM-DD')`,
@@ -57,16 +67,13 @@ export const formatFestivalDate = (dateValue, style = 'long') => {
   const date = new Date(year, month - 1, day)
 
   if (style === 'short') {
-    const label = date.toLocaleDateString('en-US', {
-      weekday: 'short',
+    return date.toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
     })
-    return label.replace(',', '')
   }
 
   return date.toLocaleDateString('en-US', {
-    weekday: 'long',
     month: 'long',
     day: 'numeric',
   })


### PR DESCRIPTION
## Summary

Three mobile UX fixes on the live event page — the surface every Instagram promo link lands on.

Closes #665
Closes #666
Closes #681

## #665 — sticky event section now collapses on scroll

Two stacked sticky blocks occupied **335px of a 393x852 viewport (39%)**, leaving ~1.8 set cards visible across a 22-set lineup. The site `<header>` already shrank on scroll (69→61px); the 266px event `<section>` never did.

- Extracted the header's existing shrink-on-scroll math into `frontend/src/hooks/useScrollCollapse.js` and refactored `Header.jsx` onto it (behaviour-preserving, same 20/140 thresholds).
- `LiveContextBar`'s mobile identity block (badge, clock, title, stats) now collapses via the same hook at 48/240.

**Anti-jitter:** progress is driven purely by `window.scrollY`, never by the collapsing element's measured height — so collapsing can't shorten the page, shift `scrollY`, and re-trigger itself. The hook's docblock explains this failure mode explicitly.

**Two judgment calls, both flagged rather than made silently:**

1. **Tabs decoupled from the filters toggle.** The Live Lineup / My Route tabs previously lived *inside* the `isFiltersOpen`-gated block, so "Hide filters" also hid the tabs — on desktop too. That directly violates the issue's "tabs must remain reachable at all times". Now only the venue/time selects are gated. Small desktop behaviour change, visible only if a desktop user clicks "Hide filters".
2. **Filters default collapsed on mobile only** (`window.innerWidth >= 640` at mount). This was the issue's own suggested biggest win. Desktop unchanged.

## #666 — poster now sits beside the event meta

A 114x142px poster sat alone on a 361px row (**247px / 68% unused**) while costing ~142px of vertical budget.

`EventPosterThumbnail` gained a `variant` prop — `standalone` (unchanged) and `inline` (no flex wrapper, `width={80}`, sits beside text). `LiveContextBar` renders `inline` beside the title/stats, so it participates in the #665 collapse.

**Edge case caught in implementation:** archived events skip `LiveContextBar` entirely. Naively hiding `standalone` on mobile would have deleted the poster outright for archived events. The `hidden sm:block` wrapper now applies only to live events; archived events keep `standalone` unconditionally at every width.

Cloudflare image-transform sizing from #661/#667 is preserved — the requested derivative width follows the new rendered dimensions.

## #681 — weekday dropped from festival dates

`formatFestivalDate` no longer emits `weekday` in either style. A festival day runs 6AM→6AM, so a fan at a venue at 1 AM saw their phone say Monday and the schedule say Sunday — the field most likely to make them think the app was broken.

Found two consumers beyond the issue's list: `admin/utils/dayOptions.js` and `DayTabs.jsx`. `Header.jsx` and `EventTimeline.jsx` duplicate the `toLocaleDateString` call rather than using the shared function — both updated.

## Verification

| Gate | Result |
|---|---|
| `npm run lint` | 0 errors |
| `npm run format:check` | clean |
| `npm test -- --run` | **632 passed** (was 618 — 14 new) |
| `npm run build` | green |
| `functions/` diff | empty — backend untouched |
| New hardcoded whites | none (`git diff` grep for `text-white`/`bg-white`/`border-white` returns nothing) |
| `prefers-reduced-motion` | inherited from the global rule at `index.css:418-424` (`transition-duration: 0.01ms !important`) — verified present |
| Tap targets | `min-h-[44px]` on tabs and both toggles |

## Not verified — needs a real device

**The occluded-height number is arithmetic, not measured.** Estimated ~158px collapsed with filters closed (target was <200px), ~216px if a user re-opens filters while scrolled. Real font metrics could shift this ±10-20px.

**Please check the Pages preview deploy on an actual phone** before merging — specifically the collapse feel, the two-column poster proportions, and that nothing jitters at the threshold.

**Visual regression snapshots will need regenerating** via `update-visual-snapshots.yml` after merge — these changes touch exactly the DOM those snapshots cover.

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event posters now appear in the mobile live-event context bar and open in the poster viewer.
  * Live-event filters start collapsed on phones while navigation tabs remain accessible.
  * Poster thumbnails support compact inline display.

* **Improvements**
  * Event dates now show month and day without weekday names for clearer festival-day scheduling.
  * Header and live-event details smoothly collapse while scrolling.

* **Bug Fixes**
  * Improved responsive poster visibility and filter controls across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->