### PR TITLE
fix(share): show set times and venues on shared routes; fix after-midnight order

### DIFF
--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -17,10 +17,27 @@ import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from '../utils/festivalDays'
 /** Sentinel for an unresolvable date — sorts last, and never counts as a festival day. */
 const UNKNOWN_DAY = Number.MAX_SAFE_INTEGER
 
+/**
+ * Parse an `HH:MM` clock value, rejecting anything out of range.
+ * A NaN check alone is not enough: "25:99" parses to two perfectly good
+ * numbers and would sort as 1599 minutes and render as "1:99 PM".
+ * Shared by the sort and the formatter so they can never disagree on what
+ * counts as a valid time.
+ */
+function parseTime(value) {
+  if (typeof value !== 'string') return null
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value)
+  if (!match) return null
+  const hour = Number(match[1])
+  const minute = Number(match[2])
+  if (hour > 23 || minute > 59) return null
+  return { hour, minute }
+}
+
 function sortKey(band) {
-  if (!band.start_time) return { day: UNKNOWN_DAY, minutes: Number.MAX_SAFE_INTEGER }
-  const [h, m] = band.start_time.split(':').map(Number)
-  if (Number.isNaN(h) || Number.isNaN(m)) return { day: UNKNOWN_DAY, minutes: Number.MAX_SAFE_INTEGER }
+  const time = parseTime(band.start_time)
+  if (!time) return { day: UNKNOWN_DAY, minutes: Number.MAX_SAFE_INTEGER }
+  const { hour: h, minute: m } = time
 
   const afterMidnight = h < AFTER_MIDNIGHT_THRESHOLD_HOUR
   const minutes = h * 60 + m + (afterMidnight ? 24 * 60 : 0)
@@ -58,14 +75,17 @@ function festivalDayLabel(band) {
 }
 
 function formatSetTime(band) {
-  if (!band.start_time) return null
-  const to12h = t => {
-    const [h, m] = t.split(':').map(Number)
-    const period = h >= 12 ? 'PM' : 'AM'
-    const hour = h % 12 === 0 ? 12 : h % 12
-    return `${hour}:${String(m).padStart(2, '0')} ${period}`
+  const start = parseTime(band.start_time)
+  if (!start) return null
+  // A bad end_time drops the range rather than rendering "8:00 PM – NaN:NaN AM";
+  // the start on its own is still useful to a fan.
+  const end = parseTime(band.end_time)
+  const to12h = ({ hour, minute }) => {
+    const period = hour >= 12 ? 'PM' : 'AM'
+    const h12 = hour % 12 === 0 ? 12 : hour % 12
+    return `${h12}:${String(minute).padStart(2, '0')} ${period}`
   }
-  return band.end_time ? `${to12h(band.start_time)} – ${to12h(band.end_time)}` : to12h(band.start_time)
+  return end ? `${to12h(start)} – ${to12h(end)}` : to12h(start)
 }
 
 export default function SharePreviewPage() {

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -5,6 +5,33 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import LockInLineupPanel from '../components/LockInLineupPanel'
 import { Alert, BandCardSkeleton } from '../components/ui'
 import { fetchPublicJson } from '../utils/publicApi'
+import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from '../utils/festivalDays'
+
+/**
+ * Sort key in minutes, applying the festival-day convention: a set starting
+ * before AFTER_MIDNIGHT_THRESHOLD_HOUR belongs to the PREVIOUS evening and must
+ * sort after the whole evening lineup, not at the top of it. Without this,
+ * Cross Dog (00:15) and Dregs (01:10) lead the shared route.
+ * The threshold has one canonical home (utils/festivalDays.js) — never re-encode it.
+ */
+function sortKey(band) {
+  if (!band.start_time) return Number.MAX_SAFE_INTEGER
+  const [h, m] = band.start_time.split(':').map(Number)
+  if (Number.isNaN(h) || Number.isNaN(m)) return Number.MAX_SAFE_INTEGER
+  const minutes = h * 60 + m
+  return h < AFTER_MIDNIGHT_THRESHOLD_HOUR ? minutes + 24 * 60 : minutes
+}
+
+function formatSetTime(band) {
+  if (!band.start_time) return null
+  const to12h = t => {
+    const [h, m] = t.split(':').map(Number)
+    const period = h >= 12 ? 'PM' : 'AM'
+    const hour = h % 12 === 0 ? 12 : h % 12
+    return `${hour}:${String(m).padStart(2, '0')} ${period}`
+  }
+  return band.end_time ? `${to12h(band.start_time)} – ${to12h(band.end_time)}` : to12h(band.start_time)
+}
 
 export default function SharePreviewPage() {
   const { slug } = useParams()
@@ -124,9 +151,19 @@ export default function SharePreviewPage() {
         </div>
 
         <ul aria-label="Bands in this route" className="mb-8 list-none space-y-3 p-0">
-          {shareData.band_names.map((name, i) => (
-            <li key={i} className="rounded-xl border border-border bg-surface px-4 py-3">
-              <p className="font-semibold text-text-primary">{name}</p>
+          {(shareData.bands?.length
+            ? [...shareData.bands].sort((a, b) => sortKey(a) - sortKey(b))
+            : shareData.band_names.map(name => ({ name }))
+          ).map((band, i) => (
+            <li key={band.performance_id ?? i} className="rounded-xl border border-border bg-surface px-4 py-3">
+              <p className="font-semibold text-text-primary">{band.name}</p>
+              {(formatSetTime(band) || band.venue) && (
+                <p className="mt-1 text-sm text-text-secondary">
+                  {formatSetTime(band)}
+                  {formatSetTime(band) && band.venue ? ' · ' : ''}
+                  {band.venue}
+                </p>
+              )}
             </li>
           ))}
         </ul>
@@ -134,7 +171,7 @@ export default function SharePreviewPage() {
         <button
           type="button"
           onClick={handleImport}
-          className="w-full min-h-[48px] rounded-xl bg-accent-500 px-6 py-3 font-semibold text-bg-navy transition-colors hover:brightness-110"
+          className="mb-6 w-full min-h-[48px] rounded-xl bg-accent-500 px-6 py-3 font-semibold text-bg-navy transition-colors hover:brightness-110"
         >
           Add {shareData.band_names.length} stop{shareData.band_names.length !== 1 ? 's' : ''} to my route for{' '}
           {shareData.event_name}

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -7,13 +7,6 @@ import { Alert, BandCardSkeleton } from '../components/ui'
 import { fetchPublicJson } from '../utils/publicApi'
 import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from '../utils/festivalDays'
 
-/**
- * Sort key in minutes, applying the festival-day convention: a set starting
- * before AFTER_MIDNIGHT_THRESHOLD_HOUR belongs to the PREVIOUS evening and must
- * sort after the whole evening lineup, not at the top of it. Without this,
- * Cross Dog (00:15) and Dregs (01:10) lead the shared route.
- * The threshold has one canonical home (utils/festivalDays.js) — never re-encode it.
- */
 /** Sentinel for an unresolvable date — sorts last, and never counts as a festival day. */
 const UNKNOWN_DAY = Number.MAX_SAFE_INTEGER
 
@@ -34,6 +27,14 @@ function parseTime(value) {
   return { hour, minute }
 }
 
+/**
+ * Sort key applying the festival-day convention: a set starting before
+ * AFTER_MIDNIGHT_THRESHOLD_HOUR belongs to the PREVIOUS evening and must sort
+ * after the whole evening lineup, not at the top of it. Without this,
+ * Cross Dog (00:15) and Dregs (01:10) lead the shared route.
+ * The threshold has one canonical home (utils/festivalDays.js) — never re-encode it.
+ * Returns `{ day, minutes }`; compare with compareBands, not by subtraction.
+ */
 function sortKey(band) {
   const time = parseTime(band.start_time)
   if (!time) return { day: UNKNOWN_DAY, minutes: Number.MAX_SAFE_INTEGER }

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -14,12 +14,13 @@ import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from '../utils/festivalDays'
  * Cross Dog (00:15) and Dregs (01:10) lead the shared route.
  * The threshold has one canonical home (utils/festivalDays.js) — never re-encode it.
  */
-const DAY_MS = 24 * 60 * 60 * 1000
+/** Sentinel for an unresolvable date — sorts last, and never counts as a festival day. */
+const UNKNOWN_DAY = Number.MAX_SAFE_INTEGER
 
 function sortKey(band) {
-  if (!band.start_time) return { day: Number.MAX_SAFE_INTEGER, minutes: Number.MAX_SAFE_INTEGER }
+  if (!band.start_time) return { day: UNKNOWN_DAY, minutes: Number.MAX_SAFE_INTEGER }
   const [h, m] = band.start_time.split(':').map(Number)
-  if (Number.isNaN(h) || Number.isNaN(m)) return { day: Number.MAX_SAFE_INTEGER, minutes: Number.MAX_SAFE_INTEGER }
+  if (Number.isNaN(h) || Number.isNaN(m)) return { day: UNKNOWN_DAY, minutes: Number.MAX_SAFE_INTEGER }
 
   const afterMidnight = h < AFTER_MIDNIGHT_THRESHOLD_HOUR
   const minutes = h * 60 + m + (afterMidnight ? 24 * 60 : 0)
@@ -28,9 +29,19 @@ function sortKey(band) {
   // is one calendar day earlier. Sorting on the raw date would split an evening
   // across two groups on a multi-day event; sorting on clock time alone (the
   // previous version) would interleave days that share a start time.
-  let day = band.performance_date ? Date.parse(`${band.performance_date}T00:00:00`) : NaN
-  if (!Number.isNaN(day) && afterMidnight) day -= DAY_MS
-  return { day: Number.isNaN(day) ? Number.MAX_SAFE_INTEGER : day, minutes }
+  //
+  // Step back a CALENDAR day, not a fixed 24h: on a DST boundary a local day is
+  // 23 or 25 hours long, so subtracting 86_400_000ms lands on the wrong date.
+  // setDate() goes through the calendar and stays correct across the transition.
+  let day = UNKNOWN_DAY
+  if (band.performance_date) {
+    const parsed = new Date(`${band.performance_date}T00:00:00`)
+    if (!Number.isNaN(parsed.getTime())) {
+      if (afterMidnight) parsed.setDate(parsed.getDate() - 1)
+      day = parsed.getTime()
+    }
+  }
+  return { day, minutes }
 }
 
 function compareBands(a, b) {
@@ -42,7 +53,7 @@ function compareBands(a, b) {
 /** Festival day label, shown only when a route spans more than one. */
 function festivalDayLabel(band) {
   const key = sortKey(band).day
-  if (key === Number.MAX_SAFE_INTEGER) return null
+  if (key === UNKNOWN_DAY) return null
   return new Date(key).toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' })
 }
 
@@ -185,7 +196,11 @@ export default function SharePreviewPage() {
                 (() => {
                   // Only surface the day on a multi-day route — on a single-night
                   // crawl it is noise on every row.
-                  const multiDay = new Set(list.map(b => sortKey(b).day)).size > 1
+                  // Count only KNOWN days. A band deleted since sharing has a
+                  // null performance_date, and letting that sentinel count would
+                  // stamp a date on every row of a single-night route.
+                  const knownDays = new Set(list.map(b => sortKey(b).day).filter(d => d !== UNKNOWN_DAY))
+                  const multiDay = knownDays.size > 1
                   const dayLabel = multiDay ? festivalDayLabel(band) : null
                   const parts = [dayLabel, formatSetTime(band), band.venue].filter(Boolean)
                   return <p className="mt-1 text-sm text-text-secondary">{parts.join(' · ')}</p>

--- a/frontend/src/pages/SharePreviewPage.jsx
+++ b/frontend/src/pages/SharePreviewPage.jsx
@@ -14,12 +14,36 @@ import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from '../utils/festivalDays'
  * Cross Dog (00:15) and Dregs (01:10) lead the shared route.
  * The threshold has one canonical home (utils/festivalDays.js) — never re-encode it.
  */
+const DAY_MS = 24 * 60 * 60 * 1000
+
 function sortKey(band) {
-  if (!band.start_time) return Number.MAX_SAFE_INTEGER
+  if (!band.start_time) return { day: Number.MAX_SAFE_INTEGER, minutes: Number.MAX_SAFE_INTEGER }
   const [h, m] = band.start_time.split(':').map(Number)
-  if (Number.isNaN(h) || Number.isNaN(m)) return Number.MAX_SAFE_INTEGER
-  const minutes = h * 60 + m
-  return h < AFTER_MIDNIGHT_THRESHOLD_HOUR ? minutes + 24 * 60 : minutes
+  if (Number.isNaN(h) || Number.isNaN(m)) return { day: Number.MAX_SAFE_INTEGER, minutes: Number.MAX_SAFE_INTEGER }
+
+  const afterMidnight = h < AFTER_MIDNIGHT_THRESHOLD_HOUR
+  const minutes = h * 60 + m + (afterMidnight ? 24 * 60 : 0)
+
+  // A 00:15 set stored on Aug 3 belongs to Aug 2's evening, so its FESTIVAL day
+  // is one calendar day earlier. Sorting on the raw date would split an evening
+  // across two groups on a multi-day event; sorting on clock time alone (the
+  // previous version) would interleave days that share a start time.
+  let day = band.performance_date ? Date.parse(`${band.performance_date}T00:00:00`) : NaN
+  if (!Number.isNaN(day) && afterMidnight) day -= DAY_MS
+  return { day: Number.isNaN(day) ? Number.MAX_SAFE_INTEGER : day, minutes }
+}
+
+function compareBands(a, b) {
+  const ka = sortKey(a)
+  const kb = sortKey(b)
+  return ka.day - kb.day || ka.minutes - kb.minutes
+}
+
+/** Festival day label, shown only when a route spans more than one. */
+function festivalDayLabel(band) {
+  const key = sortKey(band).day
+  if (key === Number.MAX_SAFE_INTEGER) return null
+  return new Date(key).toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' })
 }
 
 function formatSetTime(band) {
@@ -152,18 +176,20 @@ export default function SharePreviewPage() {
 
         <ul aria-label="Bands in this route" className="mb-8 list-none space-y-3 p-0">
           {(shareData.bands?.length
-            ? [...shareData.bands].sort((a, b) => sortKey(a) - sortKey(b))
+            ? [...shareData.bands].sort(compareBands)
             : shareData.band_names.map(name => ({ name }))
-          ).map((band, i) => (
+          ).map((band, i, list) => (
             <li key={band.performance_id ?? i} className="rounded-xl border border-border bg-surface px-4 py-3">
               <p className="font-semibold text-text-primary">{band.name}</p>
-              {(formatSetTime(band) || band.venue) && (
-                <p className="mt-1 text-sm text-text-secondary">
-                  {formatSetTime(band)}
-                  {formatSetTime(band) && band.venue ? ' · ' : ''}
-                  {band.venue}
-                </p>
-              )}
+              {(formatSetTime(band) || band.venue) &&
+                (() => {
+                  // Only surface the day on a multi-day route — on a single-night
+                  // crawl it is noise on every row.
+                  const multiDay = new Set(list.map(b => sortKey(b).day)).size > 1
+                  const dayLabel = multiDay ? festivalDayLabel(band) : null
+                  const parts = [dayLabel, formatSetTime(band), band.venue].filter(Boolean)
+                  return <p className="mt-1 text-sm text-text-secondary">{parts.join(' · ')}</p>
+                })()}
             </li>
           ))}
         </ul>

--- a/functions/api/schedule/__tests__/share-get-bands.test.js
+++ b/functions/api/schedule/__tests__/share-get-bands.test.js
@@ -47,6 +47,10 @@ describe("GET /api/schedule/share/[slug] — bands detail", () => {
       end_time: "20:30",
       venue: "Blue Room",
     });
+    // performance_date drives the preview's festival-day sort on multi-day
+    // events, so it has to be asserted, not just present in the shape.
+    expect(body.bands[0]).toHaveProperty("performance_date");
+    expect(body.bands[0].performance_date).toBe(perf.performance_date ?? null);
   });
 
   test("keeps performance_ids and band_names unchanged so the ?import=1 apply flow still works", async () => {

--- a/functions/api/schedule/__tests__/share-get-bands.test.js
+++ b/functions/api/schedule/__tests__/share-get-bands.test.js
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "vitest";
+import { onRequestGet } from "../share/[slug].js";
+import { createTestEnv, insertEvent, insertVenue, insertBand, insertShareLink } from "../../test-utils.js";
+
+// Coverage for the additive `bands` field on the share snapshot (times, venues,
+// and the deleted-performance fallback). The pre-existing suite only asserted
+// `performance_ids` / `band_names`, so a regression here would silently strip
+// set times back out of every shared route.
+describe("GET /api/schedule/share/[slug] — bands detail", () => {
+  const makeRequest = (slug) => new Request(`https://example.test/api/schedule/share/${slug}`);
+
+  function seed() {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Vol. 17", slug: "vol17" });
+    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    const venue = insertVenue(rawDb, { name: "Blue Room" });
+    return { env, rawDb, event, venue };
+  }
+
+  test("returns set times and venue for each shared performance", async () => {
+    const { env, rawDb, event, venue } = seed();
+    const perf = insertBand(rawDb, {
+      name: "Mixed Feelings",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "20:30",
+    });
+
+    insertShareLink(rawDb, {
+      slug: "abc12345",
+      event_id: event.id,
+      event_slug: "vol17",
+      performance_ids: [perf.id],
+      band_names: ["Mixed Feelings"],
+    });
+
+    const res = await onRequestGet({ request: makeRequest("abc12345"), params: { slug: "abc12345" }, env });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.bands).toHaveLength(1);
+    expect(body.bands[0]).toMatchObject({
+      performance_id: perf.id,
+      name: "Mixed Feelings",
+      start_time: "20:00",
+      end_time: "20:30",
+      venue: "Blue Room",
+    });
+  });
+
+  test("keeps performance_ids and band_names unchanged so the ?import=1 apply flow still works", async () => {
+    const { env, rawDb, event, venue } = seed();
+    const perf = insertBand(rawDb, {
+      name: "Suplex",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "23:40",
+      end_time: "00:10",
+    });
+
+    insertShareLink(rawDb, {
+      slug: "keepshape",
+      event_id: event.id,
+      event_slug: "vol17",
+      performance_ids: [perf.id],
+      band_names: ["Suplex"],
+    });
+
+    const res = await onRequestGet({ request: makeRequest("keepshape"), params: { slug: "keepshape" }, env });
+    const body = await res.json();
+
+    // App.jsx re-fetches this endpoint with ?import=1 and reads exactly these
+    // two fields to apply a shared route. They must survive the `bands` addition.
+    expect(body.performance_ids).toEqual([perf.id]);
+    expect(body.band_names).toEqual(["Suplex"]);
+  });
+
+  test("falls back to the stored name when a performance was deleted after sharing", async () => {
+    const { env, rawDb, event, venue } = seed();
+    const kept = insertBand(rawDb, {
+      name: "Kept Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "21:00",
+      end_time: "21:30",
+    });
+    const removed = insertBand(rawDb, {
+      name: "Removed Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "22:00",
+      end_time: "22:30",
+    });
+
+    insertShareLink(rawDb, {
+      slug: "deleted01",
+      event_id: event.id,
+      event_slug: "vol17",
+      performance_ids: [kept.id, removed.id],
+      band_names: ["Kept Band", "Removed Band"],
+    });
+
+    // Simulate the band being pulled from the lineup after the link was shared.
+    rawDb.prepare("DELETE FROM performances WHERE id = ?").run(removed.id);
+
+    const res = await onRequestGet({ request: makeRequest("deleted01"), params: { slug: "deleted01" }, env });
+    const body = await res.json();
+
+    // Dropping it would make the list disagree with the "N-stop route" heading
+    // and the "Add N stops" button, both of which count band_names.
+    expect(body.bands).toHaveLength(2);
+    expect(body.bands[1]).toMatchObject({
+      performance_id: removed.id,
+      name: "Removed Band",
+      start_time: null,
+      venue: null,
+    });
+    expect(body.bands[0].start_time).toBe("21:00");
+  });
+});

--- a/functions/api/schedule/share/[slug].js
+++ b/functions/api/schedule/share/[slug].js
@@ -56,12 +56,61 @@ export async function onRequestGet(context) {
       return json({ error: "Share link data is corrupted" }, 500);
     }
 
+    // Resolve set times and venues for the shared performances. `performance_ids`
+    // is the snapshot taken when the link was created, so everything the preview
+    // needs is recoverable without storing it twice.
+    //
+    // `performance_ids` and `band_names` are deliberately returned unchanged:
+    // App.jsx re-fetches this endpoint with `?import=1` to APPLY a shared route
+    // and reads those two fields. `bands` is purely additive.
+    let bands = band_names.map((name, i) => ({
+      performance_id: performance_ids[i] ?? null,
+      name,
+      start_time: null,
+      end_time: null,
+      venue: null,
+      performance_date: null,
+    }));
+
+    if (performance_ids.length > 0) {
+      // Bind ids as placeholders — never interpolate them into SQL. The array is
+      // length-capped on the write path (MAX_PERFORMANCE_IDS in ../share.js).
+      const placeholders = performance_ids.map(() => "?").join(",");
+      const detail = await DB.prepare(
+        `SELECT p.id AS performance_id, bp.name AS name, p.start_time, p.end_time,
+                p.performance_date, v.name AS venue
+         FROM performances p
+         JOIN band_profiles bp ON bp.id = p.band_profile_id
+         LEFT JOIN venues v ON v.id = p.venue_id
+         WHERE p.id IN (${placeholders})`,
+      )
+        .bind(...performance_ids)
+        .all();
+
+      const byId = new Map((detail.results || []).map((r) => [r.performance_id, r]));
+      // Fall back to the stored name when a performance has been removed from the
+      // lineup since the link was shared — dropping it would make the list
+      // disagree with the "N-stop route" count the page renders.
+      bands = performance_ids.map((id, i) => {
+        const found = byId.get(id);
+        return {
+          performance_id: id,
+          name: found?.name ?? band_names[i] ?? "Unknown artist",
+          start_time: found?.start_time ?? null,
+          end_time: found?.end_time ?? null,
+          venue: found?.venue ?? null,
+          performance_date: found?.performance_date ?? null,
+        };
+      });
+    }
+
     return json({
       slug: row.slug,
       event_slug: row.event_slug,
       event_name: row.event_name,
       performance_ids,
       band_names,
+      bands,
     });
   } catch (err) {
     console.error("Share link fetch error:", err);


### PR DESCRIPTION
Reported live during Vol. 17 — fans are sharing routes right now and recipients see only names.

## What was wrong

`GET /api/schedule/share/:slug` returned only `performance_ids[]` and `band_names[]`, so `SharePreviewPage` rendered a bare name list: no set time, no venue. Unusable for someone deciding where to meet you.

The screenshot also exposed a second bug: **Cross Dog (00:15) and Dregs (01:10) were listed first.** Those are after-midnight sets belonging to the previous evening — they should sort last.

## Fix

`share_links` already stores `performance_ids`, so times and venues are recoverable with a join. **No schema change.**

- **Endpoint** — additive `bands` field with name, start/end time, venue, date. Ids bound as `?` placeholders, never interpolated; the array is already length-capped on the write path.
- **Backwards compatible by design** — `performance_ids` and `band_names` are returned unchanged, because `App.jsx` re-fetches this same endpoint with `?import=1` to *apply* a shared route and reads exactly those two fields. Breaking them would break importing.
- **Deleted performances** fall back to the stored name instead of disappearing, so the list keeps agreeing with the "N-stop route" heading and the "Add N stops" button.
- **Ordering** uses the festival-day convention, importing `AFTER_MIDNIGHT_THRESHOLD_HOUR` from `utils/festivalDays.js` rather than re-encoding `6` — this is the recurring bug class documented in `CLAUDE.md`, and a plain `ORDER BY start_time` is precisely the wrong fix.
- **Spacing** between the Add-stops button and the Lock-in panel.

## Verification

- [x] `make gate` exit 0 — backend 896, frontend 845, lint 0 errors, build clean
- [ ] Visual check on a real shared link

Follow-up filed as #730 (compare/merge a friend's route against your own).

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared festival schedules now display band names, performance times, dates, and venues when available.
  * Performances are ordered by festival day and adjusted start time.
  * Shared links provide the latest performance details while retaining fallback names for removed performances.

* **Improvements**
  * Legacy shared links containing name-only band data remain supported.
  * Added spacing below the import button for improved page layout.
  * Set times now use a consistent 12-hour format and handle invalid values gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->