### PR TITLE
feat(admin): Next event / Past event columns on the roster, filterable by event

### DIFF
--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -207,6 +207,16 @@ export default function RosterTab({ showToast, readOnly = false }) {
         const bVal = formatOrigin(b).toLowerCase()
         return sortConfig.direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
       }
+      if (sortConfig.key === 'next_event') {
+        const aVal = (a.next_event_name || '').toLowerCase()
+        const bVal = (b.next_event_name || '').toLowerCase()
+        return sortConfig.direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+      }
+      if (sortConfig.key === 'last_event') {
+        const aVal = (a.last_event_name || '').toLowerCase()
+        const bVal = (b.last_event_name || '').toLowerCase()
+        return sortConfig.direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+      }
       if (sortConfig.key === 'follower_count') {
         const aVal = a.follower_count ?? 0
         const bVal = b.follower_count ?? 0
@@ -711,6 +721,28 @@ export default function RosterTab({ showToast, readOnly = false }) {
                       renderColumnFilterPanel={renderColumnFilterPanel}
                     />
                     <FilterableHeader
+                      sortKey="next_event"
+                      label="Next event"
+                      sortConfig={sortConfig}
+                      columnFilters={columnFilters}
+                      openFilterKey={openFilterKey}
+                      onSort={handleSort}
+                      onToggleFilter={toggleFilterPanel}
+                      triggerRef={filterRefs.next_event}
+                      renderColumnFilterPanel={renderColumnFilterPanel}
+                    />
+                    <FilterableHeader
+                      sortKey="last_event"
+                      label="Past event"
+                      sortConfig={sortConfig}
+                      columnFilters={columnFilters}
+                      openFilterKey={openFilterKey}
+                      onSort={handleSort}
+                      onToggleFilter={toggleFilterPanel}
+                      triggerRef={filterRefs.last_event}
+                      renderColumnFilterPanel={renderColumnFilterPanel}
+                    />
+                    <FilterableHeader
                       sortKey="is_active"
                       label="Status"
                       sortConfig={sortConfig}
@@ -793,6 +825,8 @@ export default function RosterTab({ showToast, readOnly = false }) {
                       </td>
                       <td className="px-4 py-3 text-white/70">{formatOrigin(band) || '-'}</td>
                       <td className="px-4 py-3 text-white/70">{band.genre || '-'}</td>
+                      <td className="px-4 py-3 text-white/70">{band.next_event_name || '-'}</td>
+                      <td className="px-4 py-3 text-white/70">{band.last_event_name || '-'}</td>
                       <td className="px-4 py-3 text-white/70">
                         <span
                           className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold ${
@@ -880,6 +914,8 @@ export default function RosterTab({ showToast, readOnly = false }) {
                   <div className="text-sm text-text-secondary space-y-1">
                     <div>Origin: {formatOrigin(band) || '-'}</div>
                     <div>Genre: {band.genre || '-'}</div>
+                    <div>Next event: {band.next_event_name || '-'}</div>
+                    <div>Past event: {band.last_event_name || '-'}</div>
                     <div>Status: {isInactive(band) ? 'Inactive' : 'Active'}</div>
                     <div className="flex items-center gap-2">
                       <span>Links:</span>

--- a/frontend/src/admin/__tests__/RosterTab.test.jsx
+++ b/frontend/src/admin/__tests__/RosterTab.test.jsx
@@ -255,6 +255,176 @@ describe('RosterTab — Links column filtering (formerly the Data-gaps popover)'
   })
 })
 
+// #710 — Next event / Past event columns let the roster be filtered down to
+// "who's missing data for THIS upcoming event" instead of a hand-written D1
+// query. next_event_name/last_event_name come from functions/api/admin/bands.js.
+const BAND_UPCOMING = {
+  id: 'profile_10',
+  band_profile_id: 10,
+  name: 'Upcoming Act',
+  genre: 'rock',
+  origin_city: 'Waterloo',
+  origin_region: 'ON',
+  is_active: 1,
+  follower_count: 0,
+  social_links: '{}',
+  next_event_name: 'Buddies Fest 2',
+  next_event_date: '2026-08-07',
+  last_event_name: null,
+  last_event_date: null,
+}
+
+const BAND_WITH_HISTORY_ONLY = {
+  id: 'profile_11',
+  band_profile_id: 11,
+  name: 'Bygone Band',
+  genre: 'jazz',
+  origin_city: 'Kitchener',
+  origin_region: 'ON',
+  is_active: 1,
+  follower_count: 0,
+  social_links: '{}',
+  next_event_name: null,
+  next_event_date: null,
+  last_event_name: 'Vol. 16',
+  last_event_date: '2025-08-02',
+}
+
+describe('RosterTab — Next event / Past event columns (#710)', () => {
+  it('renders the Next event and Past event column headers and values', async () => {
+    bandsApi.getAll.mockResolvedValue({ bands: [BAND_UPCOMING, BAND_WITH_HISTORY_ONLY] })
+    render(<RosterTab showToast={vi.fn()} />)
+    await screen.findAllByText('Upcoming Act')
+
+    expect(screen.getAllByRole('columnheader', { name: /^Next event/ }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('columnheader', { name: /^Past event/ }).length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Buddies Fest 2').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Vol. 16').length).toBeGreaterThan(0)
+  })
+
+  it('filters to a specific Next event via the column dropdown', async () => {
+    bandsApi.getAll.mockResolvedValue({ bands: [BAND_UPCOMING, BAND_WITH_HISTORY_ONLY] })
+    render(<RosterTab showToast={vi.fn()} />)
+    await screen.findAllByText('Upcoming Act')
+
+    fireEvent.click(screen.getByLabelText('Filter by Next event'))
+    fireEvent.click(screen.getByLabelText('Buddies Fest 2 — 1'))
+
+    expect(screen.getAllByText('Upcoming Act').length).toBeGreaterThan(0)
+    expect(screen.queryAllByText('Bygone Band')).toHaveLength(0)
+  })
+
+  it('an artist with no upcoming booking falls into (Blanks) under Next event', async () => {
+    bandsApi.getAll.mockResolvedValue({ bands: [BAND_UPCOMING, BAND_WITH_HISTORY_ONLY] })
+    render(<RosterTab showToast={vi.fn()} />)
+    await screen.findAllByText('Upcoming Act')
+
+    fireEvent.click(screen.getByLabelText('Filter by Next event'))
+    fireEvent.click(screen.getByLabelText('(Blanks) — 1'))
+
+    expect(screen.getAllByText('Bygone Band').length).toBeGreaterThan(0)
+    expect(screen.queryAllByText('Upcoming Act')).toHaveLength(0)
+  })
+
+  // Names are deliberately the OPPOSITE alphabetical order from their
+  // next_event_name -- same anti-coincidence trick as ZERO_LINKS_BAND above.
+  // Name-ascending (the default sort) gives [Alpha Booking, Zeta Booking];
+  // next_event-ascending must give the reverse, [Zeta Booking, Alpha
+  // Booking], since "Aaa Fest" < "Zzz Fest". A generic `a['next_event']`
+  // fallback (undefined for every row) would leave the name-ascending order
+  // untouched, so this only passes if the dedicated comparator runs.
+  const BAND_NEXT_EVENT_ZZZ = {
+    id: 'profile_30',
+    band_profile_id: 30,
+    name: 'Alpha Booking',
+    genre: 'rock',
+    origin_city: 'Waterloo',
+    origin_region: 'ON',
+    is_active: 1,
+    follower_count: 0,
+    social_links: '{}',
+    next_event_name: 'Zzz Fest',
+    last_event_name: null,
+  }
+  const BAND_NEXT_EVENT_AAA = {
+    id: 'profile_31',
+    band_profile_id: 31,
+    name: 'Zeta Booking',
+    genre: 'rock',
+    origin_city: 'Waterloo',
+    origin_region: 'ON',
+    is_active: 1,
+    follower_count: 0,
+    social_links: '{}',
+    next_event_name: 'Aaa Fest',
+    last_event_name: null,
+  }
+
+  it('sorts by Next event, alphabetically, and reverses on a second click', async () => {
+    bandsApi.getAll.mockResolvedValue({ bands: [BAND_NEXT_EVENT_ZZZ, BAND_NEXT_EVENT_AAA] })
+    render(<RosterTab showToast={vi.fn()} />)
+    await screen.findAllByText('Alpha Booking')
+
+    const nextEventButton = screen.getByRole('button', { name: /^Next event/ })
+
+    fireEvent.click(nextEventButton)
+    let rows = screen.getAllByRole('row').slice(1)
+    expect(rows[0]).toHaveTextContent('Zeta Booking') // "Aaa Fest"
+    expect(rows[1]).toHaveTextContent('Alpha Booking') // "Zzz Fest"
+
+    fireEvent.click(nextEventButton)
+    rows = screen.getAllByRole('row').slice(1)
+    expect(rows[0]).toHaveTextContent('Alpha Booking')
+    expect(rows[1]).toHaveTextContent('Zeta Booking')
+  })
+
+  // Same anti-coincidence naming trick, this time on last_event_name.
+  const BAND_LAST_EVENT_ZZZ = {
+    id: 'profile_32',
+    band_profile_id: 32,
+    name: 'Alpha History',
+    genre: 'rock',
+    origin_city: 'Waterloo',
+    origin_region: 'ON',
+    is_active: 1,
+    follower_count: 0,
+    social_links: '{}',
+    next_event_name: null,
+    last_event_name: 'Zzz Fest',
+  }
+  const BAND_LAST_EVENT_AAA = {
+    id: 'profile_33',
+    band_profile_id: 33,
+    name: 'Zeta History',
+    genre: 'rock',
+    origin_city: 'Waterloo',
+    origin_region: 'ON',
+    is_active: 1,
+    follower_count: 0,
+    social_links: '{}',
+    next_event_name: null,
+    last_event_name: 'Aaa Fest',
+  }
+
+  it('sorts by Past event, alphabetically, and reverses on a second click', async () => {
+    bandsApi.getAll.mockResolvedValue({ bands: [BAND_LAST_EVENT_ZZZ, BAND_LAST_EVENT_AAA] })
+    render(<RosterTab showToast={vi.fn()} />)
+    await screen.findAllByText('Alpha History')
+
+    const pastEventButton = screen.getByRole('button', { name: /^Past event/ })
+
+    fireEvent.click(pastEventButton)
+    let rows = screen.getAllByRole('row').slice(1)
+    expect(rows[0]).toHaveTextContent('Zeta History') // "Aaa Fest"
+    expect(rows[1]).toHaveTextContent('Alpha History') // "Zzz Fest"
+
+    fireEvent.click(pastEventButton)
+    rows = screen.getAllByRole('row').slice(1)
+    expect(rows[0]).toHaveTextContent('Alpha History')
+    expect(rows[1]).toHaveTextContent('Zeta History')
+  })
+})
+
 // Fixture set for the cross-column tests below:
 // Alpha — Active,   genre "punk"
 // Beta  — Active,   genre "metal"

--- a/frontend/src/admin/utils/__tests__/rosterColumns.test.js
+++ b/frontend/src/admin/utils/__tests__/rosterColumns.test.js
@@ -82,6 +82,28 @@ describe('getValues — genre column (multi-valued)', () => {
   })
 })
 
+describe('getValues — next_event column (#710)', () => {
+  it('returns the next event name as a single-element array', () => {
+    expect(getValuesFor('next_event', band({ next_event_name: 'Buddies Fest 2' }))).toEqual(['Buddies Fest 2'])
+  })
+
+  it('treats a missing next_event_name as blank — artists with no upcoming booking', () => {
+    expect(getValuesFor('next_event', band({ next_event_name: null }))).toEqual([BLANK])
+    expect(getValuesFor('next_event', band({}))).toEqual([BLANK])
+  })
+})
+
+describe('getValues — last_event column (#710)', () => {
+  it('returns the last (past) event name as a single-element array', () => {
+    expect(getValuesFor('last_event', band({ last_event_name: 'Vol. 16' }))).toEqual(['Vol. 16'])
+  })
+
+  it('treats a missing last_event_name as blank — artists with no performance history', () => {
+    expect(getValuesFor('last_event', band({ last_event_name: null }))).toEqual([BLANK])
+    expect(getValuesFor('last_event', band({}))).toEqual([BLANK])
+  })
+})
+
 describe('getValues — is_active (Status) column', () => {
   it('reports Inactive for is_active: 0', () => {
     expect(getValuesFor('is_active', band({ is_active: 0 }))).toEqual(['Inactive'])

--- a/frontend/src/admin/utils/rosterColumns.js
+++ b/frontend/src/admin/utils/rosterColumns.js
@@ -30,6 +30,12 @@ export const FILTERABLE_COLUMNS = [
   { key: 'name', label: 'Name', type: 'values', getValues: band => single(band.name) },
   { key: 'origin', label: 'Origin', type: 'values', getValues: band => single(formatOrigin(band)) },
   { key: 'genre', label: 'Genre', type: 'values', getValues: band => tokens(band.genre) },
+  // #710 — the earliest upcoming/in-progress event and the most recent past
+  // event for this profile (functions/api/admin/bands.js's next_event_name /
+  // last_event_name). Blank means "no upcoming booking" / "no performance
+  // history" respectively, which is itself a useful (Blanks) filter view.
+  { key: 'next_event', label: 'Next event', type: 'values', getValues: band => single(band.next_event_name) },
+  { key: 'last_event', label: 'Past event', type: 'values', getValues: band => single(band.last_event_name) },
   { key: 'is_active', label: 'Status', type: 'values', getValues: band => [isInactive(band) ? 'Inactive' : 'Active'] },
   { key: 'link_count', label: 'Links', type: 'links' },
   { key: 'contact_email', label: 'Contact', type: 'values', getValues: band => single(band.contact_email) },

--- a/functions/api/admin/bands.js
+++ b/functions/api/admin/bands.js
@@ -18,33 +18,21 @@ import { buildIntervals, intervalsOverlap } from "../../utils/timeConflicts.js";
 import { parseOrigin } from "../../utils/parseOrigin.js";
 import { normalizeBandName } from "../../utils/bandName.js";
 import { sortableName } from "../../utils/sortableName.js";
+import { eventLocalFestivalToday } from "../../utils/eventDay.js";
 
 // SQLite `ORDER BY` can't strip a leading article inline (#587), so the SQL
-// in onRequestGet below is a coarse pre-sort (correct on start_time/event_date,
-// raw-byte on name) and the exact ordering is re-derived in JS afterward,
-// swapping the name comparison for the article-stripped `sortableName` key.
-// These mirror the NULL-ordering SQLite applies by default: ASC puts NULLs
-// first, DESC puts NULLs last.
+// in onRequestGet below is a coarse pre-sort (correct on start_time, raw-byte
+// on name) and the exact ordering is re-derived in JS afterward, swapping the
+// name comparison for the article-stripped `sortableName` key. This mirrors
+// the NULL-ordering SQLite applies by default: ASC puts NULLs first, DESC
+// puts NULLs last. Only used by the eventId branch below — the no-eventId
+// (roster) branch sorts on name alone (#710 removed its per-performance
+// bare columns).
 function compareStartTimeNullsLast(a, b) {
   if (a.start_time == null && b.start_time == null) return 0;
   if (a.start_time == null) return 1;
   if (b.start_time == null) return -1;
   return a.start_time < b.start_time ? -1 : a.start_time > b.start_time ? 1 : 0;
-}
-
-function compareStartTimeNullsFirst(a, b) {
-  if (a.start_time == null && b.start_time == null) return 0;
-  if (a.start_time == null) return -1;
-  if (b.start_time == null) return 1;
-  return a.start_time < b.start_time ? -1 : a.start_time > b.start_time ? 1 : 0;
-}
-
-function compareEventDateDescNullsLast(a, b) {
-  if (a.event_date == null && b.event_date == null) return 0;
-  if (a.event_date == null) return 1;
-  if (b.event_date == null) return -1;
-  if (a.event_date === b.event_date) return 0;
-  return a.event_date > b.event_date ? -1 : 1;
 }
 
 async function getEventStatus(DB, eventId) {
@@ -205,16 +193,15 @@ export async function onRequestGet(context) {
         .all();
     } else {
       // List ALL band PROFILES — active and inactive (#619) — one row per
-      // profile (#618). A profile can have zero, one, or many performances
-      // across many events; the old query LEFT JOINed to performances with no
-      // GROUP BY, so a band with N performances produced N rows. Combined
-      // with `ORDER BY e.date DESC` + `LIMIT`, any profile whose only
-      // performances were on older events could sort past the limit and
-      // vanish entirely (#618 — Adelleda, whose sole performance was a 2024
-      // event, was missing from the roster). GROUP BY bp.id collapses that
-      // back to one row per profile, so the LIMIT now bounds roster size
-      // (~218 active + a handful of inactive profiles in prod), not
-      // performance-row count.
+      // profile (#618), guaranteed STRUCTURALLY: the base table below is
+      // `FROM band_profiles bp` with no top-level join to `performances`, so
+      // there is no row-fan-out to collapse with GROUP BY in the first place
+      // (the old query LEFT JOINed to performances with no GROUP BY, so a
+      // band with N performances produced N rows; combined with
+      // `ORDER BY e.date DESC` + `LIMIT`, a profile whose only performances
+      // were on older events could sort past the limit and vanish entirely —
+      // #618, Adelleda). LIMIT here bounds roster size (~218 active + a
+      // handful of inactive profiles in prod), never performance-row count.
       //
       // Deliberately no `WHERE bp.is_active = 1` here (#619): the admin
       // roster is the tool that manages profiles, so it must be able to see
@@ -225,29 +212,48 @@ export async function onRequestGet(context) {
       // (it never filtered on is_active); this brings the admin roster in
       // line with it.
       //
-      // The per-performance columns (event/venue name, event date, etc.) are
-      // kept for a "last played" display, sourced from the band's MOST RECENT
-      // performance: SQLite's bare-column-with-MAX() semantics say that when a
-      // query has exactly one MAX() aggregate, bare columns in the same result
-      // row are pulled from the input row that produced the max — including
-      // per GROUP BY group, not just whole-table aggregates. So MAX(e.date)
-      // plus the bare v.name/e.name/p.* columns below consistently resolve to
-      // the same (most recent) performance row, without a subquery or window
-      // function. Profiles with zero performances get NULLs throughout (LEFT
-      // JOIN), same as before.
+      // #710 — next_event_*/last_event_* replace the old MAX(e.date) +
+      // bare-column trick, which had no date predicate at all: MAX() picked
+      // the furthest-out event in EITHER direction, so a not-yet-happened
+      // event (e.g. Buddies Fest 2, still weeks away) was reported as the
+      // band's "most recent performance". Nothing in frontend/src/admin/
+      // rendered event_name/event_date either (dead weight on the wire) — both
+      // are replaced outright, along with the rest of the per-performance
+      // bare columns (venue_name, start_time, end_time, performance_date,
+      // notes) that rode along with the same broken trick and also have no
+      // consumer in this branch (RosterTab and LineupTab's ArtistPicker only
+      // read profile-level fields + band_profile_id from this branch).
+      //
+      // "Today" is `eventLocalFestivalToday()` (America/Toronto, after-
+      // midnight-aware — see functions/utils/eventDay.js), bound as a
+      // parameter — never SQLite's `date('now')` (UTC) and never the plain
+      // calendar-day `eventLocalToday()`. Between local midnight and 6 AM the
+      // calendar day has rolled but the festival night has not; an event
+      // still running (after-midnight sets) must not jump from "next" to
+      // "past" while doors are open. Multi-day events compare against
+      // COALESCE(e.end_date, e.date) so a 3-day event stays "next" through
+      // its final day rather than moving to "past" on day 2 — same
+      // COALESCE(end_date, date) convention as saveSelectedBands.
+      //
+      // event_ids (GROUP_CONCAT DISTINCT) exposes every event the profile has
+      // ever played. The roster's Next/Past event FILTERABLE_COLUMNS entries
+      // (frontend/src/admin/utils/rosterColumns.js) currently filter on
+      // next_event_name/last_event_name only, so event_ids and the *_id/*_date
+      // siblings (next_event_id, next_event_date, last_event_id,
+      // last_event_date) have no wired-up consumer yet — they're returned per
+      // #710's spec as the exact-id/date building blocks for a future
+      // name-collision-proof filter (two different events sharing a display
+      // name would otherwise be indistinguishable by name alone).
+      //
       // We construct a synthetic ID: 'profile_' || bp.id (unique per profile —
       // no consumer in this branch reads `id` as a real performance id; both
       // RosterTab and LineupTab's ArtistPicker key off `band_profile_id`).
-      result = await DB.prepare(
-        `
+      {
+        const today = eventLocalFestivalToday();
+        result = await DB.prepare(
+          `
         SELECT
           'profile_' || bp.id as id,
-          p.event_id,
-          p.venue_id,
-          p.start_time,
-          p.end_time,
-          p.performance_date,
-          p.notes,
           bp.id as band_profile_id,
           bp.name,
           bp.genre,
@@ -261,42 +267,74 @@ export async function onRequestGet(context) {
           bp.photo_alt_text,
           bp.social_links,
           (SELECT COUNT(*) FROM band_follows bf WHERE bf.band_profile_id = bp.id AND bf.verified = 1) AS follower_count,
-          v.name as venue_name,
-          e.name as event_name,
-          MAX(e.date) as event_date
+          (SELECT GROUP_CONCAT(DISTINCT perf.event_id) FROM performances perf WHERE perf.band_profile_id = bp.id) AS event_ids,
+          (
+            SELECT e.id FROM events e
+            JOIN performances perf ON perf.event_id = e.id
+            WHERE perf.band_profile_id = bp.id AND COALESCE(e.end_date, e.date) >= ?
+            ORDER BY e.date ASC, e.id ASC
+            LIMIT 1
+          ) AS next_event_id,
+          (
+            SELECT e.name FROM events e
+            JOIN performances perf ON perf.event_id = e.id
+            WHERE perf.band_profile_id = bp.id AND COALESCE(e.end_date, e.date) >= ?
+            ORDER BY e.date ASC, e.id ASC
+            LIMIT 1
+          ) AS next_event_name,
+          (
+            SELECT e.date FROM events e
+            JOIN performances perf ON perf.event_id = e.id
+            WHERE perf.band_profile_id = bp.id AND COALESCE(e.end_date, e.date) >= ?
+            ORDER BY e.date ASC, e.id ASC
+            LIMIT 1
+          ) AS next_event_date,
+          (
+            SELECT e.id FROM events e
+            JOIN performances perf ON perf.event_id = e.id
+            WHERE perf.band_profile_id = bp.id AND COALESCE(e.end_date, e.date) < ?
+            ORDER BY COALESCE(e.end_date, e.date) DESC, e.id DESC
+            LIMIT 1
+          ) AS last_event_id,
+          (
+            SELECT e.name FROM events e
+            JOIN performances perf ON perf.event_id = e.id
+            WHERE perf.band_profile_id = bp.id AND COALESCE(e.end_date, e.date) < ?
+            ORDER BY COALESCE(e.end_date, e.date) DESC, e.id DESC
+            LIMIT 1
+          ) AS last_event_name,
+          (
+            SELECT e.date FROM events e
+            JOIN performances perf ON perf.event_id = e.id
+            WHERE perf.band_profile_id = bp.id AND COALESCE(e.end_date, e.date) < ?
+            ORDER BY COALESCE(e.end_date, e.date) DESC, e.id DESC
+            LIMIT 1
+          ) AS last_event_date
         FROM band_profiles bp
-        LEFT JOIN performances p ON bp.id = p.band_profile_id
-        LEFT JOIN venues v ON p.venue_id = v.id
-        LEFT JOIN events e ON p.event_id = e.id
-        GROUP BY bp.id
-        ORDER BY event_date DESC, bp.name
+        ORDER BY bp.name
         LIMIT ?
         OFFSET ?
       `,
-      )
-        .bind(limit, offset)
-        .all();
+        )
+          .bind(today, today, today, today, today, today, limit, offset)
+          .all();
+      }
     }
 
     const bands = (result.results || []).map(unpackSocialLinks);
 
     // Re-derive the exact ordering in JS with the article-stripped sort key
-    // (#587) — see the comparator helpers above. Pagination-boundary
-    // guarantee: the eventId branch has no LIMIT/OFFSET (one event's full
-    // lineup). The no-eventId branch is GROUP BY bp.id (#618) — exactly one
-    // row per active band_profile — so its row count is bounded by roster
-    // size, not by how many performances a band has; the JS re-sort below
-    // never has to worry about a truncated LIMIT window splitting a single
-    // band across pages.
+    // (#587) — see the compareStartTimeNullsLast comment above. Pagination-
+    // boundary guarantee: the eventId branch has no LIMIT/OFFSET (one event's
+    // full lineup). The no-eventId branch has no join to `performances` at
+    // its top level (#618/#710) — exactly one row per band_profile,
+    // structurally — so its row count is bounded by roster size, not by how
+    // many performances a band has; the JS re-sort below never has to worry
+    // about a truncated LIMIT window splitting a single band across pages.
     if (eventId) {
       bands.sort((a, b) => compareStartTimeNullsLast(a, b) || sortableName(a.name).localeCompare(sortableName(b.name)));
     } else {
-      bands.sort(
-        (a, b) =>
-          compareEventDateDescNullsLast(a, b) ||
-          compareStartTimeNullsFirst(a, b) ||
-          sortableName(a.name).localeCompare(sortableName(b.name)),
-      );
+      bands.sort((a, b) => sortableName(a.name).localeCompare(sortableName(b.name)));
     }
 
     return new Response(JSON.stringify({ success: true, bands }), {

--- a/functions/api/admin/bands/__tests__/bands.test.js
+++ b/functions/api/admin/bands/__tests__/bands.test.js
@@ -294,6 +294,13 @@ describe("Admin bands API - GET without event_id returns one row per profile (#6
     expect(band.last_event_name).toBe("Already Happened");
     expect(band.last_event_date).toBe("2025-06-01");
     expect(band.next_event_name).not.toBe(band.last_event_name);
+
+    // The IDs are what a future exact-event filter will key on, and nothing
+    // else asserts them -- they could come back null or swapped and the name
+    // and date assertions above would still pass.
+    expect(band.next_event_id).toBe(futureEvent.id);
+    expect(band.last_event_id).toBe(pastEvent.id);
+    expect(band.next_event_id).not.toBe(band.last_event_id);
   });
 
   // #710 / #568 bug class — the calendar day rolls over at local midnight,

--- a/functions/api/admin/bands/__tests__/bands.test.js
+++ b/functions/api/admin/bands/__tests__/bands.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils";
 import * as bandsHandler from "../../bands.js";
 import * as bandIdHandler from "../[id].js";
@@ -160,6 +160,10 @@ describe("Admin bands API - CRUD operations", () => {
 });
 
 describe("Admin bands API - GET without event_id returns one row per profile (#618)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("a band whose only performance is on the OLDEST event still appears when total performance rows exceed the requested limit", async () => {
     const { env, rawDb, headers } = createTestEnv({ role: "editor" });
     const oldEvent = insertEvent(rawDb, { name: "Old Event 618", slug: "old-event-618", date: "2020-01-01" });
@@ -204,7 +208,13 @@ describe("Admin bands API - GET without event_id returns one row per profile (#6
     expect(names).toContain("Adelleda Regression");
   });
 
-  it("returns exactly one row per profile even when the band has multiple performances", async () => {
+  it("returns exactly one row per profile even when the band has multiple performances, all in the PAST", async () => {
+    // Pinned well after every event date below so all three are unambiguously
+    // past relative to "today" (#710: next/last must not depend on wall-clock
+    // time when the test runs).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+
     const { env, rawDb, headers } = createTestEnv({ role: "editor" });
     const ev1 = insertEvent(rawDb, { name: "Dedup Event 1", slug: "dedup-event-1", date: "2025-01-01" });
     const ev2 = insertEvent(rawDb, { name: "Dedup Event 2", slug: "dedup-event-2", date: "2025-06-01" });
@@ -240,10 +250,144 @@ describe("Admin bands API - GET without event_id returns one row per profile (#6
 
     const matches = data.bands.filter((b) => b.name === "Triple Booked Band");
     expect(matches.length).toBe(1);
-    // "Last played" context should reflect the band's MOST RECENT event (ev3),
-    // via SQLite's bare-column-with-MAX() semantics.
-    expect(matches[0].event_name).toBe("Dedup Event 3");
-    expect(matches[0].event_date).toBe("2025-12-01");
+    // All three events are past — the LATEST one (ev3) is "last played", not
+    // the MAX(e.date)-across-all-time value the old query produced. There is
+    // no upcoming booking, so next_event_* stays null/blank.
+    expect(matches[0].last_event_name).toBe("Dedup Event 3");
+    expect(matches[0].last_event_date).toBe("2025-12-01");
+    expect(matches[0].next_event_name ?? null).toBeNull();
+    // event_ids exposes every distinct event the profile played, in support
+    // of the roster's event filter (#710) — not just the one "last" event.
+    const eventIds = (matches[0].event_ids || "")
+      .split(",")
+      .map(Number)
+      .sort((a, b) => a - b);
+    expect(eventIds).toEqual([ev1.id, ev2.id, ev3.id].sort((a, b) => a - b));
+  });
+
+  // #710 — next_event and last_event must resolve to genuinely different
+  // events, not the same MAX()-across-all-time value the old query produced.
+  // An assertion that only checks "next_event_name is non-null" would still
+  // pass against the broken implementation, since the broken query's single
+  // "most recent" column could itself be non-null; asserting the two columns
+  // point at DIFFERENT events is what actually distinguishes the fix.
+  it("next_event and last_event resolve to different events for a band with one past and one future booking", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:00Z")); // "today" = 2026-01-15
+
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const pastEvent = insertEvent(rawDb, { name: "Already Happened", slug: "already-happened", date: "2025-06-01" });
+    const futureEvent = insertEvent(rawDb, { name: "Still Coming", slug: "still-coming", date: "2026-03-01" });
+    const venue = insertVenue(rawDb, { name: "Timeline Venue" });
+
+    insertBand(rawDb, { name: "Two Timeline Band", event_id: pastEvent.id, venue_id: venue.id });
+    insertBand(rawDb, { name: "Two Timeline Band", event_id: futureEvent.id, venue_id: venue.id });
+
+    const getReq = new Request("https://example.test/api/admin/bands", { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    expect(getRes.status).toBe(200);
+    const data = await getRes.json();
+    const band = data.bands.find((b) => b.name === "Two Timeline Band");
+
+    expect(band.next_event_name).toBe("Still Coming");
+    expect(band.next_event_date).toBe("2026-03-01");
+    expect(band.last_event_name).toBe("Already Happened");
+    expect(band.last_event_date).toBe("2025-06-01");
+    expect(band.next_event_name).not.toBe(band.last_event_name);
+  });
+
+  // #710 / #568 bug class — the calendar day rolls over at local midnight,
+  // but the after-midnight convention (AFTER_MIDNIGHT_THRESHOLD_HOUR = 6)
+  // says the FESTIVAL day doesn't roll until 6 AM. At 2 AM Toronto time on
+  // the morning after a show opened, an event dated the PREVIOUS calendar day
+  // is still current — doors are open, after-midnight sets may still be
+  // playing. Using the plain calendar day here would flip this event to
+  // "last" while it is still running.
+  it("an event still running after midnight stays in Next, not Past, before the 6 AM festival-day boundary", async () => {
+    // 2026-08-05T06:00:00Z = 02:00 EDT (America/Toronto is UTC-4 in August).
+    // eventLocalToday() (calendar day) = "2026-08-05".
+    // eventLocalFestivalToday() (festival day) = "2026-08-04" (hour 2 < 6).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T06:00:00Z"));
+
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const tonightsEvent = insertEvent(rawDb, {
+      name: "After Midnight Show",
+      slug: "after-midnight-show",
+      date: "2026-08-04",
+    });
+    const venue = insertVenue(rawDb, { name: "Late Night Venue" });
+    insertBand(rawDb, { name: "After Midnight Band", event_id: tonightsEvent.id, venue_id: venue.id });
+
+    const getReq = new Request("https://example.test/api/admin/bands", { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    expect(getRes.status).toBe(200);
+    const data = await getRes.json();
+    const band = data.bands.find((b) => b.name === "After Midnight Band");
+
+    expect(band.next_event_name).toBe("After Midnight Show");
+    expect(band.last_event_name ?? null).toBeNull();
+  });
+
+  // #710 — multi-day events must stay "next" through their final day, keyed
+  // off COALESCE(end_date, date) rather than the bare start date. On day 2 of
+  // a 3-day event, the bare `date` column (day 1) is already in the past, but
+  // the event itself is still running.
+  it("a multi-day event stays in Next through its final day, not Past on day 2", async () => {
+    // Noon UTC in August = 08:00 EDT — safely mid-morning on 2026-08-02,
+    // well past the 6 AM festival-day boundary.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T12:00:00Z"));
+
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const multiDayEvent = insertEvent(rawDb, {
+      name: "Three Day Fest",
+      slug: "three-day-fest",
+      date: "2026-08-01",
+      end_date: "2026-08-03",
+    });
+    const venue = insertVenue(rawDb, { name: "Fest Venue" });
+    insertBand(rawDb, { name: "Multi Day Band", event_id: multiDayEvent.id, venue_id: venue.id });
+
+    const getReq = new Request("https://example.test/api/admin/bands", { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    expect(getRes.status).toBe(200);
+    const data = await getRes.json();
+    const band = data.bands.find((b) => b.name === "Multi Day Band");
+
+    expect(band.next_event_name).toBe("Three Day Fest");
+    expect(band.last_event_name ?? null).toBeNull();
+  });
+
+  // #710 / #618 — the fix must not regress to a join that fans out per
+  // performance. Three profiles with 5 performances each (15 performances
+  // total, across 15 distinct events) must still yield exactly 3 roster rows:
+  // row count is bounded by PROFILE count, never performance count.
+  it("roster row count is bounded by roster size, not performance count", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const venue = insertVenue(rawDb, { name: "Scale Venue" });
+    const profileNames = ["Prolific A", "Prolific B", "Prolific C"];
+
+    let eventCounter = 0;
+    for (const name of profileNames) {
+      for (let i = 0; i < 5; i++) {
+        eventCounter += 1;
+        const ev = insertEvent(rawDb, {
+          name: `Scale Event ${eventCounter}`,
+          slug: `scale-event-${eventCounter}`,
+          date: `2024-${String((eventCounter % 12) + 1).padStart(2, "0")}-01`,
+        });
+        insertBand(rawDb, { name, event_id: ev.id, venue_id: venue.id });
+      }
+    }
+
+    const getReq = new Request("https://example.test/api/admin/bands", { headers });
+    const getRes = await bandsHandler.onRequestGet({ request: getReq, env, data: { user: { role: "editor" } } });
+    expect(getRes.status).toBe(200);
+    const data = await getRes.json();
+
+    const matches = data.bands.filter((b) => profileNames.includes(b.name));
+    expect(matches.length).toBe(3);
   });
 
   it("includes inactive profiles in the roster branch with is_active: 0 on the row (#619)", async () => {


### PR DESCRIPTION
## Summary

Filter the admin Roster to an upcoming event and see who is missing genre, links, or origin — before the event. Today that needs a hand-written D1 query; this is how *Where's Shane?* was found (the only Buddies Fest 2 artist of 34 missing both genre and links).

Admin-only. No fan-facing surface is touched.

Closes #710

## The field it replaces answered neither question

The roster query attached "the band's most recent performance" using `MAX(e.date)` plus SQLite's bare-column trick. Two problems, both verified against production:

1. **No date predicate**, so `MAX` picked the furthest-out event in *either* direction. As of 2026-08-04 every Buddies Fest 2 artist's "most recent performance" was **2026-08-07 — an event that has not happened.**
2. **Nothing rendered it.** `grep -rn 'event_name\|event_date' frontend/src/admin/` matched nothing. It was dead weight on the wire.

So this is not two new columns beside a working one — it replaces one field that silently conflated "next" and "last".

## What changed

| Area | Change |
|---|---|
| `functions/api/admin/bands.js` | `next_event_{id,name,date}`, `last_event_{id,name,date}`, `event_ids`; dropped the dead per-performance columns and the two JS comparators that existed only to sort them |
| `frontend/src/admin/utils/rosterColumns.js` | Two `FILTERABLE_COLUMNS` entries — the whole filter, since the dropdown, chips, `(Blanks)` bucket and cross-column counts all derive from that registry |
| `frontend/src/admin/RosterTab.jsx` | Renders both columns (desktop table + mobile card) with sort comparators |

## Two things worth a reviewer's attention

**The `#618` bug class is now structural, not test-enforced.** That prior bug had `LIMIT` counting join-multiplied performance rows instead of profiles, silently hiding 47 of 218 bands. The next/last lookups are correlated subqueries, so the query no longer joins `performances` at the top level at all — one row per profile falls out of the shape rather than depending on `GROUP BY` collapsing a fan-out. Reintroducing the join fails a test with `expected 15 to be 3`.

**"Today" is `eventLocalFestivalToday()`, not `eventLocalToday()`.** The issue text said the latter; that was my error and is corrected on the issue. Between local midnight and 06:00 the calendar day has rolled but the festival night has not, so the calendar day would move an event that is still running into the Past column while doors are open. Multi-day events compare against `COALESCE(e.end_date, e.date)` so a 3-day event stays "next" through its final day.

## Deliberately not changed

**Archived / cancelled events are not excluded** from the next/last lookups, so in principle an archived future event could surface as "Next event". Checked production: there are currently **zero** archived events with a future date, and the previous `MAX()` did not filter either — so this is not a regression. Flagged rather than silently expanding scope.

**Roster pagination ordering** — CodeRabbit found that SQL slices pages on raw `bp.name` while JS re-sorts them article-stripped (#587), so the page boundary and the page contents use different collations. Real, but **pre-existing** (this PR does not touch the top-level `ORDER BY`/`LIMIT`/`OFFSET` or the JS re-sort) and **not reachable today**: the endpoint defaults to `limit=500`, the roster is ~218 profiles, and `RosterTab` sends no limit — so the whole roster arrives in one page and no boundary exists. Filed as **#756** rather than folded into an admin PR during festival week.

## Security / correctness notes

Admin-only, behind the existing `checkPermission` middleware; no new endpoint, no schema change, no new user input. Admin is dark-pinned (`AdminApp.jsx` wraps it in `data-theme="midnight-ember"`), so `text-white` in the new markup is correct and intentional there.

## Verification

- [x] Tests: **956 backend + 916 frontend** pass, 0 failures
- [x] ESLint 0 errors; format check and build clean
- [x] `pr-review-toolkit:code-reviewer` run **before** commit — found two real gaps, both fixed (an overclaiming comment about `event_ids`, and missing sort-branch coverage it proved by deleting the comparators and getting zero failures)
- [x] CodeRabbit (`make review`) run before opening — its one finding triaged above
- [ ] Manual smoke: **pending deploy** — filter Roster to Next event = "Buddies Fest 2", apply the data-gap filter, confirm *Where's Shane?* appears

## Mutation proofs

| Mutation | Failure |
|---|---|
| `eventLocalFestivalToday()` → `eventLocalToday()` | `expected null to be 'After Midnight Show'` |
| `COALESCE(e.end_date, e.date)` → bare `e.date` | `expected null to be 'Three Day Fest'` |
| Remove the date predicate from next/last | `expected 'Already Happened' to be 'Still Coming'` |
| Reintroduce the top-level fan-out join | `expected 15 to be 3`, and `expected 3 to be 1` |
| `next_event` reads `last_event_name` | `expected [ '(Blanks)' ] to deeply equal [ 'Buddies Fest 2' ]` |
| Delete the new sort comparators | both sort tests fail on order |

Every clock-dependent test pins the clock — next-vs-past differs only by date, and the festival-day rule differs only between 00:00 and 06:00, so an unpinned test passes against a broken implementation eighteen hours a day.

---
Built by Sonny · Reviewed by Vera and Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Admin roster views now show each artist’s next event and most recent past event on desktop and mobile.
  - Roster entries can be filtered and sorted alphabetically by upcoming or past event name.
  - Event details accurately reflect festival-local dates, including multi-day events and after-midnight activity.

- **Bug Fixes**
  - Improved roster results to include active and inactive artist profiles without duplicate entries.
  - Missing event values are clearly identified as “(Blanks)” when filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->