### PR TITLE
feat(metrics): count share-link imports, the discarded conversion signal

### DIFF
--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -425,7 +425,7 @@ CREATE TABLE IF NOT EXISTS share_links (
   band_names      TEXT    NOT NULL,
   created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
   expires_at      TEXT    NOT NULL
-, view_count INTEGER NOT NULL DEFAULT 0);
+, view_count INTEGER NOT NULL DEFAULT 0, import_count INTEGER NOT NULL DEFAULT 0);
 
 CREATE INDEX IF NOT EXISTS idx_share_links_slug ON share_links(slug);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -178,6 +178,13 @@ function App() {
   const [scheduleToast, setScheduleToast] = useState(null)
   const [posterLightboxOpen, setPosterLightboxOpen] = useState(false)
   const scheduleToastTimeoutRef = useRef(null)
+  // Guards the ?import=1 refetch below against firing twice for the same shared
+  // slug (React 19 StrictMode double-invokes mount effects in dev, and `bands`
+  // populating a second time before the `share` param removal commits would
+  // otherwise double-count an import server-side). Claimed synchronously,
+  // before the async setSearchParams/fetch, so a second same-render
+  // invocation of this effect body sees the claim and bails.
+  const importedShareSlugRef = useRef(null)
 
   useEffect(() => {
     const controller = new AbortController()
@@ -449,6 +456,8 @@ function App() {
   useEffect(() => {
     const shareSlug = searchParams.get('share')
     if (!shareSlug || bands.length === 0) return
+    if (importedShareSlugRef.current === shareSlug) return
+    importedShareSlugRef.current = shareSlug
 
     setSearchParams(
       prev => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -178,13 +178,6 @@ function App() {
   const [scheduleToast, setScheduleToast] = useState(null)
   const [posterLightboxOpen, setPosterLightboxOpen] = useState(false)
   const scheduleToastTimeoutRef = useRef(null)
-  // Guards the ?import=1 refetch below against firing twice for the same shared
-  // slug (React 19 StrictMode double-invokes mount effects in dev, and `bands`
-  // populating a second time before the `share` param removal commits would
-  // otherwise double-count an import server-side). Claimed synchronously,
-  // before the async setSearchParams/fetch, so a second same-render
-  // invocation of this effect body sees the claim and bails.
-  const importedShareSlugRef = useRef(null)
 
   useEffect(() => {
     const controller = new AbortController()
@@ -456,8 +449,6 @@ function App() {
   useEffect(() => {
     const shareSlug = searchParams.get('share')
     if (!shareSlug || bands.length === 0) return
-    if (importedShareSlugRef.current === shareSlug) return
-    importedShareSlugRef.current = shareSlug
 
     setSearchParams(
       prev => {

--- a/frontend/src/admin/MetricsDashboard.jsx
+++ b/frontend/src/admin/MetricsDashboard.jsx
@@ -58,6 +58,12 @@ export default function MetricsDashboard({ eventId }) {
           <div className="text-gray-400 text-sm">Share Views</div>
           <div className="text-3xl font-bold text-white mt-2">{metrics.totalShareViews ?? 0}</div>
         </div>
+
+        {/* Shares Imported — the conversion signal: a fan adopted someone else's route */}
+        <div className="bg-bg-purple rounded-lg p-4">
+          <div className="text-gray-400 text-sm">Shares Imported</div>
+          <div className="text-3xl font-bold text-white mt-2">{metrics.totalShareImports ?? 0}</div>
+        </div>
       </div>
 
       {/* Popular Bands */}

--- a/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
+++ b/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
@@ -11,7 +11,7 @@ vi.mock('../../utils/adminApi', () => ({
 import { eventsApi } from '../../utils/adminApi'
 
 describe('MetricsDashboard', () => {
-  it('displays share analytics: shares created, share views, and top routes', async () => {
+  it('displays share analytics: shares created, share views, imports, and top routes', async () => {
     eventsApi.getMetrics.mockResolvedValue({
       metrics: {
         totalScheduleBuilds: 10,
@@ -20,6 +20,7 @@ describe('MetricsDashboard', () => {
         popularBands: [],
         totalShares: 3,
         totalShareViews: 42,
+        totalShareImports: 5,
         topSharedRoutes: [
           { slug: 'abc123', view_count: 30 },
           { slug: 'def456', view_count: 12 },
@@ -33,8 +34,30 @@ describe('MetricsDashboard', () => {
     expect(screen.getByText('3')).toBeInTheDocument()
     expect(screen.getByText('Share Views')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('Shares Imported')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
     expect(screen.getByText('Most-Viewed Shared Routes')).toBeInTheDocument()
     expect(screen.getByText(/abc123/)).toBeInTheDocument()
     expect(screen.getByText('30 views')).toBeInTheDocument()
+  })
+
+  it('renders 0 for share imports when the field is absent (older data)', async () => {
+    eventsApi.getMetrics.mockResolvedValue({
+      metrics: {
+        totalScheduleBuilds: 0,
+        uniqueVisitors: 0,
+        lastUpdated: null,
+        popularBands: [],
+        totalShares: 0,
+        totalShareViews: 0,
+        topSharedRoutes: [],
+      },
+    })
+
+    render(<MetricsDashboard eventId={1} />)
+
+    expect(await screen.findByText('Shares Imported')).toBeInTheDocument()
+    const shareImportsLabel = screen.getByText('Shares Imported')
+    expect(shareImportsLabel.parentElement.textContent).toContain('0')
   })
 })

--- a/functions/api/admin/events/[id]/metrics.js
+++ b/functions/api/admin/events/[id]/metrics.js
@@ -41,7 +41,8 @@ export async function onRequestGet(context) {
         ).bind(eventId),
         DB.prepare(
           `SELECT COUNT(*) AS total_shares,
-                COALESCE(SUM(view_count), 0) AS total_share_views
+                COALESCE(SUM(view_count), 0) AS total_share_views,
+                COALESCE(SUM(import_count), 0) AS total_share_imports
          FROM share_links WHERE event_id = ?`,
         ).bind(eventId),
         DB.prepare(
@@ -118,6 +119,7 @@ export async function onRequestGet(context) {
           popularBands: popularBands,
           totalShares: shareStats?.total_shares || 0,
           totalShareViews: shareStats?.total_share_views || 0,
+          totalShareImports: shareStats?.total_share_imports || 0,
           topSharedRoutes: topSharedRoutes,
           announcementPlanning: announcementPlanning,
           totalEventViews: telemetryStats?.total_event_views || 0,

--- a/functions/api/admin/events/__tests__/metrics.test.js
+++ b/functions/api/admin/events/__tests__/metrics.test.js
@@ -64,6 +64,42 @@ describe("GET /api/admin/events/[id]/metrics", () => {
     expect(body.metrics.topSharedRoutes[0].view_count).toBe(5);
   });
 
+  test("includes share import totals -- the conversion signal beside shares/views (#703)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Fest", slug: "fest" });
+    insertShareLink(rawDb, {
+      slug: "routeccc",
+      event_id: event.id,
+      event_slug: "fest",
+      performance_ids: [1],
+      band_names: ["A"],
+    });
+    insertShareLink(rawDb, {
+      slug: "routeddd",
+      event_id: event.id,
+      event_slug: "fest",
+      performance_ids: [1, 2],
+      band_names: ["A", "B"],
+    });
+    rawDb.prepare("UPDATE share_links SET import_count = ? WHERE slug = ?").run(3, "routeccc");
+    rawDb.prepare("UPDATE share_links SET import_count = ? WHERE slug = ?").run(1, "routeddd");
+
+    const res = await call(env, event.id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.metrics.totalShareImports).toBe(4);
+  });
+
+  test("event with no share links returns zeroed share import totals, not errors", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Quiet Share Fest", slug: "quiet-share-fest" });
+
+    const res = await call(env, event.id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.metrics.totalShareImports).toBe(0);
+  });
+
   test("popularBands is ordered by schedule_count desc and totalScheduleBuilds/uniqueVisitors reflect inserted rows", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "Band Fest", slug: "band-fest" });

--- a/functions/api/schedule/__tests__/share-get.test.js
+++ b/functions/api/schedule/__tests__/share-get.test.js
@@ -124,4 +124,97 @@ describe("GET /api/schedule/share/[slug]", () => {
     const row = rawDb.prepare("SELECT view_count FROM share_links WHERE slug = ?").get("import12");
     expect(row.view_count).toBe(0);
   });
+
+  test("increments import_count for an import refetch (?import=1) but not view_count (#703)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
+    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    insertShareLink(rawDb, {
+      slug: "import99",
+      event_id: event.id,
+      event_slug: "my-fest",
+      performance_ids: [10],
+      band_names: ["Band A"],
+    });
+
+    const importFetch = () =>
+      onRequestGet({
+        request: new Request("https://example.test/api/schedule/share/import99?import=1"),
+        params: { slug: "import99" },
+        env,
+      });
+
+    await importFetch();
+    await importFetch();
+
+    const row = rawDb.prepare("SELECT view_count, import_count FROM share_links WHERE slug = ?").get("import99");
+    expect(row.import_count).toBe(2);
+    expect(row.view_count).toBe(0);
+  });
+
+  test("a normal GET (no ?import=1) increments view_count but not import_count (#703)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
+    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    insertShareLink(rawDb, {
+      slug: "normal01",
+      event_id: event.id,
+      event_slug: "my-fest",
+      performance_ids: [10],
+      band_names: ["Band A"],
+    });
+
+    await onRequestGet({
+      request: makeRequest("normal01"),
+      params: { slug: "normal01" },
+      env,
+    });
+
+    const row = rawDb.prepare("SELECT view_count, import_count FROM share_links WHERE slug = ?").get("normal01");
+    expect(row.view_count).toBe(1);
+    expect(row.import_count).toBe(0);
+  });
+
+  test("an import-counter write failure still returns the share payload with 200 (#703)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
+    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    insertShareLink(rawDb, {
+      slug: "failimp1",
+      event_id: event.id,
+      event_slug: "my-fest",
+      performance_ids: [10],
+      band_names: ["Band A"],
+    });
+
+    // Simulate the import_count UPDATE throwing while every other statement
+    // (including the row SELECT) works normally -- the best-effort contract
+    // means this must never surface to the caller as a failed request.
+    const originalPrepare = env.DB.prepare.bind(env.DB);
+    env.DB.prepare = (sql) => {
+      if (sql.includes("UPDATE share_links SET import_count")) {
+        return {
+          bind: () => ({
+            run: () => {
+              throw new Error("simulated import-count write failure");
+            },
+          }),
+        };
+      }
+      return originalPrepare(sql);
+    };
+
+    const res = await onRequestGet({
+      request: new Request("https://example.test/api/schedule/share/failimp1?import=1"),
+      params: { slug: "failimp1" },
+      env,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slug).toBe("failimp1");
+
+    const row = rawDb.prepare("SELECT import_count FROM share_links WHERE slug = ?").get("failimp1");
+    expect(row.import_count).toBe(0);
+  });
 });

--- a/functions/api/schedule/share/[slug].js
+++ b/functions/api/schedule/share/[slug].js
@@ -45,6 +45,16 @@ export async function onRequestGet(context) {
       } catch (err) {
         console.error("Share link view-count increment failed:", slug, err);
       }
+    } else {
+      // Best-effort import counter (#703) — same discipline as the view counter
+      // above: never break share retrieval, log rather than swallow. This is the
+      // conversion signal view_count can't provide: a fan adopted someone else's
+      // route as their own, not just opened the link.
+      try {
+        await DB.prepare("UPDATE share_links SET import_count = import_count + 1 WHERE slug = ?").bind(slug).run();
+      } catch (err) {
+        console.error("Share link import-count increment failed:", slug, err);
+      }
     }
 
     let performance_ids, band_names;

--- a/functions/api/test-utils.js
+++ b/functions/api/test-utils.js
@@ -371,7 +371,8 @@ export function createTestDB() {
       band_names      TEXT    NOT NULL,
       created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
       expires_at      TEXT    NOT NULL,
-      view_count      INTEGER NOT NULL DEFAULT 0
+      view_count      INTEGER NOT NULL DEFAULT 0,
+      import_count    INTEGER NOT NULL DEFAULT 0
     );
   `);
 

--- a/migrations/0057_share_links_import_count.sql
+++ b/migrations/0057_share_links_import_count.sql
@@ -1,0 +1,12 @@
+-- Migration: 0057_share_links_import_count.sql
+-- Adds an import counter to share_links for share-conversion metrics (#703).
+--
+-- Incremented (best-effort) by functions/api/schedule/share/[slug].js on the
+-- `?import=1` refetch that App.jsx issues when a fan adopts a shared route.
+-- That refetch deliberately does NOT increment view_count (it re-fetches a
+-- snapshot already counted as a view by SharePreviewPage) -- see
+-- 0040_share_links_view_count.sql. import_count is the conversion signal
+-- view_count cannot provide: not just "was the link opened" but "did someone
+-- adopt this route as their own". Existing rows default to 0.
+
+ALTER TABLE share_links ADD COLUMN import_count INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
Closes #703

## Why this is pre-BF2 work

An import is the single most valuable event in the share feature — a fan liked someone else's route enough to adopt it as their own. `functions/api/schedule/share/[slug].js` already **detects** the import refetch and deliberately skips view-counting it (correct), but then discards the signal entirely.

This is now-or-never for Buddies Fest 2: an import that happens during the festival without a counter is gone permanently. BF2 sharing is already active pre-doors — **45 share views across 3 links**, versus Vol. 17's 13 views across 7.

## Changes

- `migrations/0057_share_links_import_count.sql` — additive `INTEGER NOT NULL DEFAULT 0`, so existing rows are unaffected.
- `functions/api/schedule/share/[slug].js` — increments `import_count` on the `?import=1` branch that previously did nothing. Sits in the `else` of the existing `if (!isImportRefetch)`, so **an import can never touch `view_count`**.
- `functions/api/admin/events/[id]/metrics.js` — exposes `totalShareImports`.
- `frontend/src/admin/MetricsDashboard.jsx` — "Shares Imported" tile beside Shares Created / Share Views, so the funnel reads at a glance. Admin is dark-pinned, so the existing `text-white` styling is matched deliberately, not migrated.
- `functions/api/test-utils.js` — the test DB hand-maintains its **own** `CREATE TABLE` statements, separate from `setup-complete.sql`; `share_links` needed the column there too.

Failure handling mirrors the view counter exactly: best-effort, wrapped in try/catch, `console.error` rather than a silent swallow. A counter failure can never break share retrieval.

## Test plan

- [x] `make gate` — exit 0. Backend 961 tests, frontend 917 tests, build green
- [x] `node scripts/regenerate-setup-complete.mjs` + `check-schema-drift.mjs` — exit 0, "matches migrations/ for 28 table(s)"
- [x] `make review` (CodeRabbit) — no findings across all 9 files
- [x] `?import=1` increments `import_count` and **not** `view_count`
- [x] A normal GET increments `view_count` and **not** `import_count`
- [x] A counter write failure still returns the share payload with 200
- [x] Every assertion mutation-tested: removing the `else` branch fails the import test; removing the try/catch fails the resilience test (500 vs 200); removing `import_count` from the SQL fails the metrics test; removing the tile JSX fails both dashboard tests

## Deliberately out of scope

The implementation also added a `useRef` guard in `frontend/src/App.jsx` against the import effect firing twice. **That was reverted** (see the second commit).

Double-counting cannot occur today — the StrictMode double-invoke path is short-circuited because `bands` starts empty, and the other path needs a polling/live-refresh feature that doesn't exist. So the counter is already accurate for BF2 without it. Against zero present benefit, it was an untested change to the fan-facing share-import path whose failure mode is silent: a false positive returns early from the effect, so the fan's shared route never applies, with no error and no toast. Wrong risk two days before doors. Filed as a follow-up to land with a real test.

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added import tracking for shared links, separately from view counts.
  - Import actions now increment an import counter while preserving view statistics.
  - Added a “Shares Imported” metric to the admin analytics dashboard.
  - Import metrics display as zero when no data is available.

- **Bug Fixes**
  - Share retrieval continues successfully if updating the import counter fails.

- **Tests**
  - Added coverage for import counting, legacy data, and links without imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->