### PR TITLE
docs: record the un-announce silent no-op and add a show-day runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,22 @@ Enforced via `checkPermission(context, "viewer"|"editor"|"admin")` in `functions
 
 ---
 
+## Pulling a band from a live lineup
+
+**Use the cancel toggle (`is_cancelled = 1`). Do not un-announce, and do not delete the row.**
+
+`is_announced = 0` is **not** a way to hide a set. Every public query guards with `AND (e.reveal_mode = 0 OR p.is_announced = 1)` — five of them: `bands/[name].js`, `bands/stats/[name].js`, `events/timeline.js`, `feeds/ical.js`, `venues/[id].js`. On a `reveal_mode = 0` event the left side short-circuits **true**, so un-announcing changes nothing the public can see. The set stays on the schedule, the artist page, the venue page and the iCal feed. Nothing errors; the failure is invisible until fans arrive at a dark venue.
+
+`reveal_mode = 0` is the normal state for a published lineup — Buddies Fest 2 (event 36) is `reveal_mode = 0`. So this trap applies to exactly the events you are most likely to be editing during a show.
+
+Deleting the performance row does hide it, but it is lossy in two ways: a fan who already saw the lineup gets no signal the set was cancelled, and `share_links` stores a `band_names` snapshot, so a deleted performance leaves the band's **name** on already-shared routes (#733).
+
+Since #732 the correct action is the reversible cancel toggle in LineupTab (`PATCH /api/admin/bands/:id` with `is_cancelled: true`, `editor` role or above). It keeps the set visible and struck through with a "Cancelled" label on every fan surface, suppresses it from "up next" routing and live/starting-soon time math, makes it unselectable, emits `STATUS:CANCELLED` to calendar subscribers, and **blocks the announcement email** — a cancelled performance can neither queue nor send a follower notification, and un-cancelling restores normal announce behaviour.
+
+Operational detail: cancelling is scoped to *one performance*. A band playing two sets (ALL and Kepi Ghoulie each play twice at BF2) needs each set cancelled separately.
+
+The human-facing version of this, plus what to do when a set time changes or something looks wrong mid-event, is `docs/SHOW_DAY_RUNBOOK.md`. Keep the two in step — if a procedure changes, change both in the same commit.
+
 ## Band Announcements
 
 Band follows are **double opt-in**: `POST /api/bands/:name/follow` creates the row `verified = 0` with a `verification_token` and sends only a confirmation email. Clicking the link hits `GET /api/bands/:name/confirm-follow?token=…`, which sets `verified = 1` and clears the token (idempotent). Announcement emails target `verified = 1` followers **only** (the `WHERE … verified = 1` filter in `admin/bands/[id].js` and `resend-announcement.js`), so an address the submitter doesn't control can never be enrolled in the announcement stream — it receives at most one confirmation email. **Do not revert follow to auto-verify (`verified = 1` on insert)** — it reopens the email-bombing vector.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ Enforced via `checkPermission(context, "viewer"|"editor"|"admin")` in `functions
 
 **Use the cancel toggle (`is_cancelled = 1`). Do not un-announce, and do not delete the row.**
 
-`is_announced = 0` is **not** a way to hide a set. Every public read path guards with `AND (e.reveal_mode = 0 OR p.is_announced = 1)` — **8 files**, and two of them bind `reveal_mode` as a parameter (`AND (? = 0 OR p.is_announced = 1)`), so grep for `is_announced = 1` rather than the literal `e.reveal_mode` form or you will undercount:
+`is_announced = 0` is **not** a way to hide a set. Every public read path **that returns per-performance rows** guards with `AND (e.reveal_mode = 0 OR p.is_announced = 1)` — **8 files**, and three of them bind `reveal_mode` as a parameter (`AND (? = 0 OR p.is_announced = 1)`): `api/events/[id]/details.js`, `api/schedule.js`, and `event/[slug].js`, which uses both forms. Grep for `is_announced = 1` rather than the literal `e.reveal_mode` form or you will undercount:
 
 `api/bands/[name].js`, `api/bands/stats/[name].js`, `api/events/[id]/details.js`, `api/events/timeline.js`, `api/feeds/ical.js`, `api/schedule.js`, `api/venues/[id].js`, `event/[slug].js`
 
@@ -238,7 +238,9 @@ On a `reveal_mode = 0` event the left side short-circuits **true**, so `is_annou
 
 Deleting the performance row does hide it, but it is lossy: a fan who already saw the lineup gets no signal the set was cancelled, and since #733 the set is **dropped entirely** from already-shared routes — `schedule/share/[slug].js` resolves live performances and filters out ids that no longer exist, so a fan reopening their shared link finds the stop silently gone rather than marked off. (Before #733 it left an orphaned name with no time or venue, which read as a rendering bug; dropping it is better, but neither tells the fan the set was cancelled.)
 
-Since #732 the correct action is the reversible cancel toggle in LineupTab (`PATCH /api/admin/bands/:id` with `is_cancelled: true`, `editor` role or above). It keeps the set visible and struck through with a "Cancelled" label on every fan surface, suppresses it from "up next" routing and live/starting-soon time math, makes it unselectable, emits `STATUS:CANCELLED` to calendar subscribers, and **blocks the announcement email** — a cancelled performance can neither queue nor send a follower notification, and un-cancelling restores normal announce behaviour.
+Since #732 the correct action is the reversible cancel toggle in LineupTab (`PATCH /api/admin/bands/:id` with `is_cancelled: true`, `editor` role or above). It keeps the set visible and struck through with a "Cancelled" label on every fan surface, suppresses it from "up next" routing and live/starting-soon time math, makes it unselectable, emits `STATUS:CANCELLED` to calendar subscribers, and **blocks the announcement email** — a cancelled performance can neither queue nor send a follower notification.
+
+**Un-cancelling does not resend anything.** The announce path fires only on an `is_announced` `0 → 1` transition (`hasAnnounced && newValue === 1 && isCancelled === 0 && performance.is_announced === 0 && !performance.band_follow_notified`). Restoring a set leaves `is_announced` untouched, so a performance that was already announced before being cancelled produces no new transition, no `band_announce_queue` rows, and no follower email. Un-cancel restores visibility and selectability only.
 
 Operational detail: cancelling is scoped to *one performance*. A band playing two sets (ALL and Kepi Ghoulie each play twice at BF2) needs each set cancelled separately.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,11 +226,17 @@ Enforced via `checkPermission(context, "viewer"|"editor"|"admin")` in `functions
 
 **Use the cancel toggle (`is_cancelled = 1`). Do not un-announce, and do not delete the row.**
 
-`is_announced = 0` is **not** a way to hide a set. Every public query guards with `AND (e.reveal_mode = 0 OR p.is_announced = 1)` — five of them: `bands/[name].js`, `bands/stats/[name].js`, `events/timeline.js`, `feeds/ical.js`, `venues/[id].js`. On a `reveal_mode = 0` event the left side short-circuits **true**, so un-announcing changes nothing the public can see. The set stays on the schedule, the artist page, the venue page and the iCal feed. Nothing errors; the failure is invisible until fans arrive at a dark venue.
+`is_announced = 0` is **not** a way to hide a set. Every public read path guards with `AND (e.reveal_mode = 0 OR p.is_announced = 1)` — **8 files**, and two of them bind `reveal_mode` as a parameter (`AND (? = 0 OR p.is_announced = 1)`), so grep for `is_announced = 1` rather than the literal `e.reveal_mode` form or you will undercount:
+
+`api/bands/[name].js`, `api/bands/stats/[name].js`, `api/events/[id]/details.js`, `api/events/timeline.js`, `api/feeds/ical.js`, `api/schedule.js`, `api/venues/[id].js`, `event/[slug].js`
+
+On a `reveal_mode = 0` event the left side short-circuits **true**, so `is_announced` is never consulted for visibility. The set stays on the schedule, the artist page, the venue page and the iCal feed. Nothing errors; the failure is invisible until fans arrive at a dark venue.
+
+`is_announced` is not meaningless on such an event, though — the **`0 → 1` transition still drives the follower announcement email** (see "Band Announcements" below). Un-announcing and re-announcing a set on a `reveal_mode = 0` event changes nothing publicly while still being capable of sending mail.
 
 `reveal_mode = 0` is the normal state for a published lineup — Buddies Fest 2 (event 36) is `reveal_mode = 0`. So this trap applies to exactly the events you are most likely to be editing during a show.
 
-Deleting the performance row does hide it, but it is lossy in two ways: a fan who already saw the lineup gets no signal the set was cancelled, and `share_links` stores a `band_names` snapshot, so a deleted performance leaves the band's **name** on already-shared routes (#733).
+Deleting the performance row does hide it, but it is lossy: a fan who already saw the lineup gets no signal the set was cancelled, and since #733 the set is **dropped entirely** from already-shared routes — `schedule/share/[slug].js` resolves live performances and filters out ids that no longer exist, so a fan reopening their shared link finds the stop silently gone rather than marked off. (Before #733 it left an orphaned name with no time or venue, which read as a rendering bug; dropping it is better, but neither tells the fan the set was cancelled.)
 
 Since #732 the correct action is the reversible cancel toggle in LineupTab (`PATCH /api/admin/bands/:id` with `is_cancelled: true`, `editor` role or above). It keeps the set visible and struck through with a "Cancelled" label on every fan surface, suppresses it from "up next" routing and live/starting-soon time math, makes it unselectable, emits `STATUS:CANCELLED` to calendar subscribers, and **blocks the announcement email** — a cancelled performance can neither queue nor send a follower notification, and un-cancelling restores normal announce behaviour.
 

--- a/docs/SHOW_DAY_RUNBOOK.md
+++ b/docs/SHOW_DAY_RUNBOOK.md
@@ -23,8 +23,8 @@ Why not the alternatives:
 
 | Action | What actually happens |
 |---|---|
-| Set `is_announced = 0` | **Nothing visible.** See "Silent no-ops" below |
-| Delete the performance row | Hides it, but a fan who already saw the lineup gets no signal, and the band's name is left stranded on already-shared routes |
+| Set `is_announced = 0` | **No public change at all** on a published lineup. See "Silent no-ops" below. It can still send email if re-announced |
+| Delete the performance row | Hides it — but a fan who already saw the lineup gets no signal, and the stop vanishes from their shared route without explanation |
 
 **A band with two sets needs each one cancelled separately.** At BF2, ALL and Kepi Ghoulie each play twice.
 
@@ -32,7 +32,11 @@ Why not the alternatives:
 
 Admin → Lineup tab → edit the set's start/end time.
 
-**If the new time is after midnight, check the date field.** `performance_date` stores **the evening the set belongs to**, not the wall-clock calendar date. A set at 00:25 on the night of Saturday the 8th is stored as `2026-08-08`, not the 9th. Getting this wrong makes the set sort to the top of the wrong day.
+**If the new time is after midnight, check the date field.** `performance_date` stores **the evening the set belongs to**, not the wall-clock calendar date.
+
+Worked example: a set that starts at **00:25 in the early hours of Sunday, August 9** — i.e. the tail of **Saturday, August 8's** night — is stored as `performance_date = 2026-08-08`. Where's Shane? is exactly this case at BF2.
+
+Getting it wrong sorts the set to the top of the wrong day instead of the end of the right one.
 
 The cutover is 6 AM: anything starting before 06:00 belongs to the previous evening.
 
@@ -50,9 +54,12 @@ This drives the "Live Tonight" / "Happening Now" edge on an event's **first day 
 
 ## Silent no-ops — things that look like they worked
 
-**Un-announcing a set on a published lineup.** Every public query guards with `AND (e.reveal_mode = 0 OR p.is_announced = 1)`. When `reveal_mode = 0` — the normal state for a published event, and BF2's state — that condition is already true, so `is_announced` is never consulted. The set stays fully visible. Nothing errors.
+**Un-announcing a set on a published lineup.** All 8 public read paths guard with `AND (e.reveal_mode = 0 OR p.is_announced = 1)`. When `reveal_mode = 0` — the normal state for a published event, and BF2's state — that condition is already true, so `is_announced` is never consulted **for visibility**. The set stays fully visible. Nothing errors.
 
-`is_announced` is only meaningful on a `reveal_mode = 1` event, where the lineup is revealed act by act.
+Two things follow, and they are easy to conflate:
+
+- **Visibility:** un-announcing hides nothing on a `reveal_mode = 0` event. Only the cancel toggle does that. Hiding act-by-act is what `reveal_mode = 1` is for.
+- **Email:** `is_announced` going `0 → 1` is still what triggers the follower announcement email, on *any* reveal mode. So un-announcing and re-announcing a set here is publicly invisible **and** capable of sending mail. (A *cancelled* set cannot send — that guard is separate and holds regardless.)
 
 **Editing a shared route.** `share_links` stores a snapshot of the band names taken when the link was created. Changing the lineup afterwards does not rewrite existing share links; the page resolves live data for times and venues, and drops sets that no longer exist.
 
@@ -60,7 +67,7 @@ This drives the "Live Tonight" / "Happening Now" edge on an event's **first day 
 
 ## If something looks wrong on the live site
 
-1. **Check the API before the page.** `https://settimes.ca/api/events/<id>/details` and `/api/venues/<id>` show exactly what the frontend receives. Most "the page is wrong" reports are the payload being wrong.
+1. **Check the API before the page.** `https://settimes.ca/api/events/{id}/details` and `https://settimes.ca/api/venues/{id}` show exactly what the frontend receives (Buddies Fest 2 is event `36`). Most "the page is wrong" reports are the payload being wrong.
 2. **Deploys are automatic on merge to `main`**, including database migrations. There is no manual apply step. A change that is merged but not visible is usually a deploy still running — check Actions.
 3. **The API caches for 5 minutes** (`Cache-Control: public, max-age=300` on the public read endpoints). A correct-looking database and a stale page is usually this; wait it out rather than re-editing.
 4. **Times are Toronto-local everywhere.** If something classifies as the wrong day, suspect the after-midnight rule (above) before suspecting a timezone bug.

--- a/docs/SHOW_DAY_RUNBOOK.md
+++ b/docs/SHOW_DAY_RUNBOOK.md
@@ -1,0 +1,79 @@
+# Show-day runbook
+
+What to do when something changes during an event, and which actions silently do nothing.
+
+Written 2026-08-05, before Buddies Fest 2 (event 36, Aug 7–9). Everything here was verified against the code and production data at that date — if a procedure stops matching the code, fix this file in the same change.
+
+---
+
+## A band drops
+
+**Cancel the set. Do not un-announce it, and do not delete it.**
+
+Admin → the event's **Lineup** tab → find the set → **Cancel**. It is reversible; **Restore** puts it back.
+
+What that does for fans:
+
+- the set stays visible, struck through, with a "Cancelled" label — on the schedule, the artist page, the venue page and the event page
+- it stops being offered as "up next", never shows "Live Now" or "starts in N minutes", and cannot be added to a route
+- calendar subscribers get `STATUS:CANCELLED`, which Google and Apple render natively
+- **no announcement email can go out** for it, even if someone announces it afterwards
+
+Why not the alternatives:
+
+| Action | What actually happens |
+|---|---|
+| Set `is_announced = 0` | **Nothing visible.** See "Silent no-ops" below |
+| Delete the performance row | Hides it, but a fan who already saw the lineup gets no signal, and the band's name is left stranded on already-shared routes |
+
+**A band with two sets needs each one cancelled separately.** At BF2, ALL and Kepi Ghoulie each play twice.
+
+## A set time changes
+
+Admin → Lineup tab → edit the set's start/end time.
+
+**If the new time is after midnight, check the date field.** `performance_date` stores **the evening the set belongs to**, not the wall-clock calendar date. A set at 00:25 on the night of Saturday the 8th is stored as `2026-08-08`, not the 9th. Getting this wrong makes the set sort to the top of the wrong day.
+
+The cutover is 6 AM: anything starting before 06:00 belongs to the previous evening.
+
+## A band is added last minute
+
+Admin → Lineup tab → add the artist, venue, and set time. If the artist has no profile yet, one is created.
+
+For a multi-day event, set the correct **performance date** — it is not inferred from the time.
+
+## Doors / gates times change
+
+Doors are stored per day on the event as `doors_json`, e.g. `{"2026-08-07":"15:00","2026-08-08":"15:00","2026-08-09":"15:00"}`.
+
+This drives the "Live Tonight" / "Happening Now" edge on an event's **first day only** — the earliest of doors time, first set, or local midnight wins. Day 2+ is never re-gated.
+
+## Silent no-ops — things that look like they worked
+
+**Un-announcing a set on a published lineup.** Every public query guards with `AND (e.reveal_mode = 0 OR p.is_announced = 1)`. When `reveal_mode = 0` — the normal state for a published event, and BF2's state — that condition is already true, so `is_announced` is never consulted. The set stays fully visible. Nothing errors.
+
+`is_announced` is only meaningful on a `reveal_mode = 1` event, where the lineup is revealed act by act.
+
+**Editing a shared route.** `share_links` stores a snapshot of the band names taken when the link was created. Changing the lineup afterwards does not rewrite existing share links; the page resolves live data for times and venues, and drops sets that no longer exist.
+
+**A fan's saved schedule.** Selections live in the fan's own browser (`localStorage`), not on the server. You cannot edit or clear someone's saved route, and cancelling a set deliberately does **not** remove it from theirs — they see it struck through and remove it themselves.
+
+## If something looks wrong on the live site
+
+1. **Check the API before the page.** `https://settimes.ca/api/events/<id>/details` and `/api/venues/<id>` show exactly what the frontend receives. Most "the page is wrong" reports are the payload being wrong.
+2. **Deploys are automatic on merge to `main`**, including database migrations. There is no manual apply step. A change that is merged but not visible is usually a deploy still running — check Actions.
+3. **The API caches for 5 minutes** (`Cache-Control: public, max-age=300` on the public read endpoints). A correct-looking database and a stale page is usually this; wait it out rather than re-editing.
+4. **Times are Toronto-local everywhere.** If something classifies as the wrong day, suspect the after-midnight rule (above) before suspecting a timezone bug.
+
+## What to avoid mid-event
+
+- **Do not run migrations or dependency upgrades during an event.** Both deploy automatically on merge.
+- **Do not delete a venue or an event** that has performances attached.
+- **Do not bulk-edit the lineup** while people are using the site; per-set edits are safe and immediate.
+
+---
+
+## Related
+
+- `CLAUDE.md` → "Pulling a band from a live lineup" — the same rule with the code paths
+- `docs/ADMIN_HANDBOOK.md` — general admin usage, not show-day specific


### PR DESCRIPTION
Two days before Buddies Fest 2, the documented way to pull a band is wrong in a way that fails silently.

Closes #734

## The trap

Setting `is_announced = 0` does **not** hide a set. Five public queries guard with `AND (e.reveal_mode = 0 OR p.is_announced = 1)` — `bands/[name].js`, `bands/stats/[name].js`, `events/timeline.js`, `feeds/ical.js`, `venues/[id].js`. On a `reveal_mode = 0` event the left side short-circuits **true**, so `is_announced` is never consulted.

`reveal_mode = 0` is the normal state for a published lineup. **Buddies Fest 2 (event 36) is `reveal_mode = 0`** — verified against production — so this applies to exactly the event most likely to be edited this weekend. The set stays on the schedule, the artist page, the venue page and the calendar feed. Nothing errors. The failure surfaces when fans reach a dark venue.

## Why the old advice is stale

The previous guidance was to delete the performance row. #732 replaced that: the correct action is now the reversible **cancel toggle**, which keeps the set visible and struck through, suppresses it from up-next routing and live/starting-soon time math, makes it unselectable, emits `STATUS:CANCELLED` to calendar subscribers, and blocks the announcement email.

Deleting is still lossy in two ways: no signal to a fan who already saw the lineup, and it strands the band name on already-shared routes (#733).

## What changed

| File | Change |
|---|---|
| `CLAUDE.md` | New "Pulling a band from a live lineup" section with the code paths |
| `docs/SHOW_DAY_RUNBOOK.md` | New — operator-facing: pull a band, change a set time, add a late act, doors times, silent no-ops, what to check when the live site looks wrong |

## Verified, not assumed

Every claim was checked against the code or production before writing:

- LineupTab renders `Cancel` / `Restore` — grepped the actual labels
- public reads carry `Cache-Control: max-age=300` — 2 endpoints confirmed
- the announce path guards on `isCancelled === 0` — confirmed present
- event 36 is `reveal_mode = 0`, `is_published = 1`, with 0 unannounced and 0 cancelled sets — queried production

## Verification

- [x] `make gate` clean (952 backend + 916 frontend, 0 lint errors)
- [x] No code changed — docs only

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for cancelling individual performances from a live lineup, including impacts on visibility, scheduling, calendar entries, and notifications.
  * Documented announcement-state changes, cancellation suppression, and restoration behaviour.
  * Added a show-day runbook covering cancellations, rescheduling, last-minute additions, door-time configuration, troubleshooting, caching, deployment, and event-time restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->