### PR TITLE
test(timeline): pin the clock in the now-classification test

### DIFF
--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -8,7 +8,7 @@
 import { describe, it, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { onRequestGet as timelineHandler } from "../timeline.js";
 import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
-import { eventLocalToday } from "../../../utils/eventDay.js";
+import { eventLocalToday, eventLocalClock } from "../../../utils/eventDay.js";
 
 // Returns the mock result set for a query string, keyed off the distinctive
 // WHERE clause for each period (now / upcoming / past). The "now" and "past"
@@ -333,10 +333,35 @@ describe("Timeline API - Optimized JOIN Queries", () => {
   });
 
   describe("reveal_mode gate - JOIN condition (not WHERE)", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it("hides unannounced bands when reveal_mode=1", async () => {
       // When the DB applies the JOIN gate, unannounced rows are NULL-expanded;
       // band_id will be null so groupEventData skips them. The mock here
       // simulates what the DB returns after the JOIN filter is applied.
+      //
+      // The fixture below hardcodes event_date: "2026-08-02" with a band
+      // playing 20:00-21:00. timeline.js's start-edge gate (#569) reads the
+      // REAL clock via eventLocalClock() and, on the event's own date, holds
+      // it out of "now" until the earliest of doors_json / first-set start —
+      // here, the 20:00 set start (no doors_json in this fixture). Once
+      // 2026-08-02 arrived, this test failed for every CI run before 20:00
+      // Toronto time and would only pass by coincidence between 20:00-21:00
+      // (#722). Pin the clock to an instant inside that window so the
+      // assertion is deterministic instead of dependent on when CI happens
+      // to run.
+      //
+      // 2026-08-03T00:30:00Z = 20:30 EDT on 2026-08-02 (America/Toronto is
+      // UTC-4 in August, i.e. DST/EDT) — squarely inside the 20:00-21:00 set,
+      // verified against eventLocalClock()'s actual Toronto conversion below.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-03T00:30:00Z"));
+      const pinnedClock = eventLocalClock();
+      expect(pinnedClock.date).toBe("2026-08-02");
+      expect(pinnedClock.time >= "20:00" && pinnedClock.time < "21:00").toBe(true);
+
       mockContext.env.DB = {
         prepare: () => ({
           bind: () => ({ query: "e.date = ?" }),

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -358,9 +358,11 @@ describe("Timeline API - Optimized JOIN Queries", () => {
       // verified against eventLocalClock()'s actual Toronto conversion below.
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-03T00:30:00Z"));
-      const pinnedClock = eventLocalClock();
-      expect(pinnedClock.date).toBe("2026-08-02");
-      expect(pinnedClock.time >= "20:00" && pinnedClock.time < "21:00").toBe(true);
+      // Assert the exact resolved clock rather than a range: eventLocalClock()
+      // is deterministic under a pinned system time, and a boolean range check
+      // collapses a wrong conversion into "expected true, got false" — which
+      // says nothing about what the clock actually resolved to.
+      expect(eventLocalClock()).toEqual({ date: "2026-08-02", time: "20:30" });
 
       mockContext.env.DB = {
         prepare: () => ({


### PR DESCRIPTION
## Summary

`functions/api/events/__tests__/timeline.test.js:385` is failing on `main`, which reddens **both** the "Test and build" and "Coverage" jobs on every open PR (they each run the backend suite, so one broken test fails two checks).

Test-only fix. No production code touched.

Refs #722

## Why it broke today

The fixture hardcodes `event_date: "2026-08-02"` — the real Vol. 17 date, i.e. **today** — with a band playing `20:00–21:00`, then asserts the event appears in `data.now`. CI ran at 17:19 UTC (13:19 Eastern). A 20:00 set is correctly not playing at 13:19, so the endpoint returns an empty `now` and the assertion fails: `expected [] to have a length of 1`.

**The endpoint is behaving correctly.** The test hardcoded a real calendar date and leaned on the wall clock, so it silently changed meaning the moment that date arrived. It would have passed between 20:00 and 21:00 tonight, then failed permanently.

The sharp end of that: it left the timeline's `now` guard unreliable on the one day the timeline actually matters.

## The fix

Pin the clock rather than weaken the assertion:

```js
vi.useFakeTimers()
vi.setSystemTime(new Date('2026-08-03T00:30:00Z')) // 20:30 EDT on 2026-08-02
```

`00:30Z` on Aug 3 is 20:30 EDT on Aug 2 — inside the set's window. The offset matters: this codebase classifies event days in **Toronto local time** via `eventLocalToday()` / `eventLocalClock()`, never UTC slicing (the #568 bug class, documented in `CLAUDE.md`). Real timers are restored afterwards so no other test inherits a frozen clock.

## Audit of the rest of the file

Every other time-sensitive test in the file was checked. **This was the only one not already pinned** — the file otherwise uses `vi.setSystemTime` in ~20 places and follows that convention consistently. This test was the lone exception, which is exactly why it was the only one to break when the date arrived.

## Verification

- [x] `make gate` exit **0**
- [x] Backend: 894 pass, 0 failures
- [x] Deterministic: file run twice, 48/48 both times
- [x] Diff is **1 file, +26/−1**, test-only — no production code
- [x] Confirmed the pre-fix failure reproduces on unmodified `main` (checked out and ran it directly), so this is not a regression from any open PR

## Merge order

Worth landing **before** #723 — that PR is red for exactly this reason and nothing else.

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved timeline test reliability by using a fixed event time.
  * Added validation for converted local dates and times in reveal-mode JOIN-gate scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->