### PR TITLE
fix(schedule): multi-day events render and sort as one day; festival-day boundaries

### DIFF
--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -3,7 +3,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useTransition 
 import { Link } from 'react-router-dom'
 import { fetchPublicJson } from '../utils/publicApi'
 import { buildBandProfileHref } from '../utils/bandProfileLink'
-import { formatTimeRange, parseLocalDate } from '../utils/timeFormat'
+import { formatPerformanceDayLabel, formatTimeRange, parseLocalDate } from '../utils/timeFormat'
 import { trackTicketClick } from '../utils/metrics'
 import { safeExternalHref } from '../utils/urlSafety'
 import { getSelectedBands, saveSelectedBands } from '../utils/scheduleStorage'
@@ -618,6 +618,13 @@ function EventCard({
   const [expanded, setExpanded] = useState(isLive) // Auto-expand live events
   const ticketHref = safeExternalHref(event.ticket_url)
 
+  // Gates the per-set day label in the "All Performers" grid below (#743) —
+  // a single-day event must never show a redundant date on every set
+  // (#540/#541 convention: no lone "Day 1"). Mirrors the admin's
+  // isMultiDayEvent (admin/utils/dayOptions.js) but kept local: this is a
+  // public-facing component and doesn't import from admin/.
+  const isMultiDayEvent = Boolean(event.end_date && event.end_date > event.date)
+
   // No `weekday` (#681): a festival day runs 6 AM -> 6 AM, so an
   // after-midnight set's calendar weekday can mismatch the festival day a
   // fan actually experienced — month/day/year carries the same information
@@ -906,6 +913,23 @@ function EventCard({
                   // matches the same coercion the collapsed chips above use
                   // (Boolean(), not a bare truthy/`0 &&` check).
                   const isCancelled = Boolean(band.is_cancelled)
+                  // The details payload carries each set's own performance_date
+                  // but not the EVENT's span, and formatPerformanceDayLabel
+                  // needs both: performance_date decides which day, while
+                  // event_date/event_end_date decide whether a "(Day N)" suffix
+                  // belongs at all (single-day events never show one, #540/#541).
+                  // Gated on isMultiDayEvent, not merely on the formatter's
+                  // return: for a SINGLE-day event it returns a bare date with
+                  // no "(Day N)" suffix, which is truthy but redundant here --
+                  // the card already shows the event's date. Single-day events
+                  // show no day row at all (#540/#541).
+                  const dayLabel = isMultiDayEvent
+                    ? formatPerformanceDayLabel({
+                        ...band,
+                        event_date: event.date,
+                        event_end_date: event.end_date,
+                      })
+                    : null
                   return (
                     <Card
                       key={band.performance_id ?? band.id}
@@ -949,6 +973,18 @@ function EventCard({
                           <MapPin size={12} aria-hidden="true" />
                           <span>{band.venue_name}</span>
                         </div>
+
+                        {/* On a multi-day event the time alone is ambiguous --
+                            "4:10 PM" could be any of three days, and a fan
+                            adding a set here cannot tell which (#743).
+                            formatPerformanceDayLabel omits the "(Day N)" suffix
+                            entirely on single-day events, so no gate is needed. */}
+                        {dayLabel && (
+                          <div className="text-text-tertiary flex items-center gap-2">
+                            <CalendarDays size={12} aria-hidden="true" />
+                            <span>{dayLabel}</span>
+                          </div>
+                        )}
 
                         <div className="text-text-tertiary flex items-center gap-2">
                           <Clock size={12} aria-hidden="true" />

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import EventTimeline from '../EventTimeline'
 import { POSTER_IMAGE_HOST } from '../../utils/posterImage'
+import { formatPerformanceDayLabel } from '../../utils/timeFormat'
 
 function jsonResponse(data) {
   return {
@@ -257,6 +258,195 @@ describe('EventTimeline recap links', () => {
     const recapLinks = screen.getAllByRole('link', { name: 'Recap' })
     expect(recapLinks).toHaveLength(1)
     expect(recapLinks[0]).toHaveAttribute('href', '/events/past-fest/recap')
+  })
+})
+
+// #743 — the "All Performers" grid rendered set times with no day, so a fan
+// looking at a multi-day event's expanded lineup couldn't tell which day a
+// set was on. formatPerformanceDayLabel() is the single source of truth for
+// that label text (do not re-derive it here) — these tests only prove
+// EventTimeline actually calls it with the right performance_date/event_date/
+// event_end_date and renders the result, and that it's suppressed entirely
+// for a single-day event (#540/#541: no lone "Day 1").
+describe('EventTimeline performance day labels (#743)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('labels each set with its own festival day for a multi-day event', async () => {
+    const timelineData = {
+      now: [],
+      upcoming: [
+        {
+          id: 1,
+          name: 'Buddies Fest 2',
+          slug: 'buddies-fest-2',
+          date: '2026-08-07',
+          end_date: '2026-08-09',
+          status: 'published',
+          is_published: true,
+          venues: [],
+          bands: [],
+          band_count: 2,
+          venue_count: 1,
+          ticket_url: null,
+        },
+      ],
+      past: [],
+    }
+
+    let resolveDetails
+    const detailsPromise = new Promise(resolve => {
+      resolveDetails = resolve
+    })
+    global.fetch = vi.fn(url => {
+      if (url.startsWith('/api/events/timeline')) {
+        return Promise.resolve(jsonResponse(timelineData))
+      }
+      if (url === '/api/events/1/details') {
+        return detailsPromise
+      }
+      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Buddies Fest 2')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }))
+    expect(await screen.findByText(/loading performers and venues/i)).toBeInTheDocument()
+
+    resolveDetails(
+      jsonResponse({
+        venues: [{ id: 7, name: 'The Mill', band_count: 2, address: '123 King St' }],
+        bands: [
+          {
+            id: 20,
+            performance_id: 201,
+            name: 'Day One Band',
+            venue_id: 7,
+            venue_name: 'The Mill',
+            start_time: '20:00',
+            end_time: '20:45',
+            performance_date: '2026-08-07',
+          },
+          {
+            id: 21,
+            performance_id: 202,
+            name: 'Day Three Band',
+            venue_id: 7,
+            venue_name: 'The Mill',
+            start_time: '16:10',
+            end_time: '16:45',
+            performance_date: '2026-08-09',
+          },
+        ],
+        band_count: 2,
+        venue_count: 1,
+      })
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading performers and venues/i)).not.toBeInTheDocument()
+    })
+
+    const day1Label = formatPerformanceDayLabel({
+      performance_date: '2026-08-07',
+      event_date: '2026-08-07',
+      event_end_date: '2026-08-09',
+    })
+    const day3Label = formatPerformanceDayLabel({
+      performance_date: '2026-08-09',
+      event_date: '2026-08-07',
+      event_end_date: '2026-08-09',
+    })
+
+    expect(await screen.findByText(day1Label)).toBeInTheDocument()
+    expect(await screen.findByText(day3Label)).toBeInTheDocument()
+  })
+
+  it('shows no day label at all for a single-day event', async () => {
+    const timelineData = {
+      now: [],
+      upcoming: [
+        {
+          id: 1,
+          name: 'One Night Only',
+          slug: 'one-night-only',
+          date: '2026-08-07',
+          end_date: null,
+          status: 'published',
+          is_published: true,
+          venues: [],
+          bands: [],
+          band_count: 1,
+          venue_count: 1,
+          ticket_url: null,
+        },
+      ],
+      past: [],
+    }
+
+    let resolveDetails
+    const detailsPromise = new Promise(resolve => {
+      resolveDetails = resolve
+    })
+    global.fetch = vi.fn(url => {
+      if (url.startsWith('/api/events/timeline')) {
+        return Promise.resolve(jsonResponse(timelineData))
+      }
+      if (url === '/api/events/1/details') {
+        return detailsPromise
+      }
+      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('One Night Only')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }))
+    expect(await screen.findByText(/loading performers and venues/i)).toBeInTheDocument()
+
+    resolveDetails(
+      jsonResponse({
+        venues: [{ id: 7, name: 'The Mill', band_count: 1, address: '123 King St' }],
+        bands: [
+          {
+            id: 20,
+            performance_id: 201,
+            name: 'Only Band',
+            venue_id: 7,
+            venue_name: 'The Mill',
+            start_time: '20:00',
+            end_time: '20:45',
+            performance_date: null,
+          },
+        ],
+        band_count: 1,
+        venue_count: 1,
+      })
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading performers and venues/i)).not.toBeInTheDocument()
+    })
+    // Appears in both the GenreDiscovery wall and the All Performers grid.
+    expect((await screen.findAllByText('Only Band'))[0]).toBeInTheDocument()
+
+    // A single-day event must not show a redundant date on every set (#540/#541).
+    const soleDayLabel = formatPerformanceDayLabel({
+      performance_date: null,
+      event_date: '2026-08-07',
+      event_end_date: null,
+    })
+    expect(screen.queryByText(soleDayLabel)).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -45,20 +45,26 @@ describe('EventTimeline', () => {
       resolveDetails = resolve
     })
 
-    global.fetch = vi.fn(url => {
-      if (url.startsWith('/api/events/timeline')) {
-        return Promise.resolve(jsonResponse(timelineData))
-      }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
 
-      if (url === '/api/events/1/details') {
-        return detailsPromise
-      }
+        if (url === '/api/events/1/details') {
+          return detailsPromise
+        }
 
-      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
-    })
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
   })
 
   afterEach(() => {
+    // restoreAllMocks does NOT undo a direct assignment to global.fetch --
+    // only unstubAllGlobals does, and only for vi.stubGlobal'd properties.
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -128,18 +134,24 @@ describe('EventTimeline duplicate performer chips (#605)', () => {
       resolveDetails = resolve
     })
 
-    global.fetch = vi.fn(url => {
-      if (url.startsWith('/api/events/timeline')) {
-        return Promise.resolve(jsonResponse(timelineData))
-      }
-      if (url === '/api/events/1/details') {
-        return detailsPromise
-      }
-      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
-    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        if (url === '/api/events/1/details') {
+          return detailsPromise
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
   })
 
   afterEach(() => {
+    // restoreAllMocks does NOT undo a direct assignment to global.fetch --
+    // only unstubAllGlobals does, and only for vi.stubGlobal'd properties.
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -230,15 +242,21 @@ describe('EventTimeline recap links', () => {
       upcoming: [{ ...baseEvent, id: 1, name: 'Upcoming Fest', slug: 'upcoming-fest', date: '2099-05-10' }],
       past: [{ ...baseEvent, id: 2, name: 'Past Fest', slug: 'past-fest', date: '2020-05-10' }],
     }
-    global.fetch = vi.fn(url => {
-      if (url.startsWith('/api/events/timeline')) {
-        return Promise.resolve(jsonResponse(timelineData))
-      }
-      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
-    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
   })
 
   afterEach(() => {
+    // restoreAllMocks does NOT undo a direct assignment to global.fetch --
+    // only unstubAllGlobals does, and only for vi.stubGlobal'd properties.
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -270,6 +288,9 @@ describe('EventTimeline recap links', () => {
 // for a single-day event (#540/#541: no lone "Day 1").
 describe('EventTimeline performance day labels (#743)', () => {
   afterEach(() => {
+    // restoreAllMocks does NOT undo a direct assignment to global.fetch --
+    // only unstubAllGlobals does, and only for vi.stubGlobal'd properties.
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -299,15 +320,18 @@ describe('EventTimeline performance day labels (#743)', () => {
     const detailsPromise = new Promise(resolve => {
       resolveDetails = resolve
     })
-    global.fetch = vi.fn(url => {
-      if (url.startsWith('/api/events/timeline')) {
-        return Promise.resolve(jsonResponse(timelineData))
-      }
-      if (url === '/api/events/1/details') {
-        return detailsPromise
-      }
-      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
-    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        if (url === '/api/events/1/details') {
+          return detailsPromise
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
 
     render(
       <MemoryRouter>
@@ -394,15 +418,18 @@ describe('EventTimeline performance day labels (#743)', () => {
     const detailsPromise = new Promise(resolve => {
       resolveDetails = resolve
     })
-    global.fetch = vi.fn(url => {
-      if (url.startsWith('/api/events/timeline')) {
-        return Promise.resolve(jsonResponse(timelineData))
-      }
-      if (url === '/api/events/1/details') {
-        return detailsPromise
-      }
-      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
-    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        if (url === '/api/events/1/details') {
+          return detailsPromise
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
 
     render(
       <MemoryRouter>
@@ -426,7 +453,11 @@ describe('EventTimeline performance day labels (#743)', () => {
             venue_name: 'The Mill',
             start_time: '20:00',
             end_time: '20:45',
-            performance_date: null,
+            // POPULATED, not null: the API supplies each set's own date, so a
+            // null fixture would only exercise the missing-date path and
+            // would not catch a regression that renders a label whenever
+            // performance_date exists on a single-day event.
+            performance_date: '2026-08-07',
           },
         ],
         band_count: 1,
@@ -442,7 +473,7 @@ describe('EventTimeline performance day labels (#743)', () => {
 
     // A single-day event must not show a redundant date on every set (#540/#541).
     const soleDayLabel = formatPerformanceDayLabel({
-      performance_date: null,
+      performance_date: '2026-08-07',
       event_date: '2026-08-07',
       event_end_date: null,
     })
@@ -455,6 +486,9 @@ describe('EventTimeline performance day labels (#743)', () => {
 // first real word) — regardless of the set-time order the API returns.
 describe('EventTimeline collapsed performer chips ordering', () => {
   afterEach(() => {
+    // restoreAllMocks does NOT undo a direct assignment to global.fetch --
+    // only unstubAllGlobals does, and only for vi.stubGlobal'd properties.
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -484,12 +518,15 @@ describe('EventTimeline collapsed performer chips ordering', () => {
       past: [],
     }
 
-    global.fetch = vi.fn(url => {
-      if (url.startsWith('/api/events/timeline')) {
-        return Promise.resolve(jsonResponse(timelineData))
-      }
-      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
-    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
 
     render(
       <MemoryRouter>
@@ -515,6 +552,9 @@ describe('EventTimeline collapsed performer chips ordering', () => {
 // haven't had a poster uploaded yet.
 describe('EventTimeline poster thumbnails (#658)', () => {
   afterEach(() => {
+    // restoreAllMocks does NOT undo a direct assignment to global.fetch --
+    // only unstubAllGlobals does, and only for vi.stubGlobal'd properties.
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -547,12 +587,15 @@ describe('EventTimeline poster thumbnails (#658)', () => {
       past: [],
     }
 
-    global.fetch = vi.fn(url => {
-      if (url.startsWith('/api/events/timeline')) {
-        return Promise.resolve(jsonResponse(timelineData))
-      }
-      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
-    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
 
     const { container } = render(
       <MemoryRouter>
@@ -599,12 +642,15 @@ describe('EventTimeline poster thumbnails (#658)', () => {
       past: [],
     }
 
-    global.fetch = vi.fn(url => {
-      if (url.startsWith('/api/events/timeline')) {
-        return Promise.resolve(jsonResponse(timelineData))
-      }
-      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
-    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
 
     const { container } = render(
       <MemoryRouter>
@@ -625,6 +671,9 @@ describe('EventTimeline poster thumbnails (#658)', () => {
 // fetches a single past poster until "Show History" is clicked.
 describe('EventTimeline past-section poster lazy mounting (#658)', () => {
   afterEach(() => {
+    // restoreAllMocks does NOT undo a direct assignment to global.fetch --
+    // only unstubAllGlobals does, and only for vi.stubGlobal'd properties.
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -650,12 +699,15 @@ describe('EventTimeline past-section poster lazy mounting (#658)', () => {
       past: [pastEvent(1, 'Past Fest One'), pastEvent(2, 'Past Fest Two'), pastEvent(3, 'Past Fest Three')],
     }
 
-    global.fetch = vi.fn(url => {
-      if (url.startsWith('/api/events/timeline')) {
-        return Promise.resolve(jsonResponse(timelineData))
-      }
-      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
-    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
 
     const { container } = render(
       <MemoryRouter>
@@ -765,12 +817,15 @@ describe('EventTimeline past-section poster lazy mounting (#658)', () => {
       ],
     }
 
-    global.fetch = vi.fn(url => {
-      if (url.startsWith('/api/events/timeline')) {
-        return Promise.resolve(jsonResponse(timelineData))
-      }
-      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
-    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
 
     const { container } = render(
       <MemoryRouter>

--- a/frontend/src/pages/VenuePage.jsx
+++ b/frontend/src/pages/VenuePage.jsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet-async'
 import { ArrowLeft, CalendarDays, Globe, MapPin, TriangleAlert } from 'lucide-react'
 import Footer from '../components/Footer'
 import ThemeToggle from '../components/ThemeToggle.jsx'
+import { formatPerformanceDayLabel } from '../utils/timeFormat'
 import { fetchPublicJson } from '../utils/publicApi'
 import { trackPageView } from '../utils/metrics'
 import { buildBandProfileHref } from '../utils/bandProfileLink'
@@ -41,10 +42,15 @@ function PerformanceRow({ perf }) {
         ) : (
           <span>{perf.event_name}</span>
         )}
-        {perf.event_date && (
+        {/* This set's OWN day, not the event's start date (#741). A venue
+            hosting 12 sets across a 3-day festival previously showed all of
+            them as day 1. formatPerformanceDayLabel adds "(Day N)" only when
+            the event actually spans more than one day (#540/#541) and returns
+            null for an unparseable date, so the whole row is gated on it. */}
+        {formatPerformanceDayLabel(perf) && (
           <span className="inline-flex items-center gap-1">
             <CalendarDays size={13} aria-hidden="true" />
-            {perf.event_date}
+            {formatPerformanceDayLabel(perf)}
           </span>
         )}
       </p>

--- a/frontend/src/pages/VenuePage.jsx
+++ b/frontend/src/pages/VenuePage.jsx
@@ -16,6 +16,12 @@ function PerformanceRow({ perf }) {
   // performance. The visible "Cancelled" label is the accessible carrier
   // (WCAG 1.4.1) -- strikethrough alone isn't announced by screen readers.
   const isCancelled = Boolean(perf.is_cancelled)
+  // Computed once: the guard and the rendered value must be the same
+  // expression, or they can drift apart. Unlike EventTimeline this is NOT
+  // gated on the event being multi-day -- this row shows no other date, so on
+  // a single-day event the label is the only one present and suppressing it
+  // would remove information rather than redundancy.
+  const dayLabel = formatPerformanceDayLabel(perf)
   return (
     <div className="rounded-lg border border-border bg-bg-purple/40 p-4">
       {perf.band_name && (
@@ -42,15 +48,10 @@ function PerformanceRow({ perf }) {
         ) : (
           <span>{perf.event_name}</span>
         )}
-        {/* This set's OWN day, not the event's start date (#741). A venue
-            hosting 12 sets across a 3-day festival previously showed all of
-            them as day 1. formatPerformanceDayLabel adds "(Day N)" only when
-            the event actually spans more than one day (#540/#541) and returns
-            null for an unparseable date, so the whole row is gated on it. */}
-        {formatPerformanceDayLabel(perf) && (
+        {dayLabel && (
           <span className="inline-flex items-center gap-1">
             <CalendarDays size={13} aria-hidden="true" />
-            {formatPerformanceDayLabel(perf)}
+            {dayLabel}
           </span>
         )}
       </p>

--- a/functions/api/events/[id]/details.js
+++ b/functions/api/events/[id]/details.js
@@ -82,7 +82,10 @@ export async function onRequestGet(context) {
       LEFT JOIN venues v ON p.venue_id = v.id
       WHERE p.event_id = ?
         AND (? = 0 OR p.is_announced = 1)
-      ORDER BY COALESCE(p.performance_date, ?) ASC, p.start_time, v.name
+      -- Final key is the BAND name, not the venue's: two bands sharing a venue
+      -- and start time would otherwise come back in non-deterministic order.
+      -- Matches recap.js, which already orders on bp.name.
+      ORDER BY COALESCE(p.performance_date, ?) ASC, p.start_time, b.name
     `,
     )
       .bind(eventId, event.reveal_mode ?? 0, event.date)

--- a/functions/api/events/[id]/details.js
+++ b/functions/api/events/[id]/details.js
@@ -86,10 +86,12 @@ export async function onRequestGet(context) {
       LEFT JOIN venues v ON p.venue_id = v.id
       WHERE p.event_id = ?
         AND (? = 0 OR p.is_announced = 1)
-      -- Final key is the BAND name, not the venue's: two bands sharing a venue
-      -- and start time would otherwise come back in non-deterministic order.
-      -- Matches recap.js, which already orders on bp.name.
-      ORDER BY COALESCE(p.performance_date, ?) ASC, p.start_time, b.name
+      -- Ordered by the BAND name rather than the venue's: two bands sharing a
+      -- venue and start time would otherwise come back in arbitrary order.
+      -- p.id is the final, UNIQUE key -- name alone still ties when one band
+      -- plays two sets at the same time slot, and SQLite gives no stable order
+      -- for a full tie. Matches the venues/[id].js ordering.
+      ORDER BY COALESCE(p.performance_date, ?) ASC, p.start_time, b.name, p.id
     `,
     )
       .bind(eventId, event.reveal_mode ?? 0, event.date)

--- a/functions/api/events/[id]/details.js
+++ b/functions/api/events/[id]/details.js
@@ -1,5 +1,5 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
-import { normalizeHttpUrl } from "../../../utils/validation.js";
+import { normalizeHttpUrl, validateId } from "../../../utils/validation.js";
 
 /**
  * Public API: Get event details (bands + venues) for a single published event
@@ -23,8 +23,12 @@ export async function onRequestGet(context) {
     return [line1, line2, line3].filter(Boolean).join(", ");
   };
 
-  const eventId = Number(params.id);
-  if (!Number.isFinite(eventId)) {
+  // Standing convention: every params.id from a Pages Functions route goes
+  // through validateId() before it reaches a query. Number.isFinite() alone
+  // accepted 1.5, 0 and -3 here; validateId requires a positive integer.
+  const idCheck = validateId(params.id);
+  const eventId = idCheck.value;
+  if (!idCheck.valid) {
     return new Response(JSON.stringify({ error: "Invalid event id" }), {
       status: 400,
       headers: { "Content-Type": "application/json" },

--- a/functions/api/events/[id]/details.js
+++ b/functions/api/events/[id]/details.js
@@ -64,6 +64,7 @@ export async function onRequestGet(context) {
         b.name as band_name,
         p.start_time,
         p.end_time,
+        p.performance_date,
         p.is_cancelled,
         b.genre,
         b.photo_url,
@@ -81,10 +82,10 @@ export async function onRequestGet(context) {
       LEFT JOIN venues v ON p.venue_id = v.id
       WHERE p.event_id = ?
         AND (? = 0 OR p.is_announced = 1)
-      ORDER BY p.start_time, v.name
+      ORDER BY COALESCE(p.performance_date, ?) ASC, p.start_time, v.name
     `,
     )
-      .bind(eventId, event.reveal_mode ?? 0)
+      .bind(eventId, event.reveal_mode ?? 0, event.date)
       .all();
 
     const rows = bandsResult.results || [];
@@ -124,6 +125,11 @@ export async function onRequestGet(context) {
         name: row.band_name,
         start_time: row.start_time,
         end_time: row.end_time,
+        // NULL for day-1 sets and single-day events (#543 convention) --
+        // exposed raw, not synthesized to event.date, since
+        // formatPerformanceDayLabel() already falls back to event_date itself
+        // when performance_date is absent.
+        performance_date: row.performance_date,
         is_cancelled: row.is_cancelled,
         genre: row.genre,
         photo_url: row.photo_url,

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -110,7 +110,10 @@ export async function onRequestGet(context) {
       JOIN band_profiles bp ON p.band_profile_id = bp.id
       LEFT JOIN venues v ON p.venue_id = v.id
       WHERE p.event_id = ?
-      ORDER BY COALESCE(p.performance_date, ?) ASC, p.start_time NULLS LAST, bp.name
+      -- p.id is the final, UNIQUE key: bp.name alone still ties when one band
+      -- plays two sets in the same slot, and SQLite gives no stable order for
+      -- a full tie. Matches details.js and venues/[id].js.
+      ORDER BY COALESCE(p.performance_date, ?) ASC, p.start_time NULLS LAST, bp.name, p.id
       `,
     )
       .bind(event.id, event.date, event.date, event.id, event.id, event.date)

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -14,6 +14,22 @@ function compareStartTimeNullsLast(a, b) {
   return a.start_time < b.start_time ? -1 : a.start_time > b.start_time ? 1 : 0;
 }
 
+// (#743) A multi-day event's sets must sort by the DAY they belong to before
+// clock time — sorting on start_time alone interleaves days (a Day 3 16:10
+// set sorting ahead of a Day 1 20:00 set). `performance_date` is NULL for
+// day-1 sets and single-day events (#543 convention), so it falls back to the
+// event's own start date. Returns a comparator closed over that fallback.
+function comparePerformanceDayThenStartTime(eventDate) {
+  return (a, b) => {
+    const dayA = a.performance_date || eventDate;
+    const dayB = b.performance_date || eventDate;
+    if (dayA !== dayB) {
+      return dayA < dayB ? -1 : 1;
+    }
+    return compareStartTimeNullsLast(a, b);
+  };
+}
+
 /**
  * Public API: Get recap stats and band list for a single archived event
  *
@@ -40,12 +56,12 @@ export async function onRequestGet(context) {
   try {
     const event = isNumeric
       ? await DB.prepare(
-          `SELECT id, name, slug, date, poster_url FROM events WHERE id = ? AND status = 'archived' LIMIT 1`,
+          `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE id = ? AND status = 'archived' LIMIT 1`,
         )
           .bind(numericId)
           .first()
       : await DB.prepare(
-          `SELECT id, name, slug, date, poster_url FROM events WHERE slug = ? AND status = 'archived' LIMIT 1`,
+          `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE slug = ? AND status = 'archived' LIMIT 1`,
         )
           .bind(rawId)
           .first();
@@ -71,6 +87,7 @@ export async function onRequestGet(context) {
         bp.photo_url,
         p.start_time,
         p.end_time,
+        p.performance_date,
         v.id   AS venue_id,
         v.name AS venue_name,
         CASE WHEN EXISTS (
@@ -93,10 +110,10 @@ export async function onRequestGet(context) {
       JOIN band_profiles bp ON p.band_profile_id = bp.id
       LEFT JOIN venues v ON p.venue_id = v.id
       WHERE p.event_id = ?
-      ORDER BY p.start_time NULLS LAST, bp.name
+      ORDER BY COALESCE(p.performance_date, ?) ASC, p.start_time NULLS LAST, bp.name
       `,
     )
-      .bind(event.id, event.date, event.date, event.id, event.id)
+      .bind(event.id, event.date, event.date, event.id, event.id, event.date)
       .all();
 
     const rows = bandsResult.results || [];
@@ -125,13 +142,19 @@ export async function onRequestGet(context) {
         photo_url: row.photo_url,
         start_time: row.start_time,
         end_time: row.end_time,
+        // NULL for day-1 sets and single-day events (#543 convention) --
+        // exposed raw, not synthesized to event.date, since
+        // formatPerformanceDayLabel() already falls back to event_date itself
+        // when performance_date is absent.
+        performance_date: row.performance_date,
         venue_id: row.venue_id,
         venue_name: row.venue_name,
         is_returning: isReturning,
       };
     });
 
-    bands.sort((a, b) => compareStartTimeNullsLast(a, b) || sortableName(a.name).localeCompare(sortableName(b.name)));
+    const comparePerformanceDay = comparePerformanceDayThenStartTime(event.date);
+    bands.sort((a, b) => comparePerformanceDay(a, b) || sortableName(a.name).localeCompare(sortableName(b.name)));
 
     const stats = {
       total_sets: rows.length, // performance slots; one band playing two sets counts as 2

--- a/functions/api/events/__tests__/details.test.js
+++ b/functions/api/events/__tests__/details.test.js
@@ -80,6 +80,80 @@ describe("GET /api/events/:id/details", () => {
   });
 });
 
+// #743 — performance_date missing from the details projection. A multi-day
+// event's sets all reported the SAME event-level `date` and were sorted by
+// `p.start_time` alone, so a Day 3 late-afternoon set sorted ahead of a Day 1
+// evening set and the frontend (EventTimeline.jsx's "All Performers" grid)
+// had no way to render which day a set belonged to.
+describe("GET /api/events/:id/details - performance_date across a multi-day event (#743)", () => {
+  test("emits performance_date on every band and orders by performance day before start_time", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Buddies Fest 2",
+      slug: "details-multiday-743",
+      date: "2026-08-07",
+      end_date: "2026-08-09",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    const venue = insertVenue(rawDb, { name: "The Mill" });
+
+    // Day 3, EARLY time -- if sorted on start_time alone this sorts FIRST.
+    const day3 = insertBand(rawDb, {
+      name: "Day 3 Early Act",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "16:10",
+      end_time: "16:45",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-08-09", day3.id);
+
+    // Day 1, LATE time -- NULL performance_date (the #543 convention: day-1
+    // sets store NULL, inheriting the event's own date).
+    const day1 = insertBand(rawDb, {
+      name: "Day 1 Late Act",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "20:45",
+    });
+
+    // Day 2, mid time.
+    const day2 = insertBand(rawDb, {
+      name: "Day 2 Mid Act",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "18:45",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-08-08", day2.id);
+
+    const request = new Request(`https://example.test/api/events/${event.id}/details`);
+    const response = await onRequestGet({
+      request,
+      env,
+      params: { id: String(event.id) },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    expect(payload.bands).toHaveLength(3);
+
+    // Every band exposes its own performance_date (day 1 NULL -- the raw
+    // stored value, not synthesized -- days 2/3 their explicit dates).
+    const byName = Object.fromEntries(payload.bands.map((b) => [b.name, b]));
+    expect(byName["Day 1 Late Act"].performance_date).toBeNull();
+    expect(byName["Day 2 Mid Act"].performance_date).toBe("2026-08-08");
+    expect(byName["Day 3 Early Act"].performance_date).toBe("2026-08-09");
+
+    // Order: Day 1 (20:00) -> Day 2 (18:00) -> Day 3 (16:10). A start_time-only
+    // sort would put Day 3's 16:10 FIRST -- assert on the actual order, not a
+    // length, to catch that regression.
+    expect(payload.bands.map((b) => b.name)).toEqual(["Day 1 Late Act", "Day 2 Mid Act", "Day 3 Early Act"]);
+  });
+});
+
 // Regression: a band playing two sets at one event was counted twice in
 // band_count (the details endpoint's expanded lineup flips the stat row from
 // "32 Bands" collapsed to 34 after expanding). `bands` stays per-performance

--- a/functions/api/events/__tests__/details.test.js
+++ b/functions/api/events/__tests__/details.test.js
@@ -110,7 +110,7 @@ describe("GET /api/events/:id/details - performance_date across a multi-day even
 
     // Day 1, LATE time -- NULL performance_date (the #543 convention: day-1
     // sets store NULL, inheriting the event's own date).
-    const day1 = insertBand(rawDb, {
+    insertBand(rawDb, {
       name: "Day 1 Late Act",
       event_id: event.id,
       venue_id: venue.id,

--- a/functions/api/events/__tests__/recap.test.js
+++ b/functions/api/events/__tests__/recap.test.js
@@ -431,6 +431,70 @@ describe("GET /api/events/:id/recap", () => {
     expect(payload.event.poster_url).toBeNull();
   });
 
+  // #743 — performance_date missing from the recap projection, and the final
+  // sort keyed on start_time ALONE, so a Day 3 late-afternoon set sorted
+  // ahead of a Day 1 evening set across a multi-day archived event.
+  test("emits performance_date + event.end_date, and orders bands by performance day before start_time", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Buddies Fest 2 Recap",
+      slug: "recap-multiday-743",
+      date: "2026-08-07",
+      end_date: "2026-08-09",
+      status: "archived",
+    });
+
+    const venue = insertVenue(rawDb, { name: "The Mill" });
+
+    // Day 3, EARLY time -- if sorted on start_time alone this sorts FIRST.
+    const day3 = insertBand(rawDb, {
+      name: "Day 3 Early Act",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "16:10",
+      end_time: "16:45",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-08-09", day3.id);
+
+    // Day 1, LATE time -- NULL performance_date (#543 convention).
+    insertBand(rawDb, {
+      name: "Day 1 Late Act",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "20:45",
+    });
+
+    // Day 2, mid time.
+    const day2 = insertBand(rawDb, {
+      name: "Day 2 Mid Act",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "18:00",
+      end_time: "18:45",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-08-08", day2.id);
+
+    const request = new Request(`https://example.test/api/events/${event.slug}/recap`);
+    const response = await onRequestGet({ request, env, params: { id: event.slug } });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    expect(payload.event.end_date).toBe("2026-08-09");
+
+    expect(payload.bands).toHaveLength(3);
+    const byName = Object.fromEntries(payload.bands.map((b) => [b.name, b]));
+    expect(byName["Day 1 Late Act"].performance_date).toBeNull();
+    expect(byName["Day 2 Mid Act"].performance_date).toBe("2026-08-08");
+    expect(byName["Day 3 Early Act"].performance_date).toBe("2026-08-09");
+
+    // Order: Day 1 (20:00) -> Day 2 (18:00) -> Day 3 (16:10). A start_time-only
+    // sort would put Day 3's 16:10 FIRST -- assert on the actual order.
+    expect(payload.bands.map((b) => b.name)).toEqual(["Day 1 Late Act", "Day 2 Mid Act", "Day 3 Early Act"]);
+  });
+
   test("returns 503 when PUBLIC_DATA_PUBLISH_ENABLED is not set", async () => {
     const { env, rawDb } = createTestEnv();
     // Do NOT set PUBLIC_DATA_PUBLISH_ENABLED

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -1425,6 +1425,166 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Real-DB — end-edge gate (#751). The "now"/"past" split bound to
+// eventLocalToday() (the CALENDAR day) drops an event out of "now" into
+// "past" at local midnight on its last night, even while its after-midnight
+// sets (AFTER_MIDNIGHT_THRESHOLD_HOUR = 6, functions/utils/eventDay.js) are
+// still playing. This mirrors the #569 start-edge suite: only the END bound
+// (`COALESCE(e.end_date, e.date) >= / < today`) uses eventLocalFestivalToday()
+// — the START bound (`e.date <= today`) stays on the plain calendar day so the
+// existing #569 "last-resort fallback" case (an event that has ALREADY
+// started earlier tonight, before 6 AM, with no doors/set-time signal) is
+// unaffected: that event's own `e.date` still equals the actual calendar day.
+// Clocks are pinned inside the 00:00–06:00 window specifically, since outside
+// it eventLocalFestivalToday() and eventLocalToday() return identical values
+// and any test would pass against both the broken and fixed implementation.
+// ---------------------------------------------------------------------------
+describe("Timeline real-DB — end-edge gate (#751)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("single-day event with an after-midnight set stays in 'now' (not 'past') at 00:15 the following calendar day", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-07-11T04:15:00Z = 00:15 EDT on Jul 11 — 15 minutes past local
+    // midnight, well before the 06:00 threshold. Calendar day has already
+    // rolled to Jul 11; the event is dated Jul 10.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-11T04:15:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "After Midnight Single Night",
+      slug: "timeline-endedge-single",
+      date: "2026-07-10",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "Roost" });
+    const evening = insertBand(rawDb, {
+      name: "Evening Headliner",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "19:00",
+      end_time: "20:00",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-07-10", evening.id);
+    const nightOwl = insertBand(rawDb, {
+      name: "Night Owl Set",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "01:00",
+      end_time: "02:00",
+    });
+    // After-midnight set: belongs to the Jul 10 evening (per convention), even
+    // though it's actually playing during the Jul 11 small hours.
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-07-10", nightOwl.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeDefined();
+    expect(data.past.find((e) => e.id === event.id)).toBeUndefined();
+  });
+
+  test("that same single-day event flips to 'past' once the 06:00 threshold passes", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-07-11T10:15:00Z = 06:15 EDT on Jul 11 — just past the after-midnight
+    // threshold. The event must not linger in "now" forever.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-11T10:15:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "After Midnight Single Night Cutover",
+      slug: "timeline-endedge-single-cutover",
+      date: "2026-07-10",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeUndefined();
+    expect(data.past.find((e) => e.id === event.id)).toBeDefined();
+  });
+
+  test("multi-day event's after-midnight sets on the LAST night keep it in 'now' at 00:15 the following day (Buddies Fest 2 production case)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 2026-08-10T04:15:00Z = 00:15 EDT on Aug 10. The event's end_date is
+    // Aug 9 -- exactly the reported production failure (#751).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-10T04:15:00Z"));
+
+    const event = insertEvent(rawDb, {
+      name: "Buddies Fest 2",
+      slug: "timeline-endedge-multiday",
+      date: "2026-08-07",
+      end_date: "2026-08-09",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "The Mill" });
+    const lastNightSet = insertBand(rawDb, {
+      name: "Last Night Owl Set",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "01:00",
+      end_time: "02:00",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-08-09", lastNightSet.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeDefined();
+    expect(data.past.find((e) => e.id === event.id)).toBeUndefined();
+  });
+
+  // Proves the START bound was deliberately left on the calendar day: the
+  // existing #569 last-resort-fallback test (an event with NO doors/set-time
+  // signal, pinned at 00:01 on its OWN start date) must stay green. If the
+  // START bound were also switched to eventLocalFestivalToday(), the event's
+  // `e.date` (today) would no longer satisfy `e.date <= today` (yesterday, in
+  // festival terms) and it would vanish from "now" entirely.
+  test("an event just past its OWN local midnight (no signals) still starts in 'now' — start bound unaffected", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T04:01:00Z")); // 00:01 EDT, Jul 10 is TODAY
+
+    const event = insertEvent(rawDb, {
+      name: "No Doors Info Event End-Edge Check",
+      slug: "timeline-endedge-startbound-check",
+      date: "2026-07-10",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    const request = new Request("https://example.test/api/events/timeline");
+    const response = await timelineHandler({ request, env });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.now.find((e) => e.id === event.id)).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Real-DB — end_date exposed on every timeline bucket (#542 PR-1). Clients key
 // schedule stale-detection on `end_date || date`; keying it on the start date
 // alone wipes a fan's saved schedule on day 2 of a multi-day event. The "now"

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -1495,10 +1495,12 @@ describe("Timeline real-DB — end-edge gate (#751)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
 
-    // 2026-07-11T10:15:00Z = 06:15 EDT on Jul 11 — just past the after-midnight
-    // threshold. The event must not linger in "now" forever.
+    // 2026-07-11T10:00:00Z = 06:00 EDT on Jul 11 -- EXACTLY at the threshold.
+    // eventLocalFestivalToday() steps back only while hour < 6, so testing
+    // 06:15 would still pass against an implementation that used > instead
+    // of >=. The boundary instant is the only one that discriminates.
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-11T10:15:00Z"));
+    vi.setSystemTime(new Date("2026-07-11T10:00:00Z"));
 
     const event = insertEvent(rawDb, {
       name: "After Midnight Single Night Cutover",

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -1,6 +1,6 @@
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { normalizeHttpUrl } from "../../utils/validation.js";
-import { eventLocalToday, eventLocalClock } from "../../utils/eventDay.js";
+import { eventLocalToday, eventLocalFestivalToday, eventLocalClock } from "../../utils/eventDay.js";
 
 /**
  * 24-hour "HH:MM" time regex — mirrors DOORS_TIME_REGEX in validation.js.
@@ -121,6 +121,18 @@ export async function onRequestGet(context) {
     };
 
     const today = eventLocalToday(); // YYYY-MM-DD, events' local (Toronto) day — not UTC
+    // (#751) The END edge of "now"/"past" uses the FESTIVAL day, not the
+    // calendar day: between local midnight and AFTER_MIDNIGHT_THRESHOLD_HOUR
+    // (06:00), an event's last night is still airing even though the calendar
+    // has already rolled over. Only the END bound (COALESCE(end_date, date)
+    // >= / < today) uses this — the START bound (e.date <= today, below)
+    // deliberately stays on the plain calendar day: the #569 start-edge gate
+    // already handles an event's OWN first-day start precisely (doors → first
+    // set → midnight fallback), and switching the START bound too would drop
+    // a same-day event with no start-edge signal out of the "now" SQL results
+    // entirely during its own 00:00-06:00 window (see the "start bound
+    // unaffected" regression test in timeline.test.js).
+    const todayFestivalEnd = eventLocalFestivalToday();
 
     // Helper function to group bands by event (processes results from JOIN query)
     function groupEventData(rows) {
@@ -256,10 +268,13 @@ export async function onRequestGet(context) {
     const slots = {};
 
     // "Now" events (happening today) - single JOIN query.
-    // e.date <= today AND COALESCE(end_date, date) >= today: today falls within
-    // the event's [date, end_date] span, so a multi-day event stays "now" on
-    // day 2+ instead of sliding into "past" (#539). NULL end_date collapses
-    // this to the original `e.date = today` for single-day events.
+    // e.date <= today AND COALESCE(end_date, date) >= todayFestivalEnd: today
+    // falls within the event's [date, end_date] span, so a multi-day event
+    // stays "now" on day 2+ instead of sliding into "past" (#539). NULL
+    // end_date collapses this to the original `e.date = today` for
+    // single-day events. The END side uses the FESTIVAL day (#751) so an
+    // event's last-night after-midnight sets keep it in "now" until 06:00 the
+    // next calendar day instead of dropping out at local midnight.
     //
     // `AND p.is_cancelled = 0` on the JOIN (not a WHERE clause, which would
     // silently demote a LEFT JOIN to an INNER JOIN and drop the event row
@@ -320,7 +335,7 @@ export async function onRequestGet(context) {
         AND COALESCE(e.end_date, e.date) >= ?
         ORDER BY e.date DESC, p.start_time, v.name
       `,
-        ).bind(today, today),
+        ).bind(today, todayFestivalEnd),
       );
     }
 
@@ -382,9 +397,13 @@ export async function onRequestGet(context) {
     }
 
     // "Past" events (historical) - single JOIN query.
-    // COALESCE(end_date, date) < today: a multi-day event isn't "past" until
-    // its end_date has elapsed, so it doesn't slip out of "now" a day early
-    // (#539). NULL end_date collapses this to the original `e.date < today`.
+    // COALESCE(end_date, date) < todayFestivalEnd: a multi-day event isn't
+    // "past" until its end_date has elapsed, so it doesn't slip out of "now" a
+    // day early (#539). NULL end_date collapses this to the original
+    // `e.date < today`. Uses the FESTIVAL day (#751, same value as the "now"
+    // query's END bound above) so the two buckets stay mutually exclusive —
+    // an event doesn't drop into "past" while its after-midnight sets are
+    // still keeping it "now".
     if (includePast) {
       slots.past = statements.length;
       statements.push(
@@ -435,7 +454,7 @@ export async function onRequestGet(context) {
         )
         ORDER BY e.date DESC, p.start_time, v.name
       `,
-        ).bind(today, today, pastLimit),
+        ).bind(todayFestivalEnd, todayFestivalEnd, pastLimit),
       );
     }
 

--- a/functions/api/venues/[id].js
+++ b/functions/api/venues/[id].js
@@ -72,7 +72,10 @@ export async function onRequestGet(context) {
       -- Ordering on start_time alone put a day-3 16:10 set ahead of a day-1
       -- 20:00 set, because every set at one event shares e.date. The coalesce
       -- keeps single-day events (NULL performance_date) working unchanged.
-      ORDER BY e.date DESC, COALESCE(p.performance_date, e.date) ASC, p.start_time
+      -- bp.name and p.id are the deterministic tie-break: without them two sets
+      -- sharing an event date, performance date and start time come back in
+      -- whatever order SQLite happens to produce, which can differ run to run.
+      ORDER BY e.date DESC, COALESCE(p.performance_date, e.date) ASC, p.start_time, bp.name, p.id
     `,
     )
       .bind(id)

--- a/functions/api/venues/[id].js
+++ b/functions/api/venues/[id].js
@@ -52,11 +52,13 @@ export async function onRequestGet(context) {
         p.id AS performance_id,
         p.start_time,
         p.end_time,
+        p.performance_date,
         p.is_cancelled,
         e.id AS event_id,
         e.name AS event_name,
         e.slug AS event_slug,
         e.date AS event_date,
+        e.end_date AS event_end_date,
         e.status AS event_status,
         bp.id AS band_id,
         bp.name AS band_name
@@ -66,7 +68,11 @@ export async function onRequestGet(context) {
       WHERE p.venue_id = ?
         AND (e.is_published = 1 OR e.status = 'archived')
         AND (e.reveal_mode = 0 OR p.is_announced = 1)
-      ORDER BY e.date DESC, p.start_time
+      -- Events newest-first, but sets CHRONOLOGICAL within an event (#741).
+      -- Ordering on start_time alone put a day-3 16:10 set ahead of a day-1
+      -- 20:00 set, because every set at one event shares e.date. The coalesce
+      -- keeps single-day events (NULL performance_date) working unchanged.
+      ORDER BY e.date DESC, COALESCE(p.performance_date, e.date) ASC, p.start_time
     `,
     )
       .bind(id)
@@ -80,15 +86,25 @@ export async function onRequestGet(context) {
     // playing. eventLocalFestivalToday() stays on the previous date until
     // 06:00, so the split doesn't flip a still-airing performance to "past".
     const today = eventLocalFestivalToday();
-    const isPast = (p) => p.event_date < today || p.event_status === "archived";
+    // Per-PERFORMANCE, not per-event (#603/#741): on a multi-day event each
+    // set's OWN day decides its bucket, so a venue's day-1 set is already
+    // "past" while its day-3 set is still "upcoming" mid-festival. NULL
+    // performance_date inherits the event's start date (the #543 convention).
+    const isPast = (p) => (p.performance_date || p.event_date) < today || p.event_status === "archived";
 
     const mapPerf = (p) => ({
       performance_id: p.performance_id,
       start_time: p.start_time,
+      // Which DAY of a multi-day event this set belongs to. Without it every
+      // set at one event reported the event's start date (#741).
+      performance_date: p.performance_date,
       end_time: p.end_time,
       is_cancelled: p.is_cancelled,
       event_id: p.event_id,
       event_name: p.event_name,
+      // NULL for single-day events. The client needs it to decide whether a
+      // "(Day N)" suffix belongs at all (#540/#541).
+      event_end_date: p.event_end_date || null,
       event_slug: p.event_slug,
       event_date: p.event_date,
       band_id: p.band_id,

--- a/functions/api/venues/[id].js
+++ b/functions/api/venues/[id].js
@@ -6,7 +6,7 @@
 
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { validateId } from "../../utils/validation.js";
-import { eventLocalToday } from "../../utils/eventDay.js";
+import { eventLocalFestivalToday } from "../../utils/eventDay.js";
 
 function json(body, status = 200, extraHeaders = {}) {
   return new Response(JSON.stringify(body), {
@@ -73,7 +73,13 @@ export async function onRequestGet(context) {
       .all();
 
     const all = perfs.results || [];
-    const today = eventLocalToday();
+    // (#750) Same bug class fixed in #732 for bands/[name].js and
+    // bands/stats/[name].js: eventLocalToday() is the CALENDAR day, which
+    // rolls over at local midnight while an after-midnight set (before
+    // AFTER_MIDNIGHT_THRESHOLD_HOUR = 6, functions/utils/eventDay.js) is still
+    // playing. eventLocalFestivalToday() stays on the previous date until
+    // 06:00, so the split doesn't flip a still-airing performance to "past".
+    const today = eventLocalFestivalToday();
     const isPast = (p) => p.event_date < today || p.event_status === "archived";
 
     const mapPerf = (p) => ({

--- a/functions/api/venues/__tests__/venue-detail.test.js
+++ b/functions/api/venues/__tests__/venue-detail.test.js
@@ -204,7 +204,12 @@ describe("GET /api/venues/:id — multi-day ordering and per-set dates (#741)", 
       start_time: "16:10",
       end_time: "16:45",
     });
-    const day1 = insertBand(rawDb, {
+    // Day 1 is deliberately left with a NULL performance_date, matching
+    // production (#543): only day 2+ carries an explicit date. Writing
+    // "2099-08-07" here would bypass the COALESCE(p.performance_date, e.date)
+    // fallback the ordering depends on, so the test would still pass with the
+    // coalesce removed.
+    insertBand(rawDb, {
       name: "Day One Band",
       event_id: event.id,
       venue_id: venue.id,
@@ -212,7 +217,6 @@ describe("GET /api/venues/:id — multi-day ordering and per-set dates (#741)", 
       end_time: "20:45",
     });
     rawDb.prepare("UPDATE performances SET performance_date = ? WHERE id = ?").run("2099-08-09", day3.id);
-    rawDb.prepare("UPDATE performances SET performance_date = ? WHERE id = ?").run("2099-08-07", day1.id);
 
     const response = await onRequestGet({
       request: new Request("https://x.test/api/venues/1"),
@@ -224,7 +228,7 @@ describe("GET /api/venues/:id — multi-day ordering and per-set dates (#741)", 
 
     // Assert on the DATES and the ORDER, not the count: a length check passes
     // against the broken version, which returned two rows too.
-    expect(payload.upcoming.map((p) => p.performance_date)).toEqual(["2099-08-07", "2099-08-09"]);
+    expect(payload.upcoming.map((p) => p.performance_date)).toEqual([null, "2099-08-09"]);
     expect(payload.upcoming.map((p) => p.band_name)).toEqual(["Day One Band", "Day Three Band"]);
     // The client needs the span to decide whether a "(Day N)" suffix belongs.
     expect(payload.upcoming[0].event_end_date).toBe("2099-08-09");

--- a/functions/api/venues/__tests__/venue-detail.test.js
+++ b/functions/api/venues/__tests__/venue-detail.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "vitest";
+import { afterEach, describe, test, expect, vi } from "vitest";
 import { onRequestGet } from "../[id].js";
 import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../test-utils.js";
 
@@ -91,5 +91,85 @@ describe("GET /api/venues/:id — reveal_mode gate", () => {
     const payload = await response.json();
     expect(payload.upcoming).toHaveLength(1);
     expect(payload.upcoming[0].band_name).toBe("Normal Venue Band");
+  });
+});
+
+// #750 — the upcoming/past split bound to eventLocalToday() (the CALENDAR
+// day), the same bug class fixed in #732 for bands/[name].js and
+// bands/stats/[name].js. A single-day event with an after-midnight set is
+// still "tonight" until AFTER_MIDNIGHT_THRESHOLD_HOUR (06:00) the next
+// calendar day. Pinning the clock inside the 00:00-06:00 window is required —
+// outside it eventLocalFestivalToday() and eventLocalToday() return identical
+// values, and an unpinned test would pass against both the broken and fixed
+// implementation.
+describe("GET /api/venues/:id — end-edge gate (#750)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("a performance at a single-day event dated the PREVIOUS calendar day stays in 'upcoming' at 00:15 local (festival day, not calendar day)", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 00:15 EDT on 2026-08-08 -> 2026-08-08T04:15Z (same instant used by the
+    // eventDay.js unit suite and the #732 bands/[name].js regression test).
+    // Calendar day is already 2026-08-08; festival day is still 2026-08-07
+    // until the 06:00 threshold.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-08T04:15:00Z"));
+
+    const venue = insertVenue(rawDb, { name: "The Mill" });
+    const event = insertEvent(rawDb, {
+      name: "Venue End-Edge Event",
+      slug: "venue-endedge-single",
+      date: "2026-08-07",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    const perf = insertBand(rawDb, {
+      name: "Night Owl Set",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "01:00",
+      end_time: "02:00",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-08-07", perf.id);
+
+    const response = await onRequestGet({ env, params: { id: String(venue.id) } });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(1);
+    expect(payload.upcoming[0].band_name).toBe("Night Owl Set");
+    expect(payload.past).toHaveLength(0);
+  });
+
+  test("that same performance flips to 'past' once the 06:00 threshold passes", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // 06:15 EDT on 2026-08-08 -> just past the after-midnight threshold.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-08T10:15:00Z"));
+
+    const venue = insertVenue(rawDb, { name: "The Mill" });
+    const event = insertEvent(rawDb, {
+      name: "Venue End-Edge Cutover Event",
+      slug: "venue-endedge-single-cutover",
+      date: "2026-08-07",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    const perf = insertBand(rawDb, {
+      name: "Cutover Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+
+    const response = await onRequestGet({ env, params: { id: String(venue.id) } });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(0);
+    expect(payload.past).toHaveLength(1);
+    expect(payload.past[0].performance_id).toBe(perf.id);
   });
 });

--- a/functions/api/venues/__tests__/venue-detail.test.js
+++ b/functions/api/venues/__tests__/venue-detail.test.js
@@ -173,3 +173,60 @@ describe("GET /api/venues/:id — end-edge gate (#750)", () => {
     expect(payload.past[0].performance_id).toBe(perf.id);
   });
 });
+
+// #741 — a venue hosting sets across every day of a multi-day event returned
+// only `event_date`, so all of them reported day 1, and ordering on
+// `start_time` alone put a late-afternoon day-3 set ahead of an evening day-1
+// set. Verified against production: The Mill had 12 sets across 3 days, all
+// reporting 2026-08-07.
+describe("GET /api/venues/:id — multi-day ordering and per-set dates (#741)", () => {
+  test("returns each set's own performance_date, ordered day 1 before day 3", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "The Mill" });
+    const event = insertEvent(rawDb, {
+      name: "Three Day Fest",
+      slug: "three-day-fest",
+      date: "2099-08-07",
+      end_date: "2099-08-09",
+      status: "published",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+
+    // Deliberately inserted out of order, with the LATEST day carrying the
+    // EARLIEST clock time -- the exact shape that made start_time-only
+    // ordering wrong.
+    const day3 = insertBand(rawDb, {
+      name: "Day Three Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "16:10",
+      end_time: "16:45",
+    });
+    const day1 = insertBand(rawDb, {
+      name: "Day One Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "20:45",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date = ? WHERE id = ?").run("2099-08-09", day3.id);
+    rawDb.prepare("UPDATE performances SET performance_date = ? WHERE id = ?").run("2099-08-07", day1.id);
+
+    const response = await onRequestGet({
+      request: new Request("https://x.test/api/venues/1"),
+      env,
+      params: { id: String(venue.id) },
+    });
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    // Assert on the DATES and the ORDER, not the count: a length check passes
+    // against the broken version, which returned two rows too.
+    expect(payload.upcoming.map((p) => p.performance_date)).toEqual(["2099-08-07", "2099-08-09"]);
+    expect(payload.upcoming.map((p) => p.band_name)).toEqual(["Day One Band", "Day Three Band"]);
+    // The client needs the span to decide whether a "(Day N)" suffix belongs.
+    expect(payload.upcoming[0].event_end_date).toBe("2099-08-09");
+  });
+});


### PR DESCRIPTION
## Summary

Four bugs, all live, three days before a three-day festival. They are two classes: a **calendar day used where the festival day is meant**, and **`performance_date` missing from projections**, so multi-day events render and sort as if they were one day.

Both tools already existed — `eventLocalFestivalToday()` and `formatPerformanceDayLabel()` shipped in #749. This is mostly applying them, plus proving the boundary.

Closes #751
Closes #750
Closes #743
Closes #741

## What changed

| # | Bug | Fix |
|---|---|---|
| **751** | An event with after-midnight sets on its final night left "Happening Now" at local midnight | `timeline.js` binds `eventLocalFestivalToday()` for the now/upcoming/past windows |
| **750** | Venue upcoming/past split flipped at calendar midnight, so a set playing at 00:35 showed as "past" | Same helper in `venues/[id].js` |
| **743** | GenreDiscovery showed set times with no day; recap sorted on `start_time` alone across days | `details.js` + `recap.js` project `performance_date` and sort on `COALESCE(...)`; the All Performers grid renders the day |
| **741** | A venue's 12 sets across 3 days all reported day 1, with the Aug 9 16:10 set listed first | `venues/[id].js` projects `performance_date` + `event_end_date`, orders correctly, splits per-set; `VenuePage` renders the day |

## Verified against production, not just reasoned about

`GET /api/venues/20` returned 12 performances, every one reporting `event_date: 2026-08-07`, with no `performance_date` field at all — while D1 held 4 sets on each of Aug 7, 8 and 9.

Worth recording: **#751 does not affect Buddies Fest 2.** It only bites at midnight on an event's *final* night, and BF2's last night ends by 23:00 with no after-midnight sets. It is a real bug and still fixed here, but the festival-critical ones are #741/#743 (three days of sets rendering as one) and #750 (a set playing at 00:35 on Aug 8 showing as "past").

## Two things the wiring exposed that the issues did not predict

**The details payload carries each set's `performance_date` but not the event's span**, and `formatPerformanceDayLabel` needs both — one decides *which* day, the other decides whether a `(Day N)` suffix belongs at all. The event's dates are merged in at the call site.

**Gating on the formatter's return value is wrong for single-day events.** It returns a bare date there, which is truthy but redundant beside the event's own date, and a lone "(Day 1)" violates #540/#541. `EventTimeline` gates on `isMultiDayEvent` instead.

`VenuePage` deliberately does **not** apply that gate. Its row renders no other date, so the label is the only one present — suppressing it on single-day events would delete information rather than remove redundancy. Same invariant, opposite correct answer for the two surfaces.

## Security / correctness notes

No auth, CSRF, or user-input surface. No schema change. All four changes are read-path only: added projections, changed ordering, and one date-comparison helper swap. Outside 00:00–06:00 local, `eventLocalFestivalToday()` and `eventLocalToday()` are identical, so the festival-day changes are no-ops for eighteen hours a day.

## Verification

- [x] Tests: **952 backend + 894 frontend** pass, 0 failures
- [x] ESLint: 0 errors; format check and build clean
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] CodeRabbit (`make review`) run **before** opening; 4 of 5 findings applied, 1 declined with reasoning (see above)
- [ ] Manual smoke: **pending deploy** — open `/venue/20`, confirm the 12 sets show their own days in chronological order

## Every test carries a mutation proof

| Mutation | Failure |
|---|---|
| Revert venue `ORDER BY` to `start_time` only | `expected [ '2099-08-09', '2099-08-07' ] to deeply equal [ '2099-08-07', '2099-08-09' ]` — reproduces the production symptom |
| Drop `performance_date` from the venue projection | `expected [ undefined, undefined ] to deeply equal [ '2099-08-07', '2099-08-09' ]` |
| Drop the event dates in EventTimeline | `Unable to find an element with the text: Fri, Aug 7 (Day 1)` |
| Force the single-day gate open | `expected document not to contain element, found <span>` |

Assertions are on **dates and order**, never counts — a length check passes against every broken version here, since they all return the same number of rows.

The boundary tests pin the clock at exactly **06:00 local**. These behaviours differ from the old ones only between midnight and 6 AM, so an unpinned test passes against both implementations eighteen hours a day, and a 06:15 pin still passes against a `>` vs `>=` regression.

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-day events now display clear performance-day labels while avoiding redundant labels for single-day events.
  * Venue, event details, and recaps show each performance’s date and event end date where applicable.
  * Performances are ordered chronologically across festival days.

* **Bug Fixes**
  * Improved timeline and venue status handling for after-midnight performances, keeping them upcoming until 6:00 a.m.
  * Corrected event classification across multi-day festivals and local festival-day boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->