### PR TITLE
fix(admin): align roster column headers, make filter funnels visible at rest

### DIFF
--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -5,7 +5,7 @@ import { DEFAULT_GENRES, getNormalizedGenreSuggestions } from '../utils/genres'
 import { parseOrigin } from '../utils/parseOrigin'
 import { sortableName } from '../utils/sortableName'
 import SocialLinksIcons from './components/SocialLinksIcons'
-import FilterFunnel from './components/FilterFunnel'
+import FilterableHeader from './components/FilterableHeader'
 import ColumnFilter from './components/ColumnFilter'
 import LinksColumnFilter from './components/LinksColumnFilter'
 import MobileFilterSheet from './components/MobileFilterSheet'
@@ -45,24 +45,6 @@ function summarizeColumnFilter(column, filter) {
   }
   const values = Array.isArray(filter?.values) ? filter.values : []
   return summarizeValues(values)
-}
-
-function SortIcon({ col, sortConfig }) {
-  return (
-    <span className="ml-1 inline-block w-4">
-      {sortConfig.key === col ? (sortConfig.direction === 'asc' ? '↑' : '↓') : ''}
-    </span>
-  )
-}
-
-// `<th>` is not natively interactive -- a keyboard user cannot activate an
-// onClick attached directly to it. Every sortable header instead puts the
-// handler on a real <button> inside the <th>, and the <th> carries aria-sort
-// reflecting the current state so assistive tech announces which column (and
-// direction) the table is sorted by.
-function ariaSortFor(sortConfig, key) {
-  if (sortConfig.key !== key) return 'none'
-  return sortConfig.direction === 'asc' ? 'ascending' : 'descending'
 }
 
 // Same pill styling as the existing Status column below — reused here so an
@@ -109,17 +91,19 @@ export default function RosterTab({ showToast, readOnly = false }) {
 
   const editFormRef = useRef(null)
 
-  // One ref per filterable column, shared between that column's FilterFunnel
-  // trigger and the panel it opens -- the panel uses it to treat a mousedown
-  // on the trigger as "inside" (no close-then-reopen flicker) and to return
-  // focus there on Escape.
-  const nameFilterRef = useRef(null)
-  const originFilterRef = useRef(null)
-  const genreFilterRef = useRef(null)
-  const statusFilterRef = useRef(null)
-  const linksFilterRef = useRef(null)
-  const contactFilterRef = useRef(null)
-  const followersFilterRef = useRef(null)
+  // Single ref map, one entry per filterable column, shared between that
+  // column's FilterFunnel trigger and the panel it opens -- the panel uses it
+  // to treat a mousedown on the trigger as "inside" (no close-then-reopen
+  // flicker) and to return focus there on Escape. Built once via useMemo
+  // (stable identity for the component's lifetime, same as the seven
+  // individual useRefs this replaces) rather than a lazily-populated
+  // useRef(), which eslint-plugin-react-hooks' ref-safety rule only allows
+  // for the single-ref `if (ref.current == null)` shape -- not a `.current`
+  // that holds a keyed map read during render.
+  const filterRefs = useMemo(
+    () => Object.fromEntries(FILTERABLE_COLUMNS.map(column => [column.key, { current: null }])),
+    []
+  )
 
   // Form state - minimized for Profile only
   const [formData, setFormData] = useState({
@@ -693,168 +677,89 @@ export default function RosterTab({ showToast, readOnly = false }) {
                         />
                       </th>
                     )}
-                    <th
-                      aria-sort={ariaSortFor(sortConfig, 'name')}
-                      className="relative px-4 py-3 text-left text-white font-semibold"
-                    >
-                      <div className="flex items-center gap-1">
-                        <button
-                          type="button"
-                          onClick={() => handleSort('name')}
-                          className="cursor-pointer hover:text-accent-400"
-                        >
-                          Name <SortIcon col="name" sortConfig={sortConfig} />
-                        </button>
-                        <FilterFunnel
-                          label="Name"
-                          active={isColumnFiltered(columnFilters, 'name')}
-                          open={openFilterKey === 'name'}
-                          panelId="roster-filter-panel-name"
-                          triggerRef={nameFilterRef}
-                          onClick={() => toggleFilterPanel('name')}
-                        />
-                      </div>
-                      {renderColumnFilterPanel('name', nameFilterRef)}
-                    </th>
-                    <th
-                      aria-sort={ariaSortFor(sortConfig, 'origin')}
-                      className="relative px-4 py-3 text-left text-white font-semibold"
-                    >
-                      <div className="flex items-center gap-1">
-                        <button
-                          type="button"
-                          onClick={() => handleSort('origin')}
-                          className="cursor-pointer hover:text-accent-400"
-                        >
-                          Origin <SortIcon col="origin" sortConfig={sortConfig} />
-                        </button>
-                        <FilterFunnel
-                          label="Origin"
-                          active={isColumnFiltered(columnFilters, 'origin')}
-                          open={openFilterKey === 'origin'}
-                          panelId="roster-filter-panel-origin"
-                          triggerRef={originFilterRef}
-                          onClick={() => toggleFilterPanel('origin')}
-                        />
-                      </div>
-                      {renderColumnFilterPanel('origin', originFilterRef)}
-                    </th>
-                    <th
-                      aria-sort={ariaSortFor(sortConfig, 'genre')}
-                      className="relative px-4 py-3 text-left text-white font-semibold"
-                    >
-                      <div className="flex items-center gap-1">
-                        <button
-                          type="button"
-                          onClick={() => handleSort('genre')}
-                          className="cursor-pointer hover:text-accent-400"
-                        >
-                          Genre <SortIcon col="genre" sortConfig={sortConfig} />
-                        </button>
-                        <FilterFunnel
-                          label="Genre"
-                          active={isColumnFiltered(columnFilters, 'genre')}
-                          open={openFilterKey === 'genre'}
-                          panelId="roster-filter-panel-genre"
-                          triggerRef={genreFilterRef}
-                          onClick={() => toggleFilterPanel('genre')}
-                        />
-                      </div>
-                      {renderColumnFilterPanel('genre', genreFilterRef)}
-                    </th>
-                    <th
-                      aria-sort={ariaSortFor(sortConfig, 'is_active')}
-                      className="relative px-4 py-3 text-left text-white font-semibold"
-                    >
-                      <div className="flex items-center gap-1">
-                        <button
-                          type="button"
-                          onClick={() => handleSort('is_active')}
-                          className="cursor-pointer hover:text-accent-400"
-                        >
-                          Status <SortIcon col="is_active" sortConfig={sortConfig} />
-                        </button>
-                        <FilterFunnel
-                          label="Status"
-                          active={isColumnFiltered(columnFilters, 'is_active')}
-                          open={openFilterKey === 'is_active'}
-                          panelId="roster-filter-panel-is_active"
-                          triggerRef={statusFilterRef}
-                          onClick={() => toggleFilterPanel('is_active')}
-                        />
-                      </div>
-                      {renderColumnFilterPanel('is_active', statusFilterRef)}
-                    </th>
-                    <th
-                      aria-sort={ariaSortFor(sortConfig, 'link_count')}
-                      className="relative px-4 py-3 text-left text-white font-semibold"
-                    >
-                      <div className="flex items-center gap-1">
-                        <button
-                          type="button"
-                          onClick={() => handleSort('link_count')}
-                          className="cursor-pointer hover:text-accent-400"
-                        >
-                          Links <SortIcon col="link_count" sortConfig={sortConfig} />
-                        </button>
-                        <FilterFunnel
-                          label="Links"
-                          active={isColumnFiltered(columnFilters, 'link_count')}
-                          open={openFilterKey === 'link_count'}
-                          panelId="roster-filter-panel-link_count"
-                          triggerRef={linksFilterRef}
-                          onClick={() => toggleFilterPanel('link_count')}
-                        />
-                      </div>
-                      {renderColumnFilterPanel('link_count', linksFilterRef)}
-                    </th>
-                    <th
-                      aria-sort={ariaSortFor(sortConfig, 'contact_email')}
-                      className="relative px-4 py-3 text-left text-white font-semibold"
-                    >
-                      <div className="flex items-center gap-1">
-                        <button
-                          type="button"
-                          onClick={() => handleSort('contact_email')}
-                          className="cursor-pointer hover:text-accent-400"
-                        >
-                          Contact <SortIcon col="contact_email" sortConfig={sortConfig} />
-                        </button>
-                        <FilterFunnel
-                          label="Contact"
-                          active={isColumnFiltered(columnFilters, 'contact_email')}
-                          open={openFilterKey === 'contact_email'}
-                          panelId="roster-filter-panel-contact_email"
-                          triggerRef={contactFilterRef}
-                          onClick={() => toggleFilterPanel('contact_email')}
-                        />
-                      </div>
-                      {renderColumnFilterPanel('contact_email', contactFilterRef)}
-                    </th>
-                    <th
-                      aria-sort={ariaSortFor(sortConfig, 'follower_count')}
-                      className="relative px-4 py-3 text-right text-white font-semibold"
-                    >
-                      <div className="flex items-center justify-end gap-1">
-                        <button
-                          type="button"
-                          onClick={() => handleSort('follower_count')}
-                          className="cursor-pointer hover:text-accent-400"
-                        >
-                          Followers <SortIcon col="follower_count" sortConfig={sortConfig} />
-                        </button>
-                        <FilterFunnel
-                          label="Followers"
-                          active={isColumnFiltered(columnFilters, 'follower_count')}
-                          open={openFilterKey === 'follower_count'}
-                          panelId="roster-filter-panel-follower_count"
-                          triggerRef={followersFilterRef}
-                          onClick={() => toggleFilterPanel('follower_count')}
-                        />
-                      </div>
-                      {renderColumnFilterPanel('follower_count', followersFilterRef)}
-                    </th>
-                    {!readOnly && <th className="px-4 py-3 text-right text-white font-semibold">Actions</th>}
+                    <FilterableHeader
+                      sortKey="name"
+                      label="Name"
+                      sortConfig={sortConfig}
+                      columnFilters={columnFilters}
+                      openFilterKey={openFilterKey}
+                      onSort={handleSort}
+                      onToggleFilter={toggleFilterPanel}
+                      triggerRef={filterRefs.name}
+                      renderColumnFilterPanel={renderColumnFilterPanel}
+                    />
+                    <FilterableHeader
+                      sortKey="origin"
+                      label="Origin"
+                      sortConfig={sortConfig}
+                      columnFilters={columnFilters}
+                      openFilterKey={openFilterKey}
+                      onSort={handleSort}
+                      onToggleFilter={toggleFilterPanel}
+                      triggerRef={filterRefs.origin}
+                      renderColumnFilterPanel={renderColumnFilterPanel}
+                    />
+                    <FilterableHeader
+                      sortKey="genre"
+                      label="Genre"
+                      sortConfig={sortConfig}
+                      columnFilters={columnFilters}
+                      openFilterKey={openFilterKey}
+                      onSort={handleSort}
+                      onToggleFilter={toggleFilterPanel}
+                      triggerRef={filterRefs.genre}
+                      renderColumnFilterPanel={renderColumnFilterPanel}
+                    />
+                    <FilterableHeader
+                      sortKey="is_active"
+                      label="Status"
+                      sortConfig={sortConfig}
+                      columnFilters={columnFilters}
+                      openFilterKey={openFilterKey}
+                      onSort={handleSort}
+                      onToggleFilter={toggleFilterPanel}
+                      triggerRef={filterRefs.is_active}
+                      renderColumnFilterPanel={renderColumnFilterPanel}
+                    />
+                    <FilterableHeader
+                      sortKey="link_count"
+                      label="Links"
+                      sortConfig={sortConfig}
+                      columnFilters={columnFilters}
+                      openFilterKey={openFilterKey}
+                      onSort={handleSort}
+                      onToggleFilter={toggleFilterPanel}
+                      triggerRef={filterRefs.link_count}
+                      renderColumnFilterPanel={renderColumnFilterPanel}
+                    />
+                    <FilterableHeader
+                      sortKey="contact_email"
+                      label="Contact"
+                      sortConfig={sortConfig}
+                      columnFilters={columnFilters}
+                      openFilterKey={openFilterKey}
+                      onSort={handleSort}
+                      onToggleFilter={toggleFilterPanel}
+                      triggerRef={filterRefs.contact_email}
+                      renderColumnFilterPanel={renderColumnFilterPanel}
+                    />
+                    <FilterableHeader
+                      sortKey="follower_count"
+                      label="Followers"
+                      align="right"
+                      sortConfig={sortConfig}
+                      columnFilters={columnFilters}
+                      openFilterKey={openFilterKey}
+                      onSort={handleSort}
+                      onToggleFilter={toggleFilterPanel}
+                      triggerRef={filterRefs.follower_count}
+                      renderColumnFilterPanel={renderColumnFilterPanel}
+                    />
+                    {!readOnly && (
+                      <th className="px-4 py-3 text-right text-white font-semibold whitespace-nowrap align-middle">
+                        Actions
+                      </th>
+                    )}
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-accent-500/10">

--- a/frontend/src/admin/components/FilterFunnel.jsx
+++ b/frontend/src/admin/components/FilterFunnel.jsx
@@ -6,7 +6,7 @@ import { ListFilter } from 'lucide-react'
 // literal with an interpolated segment (e.g. a colour variable) would
 // generate no CSS at all and silently drop the accent state.
 const INACTIVE_CLASS =
-  'inline-flex items-center justify-center h-6 w-6 rounded cursor-pointer text-white/50 hover:text-white hover:bg-white/10 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500'
+  'inline-flex items-center justify-center h-6 w-6 rounded cursor-pointer text-white/70 hover:text-white hover:bg-white/10 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500'
 
 const ACTIVE_CLASS =
   'inline-flex items-center justify-center h-6 w-6 rounded cursor-pointer text-accent-400 bg-accent-500/20 hover:bg-accent-500/30 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500'
@@ -28,7 +28,7 @@ export default function FilterFunnel({ label, active = false, open = false, pane
       aria-label={`Filter by ${label}`}
       className={active ? ACTIVE_CLASS : INACTIVE_CLASS}
     >
-      <ListFilter size={14} aria-hidden="true" />
+      <ListFilter size={16} aria-hidden="true" />
     </button>
   )
 }

--- a/frontend/src/admin/components/FilterableHeader.jsx
+++ b/frontend/src/admin/components/FilterableHeader.jsx
@@ -1,0 +1,95 @@
+import PropTypes from 'prop-types'
+import FilterFunnel from './FilterFunnel'
+import { isColumnFiltered } from '../utils/rosterColumns'
+
+// `<th>` is not natively interactive -- a keyboard user cannot activate an
+// onClick attached directly to it. Every sortable header instead puts the
+// handler on a real <button> inside the <th>, and the <th> carries aria-sort
+// reflecting the current state so assistive tech announces which column (and
+// direction) the table is sorted by.
+function ariaSortFor(sortConfig, key) {
+  if (sortConfig.key !== key) return 'none'
+  return sortConfig.direction === 'asc' ? 'ascending' : 'descending'
+}
+
+function SortIcon({ col, sortConfig }) {
+  return (
+    <span className="ml-1 inline-block w-4">
+      {sortConfig.key === col ? (sortConfig.direction === 'asc' ? '↑' : '↓') : ''}
+    </span>
+  )
+}
+
+SortIcon.propTypes = {
+  col: PropTypes.string.isRequired,
+  sortConfig: PropTypes.shape({
+    key: PropTypes.string,
+    direction: PropTypes.string,
+  }).isRequired,
+}
+
+// Single definition shared by every sortable + filterable Roster table
+// column header (previously seven hand-duplicated <th> blocks that drifted
+// out of vertical alignment with each other, #715). The caller owns the
+// `triggerRef` for this column and must pass the SAME ref object to
+// `renderColumnFilterPanel` for that column -- the panel treats a mousedown
+// on that ref's element as "inside" rather than an outside click that should
+// close it, so two different ref objects would break close-on-outside-click.
+//
+// `align: 'right'` is only used by the Followers column. Both className
+// branches below are complete literal strings -- Tailwind v4 scans source
+// text for whole class-name tokens, so building either one via string
+// interpolation would generate no CSS and silently drop the alignment.
+export default function FilterableHeader({
+  sortKey,
+  label,
+  align = 'left',
+  sortConfig,
+  columnFilters,
+  openFilterKey,
+  onSort,
+  onToggleFilter,
+  triggerRef,
+  renderColumnFilterPanel,
+}) {
+  const thClassName =
+    align === 'right'
+      ? 'relative px-4 py-3 text-right text-white font-semibold whitespace-nowrap align-middle'
+      : 'relative px-4 py-3 text-left text-white font-semibold whitespace-nowrap align-middle'
+  const wrapperClassName = align === 'right' ? 'flex items-center justify-end gap-1' : 'flex items-center gap-1'
+
+  return (
+    <th aria-sort={ariaSortFor(sortConfig, sortKey)} className={thClassName}>
+      <div className={wrapperClassName}>
+        <button type="button" onClick={() => onSort(sortKey)} className="cursor-pointer hover:text-accent-400">
+          {label} <SortIcon col={sortKey} sortConfig={sortConfig} />
+        </button>
+        <FilterFunnel
+          label={label}
+          active={isColumnFiltered(columnFilters, sortKey)}
+          open={openFilterKey === sortKey}
+          panelId={`roster-filter-panel-${sortKey}`}
+          triggerRef={triggerRef}
+          onClick={() => onToggleFilter(sortKey)}
+        />
+      </div>
+      {renderColumnFilterPanel(sortKey, triggerRef)}
+    </th>
+  )
+}
+
+FilterableHeader.propTypes = {
+  sortKey: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  align: PropTypes.oneOf(['left', 'right']),
+  sortConfig: PropTypes.shape({
+    key: PropTypes.string,
+    direction: PropTypes.string,
+  }).isRequired,
+  columnFilters: PropTypes.object.isRequired,
+  openFilterKey: PropTypes.string,
+  onSort: PropTypes.func.isRequired,
+  onToggleFilter: PropTypes.func.isRequired,
+  triggerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
+  renderColumnFilterPanel: PropTypes.func.isRequired,
+}


### PR DESCRIPTION
## Summary

Two visual bugs on the admin Roster header, reported with a screenshot: column labels sitting on inconsistent vertical baselines ("Status", "Contact", "Followers" higher than the rest), and filter funnels that were effectively invisible until hovered.

Closes #715

## Root cause

The seven header cells were **hand-duplicated** — seven near-identical `<th>` blocks each with their own flex wrapper, sort button, `SortIcon`, `FilterFunnel` and panel call, plus seven parallel `useRef`s. Nothing enforced that they stayed identical, and none carried `whitespace-nowrap` or explicit vertical alignment, so narrow columns were free to reflow independently of wide ones.

This is the duplication the design audit flagged as #715, which I deferred as "pure refactor, nothing depends on it." That was wrong — it wasn't cosmetic debt, it was the mechanism by which cells drift apart.

## What changed

| File | Change |
|------|--------|
| `admin/components/FilterableHeader.jsx` | **New.** One definition used seven times — `aria-sort`, sort `<button>`, `SortIcon`, `FilterFunnel`, panel anchor, and left/right alignment via complete literal class strings. |
| `admin/RosterTab.jsx` | Seven `<th>` blocks and seven refs replaced by seven `<FilterableHeader>` uses and one keyed ref map. `whitespace-nowrap` + `align-middle` applied uniformly, including the non-filterable Actions cell. |
| `admin/components/FilterFunnel.jsx` | Resting state `text-white/50` → `text-white/70`, icon `size={14}` → `16`. |

Net **194 insertions / 194 deletions** — an extraction, not new surface.

## Security / correctness notes

None — presentational. No API, schema, or migration change. Sorting, filtering, funnel active state, panel open/close, `aria-sort` and keyboard operability are all preserved; the sort control remains a real `<button>`.

One implementation note: the ref map uses a `useMemo`'d plain object rather than the `useRef` + `??=` sketch, because the latter tripped both the ES2020 lint config and a `react-hooks` ref-safety rule. Same guarantee — one stable ref object per column, shared by that column's funnel and its panel, which is what keeps a click on the trigger from being read as an outside-click.

## Verification

- [x] `RosterTab.test.jsx` passes **unmodified** — 25/25. That's the proof the extraction is behaviour-preserving; it covers sort and filter per column.
- [x] Frontend suite: 831/831 · ESLint 0 errors · build clean
- [ ] **Visual check** — this is a rendering fix, so it needs an eye on the header before merge

## ⚠️ CI will be red for an unrelated reason

`make gate` exits 2 on this branch **and on unmodified `main`** — I verified by checking out `main` and running the suite directly: `functions/api/events/__tests__/timeline.test.js` fails 1/48.

It is not flaky and not caused by this PR. The fixture hardcodes `event_date: "2026-08-02"` — the real Vol. 17 date, i.e. today — with a band playing `20:00–21:00`, then asserts the event appears in `data.now`. The endpoint correctly reports an empty `now` before 20:00, so the assertion fails. It will pass between 20:00 and 21:00 tonight and fail permanently after.

The product is behaving correctly; the test hardcoded a real calendar date and leaned on the wall clock, so it changed meaning the moment that date arrived — leaving the timeline's `now` guard unreliable on the one day the timeline matters most. Tracked separately in #722.

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent sorting and filtering controls to roster table headers.
  * Improved accessibility with clearer sort states and keyboard-friendly header controls.
  * Enhanced filter controls with a more visible icon and inactive-state text.

* **Refactor**
  * Standardized roster table headers using shared sorting and filtering components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->