### PR TITLE
feat(venue): offer directions wherever an address is shown

### DIFF
--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -1,8 +1,21 @@
-import { Archive, CalendarDays, Check, Clock, Funnel, History, MapPin, Music, TriangleAlert, X } from 'lucide-react'
+import {
+  Archive,
+  CalendarDays,
+  Check,
+  Clock,
+  Funnel,
+  History,
+  MapPin,
+  Music,
+  Navigation,
+  TriangleAlert,
+  X,
+} from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { Link } from 'react-router-dom'
 import { fetchPublicJson } from '../utils/publicApi'
 import { buildBandProfileHref } from '../utils/bandProfileLink'
+import { buildDirectionsHref } from '../utils/directions'
 import { formatPerformanceDayLabel, formatTimeRange, parseLocalDate } from '../utils/timeFormat'
 import { trackTicketClick } from '../utils/metrics'
 import { safeExternalHref } from '../utils/urlSafety'
@@ -890,15 +903,38 @@ function EventCard({
             <div className="p-6 border-b border-border">
               <h4 className="text-lg font-bold text-text-primary mb-4">Venues</h4>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {venueList.map(venue => (
-                  <Card key={venue.id} padding="sm" variant="elevated">
-                    <div className="font-semibold text-text-primary mb-1">{venue.name}</div>
-                    <div className="text-text-secondary text-sm">
-                      {venue.band_count} {venue.band_count === 1 ? 'band' : 'bands'}
-                    </div>
-                    {venue.address && <div className="text-text-tertiary text-xs mt-1">{venue.address}</div>}
-                  </Card>
-                ))}
+                {venueList.map(venue => {
+                  // Name + address (never address alone) so the pin lands on
+                  // the venue itself rather than mid-street (see
+                  // utils/directions.js). Returns null when address is
+                  // missing/blank, so no dead Directions link renders (#754).
+                  const directionsHref = buildDirectionsHref(venue.name, venue.address)
+                  return (
+                    <Card key={venue.id} padding="sm" variant="elevated">
+                      <div className="font-semibold text-text-primary mb-1">{venue.name}</div>
+                      <div className="text-text-secondary text-sm">
+                        {venue.band_count} {venue.band_count === 1 ? 'band' : 'bands'}
+                      </div>
+                      {venue.address && (
+                        <p className="text-text-tertiary text-xs mt-1 flex flex-wrap items-center gap-x-2 gap-y-1">
+                          <span>{venue.address}</span>
+                          {directionsHref && (
+                            <a
+                              href={directionsHref}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              aria-label={`Directions to ${venue.name}`}
+                              className="inline-flex items-center gap-1 text-accent-400 hover:text-accent-300"
+                            >
+                              <Navigation size={12} aria-hidden="true" />
+                              Directions
+                            </a>
+                          )}
+                        </p>
+                      )}
+                    </Card>
+                  )
+                })}
               </div>
             </div>
           )}

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -909,13 +909,18 @@ function EventCard({
                   // utils/directions.js). Returns null when address is
                   // missing/blank, so no dead Directions link renders (#754).
                   const directionsHref = buildDirectionsHref(venue.name, venue.address)
+                  // Guard on the TRIMMED address so this agrees with
+                  // buildDirectionsHref, which trims before deciding. A
+                  // whitespace-only address would otherwise render an address
+                  // row with no directions link inside it.
+                  const hasAddress = typeof venue.address === 'string' && venue.address.trim() !== ''
                   return (
                     <Card key={venue.id} padding="sm" variant="elevated">
                       <div className="font-semibold text-text-primary mb-1">{venue.name}</div>
                       <div className="text-text-secondary text-sm">
                         {venue.band_count} {venue.band_count === 1 ? 'band' : 'bands'}
                       </div>
-                      {venue.address && (
+                      {hasAddress && (
                         <p className="text-text-tertiary text-xs mt-1 flex flex-wrap items-center gap-x-2 gap-y-1">
                           <span>{venue.address}</span>
                           {directionsHref && (

--- a/frontend/src/components/NextMove.jsx
+++ b/frontend/src/components/NextMove.jsx
@@ -1,5 +1,5 @@
 import { ArrowRight, CircleAlert, Clock, Footprints, Guitar, Navigation } from 'lucide-react'
-import { directionsHref } from '../utils/nextMove'
+import { buildDirectionsHrefForBand } from '../utils/directions'
 
 // Glanceable live-event companion. Renders the single "what do I do right now"
 // answer produced by computeNextMove() — see utils/nextMove.js. Purely
@@ -21,7 +21,7 @@ const KIND_META = {
 }
 
 function DirectionsButton({ band }) {
-  const href = directionsHref(band)
+  const href = buildDirectionsHrefForBand(band)
   if (!href) return null
   return (
     <a

--- a/frontend/src/components/VenueInfo.jsx
+++ b/frontend/src/components/VenueInfo.jsx
@@ -23,6 +23,11 @@ function VenueInfo({ eventData }) {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-w-5xl mx-auto">
           {venues.map(venue => {
             const mapHref = safeExternalHref(venue.googleMaps)
+            // Guard the address row on the TRIMMED value, in BOTH branches.
+            // buildDirectionsHref trims before deciding, so an untrimmed
+            // truthiness check renders a MapPin next to an empty span for a
+            // whitespace-only address — an icon labelling nothing.
+            const hasAddress = typeof venue.address === 'string' && venue.address.trim() !== ''
             const cardClassName =
               'bg-bg-purple/50 hover:bg-bg-purple transition-colors p-4 rounded-lg border border-accent-500/30 text-center focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500'
 
@@ -36,10 +41,12 @@ function VenueInfo({ eventData }) {
               return (
                 <div key={venue.name} className={cardClassName}>
                   <h4 className="font-bold text-text-primary text-sm mb-2">{venue.name}</h4>
-                  <p className="text-accent-400 text-xs mb-1 flex items-center justify-center gap-2">
-                    <MapPin size={12} aria-hidden="true" />
-                    <span>{venue.address}</span>
-                  </p>
+                  {hasAddress && (
+                    <p className="text-accent-400 text-xs mb-1 flex items-center justify-center gap-2">
+                      <MapPin size={12} aria-hidden="true" />
+                      <span>{venue.address}</span>
+                    </p>
+                  )}
                   {fallbackDirectionsHref && (
                     <a
                       href={fallbackDirectionsHref}
@@ -68,10 +75,12 @@ function VenueInfo({ eventData }) {
                 aria-label={`Open directions to ${venue.name}`}
               >
                 <h4 className="font-bold text-text-primary text-sm mb-2">{venue.name}</h4>
-                <p className="text-accent-400 text-xs mb-1 flex items-center justify-center gap-2">
-                  <MapPin size={14} aria-hidden="true" />
-                  <span>{venue.address}</span>
-                </p>
+                {hasAddress && (
+                  <p className="text-accent-400 text-xs mb-1 flex items-center justify-center gap-2">
+                    <MapPin size={14} aria-hidden="true" />
+                    <span>{venue.address}</span>
+                  </p>
+                )}
                 {venue.note && <p className="text-text-tertiary text-xs italic mt-2">{venue.note}</p>}
               </a>
             )

--- a/frontend/src/components/VenueInfo.jsx
+++ b/frontend/src/components/VenueInfo.jsx
@@ -1,4 +1,5 @@
-import { MapPin } from 'lucide-react'
+import { MapPin, Navigation } from 'lucide-react'
+import { buildDirectionsHref } from '../utils/directions'
 import { safeExternalHref } from '../utils/urlSafety'
 
 function VenueInfo({ eventData }) {
@@ -26,6 +27,12 @@ function VenueInfo({ eventData }) {
               'bg-bg-purple/50 hover:bg-bg-purple transition-colors p-4 rounded-lg border border-accent-500/30 text-center focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500'
 
             if (mapHref === '#') {
+              // No admin-set googleMaps link (missing or an unsafe/invalid
+              // URL) — fall back to a directions link built from name +
+              // address rather than leaving the address as inert text
+              // (#754). Reuses the same builder as VenuePage.jsx; returns
+              // null (no link rendered) when address is missing/blank.
+              const fallbackDirectionsHref = buildDirectionsHref(venue.name, venue.address)
               return (
                 <div key={venue.name} className={cardClassName}>
                   <h4 className="font-bold text-text-primary text-sm mb-2">{venue.name}</h4>
@@ -33,6 +40,18 @@ function VenueInfo({ eventData }) {
                     <MapPin size={12} aria-hidden="true" />
                     <span>{venue.address}</span>
                   </p>
+                  {fallbackDirectionsHref && (
+                    <a
+                      href={fallbackDirectionsHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Directions to ${venue.name}`}
+                      className="inline-flex items-center justify-center gap-1.5 text-accent-400 hover:text-accent-300 text-xs mt-1"
+                    >
+                      <Navigation size={12} aria-hidden="true" />
+                      Directions
+                    </a>
+                  )}
                   {venue.note && <p className="text-text-tertiary text-xs italic mt-2">{venue.note}</p>}
                 </div>
               )

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -839,3 +839,103 @@ describe('EventTimeline past-section poster lazy mounting (#658)', () => {
     expect(img.closest('a')).toBeNull()
   })
 })
+
+// #754 — the Venues grid (expanded event details) rendered a venue's address
+// as inert text with no way to get directions. It now builds a
+// buildDirectionsHref(name, address) link.
+//
+// Testing gotcha (per #753's postmortem): an <a> with no `href` has NO
+// implicit ARIA `link` role, so `queryByRole('link', ...)` returns null even
+// against a rendered dead anchor -- a "no link" assertion written that way
+// would pass against the broken (pre-#754) implementation too. Every
+// assertion here also checks the visible "Directions" text so a regression
+// to inert text is caught either way.
+describe('EventTimeline Venues grid directions (#754)', () => {
+  beforeEach(() => {
+    const timelineData = {
+      now: [],
+      upcoming: [
+        {
+          id: 1,
+          name: 'Test Event',
+          slug: 'test-event',
+          date: '2026-05-10',
+          status: 'published',
+          is_published: true,
+          venues: [],
+          bands: [],
+          band_count: 0,
+          venue_count: 0,
+          ticket_url: null,
+        },
+      ],
+      past: [],
+    }
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        if (url === '/api/events/1/details') {
+          return Promise.resolve(
+            jsonResponse({
+              venues: [
+                { id: 7, name: 'The Mill', band_count: 1, address: '20 John Pound Road, Tillsonburg, ON' },
+                { id: 8, name: 'Roost', band_count: 1, address: null },
+              ],
+              bands: [],
+              band_count: 2,
+              venue_count: 2,
+            })
+          )
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('renders a directions link with the venue name in its accessible name', async () => {
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Test Event')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }))
+    expect(await screen.findByText('The Mill')).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: 'Directions to The Mill' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveTextContent('Directions')
+    expect(link).toHaveAttribute(
+      'href',
+      'https://www.google.com/maps/search/?api=1&query=' +
+        encodeURIComponent('The Mill, 20 John Pound Road, Tillsonburg, ON')
+    )
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'))
+  })
+
+  it('renders no crash and no directions link/address row for a venue with no address', async () => {
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Test Event')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }))
+    expect(await screen.findByText('Roost')).toBeInTheDocument()
+
+    expect(screen.queryByRole('link', { name: /directions to roost/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -937,5 +937,14 @@ describe('EventTimeline Venues grid directions (#754)', () => {
     expect(await screen.findByText('Roost')).toBeInTheDocument()
 
     expect(screen.queryByRole('link', { name: /directions to roost/i })).not.toBeInTheDocument()
+
+    // The role query above is NOT sufficient on its own: an <a> with no href
+    // has no implicit ARIA link role, so a rendered-but-dead "Directions"
+    // anchor is invisible to queryByRole and this test would pass against the
+    // broken implementation (the #753 trap). Assert on the visible label too,
+    // and pin the count so a stray second control can't hide behind it —
+    // only The Mill has an address in this fixture.
+    expect(screen.getAllByText('Directions')).toHaveLength(1)
+    expect(screen.getByRole('link', { name: /directions to the mill/i })).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/__tests__/VenueInfo.test.jsx
+++ b/frontend/src/components/__tests__/VenueInfo.test.jsx
@@ -62,6 +62,12 @@ describe('VenueInfo directions fallback (#754)', () => {
     const link = screen.getByRole('link', { name: 'Open directions to The Copper Mug' })
     expect(link).toBeInTheDocument()
     expect(link).toHaveAttribute('href', 'https://maps.example.com/copper-mug-exact-pin')
+    // This href is admin-supplied and external, so the noopener/noreferrer
+    // contract is load-bearing: without it the opened tab can reach back
+    // through window.opener. Asserted here so dropping it fails a test.
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'))
 
     // No second/competing "Directions to ..." link should exist.
     expect(screen.queryByRole('link', { name: 'Directions to The Copper Mug' })).not.toBeInTheDocument()
@@ -77,8 +83,7 @@ describe('VenueInfo directions fallback (#754)', () => {
 
   // The MapPin row must not render for a blank address, in EITHER branch —
   // otherwise a location icon sits next to an empty span, labelling nothing.
-  // CodeRabbit flagged only the no-googleMaps branch; the admin-set branch
-  // below had the identical defect and is covered here too.
+  // Both branches are covered because both build the row independently.
   it.each([
     ['null', null],
     ['empty', ''],

--- a/frontend/src/components/__tests__/VenueInfo.test.jsx
+++ b/frontend/src/components/__tests__/VenueInfo.test.jsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { describe, expect, it } from 'vitest'
+import VenueInfo from '../VenueInfo'
+
+// #754 — the `mapHref === '#'` branch (no admin-set googleMaps, or an
+// unsafe/invalid one) used to render the address as plain inert text with no
+// way to actually get directions. It now falls back to buildDirectionsHref.
+//
+// Testing gotcha this file exists to guard against (per #753's postmortem):
+// an <a> with no `href` has NO implicit ARIA `link` role, so
+// `queryByRole('link', ...)` returns null even against a *rendered* dead
+// anchor. Every assertion below checks the visible "Directions" text
+// alongside the role query, so a reintroduced href-less anchor still fails
+// these tests instead of silently passing.
+
+function renderVenueInfo(venues) {
+  return render(<VenueInfo eventData={{ venue_info: JSON.stringify(venues) }} />)
+}
+
+describe('VenueInfo directions fallback (#754)', () => {
+  it('renders a directions link with the venue name in its accessible name when googleMaps is missing', () => {
+    renderVenueInfo([{ name: 'The Mill', address: '20 John Pound Road, Tillsonburg, ON' }])
+
+    const link = screen.getByRole('link', { name: 'Directions to The Mill' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveTextContent('Directions')
+    expect(link).toHaveAttribute(
+      'href',
+      'https://www.google.com/maps/search/?api=1&query=' +
+        encodeURIComponent('The Mill, 20 John Pound Road, Tillsonburg, ON')
+    )
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'))
+  })
+
+  it('falls back to buildDirectionsHref when googleMaps is an invalid/unsafe URL', () => {
+    renderVenueInfo([
+      {
+        name: "Paddy's Underground",
+        address: '20 John Pound Road, Tillsonburg, ON',
+        googleMaps: 'javascript:alert(1)',
+      },
+    ])
+
+    const link = screen.getByRole('link', { name: "Directions to Paddy's Underground" })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', expect.stringContaining('google.com/maps/search'))
+  })
+
+  it('prefers the admin-set googleMaps URL when present, over buildDirectionsHref', () => {
+    renderVenueInfo([
+      {
+        name: 'The Copper Mug',
+        address: '79 Broadway Street, Tillsonburg, ON',
+        googleMaps: 'https://maps.example.com/copper-mug-exact-pin',
+      },
+    ])
+
+    // The whole card becomes the link (existing `else` branch, untouched).
+    const link = screen.getByRole('link', { name: 'Open directions to The Copper Mug' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', 'https://maps.example.com/copper-mug-exact-pin')
+
+    // No second/competing "Directions to ..." link should exist.
+    expect(screen.queryByRole('link', { name: 'Directions to The Copper Mug' })).not.toBeInTheDocument()
+  })
+
+  it('does not crash and renders no directions link when address is null', () => {
+    renderVenueInfo([{ name: 'Roost', address: null }])
+
+    expect(screen.getByText('Roost')).toBeInTheDocument()
+    expect(screen.queryByText('Directions')).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /directions/i })).not.toBeInTheDocument()
+  })
+
+  it('does not crash and renders no directions link when address is an empty string', () => {
+    renderVenueInfo([{ name: 'Roost', address: '' }])
+
+    expect(screen.getByText('Roost')).toBeInTheDocument()
+    expect(screen.queryByText('Directions')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/VenueInfo.test.jsx
+++ b/frontend/src/components/__tests__/VenueInfo.test.jsx
@@ -75,6 +75,33 @@ describe('VenueInfo directions fallback (#754)', () => {
     expect(screen.queryByRole('link', { name: /directions/i })).not.toBeInTheDocument()
   })
 
+  // The MapPin row must not render for a blank address, in EITHER branch —
+  // otherwise a location icon sits next to an empty span, labelling nothing.
+  // CodeRabbit flagged only the no-googleMaps branch; the admin-set branch
+  // below had the identical defect and is covered here too.
+  it.each([
+    ['null', null],
+    ['empty', ''],
+    ['whitespace-only', '   '],
+  ])('renders no address row for a %s address (no-googleMaps branch)', (_label, address) => {
+    const { container } = renderVenueInfo([{ name: 'Roost', address }])
+
+    expect(screen.getByText('Roost')).toBeInTheDocument()
+    expect(container.querySelector('svg.lucide-map-pin')).toBeNull()
+    expect(screen.queryByText('Directions')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['null', null],
+    ['empty', ''],
+    ['whitespace-only', '   '],
+  ])('renders no address row for a %s address (admin googleMaps branch)', (_label, address) => {
+    const { container } = renderVenueInfo([{ name: 'Roost', address, googleMaps: 'https://maps.google.com/?q=Roost' }])
+
+    expect(screen.getByRole('link', { name: 'Open directions to Roost' })).toBeInTheDocument()
+    expect(container.querySelector('svg.lucide-map-pin')).toBeNull()
+  })
+
   it('does not crash and renders no directions link when address is an empty string', () => {
     renderVenueInfo([{ name: 'Roost', address: '' }])
 

--- a/frontend/src/utils/__tests__/directions.test.js
+++ b/frontend/src/utils/__tests__/directions.test.js
@@ -75,6 +75,25 @@ describe('buildDirectionsHrefForBand (#754)', () => {
     expect(href).toContain(encodeURIComponent('The Roost Waterloo ON'))
   })
 
+  // Bad coordinates must degrade to the venue-name search, not build a pin
+  // that lands nowhere. A fan mid-crawl can still navigate from a name; they
+  // cannot navigate from "destination=Infinity,Infinity".
+  it.each([
+    ['Infinity', Infinity, Infinity],
+    ['-Infinity', -Infinity, -Infinity],
+    ['NaN', NaN, NaN],
+    ['out-of-range latitude', 91, -80.52],
+    ['out-of-range longitude', 43.46, 181],
+    ['string coords', '43.46', '-80.52'],
+  ])('falls back to the name search for %s coords', (_label, lat, lng) => {
+    const href = buildDirectionsHrefForBand({ venue: 'Roost', venue_lat: lat, venue_lng: lng })
+    expect(href).toBe('https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent('Roost Waterloo ON'))
+  })
+
+  it('returns null when coords are unusable and there is no venue name', () => {
+    expect(buildDirectionsHrefForBand({ venue_lat: Infinity, venue_lng: Infinity })).toBe(null)
+  })
+
   it('returns null when there is nothing to locate', () => {
     expect(buildDirectionsHrefForBand({})).toBe(null)
     expect(buildDirectionsHrefForBand(null)).toBe(null)

--- a/frontend/src/utils/__tests__/directions.test.js
+++ b/frontend/src/utils/__tests__/directions.test.js
@@ -94,6 +94,17 @@ describe('buildDirectionsHrefForBand (#754)', () => {
     expect(buildDirectionsHrefForBand({ venue_lat: Infinity, venue_lng: Infinity })).toBe(null)
   })
 
+  // A whitespace-only venue is truthy, so an untrimmed check would search for
+  // "   Waterloo ON" — a link to nowhere. Matches buildDirectionsHref's
+  // trimming invariant.
+  it.each([
+    ['whitespace-only', '   '],
+    ['empty', ''],
+    ['non-string', 42],
+  ])('returns null for a %s venue name with no usable coords', (_label, venue) => {
+    expect(buildDirectionsHrefForBand({ venue })).toBe(null)
+  })
+
   it('returns null when there is nothing to locate', () => {
     expect(buildDirectionsHrefForBand({})).toBe(null)
     expect(buildDirectionsHrefForBand(null)).toBe(null)

--- a/frontend/src/utils/__tests__/directions.test.js
+++ b/frontend/src/utils/__tests__/directions.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildDirectionsHref } from '../directions'
+import { buildDirectionsHref, buildDirectionsHrefForBand } from '../directions'
 
 // #742 — the venue page hands a fan's phone off to whichever maps app it has.
 // Assert on the resolved href string itself, not merely that a value comes
@@ -57,5 +57,26 @@ describe('buildDirectionsHref — blank-ish input', () => {
   it('falls back to the address alone when the name is whitespace-only', () => {
     const href = buildDirectionsHref('   ', '20 John Pound Road')
     expect(href).toBe('https://www.google.com/maps/search/?api=1&query=20%20John%20Pound%20Road')
+  })
+})
+
+// Migrated from utils/__tests__/nextMove.test.js — buildDirectionsHrefForBand
+// used to be nextMove.js's own directionsHref(band); #754's correction found
+// it was never folded into this file despite #753 assuming it had been.
+describe('buildDirectionsHrefForBand (#754)', () => {
+  it('builds a coordinate directions link when coords are present', () => {
+    const href = buildDirectionsHrefForBand({ venue: 'Roost', venue_lat: 43.46, venue_lng: -80.52 })
+    expect(href).toBe('https://www.google.com/maps/dir/?api=1&destination=43.46,-80.52')
+  })
+
+  it('falls back to a name search when coords are missing', () => {
+    const href = buildDirectionsHrefForBand({ venue: 'The Roost' })
+    expect(href).toContain('/maps/search/')
+    expect(href).toContain(encodeURIComponent('The Roost Waterloo ON'))
+  })
+
+  it('returns null when there is nothing to locate', () => {
+    expect(buildDirectionsHrefForBand({})).toBe(null)
+    expect(buildDirectionsHrefForBand(null)).toBe(null)
   })
 })

--- a/frontend/src/utils/__tests__/nextMove.test.js
+++ b/frontend/src/utils/__tests__/nextMove.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeNextMove, directionsHref, LIVE_WINDOW_MIN } from '../nextMove'
+import { computeNextMove, LIVE_WINDOW_MIN } from '../nextMove'
 
 const BASE = new Date('2026-08-02T20:00:00').getTime()
 const now = new Date(BASE)
@@ -92,20 +92,6 @@ describe('computeNextMove', () => {
   })
 })
 
-describe('directionsHref', () => {
-  it('builds a coordinate directions link when coords are present', () => {
-    const href = directionsHref({ venue: 'Roost', venue_lat: 43.46, venue_lng: -80.52 })
-    expect(href).toBe('https://www.google.com/maps/dir/?api=1&destination=43.46,-80.52')
-  })
-
-  it('falls back to a name search when coords are missing', () => {
-    const href = directionsHref({ venue: 'The Roost' })
-    expect(href).toContain('/maps/search/')
-    expect(href).toContain(encodeURIComponent('The Roost Waterloo ON'))
-  })
-
-  it('returns null when there is nothing to locate', () => {
-    expect(directionsHref({})).toBe(null)
-    expect(directionsHref(null)).toBe(null)
-  })
-})
+// directionsHref(band) moved to utils/directions.js as buildDirectionsHrefForBand
+// (#754 — folding nextMove.js's own copy into the one directions builder).
+// Its tests live in utils/__tests__/directions.test.js now.

--- a/frontend/src/utils/directions.js
+++ b/frontend/src/utils/directions.js
@@ -46,8 +46,16 @@ export function buildDirectionsHrefForBand(band) {
   if (hasUsableCoords) {
     return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`
   }
-  if (venue) {
-    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${venue} Waterloo ON`)}`
+  // KNOWN LIMITATION: this fallback hardcodes "Waterloo ON", which is wrong
+  // for events outside Waterloo Region (Buddies Fest 2 is in Tillsonburg).
+  // It is currently unreachable in production -- every venue row has
+  // latitude/longitude (migrations 0043/0044) and schedule.js projects them
+  // as venue_lat/venue_lng, so the coordinate branch above always wins.
+  // Threading the event's own city through here is tracked in #767; until
+  // then, do NOT rely on this branch for a non-Waterloo event.
+  const trimmedVenue = typeof venue === 'string' ? venue.trim() : ''
+  if (trimmedVenue) {
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${trimmedVenue} Waterloo ON`)}`
   }
   return null
 }

--- a/frontend/src/utils/directions.js
+++ b/frontend/src/utils/directions.js
@@ -38,7 +38,12 @@ export function buildDirectionsHref(name, address) {
 export function buildDirectionsHrefForBand(band) {
   if (!band) return null
   const { venue_lat: lat, venue_lng: lng, venue } = band
-  if (typeof lat === 'number' && typeof lng === 'number' && !Number.isNaN(lat) && !Number.isNaN(lng)) {
+  // Number.isFinite (not !Number.isNaN) — the latter accepts Infinity, which
+  // would build a literal "destination=Infinity,Infinity" URL. Range-check to
+  // WGS84 bounds too: an out-of-range pair is bad data, and a broken pin is
+  // worse than the venue-name search below, which still gets a fan there.
+  const hasUsableCoords = Number.isFinite(lat) && Number.isFinite(lng) && Math.abs(lat) <= 90 && Math.abs(lng) <= 180
+  if (hasUsableCoords) {
     return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`
   }
   if (venue) {

--- a/frontend/src/utils/directions.js
+++ b/frontend/src/utils/directions.js
@@ -6,8 +6,7 @@
 // device's own installed maps app, and it still resolves in a desktop
 // browser — so it covers every target CLAUDE.md calls out without the
 // fragility of parsing navigator.userAgent for what is, after all, just a
-// link. Matches the existing precedent in utils/nextMove.js's
-// directionsHref(), which uses the same api=1 Google Maps URL family.
+// link.
 //
 // Name + address (not address alone) so the pin lands on the venue itself
 // rather than mid-street — a bare street address can resolve to the wrong
@@ -22,4 +21,28 @@ export function buildDirectionsHref(name, address) {
   const trimmedName = typeof name === 'string' ? name.trim() : ''
   const query = trimmedName ? `${trimmedName}, ${trimmedAddress}` : trimmedAddress
   return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
+}
+
+// Directions for a performance/band object shaped like the schedule API's
+// payload (venue NAME + optional venue_lat/venue_lng — schedule.js never
+// joins the venue's address). Prefers exact coordinates, which opens the
+// device's native maps app rather than a Google web search; falls back to a
+// "<venue> Waterloo ON" name search when coordinates aren't available.
+//
+// Consolidated from utils/nextMove.js's own copy of this exact function
+// (#754) — issue #754's correction confirmed there were two directions-URL
+// builders live simultaneously, not the one #753 assumed had already
+// consolidated them. This is now the single builder both address-shaped
+// (`buildDirectionsHref`) and coordinate-shaped (this function) venue data
+// go through; do not reintroduce a third copy in a component file.
+export function buildDirectionsHrefForBand(band) {
+  if (!band) return null
+  const { venue_lat: lat, venue_lng: lng, venue } = band
+  if (typeof lat === 'number' && typeof lng === 'number' && !Number.isNaN(lat) && !Number.isNaN(lng)) {
+    return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`
+  }
+  if (venue) {
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${venue} Waterloo ON`)}`
+  }
+  return null
 }

--- a/frontend/src/utils/nextMove.js
+++ b/frontend/src/utils/nextMove.js
@@ -17,19 +17,10 @@ export const LIVE_WINDOW_MIN = 240
 
 const toMinutes = ms => Math.round(ms / 60000)
 
-// Build a maps directions deep-link for a band's venue. Prefers exact
-// coordinates (opens the Maps app on mobile); falls back to a name search.
-export function directionsHref(band) {
-  if (!band) return null
-  const { venue_lat: lat, venue_lng: lng, venue } = band
-  if (typeof lat === 'number' && typeof lng === 'number' && !Number.isNaN(lat) && !Number.isNaN(lng)) {
-    return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`
-  }
-  if (venue) {
-    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${venue} Waterloo ON`)}`
-  }
-  return null
-}
+// The directions-link builder used to live here (directionsHref(band)). It
+// moved to utils/directions.js as buildDirectionsHrefForBand — see #754 —
+// so there is exactly one venue-directions builder for coordinate-shaped
+// data, not a copy per consumer. Import it from '../utils/directions'.
 
 export function computeNextMove(bands, now, { windowMin = LIVE_WINDOW_MIN } = {}) {
   const nowMs = (now instanceof Date ? now : new Date(now || Date.now())).getTime()


### PR DESCRIPTION
Closes #754

## Why this is pre-BF2 work

**Buddies Fest 2 is not the Vol. 17 crawl.** Vol. 17 was six venues on King St N, Waterloo — walkable, where directions barely mattered. BF2 is in **Tillsonburg**, across two sites roughly **450m apart** (The Mill + Paddy's Underground at 20 John Pound Road; The Copper Mug at 79 Broadway Street), with fans driving in from Waterloo Region.

Directions matter far more at this event than at the one they were deferred from.

## Changes

Two fan-facing surfaces still rendered an address as inert text:

- **`EventTimeline.jsx`** — the Venues grid on EventsPage and EventRecapPage. Had no directions affordance at all and didn't import `directions.js`.
- **`VenueInfo.jsx`** — the event page's "Venue Locations". Already linked when an admin set `venue_info.googleMaps`, but fell back to plain text when that field was missing or invalid. The admin-set URL still wins; this only fills the gap.

**Also consolidates the two directions builders.** `nextMove.js` had its own `directionsHref(band)` living alongside `directions.js`'s `buildDirectionsHref(name, address)` — #753 was assumed to have merged them and had not. Moved to `directions.js` as `buildDirectionsHrefForBand`, preserving the coordinate preference exactly (coords open the device's native maps app; name search is the fallback). One builder for each data shape, no third copy.

## Test plan

- [x] Frontend gate — prettier 0, lint 0, **930 tests**, build 0
- [x] `make review` (CodeRabbit) — 3 minor findings, all fixed in the second commit
- [x] Directions link renders with the venue name in its accessible name
- [x] `VenueInfo` still prefers the admin `googleMaps` URL when present
- [x] `VenueInfo` falls back to `buildDirectionsHref` when that field is missing/invalid
- [x] No dead link and no crash when the address is missing or whitespace-only
- [x] Bad coordinates (Infinity, out-of-range, strings) degrade to the venue-name search
- [x] **Mutation-tested**: nulling the `VenueInfo` fallback href fails 2 tests; reverting the coordinate guard fails 5. Both pass restored.

## Review findings fixed

CodeRabbit caught a genuine correctness bug and a vacuous test:

1. `!Number.isNaN()` accepts `Infinity`, so bad coordinates built a literal `destination=Infinity,Infinity` pin rather than degrading to the usable name search. Inherited from the original `nextMove.js` copy — consolidation surfaced it.
2. The address-row guard used the untrimmed value while the builder trims, so a whitespace-only address rendered a row with no link in it.
3. The "no address" test queried only by role. An `<a>` with no `href` has no implicit ARIA `link` role, so a rendered-but-dead anchor was invisible to it and the test passed against a broken implementation — the same trap `VenueInfo.test.jsx` already guarded. Now asserts visible text and pins the count.

## Notes

Semantic theme tokens throughout (`text-text-tertiary`, `text-accent-400`) — no `text-white`/`bg-white`, which vanish on the two light themes.

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accessible Google Maps directions links to venue cards and venue details.
  * Directions links use valid venue URLs when available, with search or coordinate-based fallbacks.
  * Venue addresses are displayed only when available and non-blank.

* **Bug Fixes**
  * Improved handling of missing, invalid, or unsafe map links and location data.

* **Tests**
  * Added coverage for directions links, accessibility, security attributes, fallbacks, and missing addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->