### PR TITLE
docs: record the bandFields single-source-of-truth invariant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,18 @@ The bulk band import (`functions/api/admin/bands/import.js`) follows this patter
 
 When recreating a table in a migration (SQLite has no ALTER COLUMN), surround the table-recreation block with `PRAGMA foreign_keys = OFF` / `PRAGMA foreign_keys = ON` as migration 0032 does — D1 will reject the DROP otherwise.
 
+### Artist link presence: `bandFields.js` is the single source of truth (#712)
+
+`frontend/src/admin/utils/bandFields.js` defines every filterable artist field — the eight link fields (`LINK_FIELDS`, in Links-column render order) and the profile fields (`PROFILE_FIELDS`) — pairing each with its label, icon, Tailwind colours, and **its own URL-safety resolver**.
+
+**A link is "present" only if it resolves to a real href** — `resolveHref(value) !== '#'` — never `value !== ''`. `safeSocialProfileHref` rejects any handle containing whitespace or a colon (the necessary condition for `javascript:`, `data:`, and every other scheme), so a value can be non-empty in D1 and still render nothing. Anything asking "does this artist have Instagram?" must go through `hasField()` / `hasAnyLink()` / `countLinks()` — never inspect `social_links` directly.
+
+Both the Links column (`admin/components/SocialLinksIcons.jsx`) and the gap filter (`admin/components/DataGapFilter.jsx` + `RosterTab`) map over this one registry. **Do not reintroduce a second list of link fields.** The bug class it prevents: a filter reporting that an artist "has Instagram" while the row shows nothing, so they get skipped in exactly the data-entry pass meant to catch them. Adding a ninth platform is one registry entry that updates the column and the filter together.
+
+`formatOrigin()` lives here too, shared by the Origin column, the origin sort, the search predicate, and the origin gap check.
+
+**Tailwind colours in the registry must stay complete literal strings** (e.g. `'hover:text-pink-400 focus-visible:outline-pink-400'`). Tailwind v4 scans source *text* for whole class names and never evaluates template expressions, so `` `hover:text-${colour}` `` generates no CSS and silently drops every hover and focus style. A runtime assertion cannot catch this — the guard in `bandFields.test.js` is a `readFileSync` scan of the source.
+
 ### `ALLOW_ADMIN_SIGNUP` is test-only
 
 This env var bypasses the invite-code requirement for signup. It must never be set in production. It appears only in test helpers and E2E seed scripts.


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #712. Records the artist-link registry as a Critical Invariant so the next contributor doesn't reintroduce a second list of link fields — the exact drift the registry exists to prevent.

Closes nothing; follows the standing rule that a change establishing an invariant documents it in `CLAUDE.md`.

## What changed

| File | Change |
|------|--------|
| `CLAUDE.md` | New Critical Invariants subsection: "Artist link presence: `bandFields.js` is the single source of truth (#712)" |

Captures the two rules that were non-obvious enough to cost review rounds in #712:

1. **Presence means `resolveHref(v) !== '#'`, never `v !== ''`.** `safeSocialProfileHref` rejects any handle containing whitespace or a colon — the necessary condition for `javascript:`, `data:`, and every other scheme — so a value can be non-empty in D1 and still render nothing. A filter built on `!== ''` would report an artist "has Instagram" while the row shows blank, and they'd be skipped in exactly the data-entry pass meant to catch them.
2. **Registry Tailwind colours must stay complete literal strings.** v4 scans source *text* for whole class names and never evaluates template expressions, so `` `hover:text-${colour}` `` generates no CSS and silently drops every hover and focus style. A runtime assertion cannot police this — the guard in `bandFields.test.js` is a `readFileSync` scan of the source, which is itself worth documenting so nobody "simplifies" it back into a value check.

## Security / correctness notes

None — Markdown only, no runtime code touched.

## Verification

- [x] Tests: unchanged (no code modified)
- [x] ESLint: N/A — no JS/JSX touched
- [x] Format check: N/A — `CLAUDE.md` is outside the prettier globs (`functions/`, `scripts/`, `frontend/src/`)
- [x] Build: N/A
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] Manual: re-read the section against `frontend/src/admin/utils/bandFields.js` on `main` post-merge; every symbol named (`LINK_FIELDS`, `PROFILE_FIELDS`, `hasField`, `hasAnyLink`, `countLinks`, `formatOrigin`) exists as described

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance identifying the central source for artist links and profile fields.
  * Documented URL safety checks, field presence validation, shared origin formatting, and complete colour class definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->