### PR TITLE
fix(mobile): smooth the residual scroll-collapse jank on the live event page

### DIFF
--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -55,9 +55,21 @@ export function isIdentityVisuallyGone(scrollProgress) {
  * `scrollProgress` goes 0 -> 1, `maxHeight` must never increase. jsdom does no
  * real layout, so the test targets this function rather than rendered geometry.
  *
+ * `scrollProgress` itself only advances once per `requestAnimationFrame`
+ * (`useScrollCollapse`), and iOS momentum scrolling delivers `scroll` events
+ * irregularly — so without smoothing, these values would visibly *step*
+ * between commits rather than track continuously (#690 residual jank, after
+ * the bounce itself was fixed by the ratchet in #693). The
+ * `IDENTITY_COLLAPSE_TRANSITION_CLASS` Tailwind class applied alongside this
+ * style (not baked in here, to match the `Header.jsx` collapse precedent)
+ * interpolates between those discrete commits. That is only safe *because*
+ * the ratchet makes `scrollProgress` monotonic while scrolling down — a CSS
+ * transition on a value that can also decrease mid-scroll would ease a
+ * visible bounce instead of smoothing a one-directional collapse.
+ *
  * @param {number} scrollProgress - 0 (fully open) to 1 (fully collapsed).
  * @returns {object} React style: `opacity`, `transform`, `maxHeight`,
- *   `overflow`, `overflowAnchor`, `pointerEvents`.
+ *   `overflow`, `overflowAnchor`, `pointerEvents`, `willChange`.
  */
 export function computeIdentityCollapseStyle(scrollProgress) {
   const identityFadeProgress = Math.min(1, scrollProgress * IDENTITY_FADE_MULTIPLIER)
@@ -73,8 +85,29 @@ export function computeIdentityCollapseStyle(scrollProgress) {
     // bounces.
     overflowAnchor: 'none',
     pointerEvents: isIdentityVisuallyGone(scrollProgress) ? 'none' : 'auto',
+    // Hints the compositor-friendly properties onto their own layer, so at
+    // least the opacity/transform portion of the transition (below) can run
+    // off the main thread. `maxHeight` is deliberately excluded from this
+    // hint — it's a layout property (the entire point of #665 — collapsing
+    // it reclaims real vertical space) and stays in the transition's
+    // property list regardless, so the block below it still gets a
+    // layout+repaint every frame either way; promoting it here would just
+    // cost memory for no benefit.
+    willChange: 'opacity, transform',
   }
 }
+
+/**
+ * Tailwind transition applied to the identity block in JSX, not baked into
+ * `computeIdentityCollapseStyle` above — mirrors how `Header.jsx` pairs its
+ * own scroll-collapse inline style with a static transition class. Duration
+ * matches the codebase's dominant micro-interaction speed (`duration-150`,
+ * used throughout for hover/press transitions). The sitewide
+ * `prefers-reduced-motion` rule (`index.css`) clamps all transition
+ * durations to ~0 with `!important`, so this class collapses instantly for
+ * users who request less motion without any extra handling here.
+ */
+export const IDENTITY_COLLAPSE_TRANSITION_CLASS = 'transition-[max-height,opacity,transform] duration-150 ease-out'
 
 function LiveContextBar({
   eventData,
@@ -223,7 +256,7 @@ function LiveContextBar({
               a fan needs once they're scrolling the lineup (Tabs, filter
               toggle) lives in the always-visible block below, outside this
               wrapper. */}
-          <div style={identityCollapseStyle} inert={isIdentityCollapsed}>
+          <div className={IDENTITY_COLLAPSE_TRANSITION_CLASS} style={identityCollapseStyle} inert={isIdentityCollapsed}>
             <div className="flex items-center justify-between gap-3">
               <span
                 role="button"

--- a/frontend/src/components/__tests__/EventPosterThumbnail.test.jsx
+++ b/frontend/src/components/__tests__/EventPosterThumbnail.test.jsx
@@ -73,6 +73,21 @@ describe('EventPosterThumbnail', () => {
       expect(container).toBeEmptyDOMElement()
     })
 
+    // The inline variant renders above the fold in the sticky bar — lazy
+    // loading it would delay LCP and cause a visible pop-in. Unrelated to
+    // #690's scroll-collapse transition fix, but that fix touches the same
+    // identity block this poster lives inside, so this regression guard
+    // keeps the two changes from silently interacting.
+    it('renders eagerly with high fetch priority, unlike the standalone variant', () => {
+      render(
+        <EventPosterThumbnail posterUrl={POSTER_URL} eventName="Buddies Fest 2" onOpen={vi.fn()} variant="inline" />
+      )
+
+      const image = screen.getByRole('img', { name: 'Buddies Fest 2 poster' })
+      expect(image).toHaveAttribute('loading', 'eager')
+      expect(image).toHaveAttribute('fetchpriority', 'high')
+    })
+
     it('requests a smaller derivative than the standalone variant', () => {
       render(
         <EventPosterThumbnail posterUrl={POSTER_URL} eventName="Buddies Fest 2" onOpen={vi.fn()} variant="inline" />

--- a/frontend/src/components/__tests__/EventPosterThumbnail.test.jsx
+++ b/frontend/src/components/__tests__/EventPosterThumbnail.test.jsx
@@ -74,10 +74,7 @@ describe('EventPosterThumbnail', () => {
     })
 
     // The inline variant renders above the fold in the sticky bar — lazy
-    // loading it would delay LCP and cause a visible pop-in. Unrelated to
-    // #690's scroll-collapse transition fix, but that fix touches the same
-    // identity block this poster lives inside, so this regression guard
-    // keeps the two changes from silently interacting.
+    // loading it would delay LCP and cause a visible pop-in.
     it('renders eagerly with high fetch priority, unlike the standalone variant', () => {
       render(
         <EventPosterThumbnail posterUrl={POSTER_URL} eventName="Buddies Fest 2" onOpen={vi.fn()} variant="inline" />

--- a/frontend/src/components/__tests__/LiveContextBar.test.jsx
+++ b/frontend/src/components/__tests__/LiveContextBar.test.jsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import LiveContextBar, { computeIdentityCollapseStyle } from '../LiveContextBar'
+import LiveContextBar, { computeIdentityCollapseStyle, IDENTITY_COLLAPSE_TRANSITION_CLASS } from '../LiveContextBar'
 
 describe('computeIdentityCollapseStyle (#690 scroll-collapse bounce)', () => {
   const px = style => parseFloat(style.maxHeight)
@@ -55,6 +55,38 @@ describe('computeIdentityCollapseStyle (#690 scroll-collapse bounce)', () => {
       }
     }
   })
+
+  // #690 residual jank fix: scrollProgress only advances once per animation
+  // frame, and iOS momentum scrolling delivers `scroll` events irregularly,
+  // so without smoothing the rendered values snap in uneven steps rather
+  // than tracking continuously. `willChange` hints the compositor-friendly
+  // properties onto their own layer; `maxHeight` is deliberately excluded —
+  // it's a layout property (the whole point of #665 is reclaiming real
+  // vertical space), so promoting it buys nothing and costs memory.
+  it('hints only the compositor-friendly properties via willChange, never maxHeight', () => {
+    const style = computeIdentityCollapseStyle(0.5)
+    expect(style.willChange).toContain('opacity')
+    expect(style.willChange).toContain('transform')
+    expect(style.willChange).not.toContain('max-height')
+    expect(style.willChange).not.toContain('height')
+  })
+})
+
+// #690 residual jank fix: a short CSS transition smooths the discrete,
+// scroll-event-sized steps described above. Safe only because the #693
+// ratchet makes scrollProgress monotonic while scrolling down — a
+// transition on a value that could still decrease mid-scroll would ease a
+// visible bounce instead of smoothing a one-directional collapse.
+describe('IDENTITY_COLLAPSE_TRANSITION_CLASS (#690 residual jank)', () => {
+  it('transitions exactly the properties the collapse animates, not maxHeight alone or "all"', () => {
+    // A bare "transition-all" would also animate hover/focus states this
+    // block doesn't have, and "duration-0" or a missing duration class would
+    // silently regress to no smoothing at all.
+    expect(IDENTITY_COLLAPSE_TRANSITION_CLASS).toMatch(/transition-\[.*max-height.*opacity.*transform.*\]/)
+    // [1-9]\d* (not \d+): "duration-0" is exactly the silent-no-smoothing
+    // regression this guards against and must NOT satisfy the pattern.
+    expect(IDENTITY_COLLAPSE_TRANSITION_CLASS).toMatch(/duration-[1-9]\d*/)
+  })
 })
 
 const eventData = {
@@ -69,6 +101,20 @@ const bands = [
 
 function setViewportWidth(width) {
   Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width })
+}
+
+function setScrollY(y) {
+  Object.defineProperty(window, 'scrollY', { writable: true, configurable: true, value: y })
+}
+
+// useScrollCollapse batches its measurement into a requestAnimationFrame, so
+// the frame has to be flushed before the committed progress reaches the
+// rendered style/attributes.
+async function fireScroll() {
+  await act(async () => {
+    window.dispatchEvent(new Event('scroll'))
+    await new Promise(resolve => requestAnimationFrame(resolve))
+  })
 }
 
 describe('LiveContextBar', () => {
@@ -343,6 +389,77 @@ describe('LiveContextBar', () => {
 
       fireEvent.click(screen.getByRole('button', { name: /View .*poster/i }))
       expect(onPosterOpen).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // #690 residual jank fix, at the rendered-component level (the tests above
+  // exercise the pure functions in isolation).
+  describe('scroll-driven identity block (#690)', () => {
+    afterEach(() => {
+      setScrollY(0)
+      setViewportWidth(1024)
+    })
+
+    it('carries the collapse transition class on the identity block, mount included', () => {
+      setViewportWidth(375)
+      const { container } = render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T19:30:00')}
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+
+      const identityBlock = container.querySelector('.sm\\:hidden > div')
+      expect(identityBlock).toHaveClass('transition-[max-height,opacity,transform]')
+      expect(identityBlock).toHaveClass('duration-150')
+    })
+
+    // `inert`/`pointerEvents` flip on the committed scrollProgress value the
+    // instant it crosses IDENTITY_GONE_PROGRESS — they are NOT driven by the
+    // CSS transition, which now animates the visual opacity/maxHeight toward
+    // that state over ~150ms. So for a brief window the block can be
+    // slightly visible-but-already-inert (safe: fading out) or briefly
+    // non-zero-opacity-but-not-yet-inert only on the way IN (also safe: it's
+    // interactive exactly while it's visible). What must never happen, and
+    // what this test actually guards, is the old bug: fully invisible
+    // (opacity 0) while still interactive/focusable.
+    it('flips inert the instant scrollProgress crosses the gone threshold, in step with pointerEvents', async () => {
+      setViewportWidth(375)
+      setScrollY(0)
+      const { container } = render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T19:30:00')}
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+      const identityBlock = () => container.querySelector('.sm\\:hidden > div')
+
+      // Fully open: interactive, not inert.
+      expect(identityBlock()).not.toHaveAttribute('inert')
+      expect(identityBlock()).toHaveStyle({ pointerEvents: 'auto' })
+
+      // scrollProgress thresholds are useScrollCollapse(48, 240); 0.6 * (240-48) + 48 = ~163,
+      // comfortably past IDENTITY_GONE_PROGRESS (~0.571) where the block goes invisible.
+      setScrollY(163)
+      await fireScroll()
+      expect(identityBlock()).toHaveAttribute('inert')
+      expect(identityBlock()).toHaveStyle({ pointerEvents: 'none' })
     })
   })
 })


### PR DESCRIPTION
## Summary

PR #693 fixed the *bounce* on the live event page's mobile sticky "identity block" (a ratchet in `useScrollCollapse` stops iOS scroll jitter from re-expanding the collapse mid-scroll). Dre reported it's "improved but can still be a lot smoother." This fixes the residual jank: the block still *snapped* in uneven steps instead of collapsing continuously.

Closes #690

## Root cause (measured, not assumed)

`scrollProgress` only commits once per scroll-triggered animation frame, and iOS coalesces `scroll` **event dispatch** to a lower rate than the **paint** rate during momentum scrolling — the visual scroll position keeps moving every frame, but the JS listener (and therefore the React re-render that updates `maxHeight`/`opacity`/`transform`) only fires every few frames. With no interpolation, the rendered style sits frozen between those commits, then jumps.

**Measurement 1 — real WebKit (iPhone 14 Pro) against production (`settimes.ca/event/lwbc17`)**, driving momentum-like 8–16px scroll increments and sampling the rendered identity block's computed style every animation frame:

| | max single-frame delta | frames with >3px movement | frozen frames |
|---|---|---|---|
| production today | 16px | 17/44 | 27/44 |

**Measurement 2 — isolated fixture, frame-decoupled** (the methodology that actually isolates the mechanism: commits scroll state only every 4th frame — approximating iOS's slower event coalescing — while sampling the rendered style *every* frame). Built from the exact ratchet math in `useScrollCollapse.js` and `computeIdentityCollapseStyle`, run with real WebKit via `page.setContent` (no server needed):

| | max single-frame delta | frames with >3px movement | frozen frames (of 44) |
|---|---|---|---|
| before (ratchet only, current prod) | 54px | 5 | 39 |
| **after (this PR)** | **19.5px (-64%)** | **19 (+280%)** | **16 (-59%)** |

The mean per-frame delta is identical before/after (4.55px) — expected, since total distance travelled (200px→0) over the same frame count is invariant. The metric that matters is the *distribution*: motion goes from "almost never moves, then jumps 54px" to "moves a little almost every frame."

`prefers-reduced-motion` re-verified against the fixed build with `reducedMotion: 'reduce'` emulated: `transitionDuration` computes to `0.00001s` and the per-frame distribution is **identical** to the unfixed case — the sitewide `!important` override in `index.css` still collapses it instantly.

## What changed

| File | Change |
|------|--------|
| `frontend/src/components/LiveContextBar.jsx` | Added `IDENTITY_COLLAPSE_TRANSITION_CLASS` (`transition-[max-height,opacity,transform] duration-150 ease-out`), applied via `className` alongside the existing scroll-driven inline `style` — the same pairing `Header.jsx` already uses for its own scroll-collapse. Added `willChange: 'opacity, transform'` to the inline style (deliberately excluding `maxHeight`, a layout property that can't be composited and stays in the transition's property list regardless). |
| `frontend/src/components/__tests__/LiveContextBar.test.jsx` | New tests: `willChange` hints only compositor-friendly properties; the transition class names the right properties + a non-zero duration; the identity block carries the class in the DOM; `inert`/`pointerEvents` still flip together at the same threshold with the transition in place. |
| `frontend/src/components/__tests__/EventPosterThumbnail.test.jsx` | New regression test: the inline poster variant stays `loading="eager"`/`fetchpriority="high"` — a pre-existing invariant (LCP-critical, above the fold) that had no direct test before. |

Why this is safe *now* when a transition was rejected in #693: the ratchet makes `scrollProgress` monotonic while scrolling down, so there is no mid-scroll value for a transition to ease into a visible bounce — the only decrease is a single full reset at `scrollY <= start`, which the transition turns into an intentional ~150ms unfurl instead of a 1-frame pop.

## Security / correctness notes

None. No auth/CSRF/data paths touched; pure client-side CSS/inline-style change to an already-reviewed component. `functions/` is untouched (`git diff --stat -- functions/` is empty).

## CodeRabbit findings addressed

- **Fixed:** a test comment referenced this PR number and cross-change interaction instead of stating the runtime invariant — trimmed.
- **Declined:** CodeRabbit flagged the new `fireScroll` test helper's real `requestAnimationFrame` wait as timing-sensitive, suggesting fake timers. Declined — it's a byte-for-byte copy of the helper already in `frontend/src/hooks/__tests__/useScrollCollapse.test.jsx` (merged in #693, part of the required test gate), for the same hook. Changing only my copy would make the two test files exercising `useScrollCollapse` inconsistent for no observed flakiness.

## What is NOT verified, and why

**No real-device or full-app WebKit confirmation of the fixed build.** Two independent blockers, not one:
1. WebKit on this machine cannot reach the local wrangler dev server (`localhost:8788` / `127.0.0.1:8788` both time out — a known gap, first hit and documented on #693).
2. This repo's CI does **not** deploy a Cloudflare Pages preview for `pull_request` events — only real pushes to `main`/`dev` deploy (`should_deploy` is false whenever `EVENT_NAME == 'pull_request'`, see `.github/workflows/cloudflare-pages.yml`).

So there is no reachable URL serving the fixed build until this merges. The frame-decoupled fixture above is a mechanically faithful stand-in (verbatim ratchet/style math, real compiled Tailwind CSS rules, real WebKit rendering/transition engine) but it is **not** a substitute for watching the actual page scroll on a real device. That check is still outstanding on the deploy — the same gap #693 named and did not paper over.

## Verification

- [x] Tests: 647 pass, 0 failures (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors, 2 pre-existing warnings in `admin/` unrelated to this change (`npm run lint`)
- [x] Format check: clean (`cd frontend && npm run format:check`)
- [x] Build: green (`npm run build --prefix frontend`)
- [ ] `validate:openapi`: N/A — `docs/api-spec.yaml` not touched
- [ ] Manual smoke: real-device / post-deploy WebKit re-check — outstanding, see above

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved mobile identity panel animations for smoother scrolling and reduced visual jank.

- **Bug Fixes**
  - Prevented fully collapsed identity content from remaining interactive.
  - Ensured pointer interactions are disabled when the identity panel is hidden.

- **Tests**
  - Added coverage for animation behaviour, scroll-driven collapsing, interaction state, and high-priority inline poster image loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->