### PR TITLE
fix(a11y): light-theme WCAG contrast failures + event-night accessibility

### DIFF
--- a/frontend/src/__tests__/themeTokens.test.js
+++ b/frontend/src/__tests__/themeTokens.test.js
@@ -1,0 +1,156 @@
+// Guards the WCAG-contrast root cause behind six confirmed light-theme
+// failures (#617): axe-core's color-contrast rule can't resolve backgrounds
+// painted by a CSS gradient (BandCard's `bg-gradient-accent`) — it reports
+// those elements as `incomplete`, not `violations`, so
+// e2e/accessibility/theme-contrast.spec.js (which only asserts on
+// `results.violations`) never caught the under-tuned gradient start stop.
+// This test parses the actual token values out of index.css and checks
+// contrast directly, so it fails offline/fast whenever a token regresses —
+// no browser, no axe, no gradient-resolution blind spot.
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CSS_PATH = path.resolve(__dirname, '../index.css')
+const css = fs.readFileSync(CSS_PATH, 'utf8')
+
+const THEMES = ['midnight-ember', 'arctic-night', 'daybreak', 'silver-lining']
+const MIN_CONTRAST = 4.5
+
+// --- Minimal CSS custom-property extraction -------------------------------
+// Only needs to handle the flat `--token: value;` declarations index.css
+// actually uses inside `@theme { ... }` and `[data-theme='x'] { ... }` blocks
+// (no nested braces in either), so a simple "from the opening brace to the
+// next line that is just `}`" slice is sufficient and doesn't need a full
+// CSS parser.
+function extractBlock(source, selectorRegex) {
+  const match = selectorRegex.exec(source)
+  if (!match) return null
+  const start = match.index + match[0].length
+  const end = source.indexOf('\n}', start)
+  if (end === -1) throw new Error(`Unterminated block for ${selectorRegex}`)
+  return source.slice(start, end)
+}
+
+function getRawVar(block, varName) {
+  if (!block) return null
+  const re = new RegExp(`(?:^|\\n)\\s*${varName}:\\s*([^;]+);`)
+  const match = re.exec(block)
+  return match ? match[1].trim() : null
+}
+
+const rootBlock = extractBlock(css, /@theme\s*\{/)
+if (!rootBlock) {
+  throw new Error('themeTokens.test.js could not locate the @theme {...} root block in index.css')
+}
+
+const themeBlocks = Object.fromEntries(
+  THEMES.map(theme => [theme, extractBlock(css, new RegExp(`\\[data-theme=['"]${theme}['"]\\]\\s*\\{`))])
+)
+
+for (const theme of THEMES) {
+  if (!themeBlocks[theme]) {
+    throw new Error(`themeTokens.test.js could not locate the [data-theme='${theme}'] block in index.css`)
+  }
+}
+
+// Per-theme blocks only declare overrides — tokens they omit (e.g.
+// arctic-night never redeclares --background-image-gradient-accent or the
+// status ramps) fall through to the @theme root default, exactly like the
+// browser's CSS custom-property cascade.
+function resolveHex(varName, theme) {
+  const value = getRawVar(themeBlocks[theme], varName) || getRawVar(rootBlock, varName)
+  if (!value) {
+    throw new Error(`themeTokens.test.js: ${varName} is not defined for [data-theme='${theme}'] or the @theme root`)
+  }
+  return value
+}
+
+function resolveGradientAccentStops(theme) {
+  const raw =
+    getRawVar(themeBlocks[theme], '--background-image-gradient-accent') ||
+    getRawVar(rootBlock, '--background-image-gradient-accent')
+  if (!raw) {
+    throw new Error(`themeTokens.test.js: --background-image-gradient-accent is not defined for theme "${theme}"`)
+  }
+  const match = /linear-gradient\([^,]+,\s*(#[0-9a-fA-F]{3,8})\s*0%,\s*(#[0-9a-fA-F]{3,8})\s*100%\)/.exec(raw)
+  if (!match) {
+    throw new Error(
+      `themeTokens.test.js: could not parse start/end stops out of --background-image-gradient-accent for theme "${theme}": ${raw}`
+    )
+  }
+  return { start: match[1], end: match[2] }
+}
+
+// --- WCAG 2.x contrast (relative luminance + contrast ratio) --------------
+function hexToRgb(hex) {
+  let h = hex.replace('#', '')
+  if (h.length === 3 || h.length === 4) {
+    h = h
+      .split('')
+      .map(c => c + c)
+      .join('')
+  }
+  const num = parseInt(h.slice(0, 6), 16)
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255]
+}
+
+function relativeLuminance([r, g, b]) {
+  const [rs, gs, bs] = [r, g, b].map(c => {
+    const channel = c / 255
+    return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4)
+  })
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs
+}
+
+function contrastRatio(hexA, hexB) {
+  const lumA = relativeLuminance(hexToRgb(hexA))
+  const lumB = relativeLuminance(hexToRgb(hexB))
+  const [lighter, darker] = lumA > lumB ? [lumA, lumB] : [lumB, lumA]
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+function expectMinContrast(theme, tokenLabel, fgHex, bgHex) {
+  const ratio = contrastRatio(fgHex, bgHex)
+  expect(
+    ratio,
+    `[${theme}] ${tokenLabel} (${fgHex}) against --color-bg-navy (${bgHex}) computes to ${ratio.toFixed(2)}:1, ` +
+      `below the ${MIN_CONTRAST}:1 WCAG AA floor`
+  ).toBeGreaterThanOrEqual(MIN_CONTRAST)
+}
+
+describe('theme token contrast (WCAG AA, 4.5:1)', () => {
+  describe.each(THEMES)('%s', theme => {
+    const bgNavy = resolveHex('--color-bg-navy', theme)
+    const accent500 = resolveHex('--color-accent-500', theme)
+    const warning400 = resolveHex('--color-warning-400', theme)
+    const { start: gradientStart, end: gradientEnd } = resolveGradientAccentStops(theme)
+
+    // Root-cause regression guard for #617: BandCard's selected/"Live Now"
+    // state renders `bg-gradient-accent` behind `text-bg-navy` — both the
+    // start and end stops must independently clear 4.5:1 against bg-navy,
+    // since text can sit over either end of the gradient depending on card size.
+    it('gradient-accent start stop clears 4.5:1 against bg-navy', () => {
+      expectMinContrast(theme, '--background-image-gradient-accent start stop', gradientStart, bgNavy)
+    })
+
+    it('gradient-accent end stop clears 4.5:1 against bg-navy', () => {
+      expectMinContrast(theme, '--background-image-gradient-accent end stop', gradientEnd, bgNavy)
+    })
+
+    // warning-400 backs the "Starts in Xm" .soon-pill text and other
+    // warning-toned copy directly on paper/card backgrounds.
+    it('warning-400 clears 4.5:1 against bg-navy', () => {
+      expectMinContrast(theme, '--color-warning-400', warning400, bgNavy)
+    })
+
+    // Bonus guard: accent-500 is the token gradient-accent's stops are meant
+    // to match (VenueStrip and BandCard both use it directly against
+    // bg-navy/bg-purple) — same bug class, cheap to also pin down here.
+    it('accent-500 clears 4.5:1 against bg-navy', () => {
+      expectMinContrast(theme, '--color-accent-500', accent500, bgNavy)
+    })
+  })
+})

--- a/frontend/src/__tests__/themeTokens.test.js
+++ b/frontend/src/__tests__/themeTokens.test.js
@@ -121,6 +121,49 @@ function expectMinContrast(theme, tokenLabel, fgHex, bgHex) {
   ).toBeGreaterThanOrEqual(MIN_CONTRAST)
 }
 
+// `color-mix(in srgb, C P%, transparent)` painted over an opaque backdrop B
+// alpha-blends to `result = (P/100)*C + (1 - P/100)*B` per channel — this is
+// what a translucent-tint background (e.g. .soon-pill's) actually renders
+// as. Text-vs-raw-token contrast checks (like the ones above) are blind to
+// this: they measure against an opaque background that never appears
+// on-screen for a tinted element.
+function blend(fgHex, bgHex, alphaPercent) {
+  const [fr, fg, fb] = hexToRgb(fgHex)
+  const [br, bg, bb] = hexToRgb(bgHex)
+  const alpha = alphaPercent / 100
+  const mixChannel = (f, b) => Math.round(alpha * f + (1 - alpha) * b)
+  return `#${[mixChannel(fr, br), mixChannel(fg, bg), mixChannel(fb, bb)]
+    .map(c => c.toString(16).padStart(2, '0'))
+    .join('')}`
+}
+
+// Pulls the `.soon-pill` rule's actual `background: color-mix(...)` and
+// `color: var(...)` declarations out of index.css, instead of hardcoding a
+// copy of the tint token/percent/text-token here — so this guard tracks the
+// real CSS and can't silently drift from it.
+function resolvePillTintSpec() {
+  const soonPillBlock = extractBlock(css, /\.soon-pill\s*\{/)
+  if (!soonPillBlock) {
+    throw new Error("themeTokens.test.js could not locate the '.soon-pill' rule in index.css")
+  }
+  const backgroundRaw = getRawVar(soonPillBlock, 'background')
+  const colorRaw = getRawVar(soonPillBlock, 'color')
+  if (!backgroundRaw || !colorRaw) {
+    throw new Error("themeTokens.test.js: '.soon-pill' is missing a background or color declaration")
+  }
+  const tintMatch = /color-mix\(in srgb,\s*var\((--[\w-]+)\)\s+(\d+(?:\.\d+)?)%,\s*transparent\)/.exec(backgroundRaw)
+  if (!tintMatch) {
+    throw new Error(`themeTokens.test.js: could not parse '.soon-pill' background color-mix(): ${backgroundRaw}`)
+  }
+  const textMatch = /var\((--[\w-]+)\)/.exec(colorRaw)
+  if (!textMatch) {
+    throw new Error(`themeTokens.test.js: could not parse '.soon-pill' color token: ${colorRaw}`)
+  }
+  return { tintToken: tintMatch[1], tintPercent: Number(tintMatch[2]), textToken: textMatch[1] }
+}
+
+const pillSpec = resolvePillTintSpec()
+
 describe('theme token contrast (WCAG AA, 4.5:1)', () => {
   describe.each(THEMES)('%s', theme => {
     const bgNavy = resolveHex('--color-bg-navy', theme)
@@ -140,10 +183,41 @@ describe('theme token contrast (WCAG AA, 4.5:1)', () => {
       expectMinContrast(theme, '--background-image-gradient-accent end stop', gradientEnd, bgNavy)
     })
 
-    // warning-400 backs the "Starts in Xm" .soon-pill text and other
-    // warning-toned copy directly on paper/card backgrounds.
+    // Bonus guard for the raw design-system value itself (mirrors accent-500
+    // below) — not a claim that any consumer renders warning-400 text on a
+    // bare paper background. In practice every current UI consumer (e.g.
+    // .soon-pill) pairs warning-400 with a same-hue translucent tint, which
+    // is exactly what the composited assertion right below this one covers.
     it('warning-400 clears 4.5:1 against bg-navy', () => {
       expectMinContrast(theme, '--color-warning-400', warning400, bgNavy)
+    })
+
+    // Root-cause regression guard for the MAJOR finding on #720: the raw
+    // warning-400-vs-bg-navy check above passes (~4.77:1) but that pairing
+    // never renders — .soon-pill's text sits on its OWN
+    // `color-mix(in srgb, warning-400 15%, transparent)` tint, which
+    // (per `blend()` above) pulls the effective background toward
+    // warning-400's hue and erodes the real on-screen contrast to ~3.9:1 on
+    // daybreak/silver-lining, failing AA. This composites the tint the same
+    // way the browser does and checks the pill's actual text token
+    // (--color-warning-pill-text) against that composited result. bg-navy is
+    // used as the compositing backdrop (rather than parsing BandCard's
+    // gradient-card, which this file doesn't otherwise resolve) because
+    // gradient-card's stops are near-identical to bg-navy/bg-purple on every
+    // theme, and bg-navy is what every other assertion in this file already
+    // anchors to.
+    it('soon-pill text clears 4.5:1 against its composited (color-mix) pill background', () => {
+      const tintColor = resolveHex(pillSpec.tintToken, theme)
+      const textColor = resolveHex(pillSpec.textToken, theme)
+      const compositedPillBg = blend(tintColor, bgNavy, pillSpec.tintPercent)
+      const ratio = contrastRatio(textColor, compositedPillBg)
+      expect(
+        ratio,
+        `[${theme}] .soon-pill text (${pillSpec.textToken}=${textColor}) against its composited pill ` +
+          `background (${pillSpec.tintPercent}% ${pillSpec.tintToken}=${tintColor} color-mixed over ` +
+          `--color-bg-navy=${bgNavy} => ${compositedPillBg}) computes to ${ratio.toFixed(2)}:1, below the ` +
+          `${MIN_CONTRAST}:1 WCAG AA floor`
+      ).toBeGreaterThanOrEqual(MIN_CONTRAST)
     })
 
     // Bonus guard: accent-500 is the token gradient-accent's stops are meant

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -265,7 +265,12 @@ export default function EventTimeline() {
       <div className="mb-8">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
           <div>
-            <h1 className="text-4xl font-bold text-text-primary mb-2">Events</h1>
+            {/* Secondary heading for the events list. EventsPage.jsx already owns
+                the page's primary <h1> (SetTimes brand), so this demotes to <h2> to
+                keep one h1 per document and avoid confusing screen-reader users
+                navigating by heading level. Visual size is unchanged. See App.jsx
+                line 731-734 for the same pattern on the event schedule page. */}
+            <h2 className="text-4xl font-bold text-text-primary mb-2">Events</h2>
             <p className="text-text-secondary">Discover upcoming band crawls and music events</p>
           </div>
 

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -22,7 +22,10 @@ function Header({ eventName, eventDate, selectedVenues }) {
     paddingTop: `${headerPadding}px`,
     paddingBottom: `${headerPadding}px`,
     boxShadow: `0 8px 24px rgba(4, 8, 16, ${0.14 * scrollProgress})`,
-    backgroundColor: `rgba(8, 16, 32, ${0.65 + 0.25 * scrollProgress})`,
+    // Driven from --color-bg-navy (was a hardcoded rgba(8,16,32,…) near-black
+    // triplet) so the sticky header composites correctly on light themes too —
+    // the hardcoded value put the title at ~2.6:1 on daybreak/silver-lining (#617).
+    backgroundColor: `color-mix(in srgb, var(--color-bg-navy) ${Math.round((0.65 + 0.25 * scrollProgress) * 100)}%, transparent)`,
   }
   const titleScale = 1 - 0.12 * scrollProgress
   const fadeProgress = Math.min(1, scrollProgress * 1.75)

--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -163,17 +163,27 @@ function LiveContextBar({
   // to screen readers. On transition, set the announcement text in a hidden
   // live region. Do not announce on every render — only when the label actually
   // changes. Announce only on meaningful transitions (to Live Tonight / Recap),
-  // not on initial render (Upcoming) or cycle-back transitions.
+  // not on initial render (Upcoming) or cycle-back transitions. A transition
+  // into a non-announced label (e.g. Live Tonight → Upcoming) must still clear
+  // whatever announcement is currently sitting in the live region — otherwise
+  // it's stale text that no longer matches reality, left behind by the
+  // previous transition's now-cleaned-up timer.
   useEffect(() => {
     if (lifecycle.label !== prevLifecycleLabelRef.current) {
       prevLifecycleLabelRef.current = lifecycle.label
+      let announcement = ''
       if (lifecycle.label === 'Live Tonight') {
-        setLifecycleAnnouncement(`${eventData?.name || 'Event'} is now live`)
+        announcement = `${eventData?.name || 'Event'} is now live`
       } else if (lifecycle.label === 'Recap' || lifecycle.label === 'Archive') {
-        setLifecycleAnnouncement(`${eventData?.name || 'Event'} has ended`)
+        announcement = `${eventData?.name || 'Event'} has ended`
       }
-      // Clear after 5s to allow assistive tech time to read the announcement.
-      // Shorter delays risk the announcement never being polled by the browser.
+      if (!announcement) {
+        setLifecycleAnnouncement('')
+        return
+      }
+      setLifecycleAnnouncement(announcement)
+      // Clear after 5s so assistive tech has time to poll and read it.
+      // Shorter delays risk the announcement never being announced at all.
       const timer = setTimeout(() => setLifecycleAnnouncement(''), 5000)
       return () => clearTimeout(timer)
     }

--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -156,6 +156,25 @@ function LiveContextBar({
   // of this state; only the venue/time selects are gated by it.
   const [isFiltersOpen, setIsFiltersOpen] = useState(() => typeof window === 'undefined' || window.innerWidth >= 640)
   const [showGhost, setShowGhost] = useState(false)
+  const [lifecycleAnnouncement, setLifecycleAnnouncement] = useState('')
+  const prevLifecycleLabelRef = useRef(lifecycle.label)
+
+  // Announce lifecycle transitions (Upcoming → Live Now → Ended) to screen
+  // readers. On transition, set the announcement text in a hidden live region.
+  // Do not announce on every render — only when the label actually changes.
+  useEffect(() => {
+    if (lifecycle.label !== prevLifecycleLabelRef.current) {
+      prevLifecycleLabelRef.current = lifecycle.label
+      if (lifecycle.label === 'Live Now' || lifecycle.label === 'Happening Now') {
+        setLifecycleAnnouncement(`${eventData?.name || 'Event'} is now live`)
+      } else if (lifecycle.label === 'Ended') {
+        setLifecycleAnnouncement(`${eventData?.name || 'Event'} has ended`)
+      }
+      // Clear the announcement after a short delay so it's not re-announced
+      const timer = setTimeout(() => setLifecycleAnnouncement(''), 100)
+      return () => clearTimeout(timer)
+    }
+  }, [lifecycle.label, eventData?.name])
 
   // Collapses the mobile-only identity block (status badge, clock, title,
   // poster, stats line) once the fan scrolls past it — #665. The Tabs and
@@ -249,6 +268,9 @@ function LiveContextBar({
 
   return (
     <section className="sticky top-[57px] z-40 border-b border-border bg-bg-navy/92 backdrop-blur-xs">
+      <div role="status" aria-live="polite" className="sr-only">
+        {lifecycleAnnouncement}
+      </div>
       <div className="container mx-auto px-4 max-w-(--breakpoint-2xl) py-2.5 sm:py-3">
         <div className="sm:hidden">
           {/* Identity block: status badge, clock, poster, title, stats.

--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -159,19 +159,22 @@ function LiveContextBar({
   const [lifecycleAnnouncement, setLifecycleAnnouncement] = useState('')
   const prevLifecycleLabelRef = useRef(lifecycle.label)
 
-  // Announce lifecycle transitions (Upcoming → Live Now → Ended) to screen
-  // readers. On transition, set the announcement text in a hidden live region.
-  // Do not announce on every render — only when the label actually changes.
+  // Announce lifecycle transitions (Upcoming → Live Tonight → Recap → Archive)
+  // to screen readers. On transition, set the announcement text in a hidden
+  // live region. Do not announce on every render — only when the label actually
+  // changes. Announce only on meaningful transitions (to Live Tonight / Recap),
+  // not on initial render (Upcoming) or cycle-back transitions.
   useEffect(() => {
     if (lifecycle.label !== prevLifecycleLabelRef.current) {
       prevLifecycleLabelRef.current = lifecycle.label
-      if (lifecycle.label === 'Live Now' || lifecycle.label === 'Happening Now') {
+      if (lifecycle.label === 'Live Tonight') {
         setLifecycleAnnouncement(`${eventData?.name || 'Event'} is now live`)
-      } else if (lifecycle.label === 'Ended') {
+      } else if (lifecycle.label === 'Recap' || lifecycle.label === 'Archive') {
         setLifecycleAnnouncement(`${eventData?.name || 'Event'} has ended`)
       }
-      // Clear the announcement after a short delay so it's not re-announced
-      const timer = setTimeout(() => setLifecycleAnnouncement(''), 100)
+      // Clear after 5s to allow assistive tech time to read the announcement.
+      // Shorter delays risk the announcement never being polled by the browser.
+      const timer = setTimeout(() => setLifecycleAnnouncement(''), 5000)
       return () => clearTimeout(timer)
     }
   }, [lifecycle.label, eventData?.name])

--- a/frontend/src/components/OfflineIndicator.jsx
+++ b/frontend/src/components/OfflineIndicator.jsx
@@ -22,7 +22,7 @@ export default function OfflineIndicator() {
 
   return (
     <div
-      className="fixed left-4 right-4 z-50 flex items-center gap-2 rounded-lg bg-warning-500 px-4 py-3 text-bg-navy shadow-lg"
+      className="fixed left-4 right-4 z-50 flex items-center gap-2 rounded-lg border border-warning-500/50 bg-warning-500/20 px-4 py-3 text-text-primary shadow-lg"
       style={{ bottom: PRIVACY_BANNER_OFFSET }}
     >
       <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">

--- a/frontend/src/components/ShareButton.jsx
+++ b/frontend/src/components/ShareButton.jsx
@@ -15,7 +15,7 @@ export default function ShareButton({
   title,
   text,
   label = 'Share',
-  className = 'inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-hover focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400',
+  className = 'inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-hover focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400 min-h-[44px]',
 }) {
   const [copied, setCopied] = useState(false)
 

--- a/frontend/src/components/VenueStrip.jsx
+++ b/frontend/src/components/VenueStrip.jsx
@@ -30,7 +30,15 @@ function VenueStrip({ activeVenues = [] }) {
         aria-hidden="true"
       >
         {/* Track line — full span */}
-        <line x1={PAD_X} y1={CY} x2={W - PAD_X} y2={CY} stroke="rgba(249,115,22,0.25)" strokeWidth="2" />
+        <line
+          x1={PAD_X}
+          y1={CY}
+          x2={W - PAD_X}
+          y2={CY}
+          stroke="var(--color-accent-500)"
+          strokeOpacity="0.25"
+          strokeWidth="2"
+        />
 
         {/* Highlighted segments between consecutive active stops */}
         {KING_ST_VENUES.map((v, i) => {
@@ -44,7 +52,7 @@ function VenueStrip({ activeVenues = [] }) {
               y1={CY}
               x2={PAD_X + (i + 1) * STEP}
               y2={CY}
-              stroke="rgb(249,115,22)"
+              stroke="var(--color-accent-500)"
               strokeWidth="3"
               filter="url(#glow)"
             />
@@ -79,7 +87,8 @@ function VenueStrip({ activeVenues = [] }) {
                   cy={CY}
                   r={r + 5}
                   fill="none"
-                  stroke="rgba(249,115,22,0.35)"
+                  stroke="var(--color-accent-500)"
+                  strokeOpacity="0.35"
                   strokeWidth="2"
                   filter="url(#glow)"
                 />
@@ -89,8 +98,9 @@ function VenueStrip({ activeVenues = [] }) {
                 cx={cx}
                 cy={CY}
                 r={r}
-                fill={isActive ? 'rgb(249,115,22)' : 'rgb(30,38,60)'}
-                stroke={isActive ? 'rgb(249,115,22)' : 'rgba(249,115,22,0.4)'}
+                fill={isActive ? 'var(--color-accent-500)' : 'var(--color-bg-purple)'}
+                stroke="var(--color-accent-500)"
+                strokeOpacity={isActive ? 1 : 0.4}
                 strokeWidth="2"
                 filter={isActive ? 'url(#glow)' : undefined}
               />
@@ -102,7 +112,8 @@ function VenueStrip({ activeVenues = [] }) {
                 fontSize="9"
                 fontFamily="'SF Mono', monospace"
                 letterSpacing="0.03em"
-                fill={isActive ? 'rgba(249,115,22,0.9)' : 'rgba(255,255,255,0.35)'}
+                fill={isActive ? 'var(--color-accent-500)' : 'var(--color-text-tertiary)'}
+                fillOpacity={isActive ? 0.9 : 1}
               >
                 {label.toUpperCase()}
               </text>
@@ -117,7 +128,8 @@ function VenueStrip({ activeVenues = [] }) {
           fontSize="8"
           fontFamily="'SF Mono', monospace"
           letterSpacing="0.05em"
-          fill="rgba(255,255,255,0.2)"
+          fill="var(--color-text-tertiary)"
+          fillOpacity={0.4}
         >
           N
         </text>

--- a/frontend/src/components/__tests__/LiveContextBar.test.jsx
+++ b/frontend/src/components/__tests__/LiveContextBar.test.jsx
@@ -392,6 +392,76 @@ describe('LiveContextBar', () => {
     })
   })
 
+  // Live region for lifecycle transitions (Upcoming → Live Now → Ended),
+  // announced to screen readers when the event status changes.
+  describe('lifecycle status announcements', () => {
+    it('renders a hidden live region with role="status" aria-live="polite"', () => {
+      const { container } = render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T19:30:00')}
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+
+      const liveRegion = container.querySelector('[role="status"][aria-live="polite"].sr-only')
+      expect(liveRegion).toBeInTheDocument()
+    })
+
+    it('announces on lifecycle transitions and clears after announcing', () => {
+      vi.useFakeTimers()
+      const { rerender } = render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T12:00:00')} // Before event
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+
+      // Lifecycle should be "Upcoming" initially. Now move time to event start.
+      rerender(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T19:30:00')} // Event is live
+          bands={bands}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+
+      const liveRegion = screen.getByRole('status')
+      // Announcement is set before the 100ms timeout clears it
+      // (timing depends on the actual lifecycle transition, which may not
+      // occur with these times, so we verify the mechanism exists)
+      expect(liveRegion).toHaveAttribute('aria-live', 'polite')
+
+      // Advance past the 100ms timeout
+      vi.advanceTimersByTime(150)
+      expect(liveRegion.textContent).toBe('')
+
+      vi.useRealTimers()
+    })
+  })
+
   // #690 residual jank fix, at the rendered-component level (the tests above
   // exercise the pure functions in isolation).
   describe('scroll-driven identity block (#690)', () => {

--- a/frontend/src/components/__tests__/LiveContextBar.test.jsx
+++ b/frontend/src/components/__tests__/LiveContextBar.test.jsx
@@ -484,6 +484,93 @@ describe('LiveContextBar', () => {
       vi.useRealTimers()
     })
 
+    // MINOR finding on #720: a Live Tonight → Upcoming transition matches
+    // neither `if` branch, so the old code never called setLifecycleAnnouncement
+    // at all — the stale "is now live" text from the PRIOR transition was left
+    // sitting in the live region (a fresh 5s timer did eventually clear it, but
+    // only by accident, and a screen reader polling in that window would read
+    // status that no longer matches reality). The fix clears the region
+    // immediately on any transition that isn't itself announceable.
+    it('clears a stale "is now live" announcement when transitioning back from "Live Tonight" to "Upcoming" (#720)', () => {
+      vi.useFakeTimers()
+
+      const bandsWithTimes = [
+        {
+          id: '1',
+          venue: 'Stage A',
+          startMs: new Date('2026-05-06T19:00:00').getTime(),
+          endMs: new Date('2026-05-06T19:45:00').getTime(),
+        },
+        {
+          id: '2',
+          venue: 'Stage B',
+          startMs: new Date('2026-05-06T20:00:00').getTime(),
+          endMs: new Date('2026-05-06T20:45:00').getTime(),
+        },
+      ]
+
+      const { rerender } = render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T18:30:00')} // Upcoming, before first set
+          bands={bandsWithTimes}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+
+      const liveRegion = screen.getByRole('status')
+      expect(liveRegion.textContent).toBe('')
+
+      // Upcoming -> Live Tonight: announces "is now live".
+      act(() => {
+        rerender(
+          <LiveContextBar
+            eventData={eventData}
+            currentTime={new Date('2026-05-06T19:15:00')} // Live Tonight
+            bands={bandsWithTimes}
+            selectedCount={0}
+            view="all"
+            onViewChange={vi.fn()}
+            venueFilter={null}
+            onVenueFilterChange={vi.fn()}
+            timeFilter="all"
+            onTimeFilterChange={vi.fn()}
+          />
+        )
+      })
+      expect(liveRegion.textContent).toContain('is now live')
+
+      // Live Tonight -> Upcoming: neither announceable branch matches, but the
+      // stale "is now live" text must not be left behind — assert this BEFORE
+      // advancing any timers, since the old bug only cleared it "by accident"
+      // after a further 5s delay.
+      act(() => {
+        rerender(
+          <LiveContextBar
+            eventData={eventData}
+            currentTime={new Date('2026-05-06T18:45:00')} // back to Upcoming
+            bands={bandsWithTimes}
+            selectedCount={0}
+            view="all"
+            onViewChange={vi.fn()}
+            venueFilter={null}
+            onVenueFilterChange={vi.fn()}
+            timeFilter="all"
+            onTimeFilterChange={vi.fn()}
+          />
+        )
+      })
+      expect(liveRegion.textContent).toBe('')
+
+      vi.useRealTimers()
+    })
+
     it('does not announce when transitioning within or back to "Upcoming"', () => {
       vi.useFakeTimers()
 

--- a/frontend/src/components/__tests__/LiveContextBar.test.jsx
+++ b/frontend/src/components/__tests__/LiveContextBar.test.jsx
@@ -392,7 +392,7 @@ describe('LiveContextBar', () => {
     })
   })
 
-  // Live region for lifecycle transitions (Upcoming → Live Now → Ended),
+  // Live region for lifecycle transitions (Upcoming → Live Tonight → Recap → Archive),
   // announced to screen readers when the event status changes.
   describe('lifecycle status announcements', () => {
     it('renders a hidden live region with role="status" aria-live="polite"', () => {
@@ -415,29 +415,30 @@ describe('LiveContextBar', () => {
       expect(liveRegion).toBeInTheDocument()
     })
 
-    it('announces on lifecycle transitions and clears after announcing', () => {
+    it('announces and clears when transitioning to "Live Tonight"', () => {
       vi.useFakeTimers()
+
+      // Bands with startMs/endMs set to put event in "Upcoming" state before 19:00
+      const bandsWithTimes = [
+        {
+          id: '1',
+          venue: 'Stage A',
+          startMs: new Date('2026-05-06T19:00:00').getTime(),
+          endMs: new Date('2026-05-06T19:45:00').getTime(),
+        },
+        {
+          id: '2',
+          venue: 'Stage B',
+          startMs: new Date('2026-05-06T20:00:00').getTime(),
+          endMs: new Date('2026-05-06T20:45:00').getTime(),
+        },
+      ]
+
       const { rerender } = render(
         <LiveContextBar
           eventData={eventData}
-          currentTime={new Date('2026-05-06T12:00:00')} // Before event
-          bands={bands}
-          selectedCount={0}
-          view="all"
-          onViewChange={vi.fn()}
-          venueFilter={null}
-          onVenueFilterChange={vi.fn()}
-          timeFilter="all"
-          onTimeFilterChange={vi.fn()}
-        />
-      )
-
-      // Lifecycle should be "Upcoming" initially. Now move time to event start.
-      rerender(
-        <LiveContextBar
-          eventData={eventData}
-          currentTime={new Date('2026-05-06T19:30:00')} // Event is live
-          bands={bands}
+          currentTime={new Date('2026-05-06T18:30:00')} // Before first set starts
+          bands={bandsWithTimes}
           selectedCount={0}
           view="all"
           onViewChange={vi.fn()}
@@ -449,13 +450,88 @@ describe('LiveContextBar', () => {
       )
 
       const liveRegion = screen.getByRole('status')
-      // Announcement is set before the 100ms timeout clears it
-      // (timing depends on the actual lifecycle transition, which may not
-      // occur with these times, so we verify the mechanism exists)
-      expect(liveRegion).toHaveAttribute('aria-live', 'polite')
+      // Initially Upcoming — no announcement
+      expect(liveRegion.textContent).toBe('')
 
-      // Advance past the 100ms timeout
-      vi.advanceTimersByTime(150)
+      // Move time past first set start — transitions to "Live Tonight"
+      act(() => {
+        rerender(
+          <LiveContextBar
+            eventData={eventData}
+            currentTime={new Date('2026-05-06T19:15:00')} // Event is live
+            bands={bandsWithTimes}
+            selectedCount={0}
+            view="all"
+            onViewChange={vi.fn()}
+            venueFilter={null}
+            onVenueFilterChange={vi.fn()}
+            timeFilter="all"
+            onTimeFilterChange={vi.fn()}
+          />
+        )
+      })
+
+      // Announcement is set before the 5s timeout clears it
+      expect(liveRegion.textContent).toContain('Long Weekend Band Crawl')
+      expect(liveRegion.textContent).toContain('is now live')
+
+      // Advance past the 5s (5000ms) timeout
+      act(() => {
+        vi.advanceTimersByTime(5100)
+      })
+      expect(liveRegion.textContent).toBe('')
+
+      vi.useRealTimers()
+    })
+
+    it('does not announce when transitioning within or back to "Upcoming"', () => {
+      vi.useFakeTimers()
+
+      const bandsWithTimes = [
+        {
+          id: '1',
+          venue: 'Stage A',
+          startMs: new Date('2026-05-06T19:00:00').getTime(),
+          endMs: new Date('2026-05-06T19:45:00').getTime(),
+        },
+      ]
+
+      const { rerender } = render(
+        <LiveContextBar
+          eventData={eventData}
+          currentTime={new Date('2026-05-06T18:00:00')} // Before event
+          bands={bandsWithTimes}
+          selectedCount={0}
+          view="all"
+          onViewChange={vi.fn()}
+          venueFilter={null}
+          onVenueFilterChange={vi.fn()}
+          timeFilter="all"
+          onTimeFilterChange={vi.fn()}
+        />
+      )
+
+      const liveRegion = screen.getByRole('status')
+      expect(liveRegion.textContent).toBe('')
+
+      // Transition to a different "Upcoming" time — no announcement
+      act(() => {
+        rerender(
+          <LiveContextBar
+            eventData={eventData}
+            currentTime={new Date('2026-05-06T18:30:00')}
+            bands={bandsWithTimes}
+            selectedCount={0}
+            view="all"
+            onViewChange={vi.fn()}
+            venueFilter={null}
+            onVenueFilterChange={vi.fn()}
+            timeFilter="all"
+            onTimeFilterChange={vi.fn()}
+          />
+        )
+      })
+
       expect(liveRegion.textContent).toBe('')
 
       vi.useRealTimers()

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -263,7 +263,10 @@
   --color-band-orange: #c2410c;
 
   --background-image-gradient-primary: linear-gradient(135deg, #fb7185 0%, #be123c 100%);
-  --background-image-gradient-accent: linear-gradient(135deg, #f97316 0%, #c2410c 100%);
+  /* Start stop matched to --color-accent-500's darkness (was #f97316, the
+     bright default-theme orange) so text-bg-navy consumers (e.g. BandCard's
+     selected/"Live Now" state) clear 4.5:1 instead of ~2.3-2.9:1 (#617). */
+  --background-image-gradient-accent: linear-gradient(135deg, #7c2d12 0%, #5f2410 100%);
   --background-image-gradient-dark: linear-gradient(180deg, #f3dfca 0%, #fff8f1 100%);
   --background-image-gradient-card: linear-gradient(
     145deg,
@@ -340,7 +343,9 @@
   --color-band-orange: #3b82f6;
 
   --background-image-gradient-primary: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  --background-image-gradient-accent: linear-gradient(135deg, #60a5fa 0%, #3b82f6 100%);
+  /* Start stop matched to --color-accent-500's darkness (was #60a5fa, a light
+     blue) so text-bg-navy consumers clear 4.5:1 instead of ~2.4-3.5:1 (#617). */
+  --background-image-gradient-accent: linear-gradient(135deg, #1d4ed8 0%, #1e3a8a 100%);
   --background-image-gradient-dark: linear-gradient(180deg, #f1f5f9 0%, #f8fafc 100%);
   --background-image-gradient-card: linear-gradient(
     145deg,
@@ -578,9 +583,13 @@ body {
 
 .soon-pill {
   display: inline-block;
-  background: rgba(251, 191, 36, 0.15);
-  border: 1px solid rgba(251, 191, 36, 0.45);
-  color: #fbbf24;
+  /* Tokenized (was a hardcoded #fbbf24/rgba(251,191,36,…) triplet that
+     computed ~1.5:1 on light themes, illegible on bg-gradient-card). warning-400
+     is tuned to clear 4.5:1 on paper backgrounds — see index.css's own comment
+     near the daybreak status-ramp block (#617). */
+  background: color-mix(in srgb, var(--color-warning-400) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-warning-400) 45%, transparent);
+  color: var(--color-warning-400);
   border-radius: 9999px;
   padding: 2px 10px;
   font-size: 0.7rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,6 +39,13 @@
   --color-warning-500: #f59e0b;
   --color-warning-600: #d97706;
 
+  /* .soon-pill's text sits on a `color-mix(… warning-400 15%, transparent)`
+     tint, not a raw paper background — warning-400 alone only clears 4.5:1
+     against the latter. Root/dark-theme default equals warning-400 itself
+     (already sufficient there); daybreak/silver-lining override below. See
+     the `.soon-pill` rule for the composited-contrast math (#720). */
+  --color-warning-pill-text: #fbbf24;
+
   --color-error-400: #f87171;
   --color-error-500: #ef4444;
   --color-error-600: #dc2626;
@@ -295,6 +302,10 @@
   --color-warning-400: #b45309;
   --color-warning-500: #d97706;
   --color-warning-600: #92400e;
+  /* Overrides the @theme default (see that declaration for why): warning-400
+     itself only clears ~3.9:1 against the composited .soon-pill background on
+     this theme, so the pill text uses the darker warning-600 value instead. */
+  --color-warning-pill-text: #92400e;
   --color-error-400: #b91c1c;
   --color-error-500: #dc2626;
   --color-error-600: #991b1b;
@@ -372,6 +383,10 @@
   --color-warning-400: #b45309;
   --color-warning-500: #d97706;
   --color-warning-600: #92400e;
+  /* Overrides the @theme default (see that declaration for why): warning-400
+     itself only clears ~3.9:1 against the composited .soon-pill background on
+     this theme, so the pill text uses the darker warning-600 value instead. */
+  --color-warning-pill-text: #92400e;
   --color-error-400: #b91c1c;
   --color-error-500: #dc2626;
   --color-error-600: #991b1b;
@@ -586,10 +601,21 @@ body {
   /* Tokenized (was a hardcoded #fbbf24/rgba(251,191,36,…) triplet that
      computed ~1.5:1 on light themes, illegible on bg-gradient-card). warning-400
      is tuned to clear 4.5:1 on paper backgrounds — see index.css's own comment
-     near the daybreak status-ramp block (#617). */
+     near the daybreak status-ramp block (#617). BUT the text below doesn't sit
+     on a paper background — it sits on THIS rule's own 15%-warning-400 tint,
+     which pulls the effective background toward warning-400's hue and erodes
+     that contrast back down to ~3.9:1 on daybreak/silver-lining (still fails
+     AA). color-mix(in srgb, C P%, transparent) over an opaque backdrop B
+     alpha-blends to `result = (P/100)*C + (1 - P/100)*B` per channel, so the
+     text token has to be measured against that blended result, not against B
+     directly — see themeTokens.test.js's composited-background assertion.
+     --color-warning-pill-text carries the fix: it equals warning-400 on the
+     dark themes (already ~8:1 there, untouched) and the darker warning-600
+     value on daybreak/silver-lining (~5.5:1 against the composited tint,
+     #720). */
   background: color-mix(in srgb, var(--color-warning-400) 15%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-warning-400) 45%, transparent);
-  color: var(--color-warning-400);
+  color: var(--color-warning-pill-text);
   border-radius: 9999px;
   padding: 2px 10px;
   font-size: 0.7rem;

--- a/frontend/src/pages/ArtistsPage.jsx
+++ b/frontend/src/pages/ArtistsPage.jsx
@@ -84,10 +84,11 @@ function ArtistCard({ artist }) {
       </Link>
       {/* Icons live on their own row below the text so a long band name never
           competes with them for width (the card grows vertically instead —
-          per Dre). pl-[68px] lines the icon glyphs up with the text column:
-          64px photo + 16px gap, minus the 12px inset of the 40px hit area. */}
+          per Dre). pl-[66px] lines the icon glyphs up with the text column:
+          64px photo + 16px gap, minus the 14px inset of the 44px hit area
+          (44px hit area - 16px glyph, halved). */}
       {socialLinks.length > 0 && (
-        <div className="mt-1 flex items-center gap-1 pl-[68px]">
+        <div className="mt-1 flex items-center gap-1 pl-[66px]">
           {socialLinks.map(({ key, label, Icon, href }) => (
             <a
               key={key}
@@ -97,7 +98,7 @@ function ArtistCard({ artist }) {
               aria-label={`${artist.name} on ${label}`}
               title={label}
               onClick={() => trackSocialClick(artist.id, key)}
-              className="flex h-11 w-11 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
             >
               <Icon size={16} />
             </a>

--- a/frontend/src/pages/ArtistsPage.jsx
+++ b/frontend/src/pages/ArtistsPage.jsx
@@ -97,7 +97,7 @@ function ArtistCard({ artist }) {
               aria-label={`${artist.name} on ${label}`}
               title={label}
               onClick={() => trackSocialClick(artist.id, key)}
-              className="flex h-10 w-10 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
+              className="flex h-11 w-11 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-400"
             >
               <Icon size={16} />
             </a>


### PR DESCRIPTION
## Summary

A three-lens audit of the public surface (design system / theme tokens / accessibility) found that **two of the four themes you ship are broken on the elements fans use most**. This fixes the confirmed WCAG AA failures and adds a guard so they can't come back.

On `daybreak` and `silver-lining`, before this PR:

| Element | Contrast | |
|---|---|---|
| Selected / "Live Now" band card | **2.3–2.9:1** | the most-interacted element on the site |
| "Starts in Xm" pill | **~1.5:1** | effectively illegible |
| Sitewide sticky header title | **~2.6:1** | fails even the 3:1 large-text floor |
| Venue strip labels | white @20–35% on near-white | essentially invisible |
| Offline banner | **3.0:1** | under the 4.5:1 body-text floor |

AA requires 4.5:1. Worst ratio after this PR: **4.77:1**.

## The root cause was one token

`--background-image-gradient-accent` had its *end* stop retuned per theme but not its *start*: daybreak started at `#f97316` (bright orange) instead of the dark `#7c2d12` that `--color-accent-500` correctly uses. Every consumer inherited it.

Proof it was the token and not the pattern: `ComingUp.jsx:73` uses `bg-linear-to-r from-accent-500 to-primary-600` with the same `text-bg-navy` and computes **≥6.4:1 on all four themes**. Same idea, correct tokens, safe. `BandCard` reached for the convenience token and inherited a half-finished retune.

## Why the existing contrast test didn't catch this

`e2e/accessibility/theme-contrast.spec.js` already covers all four themes across four routes — and is structurally blind to every one of these bugs.

Line 68 asserts only on `results.violations`. axe-core's `color-contrast` rule moves an element into **`incomplete`**, not `violations`, whenever it can't resolve the background — text over a **gradient**, text over an **image** — and it doesn't evaluate **SVG text** at all. `OfflineIndicator` only renders when the browser goes offline, so it never renders during a run.

Every failure sat in a bucket the test cannot see, and they clustered there for a structural reason: gradients are where you put visual emphasis, so they land on your most important elements.

So rather than fight axe, this adds `frontend/src/__tests__/themeTokens.test.js` — a fast offline unit test that parses `index.css`, resolves each theme's real token values, and asserts the pairings components actually render clear 4.5:1 on **all four themes**. It guards the root cause, not the symptom. Mutation-verified: restoring the old daybreak gradient start makes it fail with `2.66:1` and names the theme and token.

## Accessibility fixes

- **Two visible `<h1>`s on the home page** — `EventsPage.jsx` owns the page h1, then `EventTimeline.jsx:268` rendered a second one. Demoted to `<h2>`. (`App.jsx:731` solved this on `/event/:slug` already; the fix hadn't been generalised.)
- **"Happening Now" transitions were never announced.** A screen-reader user waiting for the show got silence. Now a single polite live region announces on the label transition only.
- **Touch targets** below the project's own 44px rule: `ArtistsPage.jsx:100` social icons (40px, in a `gap-1` row) and `ShareButton.jsx:18` (~37px, alone in a page corner).

## Security / correctness notes

- No API, schema, or migration change. Presentational + one new unit test.
- **Dark themes verified unregressed** — no value inside a `midnight-ember` or `arctic-night` block changed; ratios reported for all four themes.
- `Header.jsx` uses `color-mix(in srgb, …)`. An unsupporting browser drops the invalid inline style and falls back to the existing `bg-linear-to-b from-bg-navy to-bg-purple` class already on the element — degrades gracefully, not transparent.

## Verification

- [x] Tests: full suite green, `make gate` exit 0
- [x] ESLint: 0 errors · Format check: clean · Build: green
- [x] Guard test mutation-verified (fails at 2.66:1 on the old value)
- [x] Live-region fix mutation-verified (fails with the old labels)
- [ ] **Visual check on a light theme** — the one thing automation can't do here

### Review notes

The first pass at the live region shipped **completely inert**: it compared `lifecycle.label` against `'Live Now'` / `'Happening Now'` / `'Ended'`, but `getLifecycleLabel()` only ever produces `'Upcoming'` / `'Live Tonight'` / `'Recap'` / `'Archive'`. Transition detection worked; every branch inside was unreachable. Its test only asserted the region *cleared*, never that it was ever populated — so it passed identically whether the feature worked or did nothing. Both fixed in `422772f`, and the clear delay went from 100ms to 5000ms since a polite live region polled by assistive tech can miss a 100ms populate-and-clear entirely.

---
Built by Sonny · Reviewed by Vera & Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved screen-reader announcements for live event status changes.
  - Increased interactive touch targets for sharing and artist social links.
  - Improved heading structure for event pages.

- **Visual Updates**
  - Updated offline, warning, gradient, header, and venue-map styling for better theme consistency.
  - Improved colour contrast across themes and key interface elements.

- **Tests**
  - Added coverage for theme contrast and live event announcements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->