### PR TITLE
fix(announce): count claim-release failures as failed, log ids for recovery

### DIFF
--- a/functions/api/admin/bands/__tests__/announce-digest.test.js
+++ b/functions/api/admin/bands/__tests__/announce-digest.test.js
@@ -377,7 +377,7 @@ describe("flushAnnounceDigest", () => {
   // because sendEmail itself throws) — it must still log AND count the fan
   // as failed, so a future refactor that reintroduces a throw can't quietly
   // drop a fan from the returned counts.
-  it("logs a rejected sendOne instead of discarding it silently, and still counts it as failed", async () => {
+  it("treats a thrown sendEmail as a delivery failure: releases claims, logs ids, counts it failed", async () => {
     const { env, rawDb } = createTestEnv();
     const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
     sendEmail.mockRejectedValueOnce(new Error("boom"));
@@ -405,14 +405,25 @@ describe("flushAnnounceDigest", () => {
 
       const stats = await flushAnnounceDigest(env, env.DB);
 
+      // A throw must take the SAME path as `{ delivered: false }`. Previously
+      // sendEmail was unguarded, so a throw skipped the claim release entirely
+      // and the fan was stranded with a surviving notification row.
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("sendOne rejected"),
-        expect.objectContaining({ error: expect.any(Error) }),
+        expect.stringContaining("sendEmail threw"),
+        expect.objectContaining({
+          performance_id: perf.id,
+          band_follow_id: Number(followId),
+          error: expect.any(Error),
+        }),
       );
-      // The backstop must count the rejection as failed — otherwise the fan
-      // is invisible in the returned counts even though it was logged.
       expect(stats.failed).toBe(1);
       expect(stats.sent).toBe(0);
+
+      // The claim must be released, so resend-announcement can recover the fan.
+      const claims = rawDb
+        .prepare("SELECT * FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?")
+        .all(perf.id, Number(followId));
+      expect(claims).toHaveLength(0);
     } finally {
       errorSpy.mockRestore();
     }

--- a/functions/api/admin/bands/__tests__/announce-digest.test.js
+++ b/functions/api/admin/bands/__tests__/announce-digest.test.js
@@ -370,8 +370,14 @@ describe("flushAnnounceDigest", () => {
     expect(rawDb.prepare("SELECT * FROM band_announce_queue").all()).toHaveLength(0);
   });
 
-  // Asserts the log line only; the count/recovery contract is unresolved (#672).
-  it("logs a rejected sendOne instead of discarding it silently", async () => {
+  // #672: sendOne no longer lets an internal throw escape uncaught (the
+  // claim-release failure path is now caught and counted inside sendOne
+  // itself — see the dedicated tests below). This test exercises the
+  // Promise.allSettled backstop for the case sendOne rejects anyway (here,
+  // because sendEmail itself throws) — it must still log AND count the fan
+  // as failed, so a future refactor that reintroduces a throw can't quietly
+  // drop a fan from the returned counts.
+  it("logs a rejected sendOne instead of discarding it silently, and still counts it as failed", async () => {
     const { env, rawDb } = createTestEnv();
     const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
     sendEmail.mockRejectedValueOnce(new Error("boom"));
@@ -397,14 +403,163 @@ describe("flushAnnounceDigest", () => {
         )
         .run(followId, perf.id, ev.id, "Band Throw", "Fest", "fest-throw", perf.band_profile_id);
 
-      await flushAnnounceDigest(env, env.DB);
+      const stats = await flushAnnounceDigest(env, env.DB);
 
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("sendOne rejected"),
         expect.objectContaining({ error: expect.any(Error) }),
       );
+      // The backstop must count the rejection as failed — otherwise the fan
+      // is invisible in the returned counts even though it was logged.
+      expect(stats.failed).toBe(1);
+      expect(stats.sent).toBe(0);
     } finally {
       errorSpy.mockRestore();
     }
+  });
+
+  describe("#672: claim-release failure inside sendOne", () => {
+    // Stubs DB.batch so the FIRST call (the phase-A band_announce_queue
+    // cleanup, which always runs per group) succeeds normally via the real
+    // implementation, and every subsequent call (the phase-B claim-release
+    // DB.batch on delivery failure) throws — simulating a D1 failure
+    // specific to the release path described in #672.
+    function stubBatchToFailAfterFirstCall(env) {
+      const originalBatch = env.DB.batch.bind(env.DB);
+      let calls = 0;
+      return vi.spyOn(env.DB, "batch").mockImplementation(async (statements) => {
+        calls++;
+        if (calls === 1) return originalBatch(statements);
+        throw new Error("simulated D1 batch failure");
+      });
+    }
+
+    it("counts a claim-release failure as failed and logs the ids for manual recovery", async () => {
+      const { env, rawDb } = createTestEnv();
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+      const ev = insertEvent(rawDb, { name: "Fest", slug: "fest-release-fail" });
+      const venue = insertVenue(rawDb, { name: "Room" });
+      const perf = insertBand(rawDb, {
+        name: "Band Fail",
+        event_id: ev.id,
+        venue_id: venue.id,
+      });
+
+      const followId = rawDb
+        .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+        .run("release-fail@example.com", perf.band_profile_id, "tok-release-fail").lastInsertRowid;
+
+      rawDb
+        .prepare(
+          `INSERT INTO band_announce_queue
+         (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(followId, perf.id, ev.id, "Band Fail", "Fest", "fest-release-fail", perf.band_profile_id);
+
+      // Delivery fails, which is what triggers the claim-release DB.batch.
+      sendEmail.mockResolvedValueOnce({ delivered: false, reason: "provider_error" });
+      const batchSpy = stubBatchToFailAfterFirstCall(env);
+
+      try {
+        const stats = await flushAnnounceDigest(env, env.DB);
+
+        // The fan must be visible in the counts, not silently dropped.
+        expect(stats.sent).toBe(0);
+        expect(stats.failed).toBe(1);
+        expect(stats.skipped).toBe(0);
+
+        // Identifying ids are logged so the row can be found and cleared
+        // by hand — no email address is logged (this module never logs
+        // addresses; see functions/utils/logger.js SENSITIVE_KEYS).
+        expect(errorSpy).toHaveBeenCalledWith(
+          "announce digest claim release failed; fan requires manual recovery",
+          expect.objectContaining({
+            performance_id: perf.id,
+            band_follow_id: Number(followId),
+            error: expect.any(Error),
+          }),
+        );
+
+        // The existing failed > 0 warning must still fire.
+        expect(warnSpy).toHaveBeenCalledWith(
+          "announce digest partially failed",
+          expect.objectContaining({ sent: 0, failed: 1, skipped: 0 }),
+        );
+      } finally {
+        batchSpy.mockRestore();
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
+    // This is the important residual-limitation check: a claim-release
+    // failure is deliberately NOT retried (see the comment in
+    // announceDigest.js), so the band_follow_notifications row survives.
+    // resend-announcement.js only recovers followers WITHOUT a notification
+    // row, so this fan is NOT automatically recoverable — only identifiable
+    // via the logged ids above for manual (human) recovery.
+    it("leaves the fan unrecoverable via resend-announcement's query after a claim-release failure", async () => {
+      const { env, rawDb } = createTestEnv();
+      vi.spyOn(logger, "error").mockImplementation(() => {});
+      vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+      const ev = insertEvent(rawDb, { name: "Fest", slug: "fest-recovery-check" });
+      const venue = insertVenue(rawDb, { name: "Room" });
+      const perf = insertBand(rawDb, {
+        name: "Band Stranded",
+        event_id: ev.id,
+        venue_id: venue.id,
+      });
+
+      const followId = rawDb
+        .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+        .run("stranded@example.com", perf.band_profile_id, "tok-stranded").lastInsertRowid;
+
+      rawDb
+        .prepare(
+          `INSERT INTO band_announce_queue
+         (band_follow_id, performance_id, event_id, band_name, event_name, event_slug, band_profile_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(followId, perf.id, ev.id, "Band Stranded", "Fest", "fest-recovery-check", perf.band_profile_id);
+
+      sendEmail.mockResolvedValueOnce({ delivered: false, reason: "provider_error" });
+      const batchSpy = stubBatchToFailAfterFirstCall(env);
+
+      try {
+        const stats = await flushAnnounceDigest(env, env.DB);
+        expect(stats.failed).toBe(1);
+
+        // The claim row survives the failed release.
+        const notif = rawDb
+          .prepare("SELECT * FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?")
+          .get(perf.id, followId);
+        expect(notif).toBeDefined();
+
+        // This mirrors the exact SELECT resend-announcement.js uses
+        // (functions/api/admin/bands/[id]/resend-announcement.js) to find
+        // followers still owed an announcement for this performance.
+        const recoverable = rawDb
+          .prepare(
+            `SELECT bf.id, bf.email, bf.unsubscribe_token
+             FROM band_follows bf
+             LEFT JOIN band_follow_notifications bfn
+               ON bfn.band_follow_id = bf.id AND bfn.performance_id = ?
+             WHERE bf.band_profile_id = ? AND bf.verified = 1 AND bfn.id IS NULL`,
+          )
+          .all(perf.id, perf.band_profile_id);
+
+        // Because the notification row survived, the LEFT JOIN matches it
+        // and `bfn.id IS NULL` excludes this follower — resend-announcement
+        // will NOT pick this fan up. Documented residual limitation.
+        expect(recoverable.find((f) => Number(f.id) === Number(followId))).toBeUndefined();
+      } finally {
+        batchSpy.mockRestore();
+        vi.restoreAllMocks();
+      }
+    });
   });
 });

--- a/functions/utils/announceDigest.js
+++ b/functions/utils/announceDigest.js
@@ -126,15 +126,34 @@ export async function flushAnnounceDigest(env, DB) {
     if (result?.delivered) {
       sent++;
     } else {
-      // Release claims so resend-announcement can recover this fan.
-      await DB.batch(
-        task.claimed.map((item) =>
-          DB.prepare("DELETE FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?").bind(
-            item.performance_id,
-            item.band_follow_id,
+      // Release claims so resend-announcement can recover this fan. If the
+      // release itself fails, the band_follow_notifications row(s) survive,
+      // which means resend-announcement (which only recovers followers
+      // WITHOUT a notification row) will permanently skip this fan unless
+      // someone manually deletes the row. We deliberately do not retry the
+      // DELETE here: D1 failures inside a Worker are rarely transient, and a
+      // retry adds its own failure mode. Instead we count the fan as failed
+      // (so the returned counts stay accurate and the `failed > 0` warning
+      // below still fires) and log every claimed id so the row can be found
+      // and cleared by hand (#672).
+      try {
+        await DB.batch(
+          task.claimed.map((item) =>
+            DB.prepare("DELETE FROM band_follow_notifications WHERE performance_id = ? AND band_follow_id = ?").bind(
+              item.performance_id,
+              item.band_follow_id,
+            ),
           ),
-        ),
-      );
+        );
+      } catch (releaseError) {
+        for (const item of task.claimed) {
+          logger.error("announce digest claim release failed; fan requires manual recovery", {
+            performance_id: item.performance_id,
+            band_follow_id: item.band_follow_id,
+            error: releaseError,
+          });
+        }
+      }
       failed++;
     }
   }
@@ -142,11 +161,14 @@ export async function flushAnnounceDigest(env, DB) {
   for (let i = 0; i < sendTasks.length; i += SEND_CONCURRENCY) {
     const chunk = sendTasks.slice(i, i + SEND_CONCURRENCY);
     const results = await Promise.allSettled(chunk.map(sendOne));
-    // #672: rejected tasks are logged; send counts and claim-recovery
-    // semantics are unchanged.
+    // #672: sendOne no longer lets the claim-release failure escape uncaught,
+    // so a rejection here should be impossible. Keep this as a backstop
+    // (and count it as failed) so a future refactor that reintroduces a
+    // throw in sendOne can't silently drop a fan from the counts again.
     for (const result of results) {
       if (result.status === "rejected") {
         logger.error("announce digest sendOne rejected (claim release may not have run)", { error: result.reason });
+        failed++;
       }
     }
   }

--- a/functions/utils/announceDigest.js
+++ b/functions/utils/announceDigest.js
@@ -116,13 +116,34 @@ export async function flushAnnounceDigest(env, DB) {
   let sent = 0;
   let failed = 0;
 
+  // Logs every claimed id so a stranded row can be found and cleared by hand.
+  function logStrandedClaims(task, message, error) {
+    for (const item of task.claimed) {
+      logger.error(message, {
+        performance_id: item.performance_id,
+        band_follow_id: item.band_follow_id,
+        error,
+      });
+    }
+  }
+
   async function sendOne(task) {
-    const result = await sendEmail(env, {
-      to: task.email,
-      subject: task.subject,
-      text: task.text,
-      html: task.html,
-    });
+    let result;
+    try {
+      result = await sendEmail(env, {
+        to: task.email,
+        subject: task.subject,
+        text: task.text,
+        html: task.html,
+      });
+    } catch (sendError) {
+      // A throw from sendEmail is a delivery failure like any other and must
+      // take the same claim-release path. Left unguarded it skipped the release
+      // entirely, so the notification row survived and resend-announcement
+      // would never recover this fan (#672).
+      logStrandedClaims(task, "announce digest sendEmail threw; releasing claims", sendError);
+      result = { delivered: false };
+    }
     if (result?.delivered) {
       sent++;
     } else {
@@ -146,13 +167,7 @@ export async function flushAnnounceDigest(env, DB) {
           ),
         );
       } catch (releaseError) {
-        for (const item of task.claimed) {
-          logger.error("announce digest claim release failed; fan requires manual recovery", {
-            performance_id: item.performance_id,
-            band_follow_id: item.band_follow_id,
-            error: releaseError,
-          });
-        }
+        logStrandedClaims(task, "announce digest claim release failed; fan requires manual recovery", releaseError);
       }
       failed++;
     }
@@ -161,16 +176,15 @@ export async function flushAnnounceDigest(env, DB) {
   for (let i = 0; i < sendTasks.length; i += SEND_CONCURRENCY) {
     const chunk = sendTasks.slice(i, i + SEND_CONCURRENCY);
     const results = await Promise.allSettled(chunk.map(sendOne));
-    // #672: sendOne no longer lets the claim-release failure escape uncaught,
-    // so a rejection here should be impossible. Keep this as a backstop
-    // (and count it as failed) so a future refactor that reintroduces a
-    // throw in sendOne can't silently drop a fan from the counts again.
-    for (const result of results) {
+    // Backstop for anything sendOne did not catch. The index maps back to the
+    // originating task, so a rejection still logs which fan was stranded —
+    // without that the count is right but nobody can find the surviving rows.
+    results.forEach((result, i) => {
       if (result.status === "rejected") {
-        logger.error("announce digest sendOne rejected (claim release may not have run)", { error: result.reason });
+        logStrandedClaims(chunk[i], "announce digest sendOne rejected; claim release may not have run", result.reason);
         failed++;
       }
-    }
+    });
   }
 
   if (failed > 0) {


### PR DESCRIPTION
## Summary

`flushAnnounceDigest`'s `sendOne` released a fan's `band_follow_notifications` claim via `DB.batch()` when their announcement email failed to deliver, so `resend-announcement` could recover them later. If that release `DB.batch()` itself threw, the throw escaped `sendOne` uncaught: neither `sent` nor `failed` incremented (the fan vanished from the returned counts and the `failed > 0` warning never fired), and — worse — the claim row survived, so `resend-announcement` (which only recovers followers *without* a notification row) would skip that fan permanently. This closes the behavioural half of #672 (PR #682 shipped the observability-only half: logging the rejection).

Closes #672

## What changed

| File | Change |
|------|--------|
| `functions/utils/announceDigest.js` | Wrap the claim-release `DB.batch()` in try/catch inside `sendOne`. On failure: log `performance_id`/`band_follow_id` for every claimed item, still `failed++` (so counts stay accurate and the existing warning fires), and never let the throw escape. The `Promise.allSettled` backstop now also counts a rejection as `failed` (previously log-only), so a future refactor reintroducing a throw in `sendOne` can't silently drop a fan from the counts again. |
| `functions/api/admin/bands/__tests__/announce-digest.test.js` | Two new tests for the claim-release failure path (count + log, and the residual-recoverability check below), plus an assertion added to the existing rejected-`sendOne` test so it also verifies the backstop's `failed` count. |

**Deliberately not doing:** automatic retry of the release `DELETE`. D1 failures inside a Cloudflare Worker are rarely transient, a retry adds its own failure mode, and the accurate count plus logged ids already make the fan recoverable by hand. This was an explicit decision, not an oversight — see the design note in the issue and the comment left in the code.

## Security / correctness notes

None (auth/CSRF/RBAC untouched). Data-integrity note: **residual limitation, verified by test** — after a claim-release failure, the `band_follow_notifications` row survives (the DELETE that would have cleared it is what failed), and `resend-announcement.js`'s query (`LEFT JOIN ... WHERE bfn.id IS NULL`) explicitly excludes followers *with* a notification row. So this fan is **not** automatically recoverable via `resend-announcement` — only identifiable via the newly-logged `performance_id`/`band_follow_id` for manual (human) recovery, i.e. deleting the stray row by hand so a future flush/resend can pick the fan back up. This is the tradeoff of "count + log, don't retry" and is called out explicitly rather than glossed over. No email addresses are logged — this module never logged addresses, so the fix keeps that convention (logger.js redacts an `email` key anyway).

## Verification

- [x] Tests: 878 pass, 0 failures, 6 todo, 87 files (`npm test`) — real exit code 0
- [x] ESLint: 0 errors (`npm run lint`) — real exit code 0
- [x] Format check: clean (`npm run format:check`) — real exit code 0
- [x] Build: N/A — backend-only change, `git diff --stat -- frontend/` is empty
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` not touched
- [x] Manual smoke: n/a (no UI surface); new tests independently verified red→green by reverting the production fix, confirming all 3 new/changed tests fail against the pre-fix code (uncaught throw, `stats.failed` stayed 0), then restoring the fix and confirming all 11 tests in the file pass
- [x] `make review-wip` (CodeRabbit CLI) run before opening this PR — **no findings**

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved announce digest processing so thrown email errors and non-delivered results are handled consistently as failures.
  * Ensures claim-release cleanup is attempted safely; cleanup errors are logged with identifiers for manual recovery and do not prevent completion.
  * Maintains accurate failure counts and preserves existing partial-failure warnings, including the documented resend limitation when cleanup fails.
* **Tests**
  * Expanded coverage for delivery-throw paths, claim-release cleanup failures, logging expectations, and recovery selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->