### PR TITLE
feat(venue): tap-through Directions handoff to the device's maps app

### DIFF
--- a/frontend/src/pages/VenuePage.jsx
+++ b/frontend/src/pages/VenuePage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
-import { ArrowLeft, CalendarDays, Globe, MapPin, TriangleAlert } from 'lucide-react'
+import { ArrowLeft, CalendarDays, Globe, MapPin, Navigation, TriangleAlert } from 'lucide-react'
 import Footer from '../components/Footer'
 import ThemeToggle from '../components/ThemeToggle.jsx'
 import { formatPerformanceDayLabel } from '../utils/timeFormat'
@@ -9,6 +9,7 @@ import { fetchPublicJson } from '../utils/publicApi'
 import { trackPageView } from '../utils/metrics'
 import { buildBandProfileHref } from '../utils/bandProfileLink'
 import { safeExternalHref } from '../utils/urlSafety'
+import { buildDirectionsHref } from '../utils/directions'
 
 function PerformanceRow({ perf }) {
   // #732 — functions/api/venues/[id].js already returns is_cancelled (row
@@ -106,6 +107,7 @@ export default function VenuePage() {
   }, [id])
 
   const website = venue ? safeExternalHref(venue.website) : '#'
+  const directionsHref = venue ? buildDirectionsHref(venue.name, venue.address) : null
 
   return (
     <main id="main-content" tabIndex={-1} className="min-h-screen bg-gradient-dark">
@@ -169,7 +171,23 @@ export default function VenuePage() {
                 </a>
               )}
             </div>
-            {venue.address && <p className="mt-1 text-sm text-text-tertiary">{venue.address}</p>}
+            {venue.address && (
+              <p className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-text-tertiary">
+                <span>{venue.address}</span>
+                {directionsHref && (
+                  <a
+                    href={directionsHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`Directions to ${venue.name}`}
+                    className="inline-flex min-h-[44px] items-center gap-1.5 text-accent-400 hover:text-accent-300"
+                  >
+                    <Navigation size={14} aria-hidden="true" />
+                    Directions
+                  </a>
+                )}
+              </p>
+            )}
 
             <Section title="Upcoming" items={upcoming} />
             <Section title="Past shows" items={past} />

--- a/frontend/src/pages/VenuePage.jsx
+++ b/frontend/src/pages/VenuePage.jsx
@@ -108,6 +108,9 @@ export default function VenuePage() {
 
   const website = venue ? safeExternalHref(venue.website) : '#'
   const directionsHref = venue ? buildDirectionsHref(venue.name, venue.address) : null
+  // Same trim rule as the helper: a whitespace-only address is truthy and would
+  // otherwise render an empty address row with no link beside it.
+  const displayAddress = typeof venue?.address === 'string' ? venue.address.trim() : ''
 
   return (
     <main id="main-content" tabIndex={-1} className="min-h-screen bg-gradient-dark">
@@ -171,9 +174,9 @@ export default function VenuePage() {
                 </a>
               )}
             </div>
-            {venue.address && (
+            {displayAddress && (
               <p className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-text-tertiary">
-                <span>{venue.address}</span>
+                <span>{displayAddress}</span>
                 {directionsHref && (
                   <a
                     href={directionsHref}

--- a/frontend/src/pages/__tests__/VenuePage.directions.test.jsx
+++ b/frontend/src/pages/__tests__/VenuePage.directions.test.jsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import VenuePage from '../VenuePage.jsx'
+import { ThemeProvider } from '../../components/ThemeProvider.jsx'
+import { fetchPublicJson } from '../../utils/publicApi'
+
+vi.mock('../../utils/publicApi', () => ({ fetchPublicJson: vi.fn() }))
+
+function renderPage(id = '3') {
+  return render(
+    <ThemeProvider>
+      <HelmetProvider>
+        <MemoryRouter initialEntries={[`/venue/${id}`]}>
+          <Routes>
+            <Route path="/venue/:id" element={<VenuePage />} />
+          </Routes>
+        </MemoryRouter>
+      </HelmetProvider>
+    </ThemeProvider>
+  )
+}
+
+// #742 (directions half only) — a fan standing outside a venue on their phone
+// had no way to hand off to a maps app; the address was plain text. Assert on
+// the resolved href, not just "a link exists" -- a mere-presence check would
+// still pass against a broken query string or an unencoded interpolation.
+describe('VenuePage — Directions handoff (#742)', () => {
+  it('renders a Directions link built from venue name + address, properly encoded', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venue: {
+        id: 20,
+        name: 'The Mill (Main Stage)',
+        location: 'Tillsonburg, ON',
+        address: '20 John Pound Road, Tillsonburg, ON',
+        website: null,
+      },
+      upcoming: [],
+      past: [],
+    })
+
+    renderPage('20')
+    expect(await screen.findByRole('heading', { level: 1, name: 'The Mill (Main Stage)' })).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: 'Directions to The Mill (Main Stage)' })
+    expect(link).toHaveAttribute(
+      'href',
+      'https://www.google.com/maps/search/?api=1&query=' +
+        encodeURIComponent('The Mill (Main Stage), 20 John Pound Road, Tillsonburg, ON')
+    )
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders no Directions link when the venue has no address', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venue: { id: 21, name: 'No Address Venue', location: 'Waterloo, ON', address: null, website: null },
+      upcoming: [],
+      past: [],
+    })
+
+    renderPage('21')
+    expect(await screen.findByRole('heading', { level: 1, name: 'No Address Venue' })).toBeInTheDocument()
+
+    expect(screen.queryByRole('link', { name: /Directions/i })).not.toBeInTheDocument()
+    // Belt-and-suspenders: an <a> rendered with no href has no implicit
+    // "link" ARIA role, so a role-only query would pass even against a dead
+    // anchor with the text still visible. Assert on the visible text too.
+    expect(screen.queryByText('Directions')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/VenuePage.directions.test.jsx
+++ b/frontend/src/pages/__tests__/VenuePage.directions.test.jsx
@@ -72,4 +72,25 @@ describe('VenuePage — Directions handoff (#742)', () => {
     // anchor with the text still visible. Assert on the visible text too.
     expect(screen.queryByText('Directions')).not.toBeInTheDocument()
   })
+
+  // A whitespace-only address is truthy, and reachable: formatAddress() in
+  // functions/api/venues/[id].js joins with filter(Boolean), which keeps a
+  // "   " address_line1. Neither the address row nor the link may render.
+  it('renders neither the address row nor a Directions link for a whitespace-only address', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venue: { id: 22, name: 'Blank Address Venue', location: 'Waterloo, ON', address: '   ', website: null },
+      upcoming: [],
+      past: [],
+    })
+
+    renderPage('22')
+    expect(await screen.findByRole('heading', { level: 1, name: 'Blank Address Venue' })).toBeInTheDocument()
+
+    expect(screen.queryByRole('link', { name: /Directions/i })).not.toBeInTheDocument()
+    expect(screen.queryByText('Directions')).not.toBeInTheDocument()
+    // The row itself must be gone, not merely empty -- an empty <p> beside the
+    // heading is a visible layout gap.
+    expect(document.querySelector('p.mt-1.flex')).toBeNull()
+  })
 })

--- a/frontend/src/utils/__tests__/directions.test.js
+++ b/frontend/src/utils/__tests__/directions.test.js
@@ -40,21 +40,21 @@ describe('buildDirectionsHref (#742)', () => {
 // formatAddress() in functions/api/venues/[id].js joins parts with
 // filter(Boolean), which keeps a "   " address_line1.
 describe('buildDirectionsHref — blank-ish input', () => {
-  test.each([['   '], ['\t'], ['\n  \n']])('returns null for whitespace-only address %j', blank => {
+  it.each([['   '], ['\t'], ['\n  \n']])('returns null for whitespace-only address %j', blank => {
     expect(buildDirectionsHref('The Mill', blank)).toBeNull()
   })
 
-  test('returns null for a non-string address', () => {
+  it('returns null for a non-string address', () => {
     expect(buildDirectionsHref('The Mill', undefined)).toBeNull()
     expect(buildDirectionsHref('The Mill', null)).toBeNull()
   })
 
-  test('trims surrounding whitespace instead of encoding it into the query', () => {
+  it('trims surrounding whitespace instead of encoding it into the query', () => {
     const href = buildDirectionsHref('  The Mill  ', '  20 John Pound Road  ')
     expect(href).toBe('https://www.google.com/maps/search/?api=1&query=The%20Mill%2C%2020%20John%20Pound%20Road')
   })
 
-  test('falls back to the address alone when the name is whitespace-only', () => {
+  it('falls back to the address alone when the name is whitespace-only', () => {
     const href = buildDirectionsHref('   ', '20 John Pound Road')
     expect(href).toBe('https://www.google.com/maps/search/?api=1&query=20%20John%20Pound%20Road')
   })

--- a/frontend/src/utils/__tests__/directions.test.js
+++ b/frontend/src/utils/__tests__/directions.test.js
@@ -34,3 +34,28 @@ describe('buildDirectionsHref (#742)', () => {
     expect(href).toContain(encodeURIComponent("Bob & Ray's, 1 Main St, Unit #2, Waterloo, ON"))
   })
 })
+
+// A whitespace-only address is truthy, so the original `if (!address)` guard
+// let it through and produced a link to an empty map query. It IS reachable:
+// formatAddress() in functions/api/venues/[id].js joins parts with
+// filter(Boolean), which keeps a "   " address_line1.
+describe('buildDirectionsHref — blank-ish input', () => {
+  test.each([['   '], ['\t'], ['\n  \n']])('returns null for whitespace-only address %j', blank => {
+    expect(buildDirectionsHref('The Mill', blank)).toBeNull()
+  })
+
+  test('returns null for a non-string address', () => {
+    expect(buildDirectionsHref('The Mill', undefined)).toBeNull()
+    expect(buildDirectionsHref('The Mill', null)).toBeNull()
+  })
+
+  test('trims surrounding whitespace instead of encoding it into the query', () => {
+    const href = buildDirectionsHref('  The Mill  ', '  20 John Pound Road  ')
+    expect(href).toBe('https://www.google.com/maps/search/?api=1&query=The%20Mill%2C%2020%20John%20Pound%20Road')
+  })
+
+  test('falls back to the address alone when the name is whitespace-only', () => {
+    const href = buildDirectionsHref('   ', '20 John Pound Road')
+    expect(href).toBe('https://www.google.com/maps/search/?api=1&query=20%20John%20Pound%20Road')
+  })
+})

--- a/frontend/src/utils/__tests__/directions.test.js
+++ b/frontend/src/utils/__tests__/directions.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { buildDirectionsHref } from '../directions'
+
+// #742 — the venue page hands a fan's phone off to whichever maps app it has.
+// Assert on the resolved href string itself, not merely that a value comes
+// back -- a broken query string or a raw (unencoded) interpolation would
+// still pass a "returns truthy" check.
+describe('buildDirectionsHref (#742)', () => {
+  it('builds an encoded Google Maps search URL from venue name + address', () => {
+    const href = buildDirectionsHref('The Mill (Main Stage)', '20 John Pound Road, Tillsonburg, ON')
+    expect(href).toBe(
+      'https://www.google.com/maps/search/?api=1&query=' +
+        encodeURIComponent('The Mill (Main Stage), 20 John Pound Road, Tillsonburg, ON')
+    )
+  })
+
+  it('returns null when address is missing, even with a name', () => {
+    expect(buildDirectionsHref('The Mill', null)).toBeNull()
+    expect(buildDirectionsHref('The Mill', undefined)).toBeNull()
+    expect(buildDirectionsHref('The Mill', '')).toBeNull()
+  })
+
+  it('falls back to the address alone when name is missing', () => {
+    const href = buildDirectionsHref(null, '20 John Pound Road, Tillsonburg, ON')
+    expect(href).toBe(
+      'https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent('20 John Pound Road, Tillsonburg, ON')
+    )
+  })
+
+  it('encodes special characters so the query is never raw-interpolated', () => {
+    const href = buildDirectionsHref("Bob & Ray's", '1 Main St, Unit #2, Waterloo, ON')
+    expect(href).not.toContain('&Ray')
+    expect(href).not.toContain('#2')
+    expect(href).toContain(encodeURIComponent("Bob & Ray's, 1 Main St, Unit #2, Waterloo, ON"))
+  })
+})

--- a/frontend/src/utils/directions.js
+++ b/frontend/src/utils/directions.js
@@ -1,0 +1,19 @@
+// Directions handoff (#742) — one universal Google Maps link rather than
+// sniffing the User-Agent to choose between a `geo:` URI (Android) and an
+// Apple Maps URL (iOS). Google documents this exact `api=1&query=` form
+// (https://developers.google.com/maps/documentation/urls/get-started#search-action)
+// as the one both iOS and Android intercept and offer to open in the
+// device's own installed maps app, and it still resolves in a desktop
+// browser — so it covers every target CLAUDE.md calls out without the
+// fragility of parsing navigator.userAgent for what is, after all, just a
+// link. Matches the existing precedent in utils/nextMove.js's
+// directionsHref(), which uses the same api=1 Google Maps URL family.
+//
+// Name + address (not address alone) so the pin lands on the venue itself
+// rather than mid-street — a bare street address can resolve to the wrong
+// side of the road or a neighbouring building.
+export function buildDirectionsHref(name, address) {
+  if (!address) return null
+  const query = name ? `${name}, ${address}` : address
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
+}

--- a/frontend/src/utils/directions.js
+++ b/frontend/src/utils/directions.js
@@ -13,7 +13,13 @@
 // rather than mid-street — a bare street address can resolve to the wrong
 // side of the road or a neighbouring building.
 export function buildDirectionsHref(name, address) {
-  if (!address) return null
-  const query = name ? `${name}, ${address}` : address
+  // Trim before the guard: a whitespace-only address is truthy, and it IS
+  // reachable -- formatAddress() in functions/api/venues/[id].js builds the
+  // string with filter(Boolean), which keeps a "   " address_line1. Without
+  // this, bad admin data produces a link to an empty map query.
+  const trimmedAddress = typeof address === 'string' ? address.trim() : ''
+  if (!trimmedAddress) return null
+  const trimmedName = typeof name === 'string' ? name.trim() : ''
+  const query = trimmedName ? `${trimmedName}, ${trimmedAddress}` : trimmedAddress
   return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
 }


### PR DESCRIPTION
## Summary

The venue page showed its address as inert text. A fan standing outside The Mill on their phone had nothing to tap. This adds a **Directions** link that hands off to whatever maps app the device has.

Deliberately the *directions half* of #742 only — see "Not in this PR" below.

Part of #742

## What changed

| File | Change |
|------|--------|
| `frontend/src/utils/directions.js` | New pure helper `buildDirectionsHref(name, address)` |
| `frontend/src/pages/VenuePage.jsx` | Directions link beside the address |
| Tests | Helper unit tests + page-level href/accessible-name/absent-address coverage |

No API change — `venue.address` already reached the page via `formatAddress` in `functions/api/venues/[id].js:23-27`. Verified rather than assumed.

## One universal link, not User-Agent sniffing

`https://www.google.com/maps/search/?api=1&query=<encoded name + address>` — Google's documented Search-Action form, which **both iOS and Android intercept and offer to open in the device's own maps app**, and which still resolves on desktop.

The alternative was a `geo:` URI on Android and an Apple Maps URL on iOS, chosen by parsing `navigator.userAgent`. That is fragile, and this is a link, not a capability — there is nothing to feature-detect.

It also matches existing precedent: `directionsHref()` in `frontend/src/utils/nextMove.js:22-32` already uses the same `api=1` Google Maps URL family. The app now has one directions convention instead of two competing ones.

Query is **name + address**, not address alone, so the pin lands on the venue rather than mid-street.

## Not in this PR — deliberately

- **No static map image, no embedded map, no map SDK.** Any tile host must be added to the CSP in `frontend/public/_headers`, and `Cross-Origin-Embedder-Policy: require-corp` must stay unset or the Turnstile iframe breaks. That is a separate decision, recorded in #742.
- **No `latitude`/`longitude` migration.** Venues have no coordinate columns; an address query is sufficient for a handoff link.
- **No performer-card work** (the other half of #742).

A three-day festival opens 2026-08-07, so this is scoped to be purely additive: no API change, no CSP change, no interaction change. If it were wrong, nothing that works today would break.

## A trap worth recording

The "renders nothing without an address" test was **vacuous at first**, and not for an obvious reason.

An `<a>` with no `href` has **no implicit ARIA `link` role**. So `queryByRole('link', …)` returned `null` even when a dead anchor *was* rendering — the assertion passed against the broken implementation. The test now also asserts on the visible text, which fails correctly:

```
expected document not to contain element, found <a aria-label="Directions to No Address Venue" …>
```

This generalises: any "assert no link renders" test in this codebase needs more than a role query.

## Sweep — two siblings found, not fixed here

Per the standing rule to check neighbouring surfaces rather than only the one in hand:

- **`frontend/src/components/EventTimeline.jsx:899`** (the Venues grid on `EventsPage` and `EventRecapPage`) renders `venue.address` as inert text with no directions affordance — the same gap this PR closes on VenuePage.
- **`frontend/src/components/VenueInfo.jsx:28-38`** (the event page's Venue Locations section) links only when an admin filled `venue_info.googleMaps`; otherwise it silently falls back to plain text. It could use `buildDirectionsHref` as its fallback.

**Checked against production before deciding scope:** Buddies Fest 2's `venue_info` *does* populate `googleMaps` for its venues, so the event page already offers directions this weekend. Neither miss is festival-urgent, so both stay out of this PR and get their own issue.

`admin/EventWizard.jsx:149` also shows a plain address, but it is an admin-only wizard preview — out of scope by convention.

## Security / correctness notes

The query is `encodeURIComponent`-encoded; nothing is interpolated raw. The link carries `target="_blank"` with `rel="noopener noreferrer"`. No new user input, no auth surface, no schema change. Venue names and addresses are admin-authored and rendered as URL query text, not HTML.

## Verification

- [x] Tests: **952 backend + 900 frontend** pass, 0 failures
- [x] ESLint 0 errors; format check and build clean
- [x] Theme tokens only — no `text-white`/`bg-white` (both light themes safe)
- [x] Accessible name includes the venue (`Directions to The Mill (Main Stage)`) — "Directions" alone is ambiguous with several on a page
- [ ] Manual smoke: **pending deploy** — open `/venue/20` on a phone, confirm the link opens the native maps app and the row wraps cleanly

## Mutation proofs

| Mutation | Failure |
|---|---|
| Drop `encodeURIComponent` | `Expected ".../query=The%20Mill%20(Main%20Stage)%2C%2020%20John…" Received ".../query=The Mill (Main Stage), 20 John…"` |
| `aria-label="Directions"` without the venue name | `Unable to find an accessible element with the role "link" and name "Directions to The Mill (Main Stage)"` |
| Force the render guards open | `expected document not to contain element, found <a aria-label="Directions to No Address Venue" …>` |

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an accessible **Directions** link beside venue addresses.
  - Opens an encoded Google Maps search using the venue name and address.
  - Falls back to the address when a venue name is unavailable.
  - The link appears only when a valid address is available.

- **Bug Fixes**
  - Trimmed address and venue-name whitespace for cleaner display and navigation.
  - Prevented empty address rows and Directions links for whitespace-only addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->