### PR TITLE
chore(make): add `make review` CodeRabbit pre-PR gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Use the Makefile — it exists so every agent runs the same gates with real exit
 - `make test` / `make test-backend` / `make test-frontend`
 - `make build` — frontend production build
 - `make e2e` — full local E2E: builds, seeds an isolated D1, serves wrangler on :8788, runs Playwright, cleans up
+- `make review` — **AI code review before opening a PR** (CodeRabbit CLI; `make review-wip` for uncommitted changes). Run it *before* the PR — the same review runs on the PR anyway, so findings after opening cost a fix plus a force-push. Not part of `make gate`: `gate` stays fast and offline, `review` needs the network.
 - `make schema-check` — after touching `migrations/`: regenerates `setup-complete.sql` and checks drift (its schema section is generated — never hand-edit)
 - `make validate-openapi` — if `docs/api-spec.yaml` changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,19 @@ npm test                    # from repo root — runs fine locally, including Ap
 
 **E2E tests** require a live wrangler dev server and are slow — run them only when changing routes, auth flows, or anything the E2E suite targets. The build check above catches most issues.
 
+### Before opening a PR — AI review gate
+
+```bash
+make review        # CodeRabbit review of this branch vs origin/main
+make review-wip    # same, but for uncommitted working-tree changes
+```
+
+Requires the CodeRabbit CLI (`brew install --cask coderabbit`, then `coderabbit auth login`); both targets fail with an install/auth hint if it is missing.
+
+**Run this before opening the PR, not after.** The same review runs automatically on the PR, so anything it finds post-open costs a fix plus a force-push round trip. Findings it has caught that the local gates did not: assertions that pass on the wrong branch's output, a spy recording statement *preparation* rather than *execution*, and a SQL guard that stayed inert for legacy rows after a write-side fix.
+
+`make gate` deliberately does **not** include it — `gate` must stay fast and offline-capable; `review` needs the network and takes minutes.
+
 ### Before every push (including follow-up commits during PR review)
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,12 @@ E2E_ADMIN_EMAIL ?= e2e-admin@test.local
 E2E_ADMIN_PASSWORD ?= e2e-test-password-Xk9
 
 .PHONY: help install build dev format format-check lint test test-backend test-frontend \
-	gate validate-openapi schema-check e2e e2e-setup e2e-serve e2e-run e2e-clean
+	gate review review-wip validate-openapi schema-check e2e e2e-setup e2e-serve e2e-run e2e-clean
+
+# CodeRabbit streams PostHog telemetry errors to stderr when egress is blocked.
+# They are noise, not review failures — the review still exits 0. Strip them so
+# a clean review reads as clean.
+CR_NOISE := PostHog|posthog|ConnectionRefused|^ *at async|^ *errno:|^ *path:|^ *code:
 
 help: ## List targets
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -46,6 +51,20 @@ test-frontend: ## Frontend unit tests
 test: test-backend test-frontend ## All unit tests
 
 gate: format format-check lint test build ## FULL pre-commit gate — run before every commit
+
+review: ## AI code review of this branch vs origin/main — run BEFORE opening a PR
+	@command -v coderabbit >/dev/null 2>&1 || { \
+		echo "coderabbit CLI not found. Install: brew install --cask coderabbit"; exit 1; }
+	@coderabbit auth status >/dev/null 2>&1 || { \
+		echo "Not signed in. Run: coderabbit auth login"; exit 1; }
+	@out=$$(mktemp); coderabbit review --base main >"$$out" 2>&1; status=$$?; \
+		grep -avE '$(CR_NOISE)' "$$out" || true; rm -f "$$out"; exit $$status
+
+review-wip: ## AI code review of uncommitted changes — run before committing
+	@command -v coderabbit >/dev/null 2>&1 || { \
+		echo "coderabbit CLI not found. Install: brew install --cask coderabbit"; exit 1; }
+	@out=$$(mktemp); coderabbit review --type uncommitted >"$$out" 2>&1; status=$$?; \
+		grep -avE '$(CR_NOISE)' "$$out" || true; rm -f "$$out"; exit $$status
 
 validate-openapi: ## Required when docs/api-spec.yaml changed
 	npm run validate:openapi

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ E2E_ADMIN_PASSWORD ?= e2e-test-password-Xk9
 # none can match review prose. Do NOT loosen these to bare tokens like `code:`
 # or `path:` — a finding whose text contains one would be silently swallowed,
 # and a filter that eats findings is worse than the noise it removes.
-CR_NOISE := posthog|\$$bunfs/root/cli\.js|^error: Unable to connect\.|^ *errno: 0,$$|^ *code: "ConnectionRefused"$$
+CR_NOISE := ^Error while flushing PostHog |^ *path: "https://us\.i\.posthog\.com/|\$$bunfs/root/cli\.js|^error: Unable to connect\.|^ *errno: 0,$$|^ *code: "ConnectionRefused"$$
 
 help: ## List targets
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,15 @@ E2E_ADMIN_PASSWORD ?= e2e-test-password-Xk9
 .PHONY: help install build dev format format-check lint test test-backend test-frontend \
 	gate review review-wip validate-openapi schema-check e2e e2e-setup e2e-serve e2e-run e2e-clean
 
-# CodeRabbit streams PostHog telemetry errors to stderr when egress is blocked.
-# They are noise, not review failures — the review still exits 0. Strip them so
-# a clean review reads as clean.
-CR_NOISE := PostHog|posthog|ConnectionRefused|^ *at async|^ *errno:|^ *path:|^ *code:
+# CodeRabbit emits PostHog telemetry errors when egress is blocked. They are
+# noise, not review failures — the review still exits 0. They appear on BOTH
+# stdout and stderr, so redirecting one stream is not enough.
+#
+# Every pattern here is anchored or names posthog/the CLI's own bundle path, so
+# none can match review prose. Do NOT loosen these to bare tokens like `code:`
+# or `path:` — a finding whose text contains one would be silently swallowed,
+# and a filter that eats findings is worse than the noise it removes.
+CR_NOISE := posthog|\$$bunfs/root/cli\.js|^error: Unable to connect\.|^ *errno: 0,$$|^ *code: "ConnectionRefused"$$
 
 help: ## List targets
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -57,14 +62,19 @@ review: ## AI code review of this branch vs origin/main — run BEFORE opening a
 		echo "coderabbit CLI not found. Install: brew install --cask coderabbit"; exit 1; }
 	@coderabbit auth status >/dev/null 2>&1 || { \
 		echo "Not signed in. Run: coderabbit auth login"; exit 1; }
+	@# Refresh the remote ref first: the CLI compares against origin/main when
+	@# local main has drifted, so a stale origin/main yields the wrong diff.
+	@git fetch origin --quiet
 	@out=$$(mktemp); coderabbit review --base main >"$$out" 2>&1; status=$$?; \
-		grep -avE '$(CR_NOISE)' "$$out" || true; rm -f "$$out"; exit $$status
+		grep -aivE '$(CR_NOISE)' "$$out" || true; rm -f "$$out"; exit $$status
 
 review-wip: ## AI code review of uncommitted changes — run before committing
 	@command -v coderabbit >/dev/null 2>&1 || { \
 		echo "coderabbit CLI not found. Install: brew install --cask coderabbit"; exit 1; }
+	@coderabbit auth status >/dev/null 2>&1 || { \
+		echo "Not signed in. Run: coderabbit auth login"; exit 1; }
 	@out=$$(mktemp); coderabbit review --type uncommitted >"$$out" 2>&1; status=$$?; \
-		grep -avE '$(CR_NOISE)' "$$out" || true; rm -f "$$out"; exit $$status
+		grep -aivE '$(CR_NOISE)' "$$out" || true; rm -f "$$out"; exit $$status
 
 validate-openapi: ## Required when docs/api-spec.yaml changed
 	npm run validate:openapi


### PR DESCRIPTION
## Summary

Makes the CodeRabbit subscription a **default step** rather than something to remember.

Every CodeRabbit finding this week arrived *after* the PR was open — each costing a fix plus a force-push round trip. This adds a local pre-PR gate that runs the same review before the branch leaves the machine.

- `make review` — reviews this branch vs `origin/main`
- `make review-wip` — reviews uncommitted working-tree changes

Both fail with an install/auth hint when the CLI is absent, rather than silently doing nothing.

Documented in `CLAUDE.md` and `AGENTS.md`, with concrete examples of what it has caught that the local gates did not.

## Why it is NOT part of `make gate`

Deliberate. `gate` must stay fast and offline-capable — it runs before every commit. `review` needs the network and takes minutes.

## Dogfooded on itself

I ran `make review` on this branch **before opening the PR** — the discipline the PR documents. It returned 4 findings. **3 were valid and are fixed here; 1 is declined.**

### Fixed

**1. The noise filter could eat real findings.** This is the one worth reading.

The CLI emits PostHog telemetry errors when egress is blocked. My first pass filtered them by bare tokens — `code:`, `path:`, `errno:`, `at async`. Since telemetry appears on **both stdout and stderr**, the recipe merges the streams, so a finding whose prose contained any of those tokens would be **silently dropped**. A filter that eats findings is worse than the noise it removes.

Every pattern is now anchored, or names `posthog` / the CLI's own bundle path. The match is also case-insensitive — `PostHog` was leaking past a lowercase pattern, which is why an earlier check reported 0 matches on stdout.

Verified: synthetic findings containing `path:`, `code:` and `errno:` all survive; 22 real telemetry lines are stripped.

**2. Stale `origin/main` gave the wrong diff.** The CLI compares against `origin/main` when local `main` has drifted (it says so in its own output). `review` now fetches first.

**3. `review-wip` lacked the auth guard** that `review` had. Added.

### Declined

The fourth finding wanted `review` and `review-wip` added to `gate`'s prerequisites:

```
-gate: format format-check lint test build
+gate: format format-check lint test build review review-wip
```

This inverts a deliberate decision documented in this very PR. `gate` must stay fast and offline; `review` needs the network. The proposed fix would also put `review-wip` — which reviews **uncommitted** changes — into the pre-commit gate, which is incoherent.

The finding itself offered "or explicitly document that they remain manual", which `CLAUDE.md` and `AGENTS.md` already do. CodeRabbit saw the `.PHONY` line and inferred intent the surrounding docs state the opposite of.

## Exit-code discipline

The `Makefile` header warns: *"make propagates real exit codes; never wrap these in `cmd | tail` chains."* My first draft piped straight into `grep`, doing exactly that. The recipe now writes to a temp file, captures `$?`, filters, and re-raises the status. Verified: noise stripped, non-zero status still propagates.

## Verification

- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 errors
- [x] `make help` parses; both targets listed
- [x] Exit-code propagation tested with a synthetic failing command
- [x] Filter tested against real captured output **and** synthetic findings containing the previously-swallowed tokens
- [x] `make review` run on this branch pre-PR (the point of the change)
- [x] Rebased on `main`

## Risk

Low. Two new phony targets and documentation. No existing target changed.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance to run an AI review before opening a pull request, including the required command setup and authentication requirements (network access needed).
  * Clarified timing and scope: AI review is run before submitting, and is intentionally not included in the standard `make gate` flow.
  * Documented both `make review` and `make review-wip` review commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->