### PR TITLE
security(mfa): harden backup code entropy and salt storage

### DIFF
--- a/functions/utils/__tests__/totp.test.js
+++ b/functions/utils/__tests__/totp.test.js
@@ -45,13 +45,14 @@ describe("totp utilities", () => {
   });
 
   describe("backup code entropy + salt (#675)", () => {
-    it("generates 10-character codes from the expected charset", () => {
+    it("generates 10-character codes from the expected charset in 5-5 format", () => {
       const codes = generateBackupCodes(5);
       expect(codes).toHaveLength(5);
       for (const code of codes) {
-        const stripped = code.replace("-", "");
-        expect(stripped).toHaveLength(10);
-        expect(stripped).toMatch(/^[0-9A-Z]{10}$/);
+        // Assert the full "XXXXX-XXXXX" shape directly rather than just the
+        // stripped length, so a malformed/misplaced separator (e.g.
+        // "ABCDEFGHIJ" or "-ABCDEFGHIJ") would fail this test.
+        expect(code).toMatch(/^[0-9A-Z]{5}-[0-9A-Z]{5}$/);
       }
     });
 
@@ -73,6 +74,21 @@ describe("totp utilities", () => {
       const result = await verifyBackupCode(code.toLowerCase(), hashed);
 
       expect(result.valid).toBe(true);
+    });
+
+    it("matches a code stored anywhere in the array, not just the first entry", async () => {
+      // verifyBackupCode iterates every stored hash without early-exit (by
+      // design, to avoid a position-based timing leak). Put the real match
+      // second so a hypothetical short-circuit or off-by-one would surface
+      // as a failure here, unlike the other tests which always match index 0.
+      const codes = generateBackupCodes(3);
+      const hashed = await Promise.all(codes.map((code) => hashBackupCode(code)));
+
+      const result = await verifyBackupCode(codes[1], hashed);
+
+      expect(result.valid).toBe(true);
+      expect(result.remaining).toHaveLength(2);
+      expect(result.remaining).toEqual([hashed[0], hashed[2]]);
     });
 
     it("never verifies a legacy unsalted SHA-256 hash — pre-#675 codes are invalidated by construction", async () => {

--- a/functions/utils/__tests__/totp.test.js
+++ b/functions/utils/__tests__/totp.test.js
@@ -44,6 +44,67 @@ describe("totp utilities", () => {
     expect(result.remaining).toHaveLength(1);
   });
 
+  describe("backup code entropy + salt (#675)", () => {
+    it("generates 10-character codes from the expected charset", () => {
+      const codes = generateBackupCodes(5);
+      expect(codes).toHaveLength(5);
+      for (const code of codes) {
+        const stripped = code.replace("-", "");
+        expect(stripped).toHaveLength(10);
+        expect(stripped).toMatch(/^[0-9A-Z]{10}$/);
+      }
+    });
+
+    it("salts each hash independently — hashing the same code twice yields different output", async () => {
+      const [code] = generateBackupCodes(1);
+      const hashA = await hashBackupCode(code);
+      const hashB = await hashBackupCode(code);
+
+      expect(hashA).not.toBe(hashB);
+      // Different salts, but both must still verify the same plaintext code.
+      expect((await verifyBackupCode(code, [hashA])).valid).toBe(true);
+      expect((await verifyBackupCode(code, [hashB])).valid).toBe(true);
+    });
+
+    it("accepts a lowercase-entered code (case-insensitivity)", async () => {
+      const [code] = generateBackupCodes(1);
+      const hashed = [await hashBackupCode(code)];
+
+      const result = await verifyBackupCode(code.toLowerCase(), hashed);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("never verifies a legacy unsalted SHA-256 hash — pre-#675 codes are invalidated by construction", async () => {
+      const [code] = generateBackupCodes(1);
+      // Reproduce the pre-#675 hashBackupCode format exactly: a bare base64
+      // SHA-256 digest of the normalized code, no salt, no "$" delimiter.
+      const normalized = code.replace("-", "").toUpperCase();
+      const legacyDigest = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(normalized)));
+      const legacyHash = btoa(String.fromCharCode(...legacyDigest));
+
+      const result = await verifyBackupCode(code, [legacyHash]);
+
+      // The migration (see migrations/) also nulls out every stored
+      // backup_codes row, so this legacy shape shouldn't reach production —
+      // but the hash function must fail closed on it regardless, rather than
+      // relying on the migration alone.
+      expect(result.valid).toBe(false);
+      expect(result.remaining).toHaveLength(1);
+    });
+
+    it("verifyTotp still matches numeric codes after the normalizeCode uppercase change", async () => {
+      const secret = generateTotpSecret();
+      const code = await generateTotpCode(secret);
+
+      // TOTP codes are pure digits, so normalizeCode's added .toUpperCase()
+      // must be a no-op for them — assert the invariant directly, then
+      // confirm the real verify path is unaffected.
+      expect(code.toUpperCase()).toBe(code);
+      expect(await verifyTotp(secret, code)).toBe(true);
+    });
+  });
+
   describe("negative cases", () => {
     it("verifyTotp returns false for a wrong code", async () => {
       const secret = generateTotpSecret();

--- a/functions/utils/totp.js
+++ b/functions/utils/totp.js
@@ -8,12 +8,23 @@
 const DEFAULT_TOTP_STEP_SECONDS = 30;
 const DEFAULT_TOTP_DIGITS = 6;
 const DEFAULT_BACKUP_CODE_COUNT = 10;
+// #675: 6 chars over a 36-symbol alphabet was ~2^31 (GPU-crackable offline in
+// seconds from a DB leak). 10 chars is ~2^51 — see the accepted decision on
+// the issue for why entropy (not PBKDF2) is the fix here.
+const BACKUP_CODE_LENGTH = 10;
+const BACKUP_CODE_SALT_LENGTH = 16;
+// Self-describing hash format: "sha256$<saltB64>$<hashB64>". The legacy
+// unsalted hash (a bare base64 digest, no "$") can never match this shape, so
+// codes issued before #675 are invalidated by construction rather than by
+// convention — see verifyBackupCode.
+const BACKUP_CODE_HASH_PREFIX = "sha256";
 const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"; // RFC 4648, no padding
 
 function normalizeCode(code) {
   return String(code || "")
     .trim()
-    .replace(/[\s-]/g, "");
+    .replace(/[\s-]/g, "")
+    .toUpperCase();
 }
 
 export function base32Encode(bytes) {
@@ -138,26 +149,48 @@ export function generateBackupCodes(count = DEFAULT_BACKUP_CODE_COUNT) {
 
   for (let i = 0; i < count; i += 1) {
     const chars = [];
-    while (chars.length < 6) {
-      const bytes = new Uint8Array(6);
+    while (chars.length < BACKUP_CODE_LENGTH) {
+      const bytes = new Uint8Array(BACKUP_CODE_LENGTH);
       crypto.getRandomValues(bytes);
       for (const byte of bytes) {
-        if (byte < UNBIASED_LIMIT && chars.length < 6) {
+        if (byte < UNBIASED_LIMIT && chars.length < BACKUP_CODE_LENGTH) {
           chars.push((byte % CHARSET_SIZE).toString(36));
         }
       }
     }
     const code = chars.join("").toUpperCase();
-    codes.push(`${code.slice(0, 4)}-${code.slice(4)}`);
+    codes.push(`${code.slice(0, 5)}-${code.slice(5)}`);
   }
   return codes;
 }
 
+function bytesToBase64(bytes) {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function base64ToBytes(base64) {
+  return Uint8Array.from(atob(base64), (char) => char.charCodeAt(0));
+}
+
+// SHA-256 over salt || normalizedCode. A single fast round is deliberate here
+// (not PBKDF2): verifyBackupCode must hash the candidate against every stored
+// code without short-circuiting (see comment there), and at password-strength
+// iteration counts that would multiply into millions of iterations per MFA
+// attempt on a CPU-metered Worker. The 10-char code length (~2^51) is what
+// makes a single SHA-256 round acceptable — see the decision on #675.
+async function digestBackupCode(normalizedCode, salt) {
+  const codeBytes = new TextEncoder().encode(normalizedCode);
+  const data = new Uint8Array(salt.length + codeBytes.length);
+  data.set(salt, 0);
+  data.set(codeBytes, salt.length);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", data));
+}
+
 export async function hashBackupCode(code) {
   const normalized = normalizeCode(code);
-  const data = new TextEncoder().encode(normalized);
-  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", data));
-  return btoa(String.fromCharCode(...digest));
+  const salt = crypto.getRandomValues(new Uint8Array(BACKUP_CODE_SALT_LENGTH));
+  const digest = await digestBackupCode(normalized, salt);
+  return `${BACKUP_CODE_HASH_PREFIX}$${bytesToBase64(salt)}$${bytesToBase64(digest)}`;
 }
 
 export async function verifyBackupCode(code, hashedCodes = []) {
@@ -165,12 +198,34 @@ export async function verifyBackupCode(code, hashedCodes = []) {
     return { valid: false, remaining: hashedCodes };
   }
 
-  const hashed = await hashBackupCode(code);
+  const normalized = normalizeCode(code);
   let index = -1;
 
-  // Iterate all codes without early exit to prevent position-based timing leaks.
+  // Iterate all codes without early exit to prevent position-based timing
+  // leaks. Every entry — salted, legacy, or malformed — runs through the same
+  // parse-salt-digest-compare shape (falling back to a same-length dummy salt
+  // when the stored value isn't in the current "sha256$salt$hash" format) so
+  // a legacy/malformed row costs the same as a real one and can't be
+  // distinguished by timing.
   for (let i = 0; i < hashedCodes.length; i += 1) {
-    if (constantTimeEqual(hashed, String(hashedCodes[i] || ""))) {
+    const stored = String(hashedCodes[i] || "");
+    const parts = stored.split("$");
+    const isSalted = parts.length === 3 && parts[0] === BACKUP_CODE_HASH_PREFIX;
+
+    let salt;
+    try {
+      salt = isSalted ? base64ToBytes(parts[1]) : new Uint8Array(BACKUP_CODE_SALT_LENGTH);
+    } catch {
+      salt = new Uint8Array(BACKUP_CODE_SALT_LENGTH);
+    }
+
+    const digest = await digestBackupCode(normalized, salt);
+    const candidateHash = bytesToBase64(digest);
+    // Non-salted (legacy/malformed) entries compare against "", which a real
+    // base64 digest can never equal — they always fail, deliberately.
+    const storedHash = isSalted ? parts[2] : "";
+
+    if (constantTimeEqual(candidateHash, storedHash)) {
       index = i;
     }
   }

--- a/migrations/0054_invalidate_legacy_backup_codes.sql
+++ b/migrations/0054_invalidate_legacy_backup_codes.sql
@@ -1,0 +1,23 @@
+-- Migration: 0054_invalidate_legacy_backup_codes
+-- Description: #675 — MFA backup code hashing changed from unsalted
+-- single-round SHA-256 over a 6-char (~2^31 entropy) code to a per-code-salted
+-- SHA-256 over a 10-char (~2^51 entropy) code (functions/utils/totp.js). The
+-- new hash format ("sha256$salt$hash") can never match the old bare-digest
+-- format by construction, so every backup code issued before this deploy is
+-- already unusable. This migration makes that explicit in the data instead of
+-- leaving stale, silently-dead hashes sitting in `backup_codes` — without it,
+-- GET /api/admin/mfa/status would keep reporting hasBackupCodes: true for a
+-- set that can never verify again.
+--
+-- TOTP (`totp_secret`, `totp_enabled`) is untouched — admins with MFA enabled
+-- keep signing in with their authenticator app; only the backup recovery
+-- codes are cleared. Anyone who relies on backup codes should regenerate via
+-- Settings -> MFA -> Regenerate Backup Codes (POST /api/admin/mfa/backup-codes),
+-- which only requires a live TOTP code and returns a fresh salted 10-char set.
+--
+-- Apply locally:  npm run migrate:local
+-- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
+
+UPDATE users
+SET backup_codes = NULL
+WHERE backup_codes IS NOT NULL;

--- a/migrations/0054_invalidate_legacy_backup_codes.sql
+++ b/migrations/0054_invalidate_legacy_backup_codes.sql
@@ -15,9 +15,18 @@
 -- Settings -> MFA -> Regenerate Backup Codes (POST /api/admin/mfa/backup-codes),
 -- which only requires a live TOTP code and returns a fresh salted 10-char set.
 --
+-- The WHERE clause deliberately matches only the legacy shape (a JSON array of
+-- bare base64 digests, none of which contain the "sha256$" marker) rather than
+-- blanket-nulling every non-null row. Cloudflare Pages deploys the new
+-- function code and applies migrations as separate steps, so there is a
+-- window where an admin could already regenerate codes in the new salted
+-- format before this migration runs; matching only the legacy shape means a
+-- freshly-regenerated valid set is never collaterally deleted.
+--
 -- Apply locally:  npm run migrate:local
 -- Apply to prod:  npx wrangler d1 migrations apply settimes-production-db --remote
 
 UPDATE users
 SET backup_codes = NULL
-WHERE backup_codes IS NOT NULL;
+WHERE backup_codes IS NOT NULL
+  AND backup_codes NOT LIKE '%sha256$%';


### PR DESCRIPTION
## Summary

Admin MFA backup codes were 6 characters over a 36-symbol alphabet (~2^31 entropy), hashed with a single unsalted SHA-256 round. A `users.backup_codes` DB leak would let an attacker recover every admin's full backup-code set via offline brute force in seconds on commodity GPU (issue's stated precondition: DB compromise, not an active hole — defense-in-depth). This implements the decision recorded and accepted on the issue: lengthen codes to 10 characters (~2^51 entropy) and add a per-code random salt, while deliberately **not** switching to password-strength PBKDF2 (see "Verification-loop finding" below for why, and why the fast hash + entropy tradeoff was re-confirmed rather than assumed). Also fixes the case-sensitivity availability bug reported in the same issue.

Closes #675

## What changed

| File | Change |
|------|--------|
| `functions/utils/totp.js` | `generateBackupCodes`: 6→10 chars, `4-2` → `5-5` display split (~2^31 → ~2^51 entropy). `hashBackupCode`/`verifyBackupCode`: added a 16-byte per-code random salt; new self-describing hash format `sha256$<saltB64>$<hashB64>`. `normalizeCode`: added `.toUpperCase()` so a lowercase-entered backup code (`ab12-cd34`) verifies the same as the stored uppercase form — previously only the latter worked. |
| `functions/utils/__tests__/totp.test.js` | New `#675` test group: 10-char/5-5-format entropy, per-code salt (two hashes of the same code differ, both still verify), lowercase case-insensitivity, legacy unsalted hash explicitly fails (never silently matches), match-at-non-zero-index coverage for the no-short-circuit loop, and a direct assertion that TOTP (digit-only) codes are unaffected by the `toUpperCase` change. All pre-existing RFC 6238 vector tests untouched and passing. |
| `migrations/0054_invalidate_legacy_backup_codes.sql` | Data migration: nulls `users.backup_codes` for rows still in the **legacy** shape only (`NOT LIKE '%sha256$%'`) — see correctness notes below for why it's scoped this way instead of a blanket null. |

## Security / correctness notes

**Verification-loop finding (the mandatory check before implementing).** I read `verifyBackupCode` before touching anything, per the issue's explicit instruction not to assume. It iterates every stored hash **without early exit, by design** ("Iterate all codes without early exit to prevent position-based timing leaks" — pre-existing comment, unchanged in intent). This confirms the assumption behind the recorded decision: a candidate code really is tested against all ~8-10 stored hashes on every MFA attempt, with no short-circuit to reduce that cost. At 600k-iteration PBKDF2 that's ~6M iterations per attempt inside a Cloudflare Workers CPU-time budget — a live availability risk on the admin login path, worse than the DB-compromise risk it would mitigate. **I implemented the recorded decision as-is: lengthened codes (10 chars, ~2^51) + per-code salt + a single fast SHA-256 round.** I did not deviate from the accepted decision; the check confirmed rather than overturned it.

**Timing side channel:** every loop iteration performs exactly one salt-derivation + one SHA-256 digest + one constant-time compare, regardless of whether the stored entry is in the new salted format or a legacy/malformed one (a same-length dummy salt is used as a fallback) — so a legacy row can't be distinguished from a real one by timing. Confirmed by `cloudflare-security-reviewer`.

**What happens to an admin with old backup codes saved in a password manager:** after this deploys, none of their old codes will work — the new hash format (`sha256$salt$hash`) can never match the old bare-base64-digest format by construction, and the migration explicitly nulls the legacy rows so `GET /api/admin/mfa/status`'s `hasBackupCodes` stops lying about having a usable recovery set. **This does not lock anyone out**: `totp_secret`/`totp_enabled` are completely untouched by this change, so any admin with MFA enabled keeps signing in with their authenticator app exactly as before. To get a working backup set again, they need to proactively visit Settings → MFA → **Regenerate Backup Codes**, which only requires a live TOTP code (the existing self-service endpoint, `POST /api/admin/mfa/backup-codes` — unchanged by this PR) and returns a fresh salted 10-char set, displayed once. There is no automatic "your codes were reset" prompt in the admin UI (frontend is untouched by this PR, per scope) — this should be communicated out-of-band (release notes / direct message to admins) rather than silently discovered the day someone needs recovery.

**Migration scoping (CodeRabbit catch, fixed):** the first draft of the migration blanket-nulled every non-null `backup_codes` row. CodeRabbit flagged that Cloudflare Pages deploys function code and applies D1 migrations as separate steps, so there's a window where an admin could regenerate codes in the *new* salted format before the migration runs — a blanket null would have deleted that freshly-regenerated valid set too. Fixed by scoping the `WHERE` clause to the legacy shape only (`NOT LIKE '%sha256$%'`), so an already-migrated row is left alone.

**Schema:** this is a data-only migration (no DDL) — `node scripts/regenerate-setup-complete.mjs` produced no diff to `database/setup-complete.sql`, and `node scripts/check-schema-drift.mjs` passes clean.

## Verification

- [x] Tests: 884 pass, 0 failures, 6 todo (`npm test`)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: N/A — frontend untouched (`git diff --stat -- frontend/` is empty)
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` not changed
- [ ] Manual smoke: **not performed.** This worktree has no `.dev.vars`, so a live `wrangler dev` MFA login/backup-code/regenerate click-through wasn't run. Coverage instead comes from unit tests exercising the full generate → hash → verify → consume lifecycle (including a wrong-code case, an already-consumed-code case, and a match-at-non-first-index case), plus the migration schema-drift check. Flagging this explicitly rather than checking the box.

**Red/green check on the new tests:** reverted `functions/utils/totp.js` to the pre-fix version (kept the new test file) and reran — 4 of 5 new tests failed as expected (entropy length, salt difference, case-insensitivity, legacy-hash rejection); the 5th (TOTP-digits-unaffected) correctly passed in both states since it asserts an invariant that was never broken. Restored the fix — all 15 pass.

**Review gates run:**
- `cloudflare-security-reviewer`: reviewed the salted-hash construction, the timing-equalization logic, the `normalizeCode` call sites, and all three read-sites of `backup_codes` (`status.js`, `verify.js`, `disable.js`) for migration side effects. Verdict: **ship as-is**, no HIGH/MEDIUM findings; one LOW optional-polish note (a microsecond timing asymmetry between salted vs. legacy/malformed entries from base64-decode cost, not a guessing oracle) left as-is per the reviewer's own recommendation.
- `make review` (CodeRabbit): first pass found 1 major (the migration blanket-null issue above, fixed) + 2 minor test-coverage gaps (tightened the entropy assertion to match the full `XXXXX-XXXXX` shape; added a match-at-index-1 case for the no-short-circuit loop). Second pass after fixes: **no findings**.

---
Built by Sonny · Reviewed by cloudflare-security-reviewer + CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MFA backup codes are now longer and use a clearer `XXXXX-XXXXX` format.
  - Backup-code entry is case-insensitive and accepts input with spaces or hyphens.

- **Security Improvements**
  - Backup codes now use individually salted hashing for stronger protection.
  - Previously issued backup codes using the legacy format are invalidated and must be regenerated.

- **Bug Fixes**
  - Verification now checks all available backup codes and correctly consumes a matching code, regardless of its position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->