### PR TITLE
fix(schedule): return genre from the schedule API; align fork buttons; centre card content

### DIFF
--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -3119,6 +3119,9 @@ components:
           type: integer
         name:
           type: string
+        genre:
+          type: string
+          nullable: true
         venue:
           type: string
         date:

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -3124,6 +3124,7 @@ components:
           nullable: true
         venue:
           type: string
+          nullable: true
         date:
           type: string
         startTime:

--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -83,7 +83,7 @@ function BandCard({
         </button>
       )}
 
-      <div className={`flex flex-col items-center gap-2 ${showToggleButton ? 'pr-10' : ''}`}>
+      <div className={`flex flex-col items-center gap-2 ${showToggleButton ? 'px-10' : ''}`}>
         {band.photo_url && (
           <img
             src={band.photo_url}

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -62,9 +62,9 @@ function ForkCard({ band1, band2, onToggleBand }) {
         <Split size={15} className="text-error-400 shrink-0" aria-hidden="true" />
         <span className="text-sm font-semibold text-text-primary">Fork in the road — same start time</span>
       </div>
-      <div className="grid grid-cols-2 divide-x divide-error-500/30 bg-error-500/10">
+      <div className="grid grid-cols-2 divide-x divide-error-500/30 bg-error-500/10 items-stretch">
         {sides.map(({ band, removeId }) => (
-          <div key={band.id} className="px-3 py-3 flex flex-col gap-1.5">
+          <div key={band.id} className="px-3 py-3 flex flex-col gap-1.5 h-full">
             <p className="font-bold text-text-primary text-sm leading-snug">{band.name}</p>
             {band.genre && (
               <span className="self-start text-xs px-2 py-0.5 rounded-full bg-surface border border-border text-text-secondary leading-normal">
@@ -76,7 +76,7 @@ function ForkCard({ band1, band2, onToggleBand }) {
             <button
               onClick={() => onToggleBand(removeId)}
               aria-label={`Keep ${band.name}, remove ${removeId === band2.id ? band2.name : band1.name}`}
-              className="mt-2 w-full py-2 text-xs font-semibold rounded-lg bg-accent-500/20 border border-accent-500/50 text-accent-400 hover:bg-accent-500/30 active:scale-95 transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500 min-h-[44px]"
+              className="mt-auto w-full py-2 text-xs font-semibold rounded-lg bg-accent-500/20 border border-accent-500/50 text-accent-400 hover:bg-accent-500/30 active:scale-95 transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent-500 min-h-[44px]"
             >
               Keep this one
             </button>

--- a/functions/api/__tests__/schedule-genre.test.js
+++ b/functions/api/__tests__/schedule-genre.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../test-utils";
+import * as scheduleHandler from "../schedule.js";
+
+// #725 added a genre chip to BandCard, but the fan-facing schedule endpoint
+// never selected or returned `genre`, so the chip never rendered in
+// production even though every band profile had one populated. Regression
+// coverage for the read path: genre must flow through /api/schedule.
+describe("GET /api/schedule - genre (#725)", () => {
+  it("returns genre for a band that has one", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-genre" });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    const venue = insertVenue(rawDb, { name: "Blue Room" });
+    insertBand(rawDb, { name: "Genre Band", event_id: ev.id, venue_id: venue.id, genre: "Indie Rock" });
+
+    const req = new Request("https://example.test/api/schedule?event=vol17-genre");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.bands.length).toBe(1);
+    expect(data.bands[0].genre).toBe("Indie Rock");
+  });
+
+  it("returns null genre when the band profile has none", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-no-genre" });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    insertBand(rawDb, { name: "No Genre Band", event_id: ev.id, venue_id: venue.id });
+
+    const req = new Request("https://example.test/api/schedule?event=vol17-no-genre");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.bands.length).toBe(1);
+    expect(data.bands[0].genre).toBeNull();
+  });
+});

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -79,6 +79,7 @@ export async function onRequestGet(context) {
         p.notes,
         b.social_links,
         b.photo_url,
+        b.genre,
         v.name as venue,
         v.latitude as venue_lat,
         v.longitude as venue_lng
@@ -136,6 +137,7 @@ export async function onRequestGet(context) {
         performance_id: band.performance_id,
         band_profile_id: band.band_id,
         name: band.name,
+        genre: band.genre || null,
         photo_url: band.photo_url ?? null,
         venue: band.venue ?? null,
         venue_lat: typeof band.venue_lat === "number" ? band.venue_lat : null,


### PR DESCRIPTION
## Summary

Three same-day fixes from live production screenshots, doors 18:30 tonight. Small and low-risk: **+50 / −4** across 5 files.

## 1. Genre never reached the fan schedule — the actual bug

#725 added the genre chip to `BandCard.jsx:123` and it was correct. It just never rendered, because `band.genre` was always `undefined` in production.

**Root cause: wrong endpoint.** I verified `functions/api/events/timeline.js` returns `genre` and assumed that fed the schedule. It doesn't — the fan schedule is served by **`functions/api/schedule.js`**, whose band query never selected `genre` and whose response mapper never included it.

- `schedule.js:82` — added `b.genre,` to the SELECT
- `schedule.js:140` — added `genre: band.genre || null,` to the formatted band

`prepareBands()` already spreads `...band`, so it flows straight through to the card. All 22 acts have a genre populated, so this renders on every card tonight.

Covered by a new test (`functions/api/__tests__/schedule-genre.test.js`) asserting `genre` survives into the formatted response — the gap that let a UI-only change look complete.

## 2. "Keep this one" buttons misaligned in the fork card

When one side's venue wraps to two lines ("Blue Room (Inside Revive Karaoke)") and the other doesn't, the two buttons landed at different heights.

`MySchedule.jsx` — the grid row now stretches its children (`items-stretch`), each column fills its height (`h-full`), and the button is pushed to the bottom (`mt-auto`). Both buttons now sit on a common baseline regardless of how the venue name wraps.

## 3. Performer card content sat left of centre

The `×` button was already absolutely positioned, so it wasn't stealing width. The real cause was the content wrapper reserving space **asymmetrically** — `pr-10` on the right only — which shifted the `items-center` axis ~20px left.

`BandCard.jsx:86` — `pr-10` → `px-10`. Symmetric reservation, content centres against the true card width. The `×` keeps its 44px target, `aria-label`, focus order and `onAmber` variants.

## Security / correctness notes

- `schedule.js` adds one column to an existing SELECT and one field to the response. No new query, no new table, no auth or filtering change. `genre` is already public on every other surface (band profiles, timeline, admin roster).
- No schema or migration change.
- The card interaction-model restructure (#726) is deliberately **not** in scope tonight.

## Verification

- [x] Backend: 896 pass + 2 new genre tests
- [x] Frontend: 845 pass
- [x] `make gate` exit 0 · ESLint 0 errors · build clean
- [x] `validate:openapi` clean
- [ ] Visual confirmation on a phone — the point of the exercise

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule data now includes each band’s genre when available, with a null value when no genre is configured.
  * API documentation now reflects the optional genre field and nullable venue values.

* **Bug Fixes**
  * Improved spacing within band cards when toggle controls are displayed.
  * Updated schedule conflict choices so both options have equal height and consistently aligned action buttons.

* **Tests**
  * Added coverage to verify genre information is returned correctly for scheduled bands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->