### PR TITLE
fix(a11y): strengthen vacuous a11y tests, fix weekday mislabel in set-card times

### DIFF
--- a/frontend/src/components/VenueStrip.jsx
+++ b/frontend/src/components/VenueStrip.jsx
@@ -21,7 +21,7 @@ function VenueStrip({ activeVenues = [] }) {
   const R_ACTIVE = 8
 
   return (
-    <div className="w-full overflow-x-auto" aria-label="Venue route along King St N">
+    <div className="w-full overflow-x-auto" role="img" aria-label="Venue route along King St N">
       <svg
         viewBox={`0 0 ${W} ${H}`}
         preserveAspectRatio="xMidYMid meet"

--- a/frontend/src/test/a11y.test.jsx
+++ b/frontend/src/test/a11y.test.jsx
@@ -8,25 +8,53 @@ import { ThemeProvider } from '../components/ThemeProvider.jsx'
 
 expect.extend(toHaveNoViolations)
 
-// Mock bands data
+// Mock schedule data, shaped like the real GET /api/schedule response
+// (functions/api/schedule.js): `{ bands: [...], event: {...} }`, not a bare
+// array. App.jsx (`data.bands` / `data.event`) reads the `event` key to
+// populate eventData — a bare-array mock leaves eventData permanently null,
+// which silently skips the Header event chrome, EventPosterThumbnail, and
+// LiveContextBar (it returns null without `eventData?.name`, see
+// LiveContextBar.jsx) from ever being axe-scanned (#674).
+const mockEvent = {
+  id: 1,
+  name: 'Test Band Crawl',
+  date: '2025-10-12',
+  end_date: null,
+  city: 'Waterloo',
+  slug: 'test-event',
+  ticket_url: 'https://example.com/tickets',
+  poster_url: 'https://example.com/poster.jpg',
+  is_archived: false,
+  theme_colors: null,
+  venue_info: null,
+  social_links: null,
+  doors_json: null,
+  reveal_mode: 0,
+}
+
 const mockBands = [
   {
-    id: 'test-band',
+    id: 'test-band-1',
+    performance_id: 1,
+    band_profile_id: 1,
     name: 'Test Band',
+    photo_url: 'https://example.com/band.jpg',
     venue: 'Test Venue',
+    venue_lat: 43.4643,
+    venue_lng: -80.5204,
     date: '2025-10-12',
     startTime: '20:00',
     endTime: '20:30',
-    startMs: new Date('2025-10-12T20:00:00').getTime(),
-    endMs: new Date('2025-10-12T20:30:00').getTime(),
+    url: 'https://example.com/test-band',
+    notes: null,
   },
 ]
 
-// Mock fetch for bands.json
+// Mock fetch for /api/schedule
 global.fetch = vi.fn(() =>
   Promise.resolve({
     ok: true,
-    json: () => Promise.resolve(mockBands),
+    json: () => Promise.resolve({ event: mockEvent, bands: mockBands }),
   })
 )
 
@@ -72,6 +100,10 @@ describe('Accessibility Tests', () => {
     await waitForAppToSettle()
 
     const images = container.querySelectorAll('img')
+    // A `forEach` over an empty NodeList runs zero assertions and still
+    // passes (#674) — assert the mock actually rendered images (the event
+    // poster, at minimum) before checking each one has an alt attribute.
+    expect(images.length).toBeGreaterThan(0)
     images.forEach(img => {
       expect(img).toHaveAttribute('alt')
     })
@@ -82,6 +114,8 @@ describe('Accessibility Tests', () => {
     await waitForAppToSettle()
 
     const buttons = container.querySelectorAll('button')
+    // Same vacuous-pass guard as the images test above (#674).
+    expect(buttons.length).toBeGreaterThan(0)
     buttons.forEach(button => {
       const hasText = button.textContent.trim().length > 0
       const hasAriaLabel = button.hasAttribute('aria-label')

--- a/frontend/src/utils/__tests__/timeFilter.test.js
+++ b/frontend/src/utils/__tests__/timeFilter.test.js
@@ -208,15 +208,23 @@ describe('getTimeDescription never names a weekday (#681)', () => {
     // this exercises the isHappeningThisWeek branch — the one that renders
     // in production for the days leading up to the event.
     globalThis.__debugScheduleTime = new Date(2026, 6, 29, 14, 0, 0) // Wed Jul 29, 2 PM
-    const afterMidnightSundayNightSet = { startMs: new Date(2026, 7, 3, 0, 15, 0).getTime() } // "Mon" 12:15 AM
-    const description = getTimeDescription(afterMidnightSundayNightSet)
-    expect(description).not.toMatch(/Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday/)
+    const start = new Date(2026, 7, 3, 0, 15, 0) // "Mon" 12:15 AM
+    const afterMidnightSundayNightSet = { startMs: start.getTime() }
+    // Exact equality, not a weekday-negative regex: the this-week branch is the
+    // ONLY one returning a bare time, so this pins the branch as well as the
+    // absence of a weekday. A negative regex would also pass on "Today at
+    // 12:15 AM" — i.e. on the wrong branch having run. The expected time is
+    // derived with the same options the implementation uses, so the assertion
+    // stays locale- and timezone-independent in CI.
+    const expectedTime = start.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true })
+    expect(getTimeDescription(afterMidnightSundayNightSet)).toBe(expectedTime)
   })
 
   it('does not name a weekday for a next-week performance', () => {
     globalThis.__debugScheduleTime = new Date(2026, 6, 29, 14, 0, 0) // Wed Jul 29, 2 PM
-    const nextWeekSet = { startMs: new Date(2026, 7, 5, 20, 0, 0).getTime() } // Wed Aug 5, 8 PM
-    const description = getTimeDescription(nextWeekSet)
-    expect(description).not.toMatch(/Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday/)
+    const start = new Date(2026, 7, 5, 20, 0, 0) // Wed Aug 5, 8 PM
+    const nextWeekSet = { startMs: start.getTime() }
+    const expectedTime = start.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true })
+    expect(getTimeDescription(nextWeekSet)).toBe(`Next week at ${expectedTime}`)
   })
 })

--- a/frontend/src/utils/__tests__/timeFilter.test.js
+++ b/frontend/src/utils/__tests__/timeFilter.test.js
@@ -7,6 +7,7 @@ import {
   getEndOfWeek,
   isHappeningToday,
   isHappeningThisWeek,
+  getTimeDescription,
 } from '../timeFilter.js'
 
 const NOW = 1000000000000 // fixed timestamp, 2001-09-08T21:46:40Z
@@ -185,5 +186,37 @@ describe('week boundary at the 1 AM Monday edge (#542, #550 festival-day convent
     globalThis.__debugScheduleTime = new Date(2026, 7, 3, 1, 0, 0)
     const mondayEveningSet = { startMs: new Date(2026, 7, 3, 20, 0, 0).getTime() } // Mon 8 PM
     expect(isHappeningThisWeek(mondayEveningSet)).toBe(false)
+  })
+})
+
+describe('getTimeDescription never names a weekday (#681)', () => {
+  // #681: formatFestivalDate already dropped weekday names for day
+  // dividers/headers because an after-midnight set's real (offset) timestamp
+  // has already rolled over to the next calendar day — a fan sees their
+  // phone say "Monday" for a set that belongs to Sunday night's lineup. PR
+  // #684 fixed formatFestivalDate but missed this function, which every set
+  // card's time label goes through (BandCard.jsx). Same bug, same fix: no
+  // weekday name, ever, in the "this week"/"next week" branches.
+  afterEach(() => {
+    delete globalThis.__debugScheduleTime
+  })
+
+  it('does not name a weekday for a this-week, after-midnight set (the exact #681 reproduction)', () => {
+    // Sunday Aug 2's after-midnight tail — real timestamp is Monday Aug 3,
+    // 12:15 AM (prepareBands' +1-day offset). Checked from earlier in the
+    // same festival week (Wed Jul 29), well before "today"/"now" apply, so
+    // this exercises the isHappeningThisWeek branch — the one that renders
+    // in production for the days leading up to the event.
+    globalThis.__debugScheduleTime = new Date(2026, 6, 29, 14, 0, 0) // Wed Jul 29, 2 PM
+    const afterMidnightSundayNightSet = { startMs: new Date(2026, 7, 3, 0, 15, 0).getTime() } // "Mon" 12:15 AM
+    const description = getTimeDescription(afterMidnightSundayNightSet)
+    expect(description).not.toMatch(/Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday/)
+  })
+
+  it('does not name a weekday for a next-week performance', () => {
+    globalThis.__debugScheduleTime = new Date(2026, 6, 29, 14, 0, 0) // Wed Jul 29, 2 PM
+    const nextWeekSet = { startMs: new Date(2026, 7, 5, 20, 0, 0).getTime() } // Wed Aug 5, 8 PM
+    const description = getTimeDescription(nextWeekSet)
+    expect(description).not.toMatch(/Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday/)
   })
 })

--- a/frontend/src/utils/timeFilter.js
+++ b/frontend/src/utils/timeFilter.js
@@ -295,15 +295,22 @@ export function getTimeDescription(performance) {
   }
 
   // If performance is this week
+  //
+  // No weekday name (#681): an after-midnight set's real startMs is already
+  // offset +1 calendar day by prepareBands() (bandUtils.js), so the raw
+  // Date's weekday is one day ahead of the festival day the set actually
+  // belongs to — e.g. a Sunday-night set reads "Monday" here. Same root
+  // cause and same fix as formatFestivalDate() (festivalDays.js): drop the
+  // ambiguous day label rather than show one that's sometimes wrong.
   if (isHappeningThisWeek(performance)) {
     const startDate = new Date(startTime)
-    return `${startDate.toLocaleDateString([], { weekday: 'long' })} ${startDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true })}${durationStr}`
+    return `${startDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true })}${durationStr}`
   }
 
-  // If performance is next week
+  // If performance is next week — same no-weekday rationale as above.
   if (isHappeningNextWeek(performance)) {
     const startDate = new Date(startTime)
-    return `Next ${startDate.toLocaleDateString([], { weekday: 'long' })} at ${startDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true })}${durationStr}`
+    return `Next week at ${startDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true })}${durationStr}`
   }
 
   // Default to formatted date and time


### PR DESCRIPTION
## Summary

Fixes two accessibility bugs: the a11y test suite's image/button checks passed vacuously and never actually scanned the event header/poster/LiveContextBar chrome, and a reopened weekday-mislabel bug (#681) that PR #684 missed in the set-card time label.

Closes #674
Closes #681

## What changed

| File | Change |
|------|--------|
| `frontend/src/test/a11y.test.jsx` | Added `expect(...length).toBeGreaterThan(0)` guards before the `forEach` assertions on images/buttons (a `forEach` over an empty NodeList ran zero assertions and still passed). Reshaped the fetch mock to `{ event, bands }` (matching the real `GET /api/schedule` response) instead of a bare bands array, so `App.jsx`'s `eventData` is populated and the event header, poster thumbnail, and `LiveContextBar` actually render and get axe-scanned for the first time. |
| `frontend/src/components/VenueStrip.jsx` | Added `role="img"` to the wrapping `<div aria-label="...">`. This is a **real axe violation the improved mock surfaced** (see below) — `aria-label` on a plain `div` with no ARIA role is invalid per the `aria-prohibited-attr` rule. |
| `frontend/src/utils/timeFilter.js` | `getTimeDescription()`'s "this week"/"next week" branches dropped the weekday name from the rendered time label (#681). |
| `frontend/src/utils/__tests__/timeFilter.test.js` | Added a regression test reproducing the exact prod string ("Monday 12:15 a.m." for a Sunday-night after-midnight set), confirmed red before the fix, green after. Added a companion test for the "next week" branch. |

### The axe violation the fixed mock surfaced

With the mock still returning a bare array, `eventData` was always `null` and `LiveContextBar` (which returns `null` without `eventData?.name`) never rendered — so `VenueStrip`, which lives inside it, was never scanned. Once the mock returns a realistic `{ event, bands }` shape, axe immediately flagged:

```
Elements must only use permitted ARIA attributes (aria-prohibited-attr)
<div class="w-full overflow-x-auto" aria-label="Venue route along King St N">
aria-label attribute cannot be used on a div with no valid role attribute.
```

`VenueStrip`'s inner `<svg>` is already `aria-hidden="true"` (a purely decorative transit-map diagram), so the intent was clearly "this whole widget is one labeled graphic." Adding `role="img"` to the wrapper makes `aria-label` valid there and gives the fully-decorative visual a single accessible name — small, unambiguous, no design judgment call needed. No other axe violations surfaced after this fix (full suite is clean).

### #681 (reopened) — weekday mislabel in set-card times

PR #684 fixed the weekday mislabel for day dividers/headers (`formatFestivalDate` in `festivalDays.js`) but missed `getTimeDescription()` in `timeFilter.js`, which is what actually renders every set card's time label (`BandCard.jsx`). Root cause is identical: `prepareBands()` offsets an after-midnight set's real timestamp by `+1` calendar day so it sorts after the same evening's earlier sets — but the raw `Date`'s weekday is then one day ahead of the *festival day* the set belongs to. A Sunday-night set (Vol. 17 is Sunday Aug 2, 2026) with an after-midnight start reads "Monday 12:15 AM" — confirmed live in prod at 393×852 exactly as reported.

I traced through the actual date math before touching anything to confirm which branch renders when:
- On the event day itself (and through 6 AM the next calendar day), `isHappeningToday()` covers the *entire* festival day, so the "Today at 12:15 AM" branch fires — no weekday shown, no ambiguity there.
- The buggy weekday only surfaces in the "this week"/"next week" branches, i.e. in the days *leading up to* the event — exactly matching what was observed in prod right now (5 days before Aug 2).

Fix: drop the weekday from both branches (`getTimeDescription` in `timeFilter.js`), same remediation pattern as `formatFestivalDate`. "This week" now reads as bare time + duration; "next week" reads "Next week at 8:00 PM" (kept the "next" context without naming a possibly-wrong day).

## Accepted trade-off (not a violation, flagged for visibility)

Note that `frontend/src/utils/timeFilter.js` is very much alive — 4 real importers (`App.jsx`, `TimeFilter.jsx`, `BandCard.jsx`, `ScheduleView.jsx`). An earlier draft of this PR incorrectly attempted to delete it based on issue #677's now-retracted "dead code" analysis; that was caught before any file was touched and reverted in-session. **This PR does not reference or touch #677 in any way** — no deletion, no coverage threshold change.

## Security / correctness notes

None. No auth/crypto/session/CSRF code touched. Both changes are presentational (ARIA attribute correction, date-label text) with no data-integrity implications.

## Verification

- [x] Tests: 634 pass, 0 failures (`cd frontend && npm test -- --run`, 59 files)
- [x] ESLint: 0 errors, 2 pre-existing warnings unrelated to this change (`npm run lint`, well under the `--max-warnings 5` gate)
- [x] Format check: clean (`cd frontend && npm run format:check`)
- [x] Build: green (`npm run build --prefix frontend`)
- [x] Coverage: green, unchanged (64.38% statements / 55.87% branches / 65.46% functions / 65.2% lines) — thresholds in `vitest.config.js` untouched, no regression
- [x] `validate:openapi`: N/A, `docs/api-spec.yaml` not changed
- [x] Manual smoke: ran the a11y suite in isolation multiple times; verified both new length guards fail red when pointed at a nonexistent selector, then pass green when restored; confirmed the weekday regression test reproduces the exact reported prod string before the fix and is fixed after
- [x] Backend (`functions/`) confirmed untouched: `git diff --stat -- functions/` is empty

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved the semantic accessibility of the King St N venue route by adjusting how the content is exposed to assistive technologies.
  - Strengthened accessibility tests to ensure rendered images and buttons exist and include accessible labeling.
- **Bug Fixes**
  - Updated “this week” and “next week” performance time descriptions to remove weekday names, including for after-midnight cases.
- **Tests**
  - Enhanced accessibility coverage with a more complete schedule API mock.
  - Added targeted tests for `getTimeDescription` outputs, including cleanup for debug timing state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->