### PR TITLE
style(admin): normalise border radii to the 3-tier scale

### DIFF
--- a/frontend/src/admin/AdminLogin.jsx
+++ b/frontend/src/admin/AdminLogin.jsx
@@ -125,7 +125,7 @@ export default function AdminLogin({ onLoginSuccess }) {
 
   return (
     <div className="min-h-screen bg-gradient-dark flex items-center justify-center p-4">
-      <div className="bg-gradient-card backdrop-blur-xs p-8 rounded-xl shadow-xl max-w-md w-full border border-white/10">
+      <div className="bg-gradient-card backdrop-blur-xs p-8 rounded-lg shadow-xl max-w-md w-full border border-white/10">
         <h1 className="text-2xl font-bold font-display mb-6 text-center">
           <span className="text-accent-500">Set</span>
           <span className="text-white">Times</span>

--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -1007,7 +1007,7 @@ export default function RosterTab({ showToast, readOnly = false }) {
 
         <button
           onClick={() => setMobileFilterSheetOpen(true)}
-          className="md:hidden w-full px-4 py-3 flex items-center justify-center gap-2 text-white bg-bg-navy hover:bg-bg-purple transition-colors min-h-[44px] font-medium border-t border-accent-500/10"
+          className="md:hidden w-full px-4 py-3 flex items-center justify-center gap-2 text-white bg-bg-navy hover:bg-bg-purple transition-colors min-h-[44px] font-medium border-t border-accent-500/10 rounded"
         >
           Filters
           {activeFilterCount(columnFilters) > 0 && (

--- a/frontend/src/admin/components/HelpPanel.jsx
+++ b/frontend/src/admin/components/HelpPanel.jsx
@@ -53,7 +53,7 @@ export default function HelpPanel({ topic = 'events', isOpen, onClose }) {
           ))}
         </ul>
 
-        <div className="bg-white/5 rounded-xl border border-white/10 p-3 text-sm text-white/70">
+        <div className="bg-white/5 rounded-lg border border-white/10 p-3 text-sm text-white/70">
           Need more help? Review `/docs/admin/README.md` or contact a site administrator.
         </div>
 


### PR DESCRIPTION
## Summary

Border-radius inconsistencies on the admin surface, spotted by a designer reviewing the roster work. Presentational only — three class names, no logic.

The admin surface has an established 3-tier scale, measurable across `frontend/src/admin/`:

| Tier | Class | Uses |
|---|---|---|
| Controls (buttons, inputs) | `rounded` | ~167 |
| Panels, cards | `rounded-lg` | ~68 |
| Pills, badges | `rounded-full` | ~11 |

Three places broke it.

## What changed

| File | Before | After | Why |
|---|---|---|---|
| `admin/RosterTab.jsx` | *no radius* | `rounded` | The mobile **Filters** button was the only radius-less button on the surface, sitting directly below a `rounded-lg` card |
| `admin/AdminLogin.jsx` | `rounded-xl` | `rounded-lg` | Login card — one of only two `rounded-xl` uses against 68 `rounded-lg` panels |
| `admin/components/HelpPanel.jsx` | `rounded-xl` | `rounded-lg` | Same, help card |

## Deliberately not changed

- **Four `rounded-xs` in `EventsTab.jsx`** (lines ~211, ~706, ~880, ~911). These are inline *text* links paired with `buttonFocusClass` / `linkFocusClass` — the radius only ever renders on the focus ring, and a tight ring on inline text is the correct a11y choice. Not strays.
- **`MobileFilterSheet.jsx:43`** — no radius, but its parent is `rounded-lg overflow-hidden`, so the corners are already clipped.

## One question for the designer

The mobile Filters button now carries both `border-t` and `rounded`, so its top border curves at the ends. That reads fine as a standalone control, but if the intent is a flush full-width bar, the right fix is dropping `border-t` rather than adding the radius. Happy to flip it either way — the current change makes it consistent with every other button, which is the stated problem.

## Security / correctness notes

None — three Tailwind class names. No logic, no state, no API surface.

## Verification

- [x] Tests: 894 backend + 806 frontend pass
- [x] ESLint: 0 errors · Format check: clean · Build: green
- [x] `validate:openapi`: N/A — spec unchanged
- [x] Diff confirmed to be exactly 3 changed lines in 3 files
- [ ] Visual check — this is the part automation can't do; needs an eye on the roster and login screens

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined corner rounding across the admin login card, mobile Filters button, and help panel notice for a more consistent visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->