### PR TITLE
feat(metrics): capture ticket_click and event_view instead of discarding them

### DIFF
--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -498,8 +498,6 @@ CREATE TABLE IF NOT EXISTS event_daily_stats (
 
 CREATE INDEX IF NOT EXISTS idx_event_daily_stats_date ON event_daily_stats(date);
 
-CREATE INDEX IF NOT EXISTS idx_event_daily_stats_event ON event_daily_stats(event_id);
-
 -- ============================================
 -- TEST ACCOUNTS (passwords set by scripts/setup-local-db.sh)
 -- ============================================

--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -485,6 +485,21 @@ CREATE INDEX IF NOT EXISTS idx_auth_audit_timestamp ON auth_audit(timestamp);
 
 CREATE INDEX IF NOT EXISTS idx_auth_audit_ip ON auth_audit(ip_address);
 
+CREATE TABLE IF NOT EXISTS event_daily_stats (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id INTEGER NOT NULL,
+  date TEXT NOT NULL,
+  event_views INTEGER DEFAULT 0,
+  ticket_clicks INTEGER DEFAULT 0,
+  created_at TEXT DEFAULT (datetime('now')),
+  UNIQUE(event_id, date),
+  FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_daily_stats_date ON event_daily_stats(date);
+
+CREATE INDEX IF NOT EXISTS idx_event_daily_stats_event ON event_daily_stats(event_id);
+
 -- ============================================
 -- TEST ACCOUNTS (passwords set by scripts/setup-local-db.sh)
 -- ============================================

--- a/functions/api/__tests__/metrics.test.js
+++ b/functions/api/__tests__/metrics.test.js
@@ -214,7 +214,11 @@ describe("POST /api/metrics — event_view and ticket_click write to event_daily
   });
 
   test("returns 200 and logs a warning when event_daily_stats batch fails", async () => {
-    const { env } = createTestEnv();
+    const { env, rawDb } = createTestEnv();
+    // The event must exist: unknown ids are filtered out before any statement
+    // is built, so a bogus id would produce an empty batch and never reach the
+    // failure path this test is exercising.
+    const event = insertEvent(rawDb, { name: "Warn Fest", slug: "warn-fest" });
 
     // A lone ticket_click event produces no artist_daily_stats or
     // page_views_daily statements, so this is the only batch() call made —
@@ -226,7 +230,7 @@ describe("POST /api/metrics — event_view and ticket_click write to event_daily
 
     const warnSpy = vi.spyOn(loggerModule.logger, "warn");
 
-    const events = [{ event: "ticket_click", props: { event_id: 1 } }];
+    const events = [{ event: "ticket_click", props: { event_id: event.id } }];
     const res = await onRequestPost({ request: makeRequest(events), env });
 
     // Best-effort: must still return 200
@@ -301,5 +305,41 @@ describe("POST /api/metrics — date key is Toronto-local, not UTC (#668)", () =
     expect(row.date).toBe("2026-08-02");
     expect(row.event_views).toBe(1);
     expect(row.ticket_clicks).toBe(1);
+  });
+
+  test("an unknown event_id is dropped without taking the valid rows down with it", async () => {
+    // event_id is client-supplied and only integer-validated. event_daily_stats
+    // has an FK to events and D1's batch() is ATOMIC, so an unresolvable id
+    // would fail the whole chunk and roll back the real metrics alongside it.
+    //
+    // Asserts the statement COUNT reaching batch(), not the resulting rows:
+    // better-sqlite3 does not replicate D1's atomicity, so a row-level
+    // assertion would pass with or without the guard and prove nothing.
+    const { env, rawDb } = createTestEnv();
+    const known = insertEvent(rawDb, { name: "Real Fest", slug: "real-fest" });
+
+    const batched = [];
+    const realBatch = env.DB.batch.bind(env.DB);
+    env.DB.batch = async (stmts) => {
+      batched.push(stmts.length);
+      return realBatch(stmts);
+    };
+
+    const res = await onRequestPost({
+      request: makeRequest([
+        { event: "ticket_click", props: { event_id: known.id } },
+        { event: "ticket_click", props: { event_id: 999999 } },
+        { event: "event_view", props: { event_id: known.id } },
+      ]),
+      env,
+    });
+    expect(res.status).toBe(200);
+
+    // One statement — the known event. The unknown id must never be built.
+    expect(batched).toEqual([1]);
+
+    const kept = rawDb.prepare("SELECT * FROM event_daily_stats WHERE event_id = ?").get(known.id);
+    expect(kept.ticket_clicks).toBe(1);
+    expect(kept.event_views).toBe(1);
   });
 });

--- a/functions/api/__tests__/metrics.test.js
+++ b/functions/api/__tests__/metrics.test.js
@@ -1,11 +1,13 @@
 // Tests for POST /api/metrics
 // Covers: event_view/ticket_click no longer written to page_views_daily (#445 fix),
-// page_view events still written as real path keys, and catch-logging (swallowed
-// page_views_daily failure now emits logger.warn).
+// page_view events still written as real path keys, catch-logging (swallowed
+// page_views_daily failure now emits logger.warn), and event_view/ticket_click
+// now aggregating per event_id into event_daily_stats (#706 — previously
+// allowlisted, validated, and rate-limited but silently dropped).
 import { describe, expect, test, vi, afterEach } from "vitest";
 import { onRequestPost } from "../metrics.js";
 import * as loggerModule from "../../utils/logger.js";
-import { createTestEnv, insertBand } from "../test-utils.js";
+import { createTestEnv, insertBand, insertEvent } from "../test-utils.js";
 
 function makeRequest(events) {
   return new Request("https://example.test/api/metrics", {
@@ -99,6 +101,145 @@ describe("POST /api/metrics", () => {
 });
 
 // ---------------------------------------------------------------------------
+// event_view / ticket_click → event_daily_stats (#706)
+//
+// Both events were allowlisted, validated, and rate-limited, but had no
+// consumer at all — every one was silently dropped. Fixes attribute each per
+// event_id (the only prop the client sends for either event; see
+// frontend/src/utils/metrics.js trackEventView/trackTicketClick) into a
+// dedicated table rather than page_views_daily, which is path-keyed and
+// previously double-counted the same view under two key formats when
+// event_id-keyed synthetic rows were mixed in (#445).
+// ---------------------------------------------------------------------------
+describe("POST /api/metrics — event_view and ticket_click write to event_daily_stats (#706)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("event_view events increment event_views for the right event", async () => {
+    const { env, rawDb } = createTestEnv();
+    const eventA = insertEvent(rawDb, { name: "Fest A", slug: "fest-a" });
+    const eventB = insertEvent(rawDb, { name: "Fest B", slug: "fest-b" });
+
+    const events = [
+      { event: "event_view", props: { event_id: eventA.id } },
+      { event: "event_view", props: { event_id: eventA.id } },
+      { event: "event_view", props: { event_id: eventA.id } },
+      { event: "event_view", props: { event_id: eventB.id } },
+    ];
+
+    const res = await onRequestPost({ request: makeRequest(events), env });
+    expect(res.status).toBe(200);
+
+    const rows = rawDb.prepare("SELECT * FROM event_daily_stats ORDER BY event_id").all();
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.event_id === eventA.id).event_views).toBe(3);
+    expect(rows.find((r) => r.event_id === eventA.id).ticket_clicks).toBe(0);
+    expect(rows.find((r) => r.event_id === eventB.id).event_views).toBe(1);
+  });
+
+  test("ticket_click events increment ticket_clicks for the right event", async () => {
+    const { env, rawDb } = createTestEnv();
+    const eventA = insertEvent(rawDb, { name: "Fest A", slug: "fest-a" });
+    const eventB = insertEvent(rawDb, { name: "Fest B", slug: "fest-b" });
+
+    const events = [
+      { event: "ticket_click", props: { event_id: eventA.id } },
+      { event: "ticket_click", props: { event_id: eventB.id } },
+      { event: "ticket_click", props: { event_id: eventB.id } },
+    ];
+
+    const res = await onRequestPost({ request: makeRequest(events), env });
+    expect(res.status).toBe(200);
+
+    const rows = rawDb.prepare("SELECT * FROM event_daily_stats ORDER BY event_id").all();
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.event_id === eventA.id).ticket_clicks).toBe(1);
+    expect(rows.find((r) => r.event_id === eventA.id).event_views).toBe(0);
+    expect(rows.find((r) => r.event_id === eventB.id).ticket_clicks).toBe(2);
+  });
+
+  test("event_view and ticket_click for the same event merge into a single upsert row", async () => {
+    const { env, rawDb } = createTestEnv();
+    const eventA = insertEvent(rawDb, { name: "Fest A", slug: "fest-a" });
+
+    const events = [
+      { event: "event_view", props: { event_id: eventA.id } },
+      { event: "event_view", props: { event_id: eventA.id } },
+      { event: "ticket_click", props: { event_id: eventA.id } },
+    ];
+
+    const res = await onRequestPost({ request: makeRequest(events), env });
+    expect(res.status).toBe(200);
+
+    const rows = rawDb.prepare("SELECT * FROM event_daily_stats").all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].event_views).toBe(2);
+    expect(rows[0].ticket_clicks).toBe(1);
+  });
+
+  test("a second batch on the same day accumulates onto the existing row (ON CONFLICT upsert)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const eventA = insertEvent(rawDb, { name: "Fest A", slug: "fest-a" });
+
+    await onRequestPost({
+      request: makeRequest([{ event: "ticket_click", props: { event_id: eventA.id } }]),
+      env,
+    });
+    await onRequestPost({
+      request: makeRequest([{ event: "ticket_click", props: { event_id: eventA.id } }]),
+      env,
+    });
+
+    const rows = rawDb.prepare("SELECT * FROM event_daily_stats").all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].ticket_clicks).toBe(2);
+  });
+
+  test("an unparseable event_id (missing/zero/negative) is dropped, not written as a row", async () => {
+    const { env, rawDb } = createTestEnv();
+
+    const events = [
+      { event: "event_view", props: {} },
+      { event: "ticket_click", props: { event_id: 0 } },
+      { event: "ticket_click", props: { event_id: -5 } },
+      { event: "ticket_click", props: { event_id: "not-a-number" } },
+    ];
+
+    const res = await onRequestPost({ request: makeRequest(events), env });
+    expect(res.status).toBe(200);
+
+    const rows = rawDb.prepare("SELECT * FROM event_daily_stats").all();
+    expect(rows).toHaveLength(0);
+  });
+
+  test("returns 200 and logs a warning when event_daily_stats batch fails", async () => {
+    const { env } = createTestEnv();
+
+    // A lone ticket_click event produces no artist_daily_stats or
+    // page_views_daily statements, so this is the only batch() call made —
+    // safe to stub unconditionally, mirroring the page_views_daily failure
+    // test above.
+    env.DB.batch = async () => {
+      throw new Error("simulated event_daily_stats write failure");
+    };
+
+    const warnSpy = vi.spyOn(loggerModule.logger, "warn");
+
+    const events = [{ event: "ticket_click", props: { event_id: 1 } }];
+    const res = await onRequestPost({ request: makeRequest(events), env });
+
+    // Best-effort: must still return 200
+    expect(res.status).toBe(200);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("event_daily_stats"),
+      expect.objectContaining({ statementCount: expect.any(Number) }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Toronto-local date key, not UTC-sliced (#668, CLAUDE.md "Server-side
 // 'today'/'now' is Toronto-local — never UTC-sliced"). The date key written
 // into artist_daily_stats/page_views_daily used to come from
@@ -135,5 +276,30 @@ describe("POST /api/metrics — date key is Toronto-local, not UTC (#668)", () =
 
     const pvRow = rawDb.prepare("SELECT date FROM page_views_daily WHERE page = ?").get("/bands/cool-band");
     expect(pvRow.date).toBe("2026-08-02");
+  });
+
+  test("event_view and ticket_click are written under the Toronto date, not the UTC date (#706)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Long Weekend Band Crawl Vol. 17", slug: "lwbc17" });
+
+    // Same pinned instant as above: 2026-08-02T23:30:00-04:00 is 11:30 PM EDT
+    // on Aug 2 in Toronto, but 2026-08-03T03:30:00Z in UTC. Vol. 17 is an
+    // evening event (doors 6:30 PM) — getting this wrong would misattribute
+    // every post-8PM ticket_click/event_view to the wrong day.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T23:30:00-04:00"));
+
+    const events = [
+      { event: "event_view", props: { event_id: event.id } },
+      { event: "ticket_click", props: { event_id: event.id } },
+    ];
+
+    const res = await onRequestPost({ request: makeRequest(events), env });
+    expect(res.status).toBe(200);
+
+    const row = rawDb.prepare("SELECT * FROM event_daily_stats WHERE event_id = ?").get(event.id);
+    expect(row.date).toBe("2026-08-02");
+    expect(row.event_views).toBe(1);
+    expect(row.ticket_clicks).toBe(1);
   });
 });

--- a/functions/api/admin/events/[id]/metrics.js
+++ b/functions/api/admin/events/[id]/metrics.js
@@ -20,15 +20,16 @@ export async function onRequestGet(context) {
   }
 
   try {
-    const [metricsRes, popularBandsRes, shareStatsRes, topRoutesRes, announcementPlanningRes] = await DB.batch([
-      DB.prepare(
-        `SELECT COUNT(*) as total_schedule_builds,
+    const [metricsRes, popularBandsRes, shareStatsRes, topRoutesRes, announcementPlanningRes, telemetryStatsRes] =
+      await DB.batch([
+        DB.prepare(
+          `SELECT COUNT(*) as total_schedule_builds,
                 COUNT(DISTINCT user_session) as unique_visitors,
                 MAX(created_at) as last_updated
          FROM schedule_builds WHERE event_id = ?`,
-      ).bind(eventId),
-      DB.prepare(
-        `SELECT bp.id as band_id, bp.name as band_name,
+        ).bind(eventId),
+        DB.prepare(
+          `SELECT bp.id as band_id, bp.name as band_name,
                 COUNT(sb.performance_id) as schedule_count
          FROM schedule_builds sb
          JOIN performances p ON sb.performance_id = p.id
@@ -37,24 +38,24 @@ export async function onRequestGet(context) {
          GROUP BY bp.id, bp.name
          ORDER BY schedule_count DESC
          LIMIT 10`,
-      ).bind(eventId),
-      DB.prepare(
-        `SELECT COUNT(*) AS total_shares,
+        ).bind(eventId),
+        DB.prepare(
+          `SELECT COUNT(*) AS total_shares,
                 COALESCE(SUM(view_count), 0) AS total_share_views
          FROM share_links WHERE event_id = ?`,
-      ).bind(eventId),
-      DB.prepare(
-        `SELECT slug, view_count FROM share_links
+        ).bind(eventId),
+        DB.prepare(
+          `SELECT slug, view_count FROM share_links
          WHERE event_id = ?
          ORDER BY view_count DESC, created_at DESC
          LIMIT 10`,
-      ).bind(eventId),
-      // Announcement planning: per-performance follower engagement signals for
-      // organizers deciding what to announce next. COUNT-based only against
-      // band_follows (verified = 1) — never selects email/tokens/consent_ip.
-      // See PRIVACY CONTRACT in functions/api/stats/public.js for the same discipline.
-      DB.prepare(
-        `SELECT
+        ).bind(eventId),
+        // Announcement planning: per-performance follower engagement signals for
+        // organizers deciding what to announce next. COUNT-based only against
+        // band_follows (verified = 1) — never selects email/tokens/consent_ip.
+        // See PRIVACY CONTRACT in functions/api/stats/public.js for the same discipline.
+        DB.prepare(
+          `SELECT
            p.id AS performance_id,
            bp.id AS band_id,
            bp.name AS band_name,
@@ -74,14 +75,24 @@ export async function onRequestGet(context) {
          JOIN band_profiles bp ON p.band_profile_id = bp.id
          WHERE p.event_id = ?
          ORDER BY p.is_announced ASC, follower_count DESC, bp.name`,
-      ).bind(eventId),
-    ]);
+        ).bind(eventId),
+        // Telemetry-derived counts (#706): event_view / ticket_click from
+        // functions/api/metrics.js, aggregated per event_id in event_daily_stats.
+        // Summed across all dates for this event — best-effort ingestion means
+        // this is a floor, not an exact count (see CLAUDE.md "Metrics & Analytics").
+        DB.prepare(
+          `SELECT COALESCE(SUM(event_views), 0) AS total_event_views,
+                COALESCE(SUM(ticket_clicks), 0) AS total_ticket_clicks
+         FROM event_daily_stats WHERE event_id = ?`,
+        ).bind(eventId),
+      ]);
 
     const metrics = metricsRes.results?.[0];
     const popularBands = popularBandsRes.results || [];
     const shareStats = shareStatsRes.results?.[0];
     const topSharedRoutes = topRoutesRes.results || [];
     const announcementPlanning = announcementPlanningRes.results || [];
+    const telemetryStats = telemetryStatsRes.results?.[0];
     // bp.name is only the final tiebreaker here (after is_announced, then
     // follower_count) — SQLite ORDER BY can't strip a leading article inline
     // (#587), so re-derive that last tiebreaker in JS with the article-stripped
@@ -109,6 +120,8 @@ export async function onRequestGet(context) {
           totalShareViews: shareStats?.total_share_views || 0,
           topSharedRoutes: topSharedRoutes,
           announcementPlanning: announcementPlanning,
+          totalEventViews: telemetryStats?.total_event_views || 0,
+          totalTicketClicks: telemetryStats?.total_ticket_clicks || 0,
         },
       }),
       {

--- a/functions/api/admin/events/__tests__/metrics.test.js
+++ b/functions/api/admin/events/__tests__/metrics.test.js
@@ -104,6 +104,37 @@ describe("GET /api/admin/events/[id]/metrics", () => {
     expect(body.metrics.uniqueVisitors).toBe(3);
   });
 
+  describe("telemetry-derived totals (#706)", () => {
+    test("sums event_daily_stats across dates into totalEventViews/totalTicketClicks", async () => {
+      const { env, rawDb } = createTestEnv();
+      const event = insertEvent(rawDb, { name: "Telemetry Fest", slug: "telemetry-fest" });
+
+      rawDb
+        .prepare(`INSERT INTO event_daily_stats (event_id, date, event_views, ticket_clicks) VALUES (?, ?, ?, ?)`)
+        .run(event.id, "2026-08-01", 10, 2);
+      rawDb
+        .prepare(`INSERT INTO event_daily_stats (event_id, date, event_views, ticket_clicks) VALUES (?, ?, ?, ?)`)
+        .run(event.id, "2026-08-02", 15, 5);
+
+      const res = await call(env, event.id);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.metrics.totalEventViews).toBe(25);
+      expect(body.metrics.totalTicketClicks).toBe(7);
+    });
+
+    test("event with no telemetry rows returns zeroed totals, not errors", async () => {
+      const { env, rawDb } = createTestEnv();
+      const event = insertEvent(rawDb, { name: "Quiet Telemetry Fest", slug: "quiet-telemetry-fest" });
+
+      const res = await call(env, event.id);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.metrics.totalEventViews).toBe(0);
+      expect(body.metrics.totalTicketClicks).toBe(0);
+    });
+  });
+
   describe("announcementPlanning (#556)", () => {
     // Seeds: Alpha (unannounced) with 3 verified follows (2 in the last 7 days,
     // 1 older), 1 unverified follow, and one verified follower already notified

--- a/functions/api/metrics.js
+++ b/functions/api/metrics.js
@@ -92,8 +92,14 @@ export async function onRequestPost(context) {
       const bandViewCounts = new Map();
       const socialClickCounts = new Map();
       const pageCounts = new Map(); // page path → count
-      const eventViewCounts = new Map(); // event_id → count
-      const ticketClickCounts = new Map(); // event_id → count
+      // `share_event` and `filter_use` are allowlisted but deliberately have no
+      // consumer. A share CREATE is a share_links row and a share VIEW
+      // increments share_links.view_count, so persisting share_event here would
+      // double-count it — CLAUDE.md "Metrics & Analytics" forbids wiring it up.
+      // `filter_use` has no decision attached to it yet; it stays allowlisted so
+      // clients already emitting it are not rejected. Tracked in #706.
+      const eventViewCounts = new Map();
+      const ticketClickCounts = new Map();
 
       for (const event of validEvents) {
         if (event.event === "artist_profile_view") {
@@ -190,7 +196,26 @@ export async function onRequestPost(context) {
       // Isolated in its own batch/try-catch so a missing table or write error
       // can't break the artist/page-view writes above (best-effort,
       // fire-and-forget — CLAUDE.md "Metrics & Analytics").
-      const allEventIds = new Set([...eventViewCounts.keys(), ...ticketClickCounts.keys()]);
+      // FK guard. event_daily_stats has FOREIGN KEY (event_id) REFERENCES
+      // events(id), and _middleware.js sets PRAGMA foreign_keys = ON for every
+      // mutating request. DB.batch() is atomic, so a SINGLE unknown event_id
+      // fails the whole chunk and rolls back every valid row alongside it.
+      // event_id is client-supplied and only integer-validated, so a stale
+      // client or a crafted payload could otherwise wipe real metrics. Resolve
+      // against events first and keep only ids that exist.
+      const candidateIds = [...new Set([...eventViewCounts.keys(), ...ticketClickCounts.keys()])];
+      let allEventIds = [];
+      if (candidateIds.length > 0) {
+        try {
+          const placeholders = candidateIds.map(() => "?").join(",");
+          const { results } = await env.DB.prepare(`SELECT id FROM events WHERE id IN (${placeholders})`)
+            .bind(...candidateIds)
+            .all();
+          allEventIds = (results || []).map((row) => row.id);
+        } catch (err) {
+          logger.warn("event_daily_stats id resolution failed; skipping event stats for this batch", { error: err });
+        }
+      }
 
       const eventStmts = [];
       for (const eventId of allEventIds) {

--- a/functions/api/metrics.js
+++ b/functions/api/metrics.js
@@ -92,6 +92,8 @@ export async function onRequestPost(context) {
       const bandViewCounts = new Map();
       const socialClickCounts = new Map();
       const pageCounts = new Map(); // page path → count
+      const eventViewCounts = new Map(); // event_id → count
+      const ticketClickCounts = new Map(); // event_id → count
 
       for (const event of validEvents) {
         if (event.event === "artist_profile_view") {
@@ -111,6 +113,20 @@ export async function onRequestPost(context) {
         if (event.event === "page_view") {
           const page = String(event.props?.page || "/").slice(0, 255);
           pageCounts.set(page, (pageCounts.get(page) || 0) + 1);
+        }
+
+        if (event.event === "event_view") {
+          const eventId = parseInteger(event.props?.event_id);
+          if (eventId) {
+            eventViewCounts.set(eventId, (eventViewCounts.get(eventId) || 0) + 1);
+          }
+        }
+
+        if (event.event === "ticket_click") {
+          const eventId = parseInteger(event.props?.event_id);
+          if (eventId) {
+            ticketClickCounts.set(eventId, (ticketClickCounts.get(eventId) || 0) + 1);
+          }
         }
       }
 
@@ -138,10 +154,12 @@ export async function onRequestPost(context) {
 
       // Store page views in a separate batch so a missing
       // page_views_daily table doesn't break artist_daily_stats writes.
-      // Only real path keys (page_view events) are written here — event_view and
-      // ticket_click synthetic keys (event:N / ticket:N) are intentionally not
-      // stored: the page_view for the same page already captures the visit, and
-      // the synthetic rows caused double-counting under two key formats (#445).
+      // Only real path keys (page_view events) are written here — event_view
+      // and ticket_click are keyed by event_id, not path, and are written to
+      // their own event_daily_stats table below (#706). Mixing event_id-keyed
+      // synthetic keys into this path-keyed table previously double-counted
+      // the same view under two key formats (#445) — keep the two tables
+      // separate.
       const pvStmts = [];
       for (const [page, count] of pageCounts) {
         pvStmts.push(
@@ -161,6 +179,41 @@ export async function onRequestPost(context) {
           logger.warn("page_views_daily upsert failed (table may be missing or write error)", {
             error: err,
             statementCount: pvStmts.length,
+          });
+        }
+      }
+
+      // event_view (event-page traffic) and ticket_click (the site's
+      // highest-value conversion signal) both attribute per event_id via
+      // event_daily_stats (#706). Previously allowlisted, validated, and
+      // rate-limited but never consumed — every one was silently dropped.
+      // Isolated in its own batch/try-catch so a missing table or write error
+      // can't break the artist/page-view writes above (best-effort,
+      // fire-and-forget — CLAUDE.md "Metrics & Analytics").
+      const allEventIds = new Set([...eventViewCounts.keys(), ...ticketClickCounts.keys()]);
+
+      const eventStmts = [];
+      for (const eventId of allEventIds) {
+        const views = eventViewCounts.get(eventId) || 0;
+        const clicks = ticketClickCounts.get(eventId) || 0;
+
+        eventStmts.push(
+          env.DB.prepare(
+            `INSERT INTO event_daily_stats (event_id, date, event_views, ticket_clicks)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT (event_id, date)
+             DO UPDATE SET event_views = event_views + ?, ticket_clicks = ticket_clicks + ?`,
+          ).bind(eventId, today, views, clicks, views, clicks),
+        );
+      }
+
+      if (eventStmts.length > 0) {
+        try {
+          await executeInChunks(env.DB, eventStmts);
+        } catch (err) {
+          logger.warn("event_daily_stats upsert failed (table may be missing or write error)", {
+            error: err,
+            statementCount: eventStmts.length,
           });
         }
       }

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -160,6 +160,20 @@ export function createTestDB() {
 
     CREATE INDEX idx_page_views_date ON page_views_daily(date);
 
+    CREATE TABLE event_daily_stats (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_id INTEGER NOT NULL,
+      date TEXT NOT NULL,
+      event_views INTEGER DEFAULT 0,
+      ticket_clicks INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT (datetime('now')),
+      UNIQUE(event_id, date),
+      FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX idx_event_daily_stats_date ON event_daily_stats(date);
+    CREATE INDEX idx_event_daily_stats_event ON event_daily_stats(event_id);
+
     CREATE TABLE performances (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       event_id INTEGER REFERENCES events(id) ON DELETE CASCADE,

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -172,7 +172,6 @@ export function createTestDB() {
     );
 
     CREATE INDEX idx_event_daily_stats_date ON event_daily_stats(date);
-    CREATE INDEX idx_event_daily_stats_event ON event_daily_stats(event_id);
 
     CREATE TABLE performances (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/migrations/0055_add_event_daily_stats.sql
+++ b/migrations/0055_add_event_daily_stats.sql
@@ -1,0 +1,30 @@
+-- Migration: 0055_add_event_daily_stats.sql
+-- Adds per-event daily aggregate storage for two allowlisted telemetry events
+-- (functions/api/metrics.js ALLOWED_EVENTS) that were accepted, validated, and
+-- rate-limited, but had no consumer and were silently dropped (#706):
+--   - event_view: event-page traffic
+--   - ticket_click: the site's highest-value conversion signal
+--
+-- Mirrors the artist_daily_stats pattern (0023_add_metrics_tables.sql) rather
+-- than page_views_daily: page_views_daily is keyed by path, and mixing
+-- event_id-keyed synthetic rows into it previously double-counted the same
+-- view under two key formats (#445, see the comment in metrics.js). A
+-- dedicated event_id-keyed table keeps this attribution clean.
+--
+-- Date values are the America/Toronto calendar day (eventLocalToday() from
+-- functions/utils/eventDay.js), never a UTC slice — see CLAUDE.md "Server-side
+-- 'today'/'now' is Toronto-local".
+
+CREATE TABLE IF NOT EXISTS event_daily_stats (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id INTEGER NOT NULL,
+  date TEXT NOT NULL,
+  event_views INTEGER DEFAULT 0,
+  ticket_clicks INTEGER DEFAULT 0,
+  created_at TEXT DEFAULT (datetime('now')),
+  UNIQUE(event_id, date),
+  FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_daily_stats_date ON event_daily_stats(date);
+CREATE INDEX IF NOT EXISTS idx_event_daily_stats_event ON event_daily_stats(event_id);

--- a/migrations/0055_add_event_daily_stats.sql
+++ b/migrations/0055_add_event_daily_stats.sql
@@ -27,4 +27,3 @@ CREATE TABLE IF NOT EXISTS event_daily_stats (
 );
 
 CREATE INDEX IF NOT EXISTS idx_event_daily_stats_date ON event_daily_stats(date);
-CREATE INDEX IF NOT EXISTS idx_event_daily_stats_event ON event_daily_stats(event_id);


### PR DESCRIPTION
## Summary

`ticket_click` and `event_view` were already being **sent by the browser**, allowlisted by the server, validated and rate-limited — and then silently dropped, because the handler consumed only `artist_profile_view`, `social_link_click` and `page_view`.

`ticket_click` is the highest-value conversion signal on a site that sells tickets.

Closes #706

**Time-critical:** the Vol. 17 Instagram post is already live, so this data is being lost right now. **Telemetry cannot be backfilled** — anything before this merges is gone. Migrations auto-apply on deploy, so merging is sufficient to start capture.

## What changed

| File | Change |
|---|---|
| `migrations/0055_add_event_daily_stats.sql` | New `event_daily_stats` table keyed by `(event_id, date)` with FK to `events` and date/event indexes |
| `database/setup-complete.sql` | Regenerated via `regenerate-setup-complete.mjs` (generated section — never hand-edited) |
| `functions/api/metrics.js` | Consumers for `event_view` and `ticket_click`, upserting per event per Toronto-local day |
| `functions/api/admin/events/[id]/metrics.js` | Surfaces the new counts so they are actually visible |
| `functions/api/test-utils.js` | Test schema for the new table |
| `functions/api/__tests__/metrics.test.js`, `admin/events/__tests__/metrics.test.js` | Coverage for both events, the date key, and failure isolation |

## Security / correctness notes

**Date key.** Uses `eventLocalToday()`, never a UTC slice. Vol. 17 is an evening event; the #680 bug class flips at 8 PM Eastern and would have misattributed most of the event's traffic to the following day — corrupting exactly the data this is meant to capture.

**Storage choice.** Keyed by `event_id`, deliberately *not* folded into `page_views_daily`. That table is keyed by path, and mixing `event_id`-keyed synthetic rows into it previously double-counted the same view under two key formats (#445).

**Best-effort ingestion.** CLAUDE.md requires that metrics failures never surface to users. The new writes are isolated so a failure logs and the response still succeeds, matching the existing `page_views_daily` upsert.

**Privacy.** Aggregate counts only — no IP, user agent, or PII. Consistent with the PRIVACY CONTRACT in `functions/api/stats/public.js`.

**Scope.** Server-side only. `git diff --stat -- frontend/` is empty; the client already emits both events correctly.

## Verification

- [x] Tests: 893 pass, 0 failures (`npm test`)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Schema drift: clean (`node scripts/check-schema-drift.mjs`)
- [ ] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] Frontend untouched
- [ ] **Manual smoke: not done.** Worth one ticket click on the live site after deploy, then confirming an `event_daily_stats` row appears for today's Toronto date.

## Follow-up

The admin dashboard may need a frontend change to display these counts — the endpoint now returns them, but rendering was out of scope here. Will file separately if so.

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily tracking for event views and ticket clicks by event and local (America/Toronto) calendar date.
  * Admin event metrics now include total event views and total ticket clicks aggregated across all recorded days.
* **Bug Fixes**
  * Prevented event activity metrics from being omitted or incorrectly combined with page-view statistics.
  * Invalid or unknown event identifiers are ignored safely, without disrupting other metric writes.
  * Improved reliability when event daily stats writes fail (endpoint continues successfully).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->