### PR TITLE
fix(mobile): release scroll collapse on deliberate upward drag

### DIFF
--- a/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
+++ b/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
@@ -89,6 +89,70 @@ describe('useScrollCollapse', () => {
     expect(screen.getByTestId('progress')).toHaveTextContent('1')
   })
 
+  it('releases on a deliberate upward drag and then expands gradually', async () => {
+    // A pure ratchet left scrolling up dead until scrollY reached `start`, then
+    // snapped open. Small successive upward steps are a finger drag and must
+    // release it, after which progress tracks scroll again.
+    setScrollY(0)
+    render(<Harness start={40} end={140} />)
+    setScrollY(140)
+    await fireScroll()
+    expect(screen.getByTestId('progress')).toHaveTextContent('1')
+
+    // Drag up in drag-sized increments: 8px x 8 = 64px, reaching the threshold.
+    let y = 140
+    for (let i = 0; i < 8; i++) {
+      y -= 8
+      setScrollY(y)
+      await fireScroll()
+    }
+    // y is now 76; raw = (76-40)/100 = 0.36. Released, so progress follows it
+    // rather than staying pinned at 1.
+    expect(Number(screen.getByTestId('progress').textContent)).toBeLessThan(1)
+  })
+
+  it('a single URL-bar-sized upward jump never releases it', async () => {
+    // ~60px arriving as ONE discontinuity is a viewport shift, not a drag. It
+    // exceeds the per-step cap and must contribute nothing, however often it
+    // repeats — this is the #690 flicker.
+    setScrollY(0)
+    render(<Harness start={40} end={140} />)
+    setScrollY(140)
+    await fireScroll()
+
+    // Two things this test has to get right, both of which it got wrong first:
+    //   1. The jump must EXCEED the 64px release threshold, or it passes merely
+    //      because the distance was short and never exercises the per-step cap.
+    //   2. The assertion must come IMMEDIATELY after the upward jump. Asserting
+    //      after scrolling back down passes regardless, because the downward
+    //      move re-ratchets to 1 and hides any mid-loop release.
+    for (let i = 0; i < 5; i++) {
+      setScrollY(60) // 80px up in a single step — over the threshold
+      await fireScroll()
+      expect(screen.getByTestId('progress')).toHaveTextContent('1')
+      setScrollY(140) // back down for the next iteration
+      await fireScroll()
+    }
+  })
+
+  it('downward movement resets the upward accumulator', async () => {
+    // Otherwise upward jitter would accumulate across an entire long scroll and
+    // eventually release the ratchet for no deliberate reason.
+    setScrollY(0)
+    render(<Harness start={40} end={140} />)
+    setScrollY(140)
+    await fireScroll()
+
+    // Alternate up 8 / down 8: never a sustained upward drag.
+    for (let i = 0; i < 12; i++) {
+      setScrollY(132)
+      await fireScroll()
+      setScrollY(140)
+      await fireScroll()
+    }
+    expect(screen.getByTestId('progress')).toHaveTextContent('1')
+  })
+
   it('releases the ratchet once the user is back at the top', async () => {
     setScrollY(0)
     render(<Harness start={40} end={140} />)

--- a/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
+++ b/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
@@ -106,9 +106,9 @@ describe('useScrollCollapse', () => {
       setScrollY(y)
       await fireScroll()
     }
-    // y is now 76; raw = (76-40)/100 = 0.36. Released, so progress follows it
-    // rather than staying pinned at 1.
-    expect(Number(screen.getByTestId('progress').textContent)).toBeLessThan(1)
+    // y is now 76, so raw = (76-40)/100 = 0.36. Assert that exact value: `< 1`
+    // would also pass if a regression snapped progress straight to 0.
+    expect(Number(screen.getByTestId('progress').textContent)).toBeCloseTo(0.36, 2)
   })
 
   it('a single URL-bar-sized upward jump never releases it', async () => {
@@ -120,17 +120,14 @@ describe('useScrollCollapse', () => {
     setScrollY(140)
     await fireScroll()
 
-    // Two things this test has to get right, both of which it got wrong first:
-    //   1. The jump must EXCEED the 64px release threshold, or it passes merely
-    //      because the distance was short and never exercises the per-step cap.
-    //   2. The assertion must come IMMEDIATELY after the upward jump. Asserting
-    //      after scrolling back down passes regardless, because the downward
-    //      move re-ratchets to 1 and hides any mid-loop release.
+    // The jump must exceed the 64px release threshold, or the per-step cap is
+    // never exercised. Assert before scrolling back down: downward movement
+    // re-ratchets to 1 and would mask a mid-loop release.
     for (let i = 0; i < 5; i++) {
-      setScrollY(60) // 80px up in a single step — over the threshold
+      setScrollY(60) // 80px up in a single step
       await fireScroll()
       expect(screen.getByTestId('progress')).toHaveTextContent('1')
-      setScrollY(140) // back down for the next iteration
+      setScrollY(140)
       await fireScroll()
     }
   })

--- a/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
+++ b/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
@@ -106,8 +106,7 @@ describe('useScrollCollapse', () => {
       setScrollY(y)
       await fireScroll()
     }
-    // y is now 76, so raw = (76-40)/100 = 0.36. Assert that exact value: `< 1`
-    // would also pass if a regression snapped progress straight to 0.
+    // y is now 76, so raw = (76 - 40) / 100 = 0.36.
     expect(Number(screen.getByTestId('progress').textContent)).toBeCloseTo(0.36, 2)
   })
 

--- a/frontend/src/hooks/useScrollCollapse.js
+++ b/frontend/src/hooks/useScrollCollapse.js
@@ -26,21 +26,58 @@ import { useEffect, useState } from 'react'
  * every transition/animation duration to ~0 for users who request less
  * motion — there is nothing further this hook needs to do for that.
  */
+// A single upward step larger than this is not a finger drag — it is a viewport
+// discontinuity (iOS URL-bar show/hide is ~60px, measured; rubber-band snap-back
+// is larger still). Such steps are ignored entirely rather than counted, so a
+// perturbation can never release the ratchet no matter how large.
+const UP_STEP_MAX_PX = 24
+
+// Cumulative upward drag required to release the ratchet. Comfortably above the
+// 6-12px jitter measured during momentum scrolling, and small enough that a
+// deliberate flick upward responds within roughly one thumb movement.
+const UP_RELEASE_PX = 64
+
 export function useScrollCollapse(start, end) {
   const [progress, setProgress] = useState(0)
 
   useEffect(() => {
     let frame = null
-    // Invariant: collapse is monotonic until scrollY <= start. Scroll position
-    // is perturbed constantly on iOS (URL bar, momentum, rubber-band), and
-    // tracking it directly re-expands the block mid-scroll (#690).
+    // Collapse is monotonic while scrolling DOWN: scroll position is perturbed
+    // constantly on iOS (URL bar, momentum, rubber-band) and tracking it
+    // directly re-expands the block mid-scroll (#690).
+    //
+    // But a pure ratchet made scrolling UP dead — the block stayed collapsed
+    // until scrollY reached `start`, then snapped open in one step. So the
+    // ratchet also releases on DELIBERATE upward scroll, after which progress
+    // tracks scroll again and the block expands gradually.
+    //
+    // Magnitude alone cannot tell a deliberate drag from a perturbation: a
+    // URL-bar shift is ~60px, comparable to a real flick. The difference is
+    // SHAPE — a URL-bar shift arrives as one discontinuity, a finger drag as
+    // many small increments. So only steps small enough to be a drag
+    // accumulate, and a single large jump contributes nothing.
     let ratchet = 0
+    let lastY = window.scrollY || 0
+    let upAccum = 0
     const update = () => {
       frame = null
       const y = window.scrollY || 0
       const raw = Math.min(Math.max((y - start) / (end - start), 0), 1)
-      // Back at the top: release the ratchet so the block can expand again.
-      ratchet = y <= start ? 0 : Math.max(ratchet, raw)
+      const dy = y - lastY
+      if (dy > 0) {
+        upAccum = 0
+      } else if (dy < 0 && -dy <= UP_STEP_MAX_PX) {
+        upAccum += -dy
+      }
+      lastY = y
+      if (y <= start) {
+        upAccum = 0
+        ratchet = 0
+      } else if (upAccum >= UP_RELEASE_PX) {
+        ratchet = raw
+      } else {
+        ratchet = Math.max(ratchet, raw)
+      }
       setProgress(prev => (Math.abs(prev - ratchet) < 0.01 ? prev : ratchet))
     }
     const onScroll = () => {


### PR DESCRIPTION
## Summary

Scrolling **up** on the event page did nothing until you reached the very top, then the identity block snapped open in one step. This makes upward scroll responsive without reintroducing the #690 flicker.

Refs #690 — deliberately **not** `Closes`. Dre has confirmed each prior fix "improved but could still be better", and none has had a real-device confirmation. #690 should stay open until he confirms on a device.

## What changed

| File | Change |
|---|---|
| `frontend/src/hooks/useScrollCollapse.js` | The ratchet now also releases after a deliberate upward drag, not only at `scrollY <= start`. Adds `UP_STEP_MAX_PX` (24) and `UP_RELEASE_PX` (64): only drag-sized upward steps accumulate, and downward movement resets the accumulator. |
| `frontend/src/hooks/__tests__/useScrollCollapse.test.jsx` | Three new cases — deliberate drag releases and tracks scroll; a single URL-bar-sized jump never releases; alternating movement never accumulates. |

### Why the design is shaped this way

A pure ratchet (#693) fixed the flicker by only ever increasing progress. That made upward scroll dead, and produced a full-range `1 → 0` snap at the top. #696's 150ms transition eases those pixels but cannot fix the behaviour.

Magnitude alone cannot separate a deliberate drag from a perturbation — an iOS URL-bar shift is ~60px, comparable to a real flick. The difference is **shape**: a URL-bar shift arrives as one discontinuity, a finger drag as many small increments. So steps over 24px are ignored entirely, and 64px of accumulated small steps releases the ratchet.

## Security / correctness notes

No security surface. Correctness risks and how they are held:

- **Flicker regression (#690/#693)** — a perturbation must never release the ratchet. Held by the per-step cap; a single 80px jump contributes nothing however often it repeats. Mutation-verified: raising the cap fails that test.
- **Jitter accumulation** — upward jitter must not add up across a long scroll. Held by resetting the accumulator on any downward movement.
- **`Header.jsx` shares this hook** at 20/140 and inherits the behaviour. Its block is much shorter so the effect is smaller — unmeasured, see below.
- No data, auth, or schema surface touched. Backend diff empty.

## Verification

- [x] Tests: 650 pass, 0 failures (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`cd frontend && npm run format:check`)
- [x] Build: green (`npm run build --prefix frontend`)
- [ ] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [ ] **Manual smoke: NOT DONE.** No device or WebKit measurement of this build. The two constants are grounded in numbers measured earlier on real WebKit (6–12px momentum jitter, ~60px URL-bar shift), but 24px and 64px are the parts most likely to need tuning by feel, and only a real thumb settles that.

### Mutation testing

Every new guard was verified to fail when the thing it guards is removed:

| Remove | Test that fails |
|---|---|
| the upward-release branch | deliberate-upward-drag |
| the per-step cap | URL-bar-sized jump |
| `ratchet = raw` → `ratchet = 0` on release | deliberate-upward-drag (exact-value assertion) |

The URL-bar test was wrong twice before it had teeth — first the jump was under the threshold, then it asserted after the downward reset. Both were caught by mutation testing, not by the suite passing.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scroll-collapse behavior for upward gestures using an “upward ratchet release” to distinguish deliberate dragging from browser/URL-bar perturbations.
  - Prevented premature release from small upward jitter by limiting how upward discontinuities affect state.
  - Kept progress mapping consistent while making the collapse/release state transitions more reliable.
- **Tests**
  - Expanded async test coverage for the ratchet “release” and reset behaviors, including precise progress value assertions and downward reset scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->