### PR TITLE
fix(mobile): ratchet scroll collapse so iOS jitter cannot re-expand it

### DIFF
--- a/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
+++ b/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
@@ -21,6 +21,13 @@ async function fireScroll() {
   })
 }
 
+async function fireResize() {
+  await act(async () => {
+    window.dispatchEvent(new Event('resize'))
+    await new Promise(resolve => requestAnimationFrame(resolve))
+  })
+}
+
 describe('useScrollCollapse', () => {
   afterEach(() => {
     setScrollY(0)
@@ -54,11 +61,6 @@ describe('useScrollCollapse', () => {
   })
 
   it('does not re-expand when scroll drifts back up mid-page', async () => {
-    // The iOS flicker: the URL bar shows/hides while scrolling, moving scrollY
-    // ~60px, and momentum/rubber-band add smaller jitter. Measured on WebKit at
-    // an iPhone viewport, a 62px jump swung the block's opacity by 0.565 and
-    // its height between 194px and 251px. Progress must ratchet — perturbation
-    // below the current high-water mark is ignored.
     setScrollY(0)
     render(<Harness start={40} end={140} />)
 
@@ -75,9 +77,19 @@ describe('useScrollCollapse', () => {
     expect(screen.getByTestId('progress')).toHaveTextContent('1')
   })
 
+  it('recomputes on resize alone, without any scroll event', async () => {
+    // iOS fires resize when the URL bar collapses. Dispatch ONLY resize, so
+    // this fails if the listener is dropped even while scroll still works.
+    setScrollY(0)
+    render(<Harness start={40} end={140} />)
+    expect(screen.getByTestId('progress')).toHaveTextContent('0')
+
+    setScrollY(140)
+    await fireResize()
+    expect(screen.getByTestId('progress')).toHaveTextContent('1')
+  })
+
   it('releases the ratchet once the user is back at the top', async () => {
-    // Ratcheting must not be permanent — returning to the top region restores
-    // the full identity block, which is the whole point of showing it there.
     setScrollY(0)
     render(<Harness start={40} end={140} />)
 

--- a/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
+++ b/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
@@ -53,6 +53,43 @@ describe('useScrollCollapse', () => {
     expect(screen.getByTestId('progress')).toHaveTextContent('0.5')
   })
 
+  it('does not re-expand when scroll drifts back up mid-page', async () => {
+    // The iOS flicker: the URL bar shows/hides while scrolling, moving scrollY
+    // ~60px, and momentum/rubber-band add smaller jitter. Measured on WebKit at
+    // an iPhone viewport, a 62px jump swung the block's opacity by 0.565 and
+    // its height between 194px and 251px. Progress must ratchet — perturbation
+    // below the current high-water mark is ignored.
+    setScrollY(0)
+    render(<Harness start={40} end={140} />)
+
+    setScrollY(140) // fully collapsed
+    await fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('1')
+
+    setScrollY(90) // URL-bar-sized jump back up, still mid-page
+    await fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('1')
+
+    setScrollY(78) // small drift
+    await fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('1')
+  })
+
+  it('releases the ratchet once the user is back at the top', async () => {
+    // Ratcheting must not be permanent — returning to the top region restores
+    // the full identity block, which is the whole point of showing it there.
+    setScrollY(0)
+    render(<Harness start={40} end={140} />)
+
+    setScrollY(140)
+    await fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('1')
+
+    setScrollY(40) // at the start threshold — release
+    await fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('0')
+  })
+
   it('clamps to 1 at and beyond the end threshold', async () => {
     setScrollY(0)
     render(<Harness start={40} end={140} />)

--- a/frontend/src/hooks/useScrollCollapse.js
+++ b/frontend/src/hooks/useScrollCollapse.js
@@ -31,20 +31,9 @@ export function useScrollCollapse(start, end) {
 
   useEffect(() => {
     let frame = null
-    // Ratchet: progress only ever increases until the user returns to the top
-    // region (scrollY <= start), where it resets and tracks scroll again.
-    //
-    // Without this the collapse is a direct function of raw scrollY, so ANY
-    // perturbation of scrollY re-expands the block mid-scroll. On iOS that is
-    // constant: the URL bar shows/hides while scrolling, moving the scroll
-    // position ~60px, and momentum and rubber-band overscroll add smaller
-    // jitter. Measured on WebKit at an iPhone viewport: a 62px jump swung the
-    // block's opacity by 0.565 and its height between 194px and 251px; drift of
-    // 6-10px swung opacity by 0.119. That reads as a jarring flicker.
-    //
-    // Smoothing (a CSS transition or a per-frame rate limit) would only ease
-    // the snap — the block would still pulse. It must simply not re-expand
-    // while the reader is working down the page.
+    // Invariant: collapse is monotonic until scrollY <= start. Scroll position
+    // is perturbed constantly on iOS (URL bar, momentum, rubber-band), and
+    // tracking it directly re-expands the block mid-scroll (#690).
     let ratchet = 0
     const update = () => {
       frame = null

--- a/frontend/src/hooks/useScrollCollapse.js
+++ b/frontend/src/hooks/useScrollCollapse.js
@@ -31,11 +31,28 @@ export function useScrollCollapse(start, end) {
 
   useEffect(() => {
     let frame = null
+    // Ratchet: progress only ever increases until the user returns to the top
+    // region (scrollY <= start), where it resets and tracks scroll again.
+    //
+    // Without this the collapse is a direct function of raw scrollY, so ANY
+    // perturbation of scrollY re-expands the block mid-scroll. On iOS that is
+    // constant: the URL bar shows/hides while scrolling, moving the scroll
+    // position ~60px, and momentum and rubber-band overscroll add smaller
+    // jitter. Measured on WebKit at an iPhone viewport: a 62px jump swung the
+    // block's opacity by 0.565 and its height between 194px and 251px; drift of
+    // 6-10px swung opacity by 0.119. That reads as a jarring flicker.
+    //
+    // Smoothing (a CSS transition or a per-frame rate limit) would only ease
+    // the snap — the block would still pulse. It must simply not re-expand
+    // while the reader is working down the page.
+    let ratchet = 0
     const update = () => {
       frame = null
       const y = window.scrollY || 0
-      const next = Math.min(Math.max((y - start) / (end - start), 0), 1)
-      setProgress(prev => (Math.abs(prev - next) < 0.01 ? prev : next))
+      const raw = Math.min(Math.max((y - start) / (end - start), 0), 1)
+      // Back at the top: release the ratchet so the block can expand again.
+      ratchet = y <= start ? 0 : Math.max(ratchet, raw)
+      setProgress(prev => (Math.abs(prev - ratchet) < 0.01 ? prev : ratchet))
     }
     const onScroll = () => {
       if (frame) return
@@ -43,8 +60,12 @@ export function useScrollCollapse(start, end) {
     }
     update()
     window.addEventListener('scroll', onScroll, { passive: true })
+    // iOS fires resize when the URL bar collapses; without this the block can
+    // sit mid-collapse until the next scroll event.
+    window.addEventListener('resize', onScroll)
     return () => {
       window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
       if (frame) cancelAnimationFrame(frame)
     }
   }, [start, end])


### PR DESCRIPTION
## Summary

The event page still flickers on iOS after #692. This fixes the actual cause.

**#692 does not address it.** `overflow-anchor: none` targets Chrome's scroll-anchoring compensation. The iOS flicker has a different mechanism, and #692 is orthogonal to it (it is still correct for Chrome — not reverted).

## Reproduced on real WebKit

I installed WebKit and probed production at an iPhone 14 Pro viewport. Chromium could not have shown this.

| Perturbation | Result |
|---|---|
| Scroll drift of 6–10px | block opacity swings **0.119** |
| 62px scroll jump | opacity swings **0.565**, section height snaps **194px ↔ 251px**, repeatedly |

62px is URL-bar magnitude. On iOS the URL bar shows and hides continuously while scrolling, moving the scroll position; momentum and rubber-band overscroll add smaller jitter. Because progress was a direct function of raw `scrollY`, **every one of those perturbations re-drove the collapse.**

## Fix — ratchet, don't smooth

Progress now only increases, until the reader returns to the top region (`scrollY <= start`), where it resets and tracks scroll again. Perturbation below the current high-water mark is ignored, so the block cannot re-expand while the reader works down the page.

**Smoothing was considered and rejected.** A CSS transition or a per-frame rate limit would only ease the snap into a pulse — still visible. The block must not re-expand at all.

Also added a `resize` listener: iOS fires it when the URL bar collapses, and without it the block could sit mid-collapse until the next scroll event.

## Test plan

- Perturbation below the high-water mark (62px jump, then 12px drift) holds progress at 1
- Returning to the top releases the ratchet, so the identity block still comes back
- **Verified red** — reverting to raw `scrollY` fails the perturbation test

`lint` 0 · `format:check` clean · **641 passed** · `build` green

## What is NOT verified, and why

**No end-to-end WebKit run against the fixed build.** WebKit on this machine cannot reach the local wrangler server — it reaches production fine, so this is a WebKit-to-localhost issue, not a server one. I did not substitute a Chromium run and call it equivalent, because Chromium never reproduced the bug in the first place.

So the evidence is: **WebKit confirmation of the mechanism on the old code**, plus **unit tests on the new code**, verified red-then-green.

**This needs a real-device check on the deploy before we call it fixed.** That is the same gap that let the original flicker ship on #665, and I would rather name it than paper over it.

## Corrections to my earlier claims in this thread

- I stated Safari does not support `overflow-anchor`. **Wrong** — WebKit 26.5 reports `CSS.supports('overflow-anchor','none') === true`.
- My first local A/B for #692 was **invalid**: a cached service-worker bundle meant both runs measured the same build. This PR's probes block service workers.
- The production bounce is **intermittent** — one run showed +18px regrowth, a later identical run showed none. My original single reproduction was not a reliable characterisation.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured scroll-to-collapse progress is monotonic, preventing jitter from causing collapsed sections to re-expand unexpectedly.
  * Improved mobile behaviour by recalculating progress on viewport changes (such as resize) even when no scroll event occurs.
  * Restores normal expansion once the user returns to the top/start region.
* **Tests**
  * Added coverage for ratcheting/anti-jitter behaviour and resize-triggered progress recalculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->