### PR TITLE
fix(band-profile): multi-day sets show the event's start date; per-set notes never rendered

### DIFF
--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -741,13 +741,13 @@ export default function BandProfilePage() {
                   </h2>
                 </div>
                 <div className="space-y-4">
-                  {profile.upcoming.map((performance, idx) => {
+                  {profile.upcoming.map(performance => {
                     // Computed once: the guard and the rendered value must be
                     // the same expression, or an unparseable date passes the
                     // guard and renders a calendar icon with no label.
                     const dayLabel = formatPerformanceDayLabel(performance)
                     return (
-                      <Card key={idx} variant="outline" hoverable className="p-4">
+                      <Card key={performance.id} variant="outline" hoverable className="p-4">
                         <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                           <div className="flex-1">
                             <h3 className="text-xl font-semibold text-accent-500 mb-2">
@@ -833,13 +833,13 @@ export default function BandProfilePage() {
                   </h2>
                 </div>
                 <div className="space-y-4">
-                  {profile.past.map((performance, idx) => {
+                  {profile.past.map(performance => {
                     // Computed once: the guard and the rendered value must be
                     // the same expression, or an unparseable date passes the
                     // guard and renders a calendar icon with no label.
                     const dayLabel = formatPerformanceDayLabel(performance)
                     return (
-                      <Card key={idx} variant="outline" hoverable className="p-4">
+                      <Card key={performance.id} variant="outline" hoverable className="p-4">
                         <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                           <div className="flex-1">
                             <div className="flex items-center gap-2 mb-2 flex-wrap">

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -22,7 +22,7 @@ import { Alert, Badge, Button, Card, BandProfileSkeleton } from '../components/u
 import { trackArtistView, trackPageView, trackSocialClick } from '../utils/metrics'
 import { fetchPublicJson } from '../utils/publicApi'
 import { getSelectedBands, saveSelectedBands, hasAnySchedule, getScheduleEventSlug } from '../utils/scheduleStorage'
-import { formatTimeRange, parseLocalDate } from '../utils/timeFormat'
+import { formatPerformanceDayLabel, formatTimeRange } from '../utils/timeFormat'
 import { safeExternalHref, safeInstagramHref } from '../utils/urlSafety'
 import { useTurnstile } from '../hooks/useTurnstile'
 
@@ -758,16 +758,10 @@ export default function BandProfilePage() {
                             )}
                           </h3>
                           <div className="flex flex-wrap gap-3 text-sm text-text-secondary">
-                            {performance.event_date && (
+                            {(performance.performance_date || performance.event_date) && (
                               <span className="flex items-center gap-2">
                                 <CalendarDays size={14} className="text-accent-500" />
-                                {(
-                                  parseLocalDate(performance.event_date) || new Date(performance.event_date)
-                                ).toLocaleDateString('en-US', {
-                                  year: 'numeric',
-                                  month: 'long',
-                                  day: 'numeric',
-                                })}
+                                {formatPerformanceDayLabel(performance)}
                               </span>
                             )}
                             {performance.venue_name && (
@@ -792,6 +786,9 @@ export default function BandProfilePage() {
                               </span>
                             )}
                           </div>
+                          {performance.notes && (
+                            <p className="mt-2 text-sm italic text-text-tertiary">{performance.notes}</p>
+                          )}
                         </div>
                         <div className="flex flex-col gap-2">
                           <Button
@@ -855,16 +852,10 @@ export default function BandProfilePage() {
                             )}
                           </div>
                           <div className="flex flex-wrap gap-3 text-sm text-text-secondary">
-                            {performance.event_date && (
+                            {(performance.performance_date || performance.event_date) && (
                               <span className="flex items-center gap-2">
                                 <CalendarDays size={14} className="text-text-tertiary" />
-                                {(
-                                  parseLocalDate(performance.event_date) || new Date(performance.event_date)
-                                ).toLocaleDateString('en-US', {
-                                  year: 'numeric',
-                                  month: 'long',
-                                  day: 'numeric',
-                                })}
+                                {formatPerformanceDayLabel(performance)}
                               </span>
                             )}
                             {performance.venue_name && (
@@ -889,6 +880,9 @@ export default function BandProfilePage() {
                               </span>
                             )}
                           </div>
+                          {performance.notes && (
+                            <p className="mt-2 text-sm italic text-text-tertiary">{performance.notes}</p>
+                          )}
                         </div>
                         {performance.event_slug && (
                           <Button as={Link} to={`/event/${performance.event_slug}`} variant="secondary" size="sm">

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -741,73 +741,79 @@ export default function BandProfilePage() {
                   </h2>
                 </div>
                 <div className="space-y-4">
-                  {profile.upcoming.map((performance, idx) => (
-                    <Card key={idx} variant="outline" hoverable className="p-4">
-                      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                        <div className="flex-1">
-                          <h3 className="text-xl font-semibold text-accent-500 mb-2">
-                            {performance.event_slug ? (
-                              <Link
-                                to={`/event/${performance.event_slug}`}
-                                className="transition-colors hover:text-accent-400 hover:underline"
-                              >
-                                {performance.event_name}
-                              </Link>
-                            ) : (
-                              performance.event_name
-                            )}
-                          </h3>
-                          <div className="flex flex-wrap gap-3 text-sm text-text-secondary">
-                            {formatPerformanceDayLabel(performance) && (
-                              <span className="flex items-center gap-2">
-                                <CalendarDays size={14} className="text-accent-500" />
-                                {formatPerformanceDayLabel(performance)}
-                              </span>
-                            )}
-                            {performance.venue_name && (
-                              <span className="flex items-center gap-2">
-                                <MapPin size={14} className="text-accent-500" />
-                                {performance.venue_id ? (
-                                  <Link
-                                    to={`/venue/${performance.venue_id}`}
-                                    className="transition-colors hover:text-accent-400 hover:underline"
-                                  >
-                                    {performance.venue_name}
-                                  </Link>
-                                ) : (
-                                  performance.venue_name
-                                )}
-                              </span>
-                            )}
-                            {performance.start_time && performance.end_time && (
-                              <span className="flex items-center gap-2">
-                                <Clock size={14} className="text-accent-500" />
-                                {formatTimeRange(performance.start_time, performance.end_time)}
-                              </span>
+                  {profile.upcoming.map((performance, idx) => {
+                    // Computed once: the guard and the rendered value must be
+                    // the same expression, or an unparseable date passes the
+                    // guard and renders a calendar icon with no label.
+                    const dayLabel = formatPerformanceDayLabel(performance)
+                    return (
+                      <Card key={idx} variant="outline" hoverable className="p-4">
+                        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                          <div className="flex-1">
+                            <h3 className="text-xl font-semibold text-accent-500 mb-2">
+                              {performance.event_slug ? (
+                                <Link
+                                  to={`/event/${performance.event_slug}`}
+                                  className="transition-colors hover:text-accent-400 hover:underline"
+                                >
+                                  {performance.event_name}
+                                </Link>
+                              ) : (
+                                performance.event_name
+                              )}
+                            </h3>
+                            <div className="flex flex-wrap gap-3 text-sm text-text-secondary">
+                              {dayLabel && (
+                                <span className="flex items-center gap-2">
+                                  <CalendarDays size={14} className="text-accent-500" />
+                                  {dayLabel}
+                                </span>
+                              )}
+                              {performance.venue_name && (
+                                <span className="flex items-center gap-2">
+                                  <MapPin size={14} className="text-accent-500" />
+                                  {performance.venue_id ? (
+                                    <Link
+                                      to={`/venue/${performance.venue_id}`}
+                                      className="transition-colors hover:text-accent-400 hover:underline"
+                                    >
+                                      {performance.venue_name}
+                                    </Link>
+                                  ) : (
+                                    performance.venue_name
+                                  )}
+                                </span>
+                              )}
+                              {performance.start_time && performance.end_time && (
+                                <span className="flex items-center gap-2">
+                                  <Clock size={14} className="text-accent-500" />
+                                  {formatTimeRange(performance.start_time, performance.end_time)}
+                                </span>
+                              )}
+                            </div>
+                            {performance.notes && (
+                              <p className="mt-2 text-sm italic text-text-tertiary">{performance.notes}</p>
                             )}
                           </div>
-                          {performance.notes && (
-                            <p className="mt-2 text-sm italic text-text-tertiary">{performance.notes}</p>
-                          )}
-                        </div>
-                        <div className="flex flex-col gap-2">
-                          <Button
-                            onClick={() => toggleSchedule(performance)}
-                            variant={isInSchedule(performance) ? 'success' : 'secondary'}
-                            size="sm"
-                            icon={isInSchedule(performance) ? <Check size={14} /> : <Plus size={14} />}
-                          >
-                            {isInSchedule(performance) ? 'In Schedule' : 'Add to Schedule'}
-                          </Button>
-                          {performance.event_slug && (
-                            <Button as={Link} to={`/event/${performance.event_slug}`} variant="primary" size="sm">
-                              View Event →
+                          <div className="flex flex-col gap-2">
+                            <Button
+                              onClick={() => toggleSchedule(performance)}
+                              variant={isInSchedule(performance) ? 'success' : 'secondary'}
+                              size="sm"
+                              icon={isInSchedule(performance) ? <Check size={14} /> : <Plus size={14} />}
+                            >
+                              {isInSchedule(performance) ? 'In Schedule' : 'Add to Schedule'}
                             </Button>
-                          )}
+                            {performance.event_slug && (
+                              <Button as={Link} to={`/event/${performance.event_slug}`} variant="primary" size="sm">
+                                View Event →
+                              </Button>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    </Card>
-                  ))}
+                      </Card>
+                    )
+                  })}
                 </div>
               </Card>
             )}
@@ -827,71 +833,77 @@ export default function BandProfilePage() {
                   </h2>
                 </div>
                 <div className="space-y-4">
-                  {profile.past.map((performance, idx) => (
-                    <Card key={idx} variant="outline" hoverable className="p-4">
-                      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                        <div className="flex-1">
-                          <div className="flex items-center gap-2 mb-2 flex-wrap">
-                            <h3 className="text-xl font-semibold text-accent-500">
-                              {performance.event_slug ? (
-                                <Link
-                                  to={`/event/${performance.event_slug}`}
-                                  className="transition-colors hover:text-accent-400 hover:underline"
-                                >
-                                  {performance.event_name}
-                                </Link>
-                              ) : (
-                                performance.event_name
-                              )}
-                            </h3>
-                            {performance.event_status === 'archived' && (
-                              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-text-primary/10 text-text-tertiary border border-text-primary/10">
-                                <Archive size={12} aria-hidden="true" />
-                                Archived
-                              </span>
-                            )}
-                          </div>
-                          <div className="flex flex-wrap gap-3 text-sm text-text-secondary">
-                            {(performance.performance_date || performance.event_date) && (
-                              <span className="flex items-center gap-2">
-                                <CalendarDays size={14} className="text-text-tertiary" />
-                                {formatPerformanceDayLabel(performance)}
-                              </span>
-                            )}
-                            {performance.venue_name && (
-                              <span className="flex items-center gap-2">
-                                <MapPin size={14} className="text-text-tertiary" />
-                                {performance.venue_id ? (
+                  {profile.past.map((performance, idx) => {
+                    // Computed once: the guard and the rendered value must be
+                    // the same expression, or an unparseable date passes the
+                    // guard and renders a calendar icon with no label.
+                    const dayLabel = formatPerformanceDayLabel(performance)
+                    return (
+                      <Card key={idx} variant="outline" hoverable className="p-4">
+                        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2 mb-2 flex-wrap">
+                              <h3 className="text-xl font-semibold text-accent-500">
+                                {performance.event_slug ? (
                                   <Link
-                                    to={`/venue/${performance.venue_id}`}
+                                    to={`/event/${performance.event_slug}`}
                                     className="transition-colors hover:text-accent-400 hover:underline"
                                   >
-                                    {performance.venue_name}
+                                    {performance.event_name}
                                   </Link>
                                 ) : (
-                                  performance.venue_name
+                                  performance.event_name
                                 )}
-                              </span>
-                            )}
-                            {performance.start_time && performance.end_time && (
-                              <span className="flex items-center gap-2">
-                                <Clock size={14} className="text-text-tertiary" />
-                                {formatTimeRange(performance.start_time, performance.end_time)}
-                              </span>
+                              </h3>
+                              {performance.event_status === 'archived' && (
+                                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-text-primary/10 text-text-tertiary border border-text-primary/10">
+                                  <Archive size={12} aria-hidden="true" />
+                                  Archived
+                                </span>
+                              )}
+                            </div>
+                            <div className="flex flex-wrap gap-3 text-sm text-text-secondary">
+                              {dayLabel && (
+                                <span className="flex items-center gap-2">
+                                  <CalendarDays size={14} className="text-text-tertiary" />
+                                  {dayLabel}
+                                </span>
+                              )}
+                              {performance.venue_name && (
+                                <span className="flex items-center gap-2">
+                                  <MapPin size={14} className="text-text-tertiary" />
+                                  {performance.venue_id ? (
+                                    <Link
+                                      to={`/venue/${performance.venue_id}`}
+                                      className="transition-colors hover:text-accent-400 hover:underline"
+                                    >
+                                      {performance.venue_name}
+                                    </Link>
+                                  ) : (
+                                    performance.venue_name
+                                  )}
+                                </span>
+                              )}
+                              {performance.start_time && performance.end_time && (
+                                <span className="flex items-center gap-2">
+                                  <Clock size={14} className="text-text-tertiary" />
+                                  {formatTimeRange(performance.start_time, performance.end_time)}
+                                </span>
+                              )}
+                            </div>
+                            {performance.notes && (
+                              <p className="mt-2 text-sm italic text-text-tertiary">{performance.notes}</p>
                             )}
                           </div>
-                          {performance.notes && (
-                            <p className="mt-2 text-sm italic text-text-tertiary">{performance.notes}</p>
+                          {performance.event_slug && (
+                            <Button as={Link} to={`/event/${performance.event_slug}`} variant="secondary" size="sm">
+                              View Event →
+                            </Button>
                           )}
                         </div>
-                        {performance.event_slug && (
-                          <Button as={Link} to={`/event/${performance.event_slug}`} variant="secondary" size="sm">
-                            View Event →
-                          </Button>
-                        )}
-                      </div>
-                    </Card>
-                  ))}
+                      </Card>
+                    )
+                  })}
                 </div>
               </Card>
             )}

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -758,7 +758,7 @@ export default function BandProfilePage() {
                             )}
                           </h3>
                           <div className="flex flex-wrap gap-3 text-sm text-text-secondary">
-                            {(performance.performance_date || performance.event_date) && (
+                            {formatPerformanceDayLabel(performance) && (
                               <span className="flex items-center gap-2">
                                 <CalendarDays size={14} className="text-accent-500" />
                                 {formatPerformanceDayLabel(performance)}

--- a/frontend/src/pages/__tests__/BandProfilePage.test.jsx
+++ b/frontend/src/pages/__tests__/BandProfilePage.test.jsx
@@ -108,6 +108,70 @@ describe('BandProfilePage — per-set performance_date, notes, and Day N label (
     expect(screen.getByText('Bonus set: ALL w/ Chad (Price)')).toBeInTheDocument()
   })
 
+  // Regression: the PAST section kept a raw-field date guard after the
+  // upcoming section moved to gating on the computed label, so an unparseable
+  // date passed the guard and rendered a calendar icon with no text beside it.
+  // Both reviewers caught this because no page-level test exercised the past
+  // section at all — this is that test.
+  it('suppresses the whole date row in the PAST section when the date is unparseable', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      id: 206,
+      name: 'ALL',
+      photo_url: null,
+      photo_alt_text: null,
+      description: null,
+      genre: null,
+      origin: null,
+      social: {},
+      stats: null,
+      upcoming: [],
+      past: [
+        {
+          id: 3001,
+          event_id: 70,
+          event_name: 'Corrupted Date Show',
+          event_slug: 'corrupted-date-show',
+          event_date: 'not-a-date',
+          event_end_date: null,
+          event_status: 'published',
+          performance_date: 'not-a-date',
+          notes: null,
+          venue_id: 5,
+          venue_name: 'Blue Room',
+          venue_address: null,
+          start_time: '20:00',
+          end_time: '21:00',
+        },
+      ],
+    })
+
+    const { container } = renderPage('206')
+    expect(await screen.findByRole('heading', { level: 1, name: 'ALL' })).toBeInTheDocument()
+
+    // The event still renders (the name appears in both the card heading and
+    // its event link, hence getAllByText); only the unusable date row goes.
+    expect(screen.getAllByText('Corrupted Date Show').length).toBeGreaterThan(0)
+    expect(screen.getByText('Blue Room')).toBeInTheDocument()
+    expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument()
+    expect(screen.queryByText('not-a-date')).not.toBeInTheDocument()
+
+    // Text assertions alone CANNOT catch this regression: with the old
+    // raw-field guard the label is null either way, so the row renders as a
+    // calendar icon with empty text and no assertion above changes. The
+    // defect is structural, so assert structurally — the metadata row holds
+    // the venue only, with no orphaned date entry beside it.
+    const metaRow = container.querySelector('.flex.flex-wrap.gap-3')
+    expect(metaRow).not.toBeNull()
+    const entries = [...metaRow.querySelectorAll(':scope > span')]
+    // Venue + set time only — no third, textless entry for the dead date.
+    expect(entries).toHaveLength(2)
+    // The load-bearing assertion: every entry carries text. A suppressed row
+    // is absent; a badly-guarded one is present but empty beside its icon.
+    expect(entries.map(entry => entry.textContent.trim())).not.toContain('')
+    expect(metaRow.textContent).toContain('Blue Room')
+  })
+
   it('shows no Day N label on a single-day event', async () => {
     fetchPublicJson.mockReset()
     fetchPublicJson.mockResolvedValue({

--- a/frontend/src/pages/__tests__/BandProfilePage.test.jsx
+++ b/frontend/src/pages/__tests__/BandProfilePage.test.jsx
@@ -1,0 +1,136 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import BandProfilePage from '../BandProfilePage.jsx'
+import { ThemeProvider } from '../../components/ThemeProvider.jsx'
+import { fetchPublicJson } from '../../utils/publicApi'
+
+vi.mock('../../utils/publicApi', () => ({ fetchPublicJson: vi.fn() }))
+
+function renderPage(id = '206') {
+  return render(
+    <ThemeProvider>
+      <HelmetProvider>
+        <MemoryRouter initialEntries={[`/band/${id}`]}>
+          <Routes>
+            <Route path="/band/:id" element={<BandProfilePage />} />
+          </Routes>
+        </MemoryRouter>
+      </HelmetProvider>
+    </ThemeProvider>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// #739 — production bug: ALL (band profile 206) plays Buddies Fest 2 on both
+// Aug 7 and Aug 8, but the profile showed both sets as Aug 7 and neither
+// set's notes. Mirrors the real production payload shape once the backend
+// fix (performance_date + notes emitted, ordered day 1 before day 2) lands.
+// ---------------------------------------------------------------------------
+describe('BandProfilePage — per-set performance_date, notes, and Day N label (#739)', () => {
+  it("renders each set's OWN date (Aug 7 and Aug 8), not the event start date twice, with a Day N label on the multi-day event", async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      id: 206,
+      name: 'ALL',
+      photo_url: null,
+      photo_alt_text: null,
+      description: null,
+      genre: 'Punk',
+      origin: null,
+      social: {},
+      stats: null,
+      upcoming: [
+        {
+          id: 1001,
+          event_id: 55,
+          event_name: 'Buddies Fest 2',
+          event_slug: 'buddies-fest-2',
+          event_date: '2099-08-07',
+          event_end_date: '2099-08-09',
+          event_status: 'published',
+          performance_date: '2099-08-07',
+          notes: 'Bonus set: ALL w/ Scott (Reynolds) -- sold out',
+          venue_id: 3,
+          venue_name: 'Room 47',
+          venue_address: null,
+          start_time: '22:00',
+          end_time: '23:00',
+        },
+        {
+          id: 1002,
+          event_id: 55,
+          event_name: 'Buddies Fest 2',
+          event_slug: 'buddies-fest-2',
+          event_date: '2099-08-07',
+          event_end_date: '2099-08-09',
+          event_status: 'published',
+          performance_date: '2099-08-08',
+          notes: 'Bonus set: ALL w/ Chad (Price)',
+          venue_id: 3,
+          venue_name: 'Room 47',
+          venue_address: null,
+          start_time: '21:00',
+          end_time: '22:00',
+        },
+      ],
+      past: [],
+    })
+
+    renderPage('206')
+    expect(await screen.findByRole('heading', { level: 1, name: 'ALL' })).toBeInTheDocument()
+
+    // Each set shows its OWN day, with the multi-day (Day N) label — the two
+    // dates must be distinct, not both showing the event's Aug 7 start date.
+    expect(screen.getByText('Fri, Aug 7 (Day 1)')).toBeInTheDocument()
+    expect(screen.getByText('Sat, Aug 8 (Day 2)')).toBeInTheDocument()
+
+    // Notes render on the correct set, not swapped.
+    expect(screen.getByText('Bonus set: ALL w/ Scott (Reynolds) -- sold out')).toBeInTheDocument()
+    expect(screen.getByText('Bonus set: ALL w/ Chad (Price)')).toBeInTheDocument()
+  })
+
+  it('shows no Day N label on a single-day event', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      id: 202,
+      name: 'Kepi Ghoulie',
+      photo_url: null,
+      photo_alt_text: null,
+      description: null,
+      genre: null,
+      origin: null,
+      social: {},
+      stats: null,
+      upcoming: [
+        {
+          id: 2001,
+          event_id: 60,
+          event_name: 'Single Night Show',
+          event_slug: 'single-night-show',
+          event_date: '2099-09-05',
+          event_end_date: null,
+          event_status: 'published',
+          performance_date: null,
+          notes: null,
+          venue_id: 4,
+          venue_name: 'Roost',
+          venue_address: null,
+          start_time: '20:00',
+          end_time: '21:00',
+        },
+      ],
+      past: [],
+    })
+
+    renderPage('202')
+    expect(await screen.findByRole('heading', { level: 1, name: 'Kepi Ghoulie' })).toBeInTheDocument()
+
+    // Single-day event convention (#540/#541): the date renders, but with no
+    // "(Day N)" suffix at all.
+    expect(screen.getByText('Sat, Sep 5')).toBeInTheDocument()
+    expect(screen.queryByText(/\(Day \d+\)/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/BandProfilePage.test.jsx
+++ b/frontend/src/pages/__tests__/BandProfilePage.test.jsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import BandProfilePage from '../BandProfilePage.jsx'
 import { ThemeProvider } from '../../components/ThemeProvider.jsx'
 import { fetchPublicJson } from '../../utils/publicApi'
@@ -30,6 +30,22 @@ function renderPage(id = '206') {
 // fix (performance_date + notes emitted, ordered day 1 before day 2) lands.
 // ---------------------------------------------------------------------------
 describe('BandProfilePage — per-set performance_date, notes, and Day N label (#739)', () => {
+  // The fixtures below use 2099 so the sets always classify as "upcoming"
+  // regardless of when the suite runs. Pin the clock into that same year so
+  // they also read as CURRENT-year dates — which is what the real case is
+  // (Buddies Fest 2 is a current-year event), and the year suffix that
+  // formatPerformanceDayLabel adds for other years therefore stays out of the
+  // expected strings. Without this, the assertions would encode a rendering
+  // ("Fri, Aug 7, 2099") that never appears for the bug being fixed.
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date(2099, 7, 1)) // 2099-08-01, before both fixtures
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it("renders each set's OWN date (Aug 7 and Aug 8), not the event start date twice, with a Day N label on the multi-day event", async () => {
     fetchPublicJson.mockReset()
     fetchPublicJson.mockResolvedValue({

--- a/frontend/src/pages/__tests__/BandProfilePage.test.jsx
+++ b/frontend/src/pages/__tests__/BandProfilePage.test.jsx
@@ -108,11 +108,9 @@ describe('BandProfilePage — per-set performance_date, notes, and Day N label (
     expect(screen.getByText('Bonus set: ALL w/ Chad (Price)')).toBeInTheDocument()
   })
 
-  // Regression: the PAST section kept a raw-field date guard after the
-  // upcoming section moved to gating on the computed label, so an unparseable
-  // date passed the guard and rendered a calendar icon with no text beside it.
-  // Both reviewers caught this because no page-level test exercised the past
-  // section at all — this is that test.
+  // #739: an unparseable-but-non-empty date must suppress the ENTIRE date row,
+  // icon included. Guarding on the raw date field instead of the computed
+  // label leaves the icon rendered beside empty text.
   it('suppresses the whole date row in the PAST section when the date is unparseable', async () => {
     fetchPublicJson.mockReset()
     fetchPublicJson.mockResolvedValue({
@@ -146,7 +144,7 @@ describe('BandProfilePage — per-set performance_date, notes, and Day N label (
       ],
     })
 
-    const { container } = renderPage('206')
+    renderPage('206')
     expect(await screen.findByRole('heading', { level: 1, name: 'ALL' })).toBeInTheDocument()
 
     // The event still renders (the name appears in both the card heading and
@@ -161,7 +159,10 @@ describe('BandProfilePage — per-set performance_date, notes, and Day N label (
     // calendar icon with empty text and no assertion above changes. The
     // defect is structural, so assert structurally — the metadata row holds
     // the venue only, with no orphaned date entry beside it.
-    const metaRow = container.querySelector('.flex.flex-wrap.gap-3')
+    // Anchored on THIS performance's venue: a page-level query would match the
+    // first metadata row anywhere on the page, which could belong to a
+    // different performance and would let the empty entry survive undetected.
+    const metaRow = screen.getByText('Blue Room').closest('.flex.flex-wrap.gap-3')
     expect(metaRow).not.toBeNull()
     const entries = [...metaRow.querySelectorAll(':scope > span')]
     // Venue + set time only — no third, textless entry for the dead date.

--- a/frontend/src/utils/__tests__/timeFormat.test.js
+++ b/frontend/src/utils/__tests__/timeFormat.test.js
@@ -9,6 +9,18 @@ import { formatPerformanceDayLabel } from '../timeFormat'
 // (#540/#541).
 // ---------------------------------------------------------------------------
 describe('formatPerformanceDayLabel (#739)', () => {
+  // These fixtures are 2026 dates asserted WITHOUT a year, which is only
+  // correct while 2026 is the current year. Unpinned, every expectation here
+  // starts failing on 2027-01-01 when the year is correctly appended.
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 3)) // 2026-08-03, local midnight
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   test('single-day event: no Day N label, even when performance_date is set', () => {
     const label = formatPerformanceDayLabel({
       performance_date: '2026-08-08',
@@ -134,6 +146,18 @@ describe('formatPerformanceDayLabel — year and single-day gating (#739)', () =
       event_end_date: '2027-08-09',
     })
     expect(label).toBe('Sun, Aug 8, 2027 (Day 2)')
+  })
+
+  // A malformed date is non-empty, so a caller guarding on "is the field set?"
+  // reaches the formatter. It must return null, not the literal string
+  // "Invalid Date" rendered onto the page next to a calendar icon.
+  test('malformed date returns null rather than "Invalid Date"', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: 'not-a-date',
+      event_date: 'not-a-date',
+      event_end_date: null,
+    })
+    expect(label).toBeNull()
   })
 
   test('event_end_date EQUAL to event_date is single-day: no Day label', () => {

--- a/frontend/src/utils/__tests__/timeFormat.test.js
+++ b/frontend/src/utils/__tests__/timeFormat.test.js
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest'
+import { formatPerformanceDayLabel } from '../timeFormat'
+
+// ---------------------------------------------------------------------------
+// #739 — a band playing day 2+ of a multi-day event must show a "(Day N)"
+// label next to its OWN performance date, not the event's start date. This
+// is gated on the event actually being multi-day (event_end_date non-null) —
+// day labels on a single-day event are a standing convention violation
+// (#540/#541).
+// ---------------------------------------------------------------------------
+describe('formatPerformanceDayLabel (#739)', () => {
+  test('single-day event: no Day N label, even when performance_date is set', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: '2026-08-08',
+      event_date: '2026-08-08',
+      event_end_date: null,
+    })
+    expect(label).toBe('Sat, Aug 8')
+  })
+
+  test('multi-day event, day 1 (performance_date equals event start): "(Day 1)"', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: '2026-08-07',
+      event_date: '2026-08-07',
+      event_end_date: '2026-08-09',
+    })
+    expect(label).toBe('Fri, Aug 7 (Day 1)')
+  })
+
+  test('multi-day event, day 2: "(Day 2)" — the exact ALL/Buddies Fest 2 production case', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: '2026-08-08',
+      event_date: '2026-08-07',
+      event_end_date: '2026-08-09',
+    })
+    expect(label).toBe('Sat, Aug 8 (Day 2)')
+  })
+
+  test('multi-day event, day 3', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: '2026-08-09',
+      event_date: '2026-08-07',
+      event_end_date: '2026-08-09',
+    })
+    expect(label).toBe('Sun, Aug 9 (Day 3)')
+  })
+
+  test('multi-day event, NULL performance_date (the #543 day-1 convention) inherits event_date and shows Day 1', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: null,
+      event_date: '2026-08-07',
+      event_end_date: '2026-08-09',
+    })
+    expect(label).toBe('Fri, Aug 7 (Day 1)')
+  })
+
+  // The after-midnight interaction (#739): performance_date already stores
+  // the EVENING a set belongs to, so a 00:35 set stored under day 1 must
+  // stay "(Day 1)" — the 6AM after-midnight threshold must NOT be applied a
+  // second time on top of performance_date. This function takes no
+  // start_time input at all, so an implementation that reached for
+  // AFTER_MIDNIGHT_THRESHOLD_HOUR here would be adding a parameter/behavior
+  // that doesn't belong — asserting the plain day-1 case is exactly what
+  // catches a wrongly-reintroduced offset if start_time were later wired in.
+  test('a 00:35 set stored under performance_date=day 1 stays "(Day 1)", not shifted to Day 2', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: '2026-08-07',
+      event_date: '2026-08-07',
+      event_end_date: '2026-08-09',
+      start_time: '00:35',
+    })
+    expect(label).toBe('Fri, Aug 7 (Day 1)')
+  })
+
+  test('multi-day event with malformed event_date falls back to the plain date label without crashing', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: '2026-08-08',
+      event_date: 'not-a-date',
+      event_end_date: '2026-08-09',
+    })
+    expect(label).toBe('Sat, Aug 8')
+  })
+
+  test('returns null when no usable date is present', () => {
+    expect(formatPerformanceDayLabel({ performance_date: null, event_date: null, event_end_date: null })).toBeNull()
+  })
+})

--- a/frontend/src/utils/__tests__/timeFormat.test.js
+++ b/frontend/src/utils/__tests__/timeFormat.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { formatPerformanceDayLabel } from '../timeFormat'
 
 // ---------------------------------------------------------------------------
@@ -83,5 +83,65 @@ describe('formatPerformanceDayLabel (#739)', () => {
 
   test('returns null when no usable date is present', () => {
     expect(formatPerformanceDayLabel({ performance_date: null, event_date: null, event_end_date: null })).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #739 follow-ups. Both are cases where the first implementation was WRONG in
+// a way the original tests could not see:
+//
+//  1. Dropping the year renders a 2022 set as "Sun, May 22" — the one piece of
+//     information that places an archived performance in time is gone.
+//  2. Gating "(Day N)" on `event_end_date` being merely non-null treats an
+//     event stored with end_date EQUAL to date as multi-day, so a single-day
+//     event renders a redundant "(Day 1)" (#540/#541).
+//
+// The clock is pinned: deriving "current year" from the wall clock would make
+// the first pair of tests silently invert on 2027-01-01.
+// ---------------------------------------------------------------------------
+describe('formatPerformanceDayLabel — year and single-day gating (#739)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 3)) // 2026-08-03, local midnight
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('current-year performance omits the year', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: '2026-08-08',
+      event_date: '2026-08-07',
+      event_end_date: '2026-08-09',
+    })
+    expect(label).toBe('Sat, Aug 8 (Day 2)')
+  })
+
+  test('prior-year performance keeps its year', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: '2022-05-22',
+      event_date: '2022-05-22',
+      event_end_date: null,
+    })
+    expect(label).toBe('Sun, May 22, 2022')
+  })
+
+  test('future-year performance keeps its year', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: '2027-08-08',
+      event_date: '2027-08-07',
+      event_end_date: '2027-08-09',
+    })
+    expect(label).toBe('Sun, Aug 8, 2027 (Day 2)')
+  })
+
+  test('event_end_date EQUAL to event_date is single-day: no Day label', () => {
+    const label = formatPerformanceDayLabel({
+      performance_date: '2026-08-08',
+      event_date: '2026-08-08',
+      event_end_date: '2026-08-08',
+    })
+    expect(label).toBe('Sat, Aug 8')
   })
 })

--- a/frontend/src/utils/timeFormat.js
+++ b/frontend/src/utils/timeFormat.js
@@ -49,7 +49,11 @@ export function formatPerformanceDayLabel(performance) {
   const rawDate = performance?.performance_date || performance?.event_date
   if (!rawDate) return null
 
+  // A malformed date string is non-empty, so a caller guarding on "is the date
+  // field set?" would still reach this. Return null rather than letting
+  // toLocaleDateString render the literal text "Invalid Date" onto the page.
   const displayDate = parseLocalDate(rawDate) || new Date(rawDate)
+  if (Number.isNaN(displayDate.getTime())) return null
   // Keep the year on anything outside the current one. A band's history spans
   // years, and "Sun, May 22" strips the only thing that places an archived set
   // in time; current-year dates stay compact.

--- a/frontend/src/utils/timeFormat.js
+++ b/frontend/src/utils/timeFormat.js
@@ -20,6 +20,54 @@ export function parseLocalDate(dateStr) {
   return new Date(year, month - 1, day)
 }
 
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+
+/**
+ * Format a performance's date for display, appending a "(Day N)" label when
+ * the event is multi-day (#739).
+ *
+ * - Uses `performance_date` when present, falling back to `event_date` (the
+ *   #543 convention: day-1 sets and single-day events store NULL
+ *   performance_date).
+ * - The "(Day N)" suffix is gated on `event_end_date` being non-null — a
+ *   single-day event must never show a day label (#540/#541 convention).
+ * - `performance_date` already stores the EVENING a set belongs to, so no
+ *   after-midnight (6AM) offset is applied here on top of it — that would
+ *   wrongly push a 00:35 set stored under day 1 to "(Day 2)".
+ * - Day offset arithmetic uses parseLocalDate (calendar-local midnight), not
+ *   `new Date('YYYY-MM-DD')`, which parses as UTC midnight and shifts the
+ *   day in UTC-negative timezones.
+ *
+ * @param {{performance_date?: string|null, event_date?: string|null, event_end_date?: string|null}} performance
+ * @returns {string|null}
+ */
+export function formatPerformanceDayLabel(performance) {
+  const rawDate = performance?.performance_date || performance?.event_date
+  if (!rawDate) return null
+
+  const displayDate = parseLocalDate(rawDate) || new Date(rawDate)
+  const dateLabel = displayDate.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  })
+
+  if (!performance?.event_end_date) {
+    return dateLabel
+  }
+
+  const eventStart = parseLocalDate(performance.event_date)
+  const perfDay = parseLocalDate(rawDate)
+  if (!eventStart || !perfDay) {
+    return dateLabel
+  }
+
+  const dayOffset = Math.round((perfDay.getTime() - eventStart.getTime()) / MS_PER_DAY)
+  const dayNumber = dayOffset + 1
+
+  return dayNumber >= 1 ? `${dateLabel} (Day ${dayNumber})` : dateLabel
+}
+
 export function formatTime(time24, { fallback = '—' } = {}) {
   if (!isValidTimeString(time24)) {
     return fallback

--- a/frontend/src/utils/timeFormat.js
+++ b/frontend/src/utils/timeFormat.js
@@ -29,8 +29,12 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24
  * - Uses `performance_date` when present, falling back to `event_date` (the
  *   #543 convention: day-1 sets and single-day events store NULL
  *   performance_date).
- * - The "(Day N)" suffix is gated on `event_end_date` being non-null — a
- *   single-day event must never show a day label (#540/#541 convention).
+ * - The "(Day N)" suffix is gated on the event actually SPANNING more than one
+ *   day (`event_end_date` strictly after `event_date`) — a single-day event
+ *   must never show a day label (#540/#541 convention), including one stored
+ *   with an `end_date` equal to its `date`.
+ * - The year is shown only when it is not the current year, so an archived
+ *   performance keeps the context that places it in time.
  * - `performance_date` already stores the EVENING a set belongs to, so no
  *   after-midnight (6AM) offset is applied here on top of it — that would
  *   wrongly push a 00:35 set stored under day 1 to "(Day 2)".
@@ -46,19 +50,25 @@ export function formatPerformanceDayLabel(performance) {
   if (!rawDate) return null
 
   const displayDate = parseLocalDate(rawDate) || new Date(rawDate)
+  // Keep the year on anything outside the current one. A band's history spans
+  // years, and "Sun, May 22" strips the only thing that places an archived set
+  // in time; current-year dates stay compact.
+  const showYear = displayDate.getFullYear() !== new Date().getFullYear()
   const dateLabel = displayDate.toLocaleDateString('en-US', {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
+    ...(showYear ? { year: 'numeric' } : {}),
   })
 
-  if (!performance?.event_end_date) {
-    return dateLabel
-  }
-
-  const eventStart = parseLocalDate(performance.event_date)
+  const eventStart = parseLocalDate(performance?.event_date)
+  const eventEnd = parseLocalDate(performance?.event_end_date)
   const perfDay = parseLocalDate(rawDate)
-  if (!eventStart || !perfDay) {
+  // "Multi-day" means the event actually SPANS more than one day. Gating on
+  // event_end_date being merely non-null treats an event stored with end_date
+  // EQUAL to date as multi-day and renders a redundant "(Day 1)" on what is a
+  // single-day event (#540/#541).
+  if (!eventStart || !eventEnd || !perfDay || eventEnd.getTime() <= eventStart.getTime()) {
     return dateLabel
   }
 

--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -102,6 +102,7 @@ export async function onRequestGet(context) {
         p.start_time,
         p.end_time,
         p.performance_date,
+        p.notes,
         v.id as venue_id,
         v.name as venue_name,
         v.address as venue_address,
@@ -123,7 +124,7 @@ export async function onRequestGet(context) {
       WHERE p.band_profile_id = ?
         AND e.status IN ('published', 'archived')
         AND (e.reveal_mode = 0 OR p.is_announced = 1)
-      ORDER BY e.date DESC, p.start_time
+      ORDER BY e.date DESC, COALESCE(p.performance_date, e.date) ASC, p.start_time
     `,
     )
       .bind(bandProfile.id)
@@ -238,6 +239,12 @@ export async function onRequestGet(context) {
         // event's saved schedule isn't wiped as stale on day 2.
         event_end_date: p.event_end_date || null,
         event_status: p.event_status,
+        // The evening this SET belongs to (#739) — distinct from event_date
+        // on day 2+ of a multi-day event. NULL for day-1 sets and
+        // single-day events (the #543 convention); clients fall back to
+        // event_date themselves.
+        performance_date: p.performance_date || null,
+        notes: p.notes || null,
         venue_id: p.venue_id,
         venue_name: p.venue_name,
         venue_address: p.venue_address || formatVenueAddress(p),
@@ -252,6 +259,8 @@ export async function onRequestGet(context) {
         event_date: p.event_date,
         event_end_date: p.event_end_date || null,
         event_status: p.event_status,
+        performance_date: p.performance_date || null,
+        notes: p.notes || null,
         venue_id: p.venue_id,
         venue_name: p.venue_name,
         venue_address: p.venue_address || formatVenueAddress(p),

--- a/functions/api/bands/stats/__tests__/stats.test.js
+++ b/functions/api/bands/stats/__tests__/stats.test.js
@@ -395,3 +395,122 @@ describe("GET /api/bands/stats/:name — per-performance classification (#603)",
     expect(payload.upcoming).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #739 — a band playing two days of the same multi-day event must expose
+// each set's OWN performance_date and notes, and the two sets must be
+// ordered by that per-set day (day 1 before day 2), not by the tie-prone
+// e.date + start_time pairing that put ALL's Aug 8 set ahead of its Aug 7
+// set in production. Mirrors the real "ALL" / Buddies Fest 2 production data
+// from the issue (two bonus sets, distinct notes on each).
+// ---------------------------------------------------------------------------
+describe("GET /api/bands/stats/:name — per-set performance_date, notes, and ordering (#739)", () => {
+  test("upcoming: two sets at one multi-day event carry distinct performance_date + notes, ordered day 1 before day 2", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Room 47" });
+    const event = insertEvent(rawDb, {
+      name: "Buddies Fest 2",
+      slug: "buddies-fest-2-739",
+      date: "2099-08-07",
+      end_date: "2099-08-09",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    // Day-1 bonus set: later performance_date-adjacent clock time (22:00) but
+    // the EARLIER performance_date — this is the exact shape that broke
+    // under "ORDER BY e.date DESC, p.start_time" (ties on e.date, so
+    // start_time alone decided order and put day 2 first).
+    const day1 = insertBand(rawDb, {
+      name: "ALL",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "22:00",
+      end_time: "23:00",
+    });
+    rawDb
+      .prepare("UPDATE performances SET performance_date=?, notes=? WHERE id=?")
+      .run("2099-08-07", "Bonus set: ALL w/ Scott (Reynolds) -- sold out", day1.id);
+
+    const day2 = insertBand(rawDb, {
+      name: "ALL",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "21:00",
+      end_time: "22:00",
+    });
+    rawDb
+      .prepare("UPDATE performances SET performance_date=?, notes=? WHERE id=?")
+      .run("2099-08-08", "Bonus set: ALL w/ Chad (Price)", day2.id);
+
+    const request = new Request("https://example.test/api/bands/stats/ALL");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(2);
+
+    // Assert on the actual dates, not just array length (a broken
+    // implementation that omits performance_date entirely still returns 2
+    // items here).
+    const dates = payload.upcoming.map((p) => p.performance_date);
+    expect(dates).toEqual(["2099-08-07", "2099-08-08"]);
+    expect(dates[0]).not.toBe(dates[1]);
+
+    // Notes on the correct set, not swapped.
+    expect(payload.upcoming[0].notes).toBe("Bonus set: ALL w/ Scott (Reynolds) -- sold out");
+    expect(payload.upcoming[1].notes).toBe("Bonus set: ALL w/ Chad (Price)");
+  });
+
+  test("past: two sets at one multi-day event carry distinct performance_date + notes, ordered day 1 before day 2", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    const event = insertEvent(rawDb, {
+      name: "Past Buddies Fest",
+      slug: "past-buddies-fest-739",
+      date: "2001-08-07",
+      end_date: "2001-08-09",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const day1 = insertBand(rawDb, {
+      name: "Kepi Ghoulie",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "18:25",
+      end_time: "18:55",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2001-08-07", day1.id);
+
+    const day2 = insertBand(rawDb, {
+      name: "Kepi Ghoulie",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "15:55",
+      end_time: "16:30",
+    });
+    rawDb
+      .prepare("UPDATE performances SET performance_date=?, notes=? WHERE id=?")
+      .run("2001-08-08", "All-ages kids set", day2.id);
+
+    const request = new Request("https://example.test/api/bands/stats/Kepi%20Ghoulie");
+    const response = await onRequestGet({ request, env });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.past).toHaveLength(2);
+
+    const dates = payload.past.map((p) => p.performance_date);
+    expect(dates).toEqual(["2001-08-07", "2001-08-08"]);
+
+    // day1 has no notes in production data — must come through as null, not
+    // undefined or the string "null".
+    expect(payload.past[0].notes).toBeNull();
+    expect(payload.past[1].notes).toBe("All-ages kids set");
+  });
+});


### PR DESCRIPTION
## Summary

On a multi-day event, every one of a band's sets rendered with the **event's start date** and none of its notes. ALL plays Buddies Fest 2 on both Aug 7 and Aug 8; the profile showed two sets both dated Aug 7, in the wrong order, with neither "Bonus set" note. Kepi Ghoulie was the same. Every artist playing day 2+ of a multi-day event was affected, on a festival that opens 2026-08-07.

The D1 data was correct throughout — this was a projection and ordering bug in the stats endpoint plus a rendering gap on the page.

Closes #739

## What changed

| File | Change |
|------|--------|
| `functions/api/bands/stats/[name].js` | Select `p.notes`; emit `performance_date` and `notes` in **both** the `upcoming` and `past` mappings (both were previously dropped); fix the ORDER BY |
| `functions/api/bands/stats/__tests__/stats.test.js` | Ordering + per-set date/notes coverage for a multi-day event |
| `frontend/src/utils/timeFormat.js` | New `formatPerformanceDayLabel()` — per-set date, `(Day N)` on multi-day events only, year when not the current year, `null` for unparseable input |
| `frontend/src/utils/__tests__/timeFormat.test.js` | 13 tests, clock pinned |
| `frontend/src/pages/BandProfilePage.jsx` | Both render sites use the per-set date and render notes |
| `frontend/src/pages/__tests__/BandProfilePage.test.jsx` | New file — end-to-end wiring tests |

### Three defects in one query

1. **`performance_date` was selected but never emitted.** It was used internally to classify upcoming vs. past, then dropped from both response mappings, which emitted only `event_date` — the event's *start* date. Invisible on single-day events, where the two coincide.
2. **`notes` was neither selected nor emitted**, so per-set notes had no path to the page.
3. **Ordering keyed on the event date.** Two sets at one event share `e.date`, so they sorted by clock time alone — ALL's Aug 8 set (21:00) listed *before* its Aug 7 set (22:00).

Note the issue's originally-prescribed `ORDER BY COALESCE(p.performance_date, e.date) DESC` was **wrong** and preserved defect 3 — `DESC` puts Aug 8 first. Verified against real SQLite before writing tests. The shipped form keeps `e.date DESC` as the outer key (events newest-first, unchanged) with the coalesced date ASC as the intra-event tiebreak.

### `(Day N)`

Rendered as `Sat, Aug 8 (Day 2)`, gated on the event **actually spanning more than one day** — not merely on `event_end_date` being non-null, which would stamp a redundant `(Day 1)` on a single-day event stored with `end_date` equal to `date` (#540/#541 convention). Day arithmetic uses `parseLocalDate`, not `new Date('YYYY-MM-DD')`; swapping in the naive parser fails 7 of 8 tests with off-by-one shifts in this timezone.

`performance_date` already stores the **evening** a set belongs to, so no after-midnight offset is applied on top of it — a 00:35 set stored under day 1 stays Day 1. Covered by a test.

## Security / correctness notes

No auth, CSRF, or user-input surface. `notes` is admin-authored and rendered as text, not HTML — no XSS vector introduced. The endpoint's existing `is_cancelled = 0` filter and public gating are untouched. No schema change.

Correctness risk is the date boundary, which is why the year rule and both suites are clock-pinned rather than wall-clock dependent.

## Verification

- [x] Tests: 901 backend + 860 frontend pass, 0 failures
- [x] ESLint: 0 errors (2 pre-existing warnings, none introduced)
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] CodeRabbit (`make review`) run **before** opening; both findings fixed in d64d112
- [ ] Manual smoke: **pending deploy** — verify ALL (`/band/206?fromEvent=buddiesfest2`) shows Aug 7 (Day 1) and Aug 8 (Day 2) with both bonus-set notes, in that order

### Every test carries a mutation proof

| Mutation | Failure |
|---|---|
| Revert the ORDER BY | `expected ['2099-08-08','2099-08-07'] to deeply equal ['2099-08-07','2099-08-08']` — reproduces the production bug |
| Drop `performance_date` from `upcoming` only | `expected [undefined, undefined] to deeply equal ['2099-08-07','2099-08-08']`; `past` still passed |
| Swap the two notes | `expected 'Bonus set: ALL w/ Chad (Price)' to be 'Bonus set: ALL w/ Scott (Reynolds) -- sold out'` |
| Naive `new Date('YYYY-MM-DD')` | 7 of 8 failed with off-by-one day shifts |
| After-midnight offset on `performance_date` | `expected 'Fri, Aug 7 (Day 2)' to be 'Fri, Aug 7 (Day 1)'` |
| Drop the multi-day span check | `expected 'Sat, Aug 8 (Day 1)' to be 'Sat, Aug 8'` |
| Drop the year rule | `expected 'Sun, May 22' to be 'Sun, May 22, 2022'` |
| Remove the Invalid-Date guard | `expected 'Invalid Date' to be null` |
| Advance the pinned clock to 2027 | 10 tests fail — confirms the pin is load-bearing |

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Performance listings now show notes for upcoming and past sets.
  * Multi-day events display the appropriate “Day N” label for each performance.
  * Performance dates include clearer weekday, month, day, and year formatting.

* **Bug Fixes**
  * Corrected date and note associations for multiple performances within the same event.
  * Invalid past-event dates are no longer displayed.

* **Tests**
  * Added coverage for date formatting, day labels, notes, ordering, and missing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->