### PR TITLE
docs: record functions/utils/eventDay.js as the server-side after-midnight home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,10 @@ Canonical active roadmap: `docs/ROADMAP.md`. Use it for handoffs between Claude,
 
 Bands starting before 6 AM are "after-midnight" sets that belong to the *previous evening*. They must be offset by +1 day so they sort after the evening lineup, not at the top of the schedule.
 
-- Threshold: `AFTER_MIDNIGHT_THRESHOLD_HOUR = 6`, canonically defined in `frontend/src/utils/festivalDays.js` (#550). `frontend/src/utils/bandUtils.js` and `frontend/src/admin/utils/timeUtils.js` (`AFTER_MIDNIGHT_THRESHOLD_MINUTES = AFTER_MIDNIGHT_THRESHOLD_HOUR * 60`) both import it rather than re-encoding `6`.
+- Threshold: `AFTER_MIDNIGHT_THRESHOLD_HOUR = 6`. There are **two** canonical homes, one per side of the build boundary — Pages Functions cannot import from `frontend/`, so a single definition is impossible:
+  - **Frontend:** `frontend/src/utils/festivalDays.js` (#550). `frontend/src/utils/bandUtils.js` and `frontend/src/admin/utils/timeUtils.js` (`AFTER_MIDNIGHT_THRESHOLD_MINUTES = AFTER_MIDNIGHT_THRESHOLD_HOUR * 60`) both import it rather than re-encoding `6`.
+  - **Server:** `functions/utils/eventDay.js`, which also exports `eventLocalFestivalToday()` — the festival-day equivalent of `eventLocalToday()`, stepping back one calendar day when the Toronto-local hour is below the threshold. Use it for any "which festival day is it?" question server-side; a plain calendar-day comparison flips at midnight while the festival day is still running (bug class fixed in #751).
+- **Two homes, not more.** `functions/api/events/timeline.js` and `functions/event/[slug].js` still re-encode the threshold privately (as `"06:00"` and `6` respectively) instead of importing it — tracked in #746. Do not add a third; import from the appropriate canonical home.
 - Logic: `prepareBands()` adds `MS_PER_DAY` to `startMs`/`endMs` for times below this threshold
 - **Never remove or lower this threshold.** Any sort, filter, or conflict-detection that touches performance times must apply the same offset or delegate to `prepareBands`.
 


### PR DESCRIPTION
## Summary

CLAUDE.md named `frontend/src/utils/festivalDays.js` as the **sole** canonical home for `AFTER_MIDNIGHT_THRESHOLD_HOUR`. That is incomplete — Pages Functions cannot import from `frontend/`, so `functions/utils/eventDay.js` necessarily defines its own, and also exports `eventLocalFestivalToday()`, the helper that fixed the midnight-flip bug class in #751.

A reader following CLAUDE.md today would not know the server-side authority exists, and would either re-encode the constant or reach for a plain calendar-day comparison — the exact two mistakes the invariant is meant to prevent.

Found while auditing the open issue backlog against current code.

## Changes

- Documents **two** canonical homes, one per side of the build boundary, and says why a single one is impossible.
- Points server-side "which festival day is it?" questions at `eventLocalFestivalToday()`, citing #751.
- Names the two files that still re-encode the threshold privately (`functions/api/events/timeline.js`, `functions/event/[slug].js`) so the remaining cleanup in #746 is visible from the invariant itself.

## Test plan

- [x] `make gate` green — exit 0, 956 backend + 916 frontend tests passing
- [x] `make review` (CodeRabbit) — no findings
- [x] Verified both claims against source: `festivalDays.js:36` and `eventDay.js:51` both export the constant; `eventDay.js:68` exports `eventLocalFestivalToday`
- [x] Docs-only — no runtime change

## Notes

CLAUDE.md is outside the repo's prettier scope (`format:check` covers `functions/`, `scripts/`, `e2e/` only) and already failed `--check` on `main`, so it is deliberately **not** reformatted here — that would be unrelated noise.

Refs #746

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified after-midnight sorting rules for frontend and server processing.
  * Documented Toronto-local festival-day classification and related import relationships.
  * Added notes on remaining threshold definitions and tracking issue 746.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->