### PR TITLE
test: make the perf suite deterministic and fix the contrast guard's backdrop

### DIFF
--- a/frontend/src/__tests__/themeTokens.test.js
+++ b/frontend/src/__tests__/themeTokens.test.js
@@ -84,6 +84,34 @@ function resolveGradientAccentStops(theme) {
   return { start: match[1], end: match[2] }
 }
 
+// gradient-card's stops are `rgba(...)` with real alpha (0.9-0.96), unlike
+// gradient-accent's opaque hex stops above — the card itself is a
+// translucent overlay on the page background, not a solid fill. Returns both
+// stops as {rgb, alpha} so the caller can composite each over the page
+// background and use whichever is darker (#721).
+function resolveGradientCardStops(theme) {
+  const raw =
+    getRawVar(themeBlocks[theme], '--background-image-gradient-card') ||
+    getRawVar(rootBlock, '--background-image-gradient-card')
+  if (!raw) {
+    throw new Error(`themeTokens.test.js: --background-image-gradient-card is not defined for theme "${theme}"`)
+  }
+  const match =
+    /rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\s*\)\s*0%,\s*rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\s*\)\s*100%/.exec(
+      raw
+    )
+  if (!match) {
+    throw new Error(
+      `themeTokens.test.js: could not parse rgba start/end stops out of --background-image-gradient-card for theme "${theme}": ${raw}`
+    )
+  }
+  const [, r1, g1, b1, a1, r2, g2, b2, a2] = match
+  return {
+    start: { rgb: [Number(r1), Number(g1), Number(b1)], alpha: a1 === undefined ? 1 : Number(a1) },
+    end: { rgb: [Number(r2), Number(g2), Number(b2)], alpha: a2 === undefined ? 1 : Number(a2) },
+  }
+}
+
 // --- WCAG 2.x contrast (relative luminance + contrast ratio) --------------
 function hexToRgb(hex) {
   let h = hex.replace('#', '')
@@ -135,6 +163,19 @@ function blend(fgHex, bgHex, alphaPercent) {
   return `#${[mixChannel(fr, br), mixChannel(fg, bg), mixChannel(fb, bb)]
     .map(c => c.toString(16).padStart(2, '0'))
     .join('')}`
+}
+
+function rgbToHex([r, g, b]) {
+  return `#${[r, g, b].map(c => c.toString(16).padStart(2, '0')).join('')}`
+}
+
+// gradient-card is a translucent overlay (real rgba alpha, not an opaque
+// fill) painted over the page background, so a gradient-card stop has to be
+// resolved to what actually renders on screen — the stop alpha-blended over
+// the page backdrop — before anything else (e.g. the pill tint) can be
+// composited on top of it in turn (#721).
+function compositeCardStopOverPage(stop, pageBgHex) {
+  return blend(rgbToHex(stop.rgb), pageBgHex, stop.alpha * 100)
 }
 
 // Pulls the `.soon-pill` rule's actual `background: color-mix(...)` and
@@ -197,26 +238,41 @@ describe('theme token contrast (WCAG AA, 4.5:1)', () => {
     // never renders — .soon-pill's text sits on its OWN
     // `color-mix(in srgb, warning-400 15%, transparent)` tint, which
     // (per `blend()` above) pulls the effective background toward
-    // warning-400's hue and erodes the real on-screen contrast to ~3.9:1 on
-    // daybreak/silver-lining, failing AA. This composites the tint the same
-    // way the browser does and checks the pill's actual text token
-    // (--color-warning-pill-text) against that composited result. bg-navy is
-    // used as the compositing backdrop (rather than parsing BandCard's
-    // gradient-card, which this file doesn't otherwise resolve) because
-    // gradient-card's stops are near-identical to bg-navy/bg-purple on every
-    // theme, and bg-navy is what every other assertion in this file already
-    // anchors to.
-    it('soon-pill text clears 4.5:1 against its composited (color-mix) pill background', () => {
+    // warning-400's hue and erodes the real on-screen contrast. This
+    // composites the tint the same way the browser does and checks the
+    // pill's actual text token (--color-warning-pill-text) against that
+    // composited result.
+    //
+    // The pill only ever renders on BandCard's default `bg-gradient-card`
+    // state (BandCard.jsx swaps to the opaque `.soon-pill--dark` style
+    // whenever the amber `bg-gradient-accent` background is active), and
+    // gradient-card is a translucent rgba overlay — NOT near-identical to
+    // bg-navy, contrary to what this comment used to claim (#721). On
+    // daybreak, gradient-card's darkest stop is rgba(247,234,220,0.92)
+    // against bg-navy #fff8f1 — visibly darker, which erodes contrast for
+    // the pill's dark text. So the real backdrop for the pill tint is
+    // gradient-card's stop, itself composited over the page background
+    // (bg-navy), not bg-navy directly. Both gradient-card stops are checked
+    // and the lower (worse) resulting ratio is asserted, since the pill can
+    // sit anywhere along the card's gradient.
+    it('soon-pill text clears 4.5:1 against its composited (color-mix over gradient-card) pill background', () => {
       const tintColor = resolveHex(pillSpec.tintToken, theme)
       const textColor = resolveHex(pillSpec.textToken, theme)
-      const compositedPillBg = blend(tintColor, bgNavy, pillSpec.tintPercent)
-      const ratio = contrastRatio(textColor, compositedPillBg)
+      const cardStops = resolveGradientCardStops(theme)
+
+      const results = [cardStops.start, cardStops.end].map(stop => {
+        const cardBg = compositeCardStopOverPage(stop, bgNavy)
+        const pillBg = blend(tintColor, cardBg, pillSpec.tintPercent)
+        return { cardBg, pillBg, ratio: contrastRatio(textColor, pillBg) }
+      })
+      const worst = results[0].ratio <= results[1].ratio ? results[0] : results[1]
+
       expect(
-        ratio,
+        worst.ratio,
         `[${theme}] .soon-pill text (${pillSpec.textToken}=${textColor}) against its composited pill ` +
-          `background (${pillSpec.tintPercent}% ${pillSpec.tintToken}=${tintColor} color-mixed over ` +
-          `--color-bg-navy=${bgNavy} => ${compositedPillBg}) computes to ${ratio.toFixed(2)}:1, below the ` +
-          `${MIN_CONTRAST}:1 WCAG AA floor`
+          `background (${pillSpec.tintPercent}% ${pillSpec.tintToken}=${tintColor} color-mixed over the ` +
+          `gradient-card stop composited over --color-bg-navy=${bgNavy} => ${worst.cardBg} => ${worst.pillBg}) ` +
+          `computes to ${worst.ratio.toFixed(2)}:1, below the ${MIN_CONTRAST}:1 WCAG AA floor`
       ).toBeGreaterThanOrEqual(MIN_CONTRAST)
     })
 

--- a/frontend/src/utils/__tests__/performance.test.js
+++ b/frontend/src/utils/__tests__/performance.test.js
@@ -80,9 +80,13 @@ describe('Performance Utilities - Console Logging', () => {
       const { measurePageLoad } = await import('../performance.js')
       measurePageLoad()
       window.dispatchEvent(new Event('load'))
-      await new Promise(resolve => setTimeout(resolve, 10))
 
-      expect(consoleTableSpy).toHaveBeenCalled()
+      // Same fixed-sleep flake as the LCP test below (#758): this waits on
+      // the production code's own setTimeout(0) inside runMeasurements, which
+      // can be delayed past a fixed window under a loaded `vitest run`.
+      await vi.waitFor(() => {
+        expect(consoleTableSpy).toHaveBeenCalled()
+      })
     })
 
     it('should log LCP metric in dev mode', async () => {
@@ -274,57 +278,68 @@ describe('Performance Utilities - Console Logging', () => {
       }
     })
 
+    // No fixed sleep here (#758 sibling): the wait now happens per-assertion
+    // via vi.waitFor below, so this only performs the synchronous setup.
     async function runAndFlush() {
       const { measurePageLoad } = await import('../performance.js')
       measurePageLoad()
       window.dispatchEvent(new Event('load'))
-      await new Promise(resolve => setTimeout(resolve, 10))
     }
 
     it('should calculate DNS time correctly', async () => {
       await runAndFlush()
-      expect(consoleTableSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          dns: 20,
-        })
-      )
+      await vi.waitFor(() => {
+        expect(consoleTableSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            dns: 20,
+          })
+        )
+      })
     })
 
     it('should calculate TCP time correctly', async () => {
       await runAndFlush()
-      expect(consoleTableSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tcp: 30,
-        })
-      )
+      await vi.waitFor(() => {
+        expect(consoleTableSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tcp: 30,
+          })
+        )
+      })
     })
 
     it('should calculate total load time correctly', async () => {
       await runAndFlush()
-      expect(consoleTableSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          load: 500,
-        })
-      )
+      await vi.waitFor(() => {
+        expect(consoleTableSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            load: 500,
+          })
+        )
+      })
     })
 
     it('should extract FCP metric', async () => {
       await runAndFlush()
-      expect(consoleTableSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          fcp: 300,
-        })
-      )
+      await vi.waitFor(() => {
+        expect(consoleTableSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fcp: 300,
+          })
+        )
+      })
     })
 
     it('should return null for missing FCP', async () => {
       global.performance.getEntriesByType = vi.fn().mockReturnValue([])
       await runAndFlush()
-      expect(consoleTableSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          fcp: null,
-        })
-      )
+      await vi.waitFor(() => {
+        expect(consoleTableSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fcp: null,
+          })
+        )
+      })
     })
   })
 

--- a/frontend/src/utils/__tests__/performance.test.js
+++ b/frontend/src/utils/__tests__/performance.test.js
@@ -117,9 +117,17 @@ describe('Performance Utilities - Console Logging', () => {
       const { measurePageLoad } = await import('../performance.js')
       measurePageLoad()
       window.dispatchEvent(new Event('load'))
-      await new Promise(resolve => setTimeout(resolve, 10))
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('LCP:', expect.any(Number), 'ms')
+      // A fixed sleep here stood in for "the PerformanceObserver callback has
+      // fired" and flaked under a loaded `vitest run` (#758): the mock's own
+      // `setTimeout(..., 0)` is a THIRD timer registered dynamically inside
+      // the production code's own `setTimeout(..., 0)`, so under contention
+      // it can land in a later event-loop tick than a single fixed-delay
+      // wait registered up front. vi.waitFor polls the real assertion
+      // instead of guessing a delay, so it's correct under any load.
+      await vi.waitFor(() => {
+        expect(consoleLogSpy).toHaveBeenCalledWith('LCP:', expect.any(Number), 'ms')
+      })
     })
   })
 


### PR DESCRIPTION
Two test-infrastructure bugs. No product code changes — both make the test signal trustworthy, which is what matters if something needs a fast confident fix during an event.

Closes #758
Closes #721

## #758 — the perf suite was flaky under load

It blocked `make gate` twice on 2026-08-04, both times on changes that could not affect it, and passed 3/3 in isolation each time.

The mechanism, traced rather than assumed: the mocked `PerformanceObserver` schedules its callback via a **dynamically re-registered** `setTimeout(…, 0)` nested inside production code’s own `setTimeout(…, 0)`. Under contention the overdue 10 ms wait fires in the same timer pass as the first 0 ms timer, but the re-registered one slips to the next loop iteration — so the assertion runs exactly one tick early.

Fixed by waiting on the signal instead of the clock (`vi.waitFor`), not by lengthening the sleep — a longer sleep just moves the flake to a slower runner.

**Then swept the file**, which is where most of this PR is: five more identical `measurePageLoad(); dispatchEvent; await sleep(10)` sites. Two carried the same race and were converted (plus a `runAndFlush()` helper and its 5 callers). Three were left alone, and the reason is the interesting part — see below.

## The three that were left, and why

My instruction to the implementer was that the `.not.toHaveBeenCalled()` sites had the *opposite* defect: that under load "nothing happened in 10 ms" could be a false pass.

**That was wrong, and it was disproved with a probe rather than an argument.** Instrumenting `setTimeout` around a production-mode `measurePageLoad()` recorded **0 scheduled calls**, because `runMeasurements()` returns at `performance.js:19` — before the `setTimeout` at line 23 — when not in dev. Nothing async is ever in flight in production mode, so those sleeps are inert filler, not weak guards. There is no positive "pipeline ran" signal to wait for because the pipeline deliberately does not run.

They are arguably dead weight that could be deleted; left as-is rather than improvised into scope.

## #721 — the contrast guard composited against the wrong backdrop

The theme-token guard composited `.soon-pill` against `bg-navy`, but the pill only ever renders on the card’s default `bg-gradient-card` state (the selected/amber state swaps to an unrelated opaque style). So the guard was computing ratios against a colour never on screen.

Corrected numbers — **no token fails, but the real margins are thinner than the guard reported**:

| Theme | Buggy | Corrected |
|---|---|---|
| daybreak | 5.50:1 | **5.00:1** |
| silver-lining | 5.54:1 | **5.36:1** |
| midnight-ember | 8.62:1 | 7.75:1 |
| arctic-night | 7.91:1 | 6.46:1 |

Everything still clears 4.5:1, so nothing is filed. Worth knowing that daybreak’s true headroom is 0.50, not 1.00, before anyone adjusts a light-theme colour.

Cross-checked two ways: a standalone script reproducing the compositing maths, and an in-test probe that temporarily reverted to `bg-navy` and reproduced the old inflated figures.

## Verification

- [x] `make gate` clean — 956 backend + 916 frontend, 0 lint errors
- [x] **13 full-suite runs** for #758 (8 for the initial fix, 5 for the sweep), including 5 launched concurrently to force real CPU contention. Zero flakes.
- [x] Mutation proofs: disabling `console.log("LCP:"…)` and `console.table(metrics)` each failed every converted assertion; both reverted cleanly

Stability was proven under load, not in isolation — isolation was never the failing case.

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contrast checks for theme gradients and pill labels so colour combinations are evaluated more accurately across backgrounds.
* **Tests**
  * Updated development performance tests to use more reliable waiting and assertion polling, reducing flaky timing-related failures.
  * Expanded theme token coverage to validate translucent gradient stops and background compositing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->