### PR TITLE
fix(deps): override transitive js-yaml to 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1703,9 +1703,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
   "dependencies": {
     "csrf-csrf": "^4.0.3",
     "email-validator": "^2.0.4"
+  },
+  "overrides": {
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
## Summary

Closes the open Dependabot **high** on `js-yaml`. Root `node_modules/js-yaml` resolved to **4.2.0** — vulnerable to the YAML merge-key quadratic-CPU advisory — while `frontend/` was already pinned to the patched **4.3.0** via its own `overrides` block. Root had no `overrides` block at all.

It arrives transitively: `@apidevtools/swagger-parser` → `@apidevtools/json-schema-ref-parser` → `js-yaml`.

## What changed

| File | Change |
|------|--------|
| `package.json` | New `overrides` block pinning `js-yaml` to `4.3.0`, mirroring what `frontend/package.json` already does |
| `package-lock.json` | Regenerated |

## Security / correctness notes

- **Dev-only, never a production surface.** `swagger-parser` backs `npm run validate:openapi`; it isn't bundled into the Worker or the frontend. The advisory needs attacker-controlled YAML, and the only YAML parsed here is our own committed `docs/api-spec.yaml`. Real alert, low real risk — worth closing, not worth alarm.
- Within-major bump (4.2.0 → 4.3.0), no API change.

## Verification

- [x] Root `node_modules/js-yaml` now resolves to 4.3.0
- [x] `npm run validate:openapi`: clean — 72 documented + 1 internal (allowlisted) = 73 route files, no drift
- [x] Tests: 894 backend + 799 frontend pass
- [x] ESLint: 0 errors · Format check: clean · Build: green
- [x] Manual smoke: N/A — dev-tooling dependency only

### Note on the other Dependabot alert

The remaining open alert is **react-router — RSC Mode CSRF Bypass**, patched in `8.3.0`. Deliberately **not** addressed here:

- The advisory covers React Router's **RSC mode**. This app is a client-side SPA on `react-router-dom@7.18.1` with no `react-router/rsc`, `createStaticHandler`, or `@react-router/server` anywhere in `frontend/src` — the vulnerable path isn't in the bundle.
- "Patched in 8.3.0" from 7.18.1 is a **major migration**, not a bump.

Worth doing as its own planned upgrade, not as a drive-by two days before Vol. 17.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the `js-yaml` dependency to version 4.3.0 for more consistent builds and installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->