### PR TITLE
fix(mobile): stop the sticky event section bouncing while scrolling

### DIFF
--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -29,48 +29,50 @@ function formatCurrentTime(value) {
   })
 }
 
+// The identity block fades out faster than it shrinks, so opacity reaches 0
+// before maxHeight does.
+const IDENTITY_FADE_MULTIPLIER = 1.75
+const IDENTITY_OPEN_HEIGHT_PX = 200
+
 /**
- * Pure style computation for the mobile identity block's scroll-collapse
- * (#665, revisited in #690). Extracted so the monotonicity property can be
- * asserted directly in a unit test: as `scrollProgress` increases 0->1,
- * `maxHeight` must never increase.
+ * The `scrollProgress` at which the identity block becomes fully transparent.
+ * Derived from the fade multiplier rather than hardcoded so it cannot drift:
+ * anything invisible must be non-interactive AND out of the tab order, and a
+ * separately-tuned constant previously left a window where the block was
+ * opacity 0 but still clickable and focusable.
+ */
+export const IDENTITY_GONE_PROGRESS = 1 / IDENTITY_FADE_MULTIPLIER
+
+/** True once the identity block is visually gone — drives pointerEvents and `inert`. */
+export function isIdentityVisuallyGone(scrollProgress) {
+  return scrollProgress >= IDENTITY_GONE_PROGRESS
+}
+
+/**
+ * Style for the mobile identity block's scroll-collapse (#665).
  *
- * `overflowAnchor: 'none'` is the actual fix for #690's bounce. Root cause,
- * confirmed with a scripted probe against production (see PR body): this is
- * NOT the text-rewrap theory #690 opened with -- the block's unclamped
- * `scrollHeight` measured constant across every sampled scroll position, so
- * nothing inside it was reflowing. The real cause is one layer up. Chrome's
- * scroll-anchoring heuristic can select this block (or a sibling in the same
- * sticky region) as an anchor node; because `maxHeight` genuinely shrinks
- * page layout height while the user is mid-scroll over it, the browser
- * compensates by silently adjusting `window.scrollY` to hold the anchor
- * node's viewport position steady. That adjustment perturbs the very
- * `scrollY` this collapse is driven from, so the collapse regrows, which
- * changes the layout height again, which triggers another anchor
- * compensation -- a real feedback loop, just occurring in the browser's
- * scroll-position math rather than in this component's own state.
- * `useScrollCollapse`'s docblock is correct that reading only `scrollY`
- * stops the *hook's* calculation from feeding back into itself; that
- * guarantee never covered the browser adjusting `scrollY` out from under it
- * for an unrelated reason. `overflow-anchor: none` opts this subtree out of
- * anchor-candidacy, which removes the compensation and restores real
- * monotonicity. Verified empirically: with the default `overflow-anchor:
- * auto`, a scripted `scrollTo` to monotonically increasing targets produced
- * a non-monotonic actual `window.scrollY` once this block was mid-collapse;
- * with `overflow-anchor: none` on the block, `scrollY` tracked the targets
- * (sub-pixel rounding aside).
+ * Pure and exported so the monotonicity invariant is unit-testable: as
+ * `scrollProgress` goes 0 -> 1, `maxHeight` must never increase. jsdom does no
+ * real layout, so the test targets this function rather than rendered geometry.
+ *
+ * @param {number} scrollProgress - 0 (fully open) to 1 (fully collapsed).
+ * @returns {object} React style: `opacity`, `transform`, `maxHeight`,
+ *   `overflow`, `overflowAnchor`, `pointerEvents`.
  */
 export function computeIdentityCollapseStyle(scrollProgress) {
-  const identityFadeProgress = Math.min(1, scrollProgress * 1.75)
+  const identityFadeProgress = Math.min(1, scrollProgress * IDENTITY_FADE_MULTIPLIER)
   return {
     opacity: 1 - identityFadeProgress,
     transform: `translateY(${scrollProgress * -6}px)`,
-    maxHeight: `${Math.round(200 * (1 - scrollProgress))}px`,
+    maxHeight: `${Math.round(IDENTITY_OPEN_HEIGHT_PX * (1 - scrollProgress))}px`,
     overflow: 'hidden',
-    // Opts this block out of being a scroll-anchor candidate -- see the
-    // function docblock above. This is the fix for #690.
+    // #690: opts this subtree out of scroll-anchor candidacy. Shrinking
+    // maxHeight mid-scroll makes the browser adjust window.scrollY to hold an
+    // anchor node steady — which perturbs the very scrollY this collapse reads,
+    // regrowing it. Without this the collapse is not monotonic and visibly
+    // bounces.
     overflowAnchor: 'none',
-    pointerEvents: scrollProgress > 0.7 ? 'none' : 'auto',
+    pointerEvents: isIdentityVisuallyGone(scrollProgress) ? 'none' : 'auto',
   }
 }
 
@@ -129,11 +131,12 @@ function LiveContextBar({
   // site header's (20-140) because this block starts taller: fully
   // collapsed well before `scrollY` reaches the ~600px this was measured at.
   const scrollProgress = useScrollCollapse(48, 240)
-  // Past this point the identity block is visually gone. `pointerEvents: none`
-  // alone would still leave its focusable children (the status badge) in the
-  // tab order, so a keyboard user could focus an invisible zero-height
-  // control; `inert` removes them from focus and the a11y tree too.
-  const isIdentityCollapsed = scrollProgress > 0.7
+  // Same threshold the style uses for pointerEvents: `pointerEvents: none`
+  // alone would still leave focusable children (the status badge) in the tab
+  // order, so a keyboard user could focus an invisible control. `inert`
+  // removes them from focus and the a11y tree too, and both must flip at the
+  // moment the block becomes invisible — not later.
+  const isIdentityCollapsed = isIdentityVisuallyGone(scrollProgress)
   const identityCollapseStyle = computeIdentityCollapseStyle(scrollProgress)
   const tapCountRef = useRef(0)
   const firstTapTimeRef = useRef(0)

--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -29,6 +29,51 @@ function formatCurrentTime(value) {
   })
 }
 
+/**
+ * Pure style computation for the mobile identity block's scroll-collapse
+ * (#665, revisited in #690). Extracted so the monotonicity property can be
+ * asserted directly in a unit test: as `scrollProgress` increases 0->1,
+ * `maxHeight` must never increase.
+ *
+ * `overflowAnchor: 'none'` is the actual fix for #690's bounce. Root cause,
+ * confirmed with a scripted probe against production (see PR body): this is
+ * NOT the text-rewrap theory #690 opened with -- the block's unclamped
+ * `scrollHeight` measured constant across every sampled scroll position, so
+ * nothing inside it was reflowing. The real cause is one layer up. Chrome's
+ * scroll-anchoring heuristic can select this block (or a sibling in the same
+ * sticky region) as an anchor node; because `maxHeight` genuinely shrinks
+ * page layout height while the user is mid-scroll over it, the browser
+ * compensates by silently adjusting `window.scrollY` to hold the anchor
+ * node's viewport position steady. That adjustment perturbs the very
+ * `scrollY` this collapse is driven from, so the collapse regrows, which
+ * changes the layout height again, which triggers another anchor
+ * compensation -- a real feedback loop, just occurring in the browser's
+ * scroll-position math rather than in this component's own state.
+ * `useScrollCollapse`'s docblock is correct that reading only `scrollY`
+ * stops the *hook's* calculation from feeding back into itself; that
+ * guarantee never covered the browser adjusting `scrollY` out from under it
+ * for an unrelated reason. `overflow-anchor: none` opts this subtree out of
+ * anchor-candidacy, which removes the compensation and restores real
+ * monotonicity. Verified empirically: with the default `overflow-anchor:
+ * auto`, a scripted `scrollTo` to monotonically increasing targets produced
+ * a non-monotonic actual `window.scrollY` once this block was mid-collapse;
+ * with `overflow-anchor: none` on the block, `scrollY` tracked the targets
+ * (sub-pixel rounding aside).
+ */
+export function computeIdentityCollapseStyle(scrollProgress) {
+  const identityFadeProgress = Math.min(1, scrollProgress * 1.75)
+  return {
+    opacity: 1 - identityFadeProgress,
+    transform: `translateY(${scrollProgress * -6}px)`,
+    maxHeight: `${Math.round(200 * (1 - scrollProgress))}px`,
+    overflow: 'hidden',
+    // Opts this block out of being a scroll-anchor candidate -- see the
+    // function docblock above. This is the fix for #690.
+    overflowAnchor: 'none',
+    pointerEvents: scrollProgress > 0.7 ? 'none' : 'auto',
+  }
+}
+
 function LiveContextBar({
   eventData,
   currentTime,
@@ -84,19 +129,12 @@ function LiveContextBar({
   // site header's (20-140) because this block starts taller: fully
   // collapsed well before `scrollY` reaches the ~600px this was measured at.
   const scrollProgress = useScrollCollapse(48, 240)
-  const identityFadeProgress = Math.min(1, scrollProgress * 1.75)
   // Past this point the identity block is visually gone. `pointerEvents: none`
   // alone would still leave its focusable children (the status badge) in the
   // tab order, so a keyboard user could focus an invisible zero-height
   // control; `inert` removes them from focus and the a11y tree too.
   const isIdentityCollapsed = scrollProgress > 0.7
-  const identityCollapseStyle = {
-    opacity: 1 - identityFadeProgress,
-    transform: `translateY(${scrollProgress * -6}px)`,
-    maxHeight: `${Math.round(200 * (1 - scrollProgress))}px`,
-    overflow: 'hidden',
-    pointerEvents: isIdentityCollapsed ? 'none' : 'auto',
-  }
+  const identityCollapseStyle = computeIdentityCollapseStyle(scrollProgress)
   const tapCountRef = useRef(0)
   const firstTapTimeRef = useRef(0)
 

--- a/frontend/src/components/__tests__/LiveContextBar.test.jsx
+++ b/frontend/src/components/__tests__/LiveContextBar.test.jsx
@@ -1,6 +1,42 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import LiveContextBar from '../LiveContextBar'
+import LiveContextBar, { computeIdentityCollapseStyle } from '../LiveContextBar'
+
+describe('computeIdentityCollapseStyle (#690 scroll-collapse bounce)', () => {
+  const px = style => parseFloat(style.maxHeight)
+
+  it('never grows maxHeight as scrollProgress increases', () => {
+    // The #690 bug was a NON-MONOTONIC collapse: while scrolling down, the
+    // block shrank then grew back ~18px, producing a visible flicker and
+    // CLS 0.2875 in production. Height must be a non-increasing function of
+    // progress across the whole range, not merely smaller at the endpoints.
+    let previous = Infinity
+    for (let p = 0; p <= 1.0001; p += 0.01) {
+      const current = px(computeIdentityCollapseStyle(Math.min(p, 1)))
+      expect(current).toBeLessThanOrEqual(previous)
+      previous = current
+    }
+  })
+
+  it('opts out of scroll anchoring, the actual cause of the bounce', () => {
+    // Chrome's scroll-anchoring compensates for the shrinking block by
+    // adjusting window.scrollY — the very value the collapse is driven from.
+    // That feedback loop is what produced the non-monotonic scrollY.
+    // Removing this opts the subtree back into anchor candidacy and the
+    // bounce returns, so it is asserted rather than left as a bare style.
+    expect(computeIdentityCollapseStyle(0.5).overflowAnchor).toBe('none')
+  })
+
+  it('is fully collapsed at progress 1 and fully open at 0', () => {
+    expect(px(computeIdentityCollapseStyle(0))).toBeGreaterThan(0)
+    expect(px(computeIdentityCollapseStyle(1))).toBe(0)
+  })
+
+  it('disables pointer events only once the block is visually gone', () => {
+    expect(computeIdentityCollapseStyle(0.5).pointerEvents).toBe('auto')
+    expect(computeIdentityCollapseStyle(0.8).pointerEvents).toBe('none')
+  })
+})
 
 const eventData = {
   name: 'Long Weekend Band Crawl',

--- a/frontend/src/components/__tests__/LiveContextBar.test.jsx
+++ b/frontend/src/components/__tests__/LiveContextBar.test.jsx
@@ -32,9 +32,28 @@ describe('computeIdentityCollapseStyle (#690 scroll-collapse bounce)', () => {
     expect(px(computeIdentityCollapseStyle(1))).toBe(0)
   })
 
-  it('disables pointer events only once the block is visually gone', () => {
+  it('disables pointer events the moment the block becomes invisible, not later', () => {
+    // The fade multiplier (1.75) drives opacity to 0 at progress ~0.571, but
+    // pointerEvents was separately hardcoded to flip at 0.7 — leaving a window
+    // where the block was fully transparent yet still clickable and focusable.
+    // 0.6 sits inside that old window and is the regression guard.
     expect(computeIdentityCollapseStyle(0.5).pointerEvents).toBe('auto')
+    expect(computeIdentityCollapseStyle(0.5).opacity).toBeGreaterThan(0)
+
+    expect(computeIdentityCollapseStyle(0.6).opacity).toBe(0)
+    expect(computeIdentityCollapseStyle(0.6).pointerEvents).toBe('none')
     expect(computeIdentityCollapseStyle(0.8).pointerEvents).toBe('none')
+  })
+
+  it('never leaves the block invisible while still interactive', () => {
+    // The general property behind the case above: opacity 0 implies
+    // non-interactive, at every progress value.
+    for (let p = 0; p <= 1.0001; p += 0.01) {
+      const style = computeIdentityCollapseStyle(Math.min(p, 1))
+      if (style.opacity === 0) {
+        expect(style.pointerEvents).toBe('none')
+      }
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

The sticky event section bounced while scrolling down — a visible flicker on the page every promo link lands on, with **CLS 0.2875** (Google's "poor" threshold is 0.25).

Closes #690

## Root cause — not the one the issue was filed with

I opened #690 theorising **text rewrap**: as the poster and title collapsed out, remaining text would re-wrap to a different line count, making section height non-monotonic.

**That was wrong, and it was disproved with a probe.** The block's unclamped `scrollHeight` measured **constant** at every sampled scroll position — nothing inside it was reflowing.

The real cause is **Chrome's scroll anchoring**. Because `maxHeight` genuinely shrinks page layout height while the user is mid-scroll over it, the browser compensates by adjusting `window.scrollY` to hold its chosen anchor node steady. That adjustment perturbs the very `scrollY` the collapse is driven from: the collapse regrows, layout height changes again, another compensation fires.

A real feedback loop — but in the browser's scroll math, not the component's state.

`useScrollCollapse`'s docblock is **correct** that reading only `scrollY` stops the *hook's* calculation from feeding back into itself. That guarantee simply never covered the browser moving `scrollY` out from under it for an unrelated reason.

## Fix

`overflow-anchor: none` on the collapsing block, opting the subtree out of anchor candidacy.

Verified empirically: with the default `overflow-anchor: auto`, a scripted `scrollTo` to **monotonically increasing** targets produced a **non-monotonic actual `window.scrollY`** once the block was mid-collapse. With `overflow-anchor: none`, `scrollY` tracked the targets (sub-pixel rounding aside).

Also extracted the style math into `computeIdentityCollapseStyle()` so the monotonicity property is directly assertable — jsdom performs no real layout, so the regression test targets the pure function rather than rendered geometry.

## Test plan

Four new tests in `LiveContextBar.test.jsx`:

- **monotonicity** — `maxHeight` never increases across 100 steps of `scrollProgress` 0→1. This is the property that was violated; asserting only the endpoints would have missed it.
- **`overflowAnchor: 'none'`** — verified red: deleting the line fails this test.
- endpoints (fully open at 0, fully collapsed at 1)
- `pointerEvents` flips only once the block is visually gone

## Preserved

- [x] The #665 collapse itself — occluded chrome still drops ~320px → ~161px
- [x] `inert` on collapse (a11y — keyboard focus must not enter the hidden block)
- [x] Inline poster stays `loading="eager"` / `fetchPriority="high"`
- [x] `prefers-reduced-motion` behaviour unchanged

## Verification

- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm test -- --run` — **638 passed** (was 634)
- [x] `npm run build` — green
- [x] `coderabbit review --base main` before opening this PR — **no findings**
- [x] Backend untouched (`git diff --stat -- functions/` empty)
- [x] Rebased on `main`

## Still outstanding

**A real-device check.** The scroll-anchoring behaviour was verified with a scripted probe in a desktop Chrome viewport at 393×852, not on a physical phone. iOS Safari implements scroll anchoring differently and may not have exhibited the bug in the first place — worth a look on the preview deploy before merge.

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mobile identity section’s collapse behaviour while scrolling.
  * Prevented the section from expanding unexpectedly during scroll “bounce”.
  * Disabled interaction only after the section is fully hidden.
  * Improved scroll anchoring for a smoother transition as the section collapses.
* **Tests**
  * Added coverage to verify the collapse styling stays consistent across the full scroll progress range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->