### PR TITLE
feat(venue): project lat/lng and show performer cards on the venue page

### DIFF
--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -1,4 +1,4 @@
-import { Plus, TriangleAlert, X, Zap } from 'lucide-react'
+import { CalendarDays, Plus, TriangleAlert, X, Zap } from 'lucide-react'
 import { memo } from 'react'
 import { Link } from 'react-router-dom'
 import { buildBandProfileHref } from '../utils/bandProfileLink'
@@ -17,6 +17,7 @@ function BandCard({
   warningType,
   warningText,
   currentTime,
+  dayLabel,
 }) {
   const handleToggle = () => {
     if (!isInteractive) return
@@ -165,6 +166,23 @@ function BandCard({
           {getTimeDescription(band)}
           {isPlaying && <span className="ml-2 text-xs uppercase tracking-wide">Live Now</span>}
         </p>
+        {/* Optional per-set day indicator (#742, venue page). getTimeDescription
+            above is date-blind within the same festival week -- three sets on
+            three different days of a multi-day event at the same clock time all
+            read as a bare "8:00 PM" with nothing to tell them apart. Callers on
+            a single event already disambiguate via day tabs/dividers outside
+            this card, so dayLabel is opt-in and every existing caller is
+            unaffected. */}
+        {dayLabel && (
+          <p
+            className={`flex items-center gap-1.5 text-xs font-medium leading-snug ${
+              onAmber ? 'text-bg-navy/80' : 'text-text-tertiary'
+            }`}
+          >
+            <CalendarDays size={12} aria-hidden="true" />
+            {dayLabel}
+          </p>
+        )}
         {showVenue && (
           <p className={`text-sm font-medium leading-snug ${onAmber ? 'text-bg-navy' : 'text-text-tertiary'}`}>
             {band.venue}

--- a/frontend/src/components/__tests__/BandCard.dayLabel.test.jsx
+++ b/frontend/src/components/__tests__/BandCard.dayLabel.test.jsx
@@ -39,7 +39,19 @@ describe('BandCard — optional dayLabel prop (#742)', () => {
   })
 
   it('renders no day label row when dayLabel is an empty string', () => {
-    renderCard({ dayLabel: '' })
+    const { container } = renderCard({ dayLabel: '' })
     expect(screen.queryByText(/Day \d/)).toBeNull()
+    // Assert the same icon absence the omitted case checks. A text-only
+    // assertion would still pass if an empty label row rendered -- an icon
+    // with nothing beside it, which is exactly the defect this guards.
+    expect(container.querySelector('svg.lucide-calendar-days')).toBeNull()
+  })
+
+  it('renders the day label with its calendar icon when provided', () => {
+    const { container } = renderCard({ dayLabel: 'Fri, Aug 7 (Day 1)' })
+    expect(screen.getByText('Fri, Aug 7 (Day 1)')).toBeInTheDocument()
+    // Pins the positive half of the contract the two absence tests assert
+    // against, so "icon absent" stays meaningful rather than vacuously true.
+    expect(container.querySelector('svg.lucide-calendar-days')).not.toBeNull()
   })
 })

--- a/frontend/src/components/__tests__/BandCard.dayLabel.test.jsx
+++ b/frontend/src/components/__tests__/BandCard.dayLabel.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import BandCard from '../BandCard'
+
+const baseBand = {
+  id: 'venue-card-1',
+  name: 'Deer Fang',
+  venue: 'Room 47',
+}
+
+const renderCard = props =>
+  render(
+    <MemoryRouter>
+      <BandCard band={baseBand} onToggle={vi.fn()} {...props} />
+    </MemoryRouter>
+  )
+
+// #742 — VenuePage's cards span multiple days of a multi-day event (Buddies
+// Fest 2, Aug 7-9), and getTimeDescription (already inside this card) can't
+// tell those days apart at the same clock time -- it renders a bare "8:00 PM"
+// for any day within the same festival week. `dayLabel` is the opt-in prop
+// that lets a caller supply the disambiguating date explicitly, without
+// forcing every OTHER caller (which already shows the date via day tabs/
+// dividers outside this card) to grow one too.
+describe('BandCard — optional dayLabel prop (#742)', () => {
+  it('renders the day label text when dayLabel is provided', () => {
+    renderCard({ dayLabel: 'Sat, Aug 8 (Day 2)' })
+    expect(screen.getByText('Sat, Aug 8 (Day 2)')).toBeInTheDocument()
+  })
+
+  it('renders no day label row when dayLabel is omitted (existing callers unaffected)', () => {
+    const { container } = renderCard()
+    // The day label paragraph is the only <p> that would carry a CalendarDays
+    // icon inside this card; assert the icon itself is absent rather than
+    // guessing at a class name, so this doesn't silently pass if the markup
+    // shape changes.
+    expect(container.querySelector('svg.lucide-calendar-days')).toBeNull()
+  })
+
+  it('renders no day label row when dayLabel is an empty string', () => {
+    renderCard({ dayLabel: '' })
+    expect(screen.queryByText(/Day \d/)).toBeNull()
+  })
+})

--- a/frontend/src/pages/VenuePage.jsx
+++ b/frontend/src/pages/VenuePage.jsx
@@ -100,9 +100,6 @@ export default function VenuePage() {
   const [past, setPast] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
-  // Feeds BandCard's "starting soon" minute math; a one-time snapshot is
-  // enough here since these cards are read-only (no live add/remove UI to
-  // keep in sync with a ticking clock).
   const [currentTime, setCurrentTime] = useState(() => new Date())
 
   // BandCard derives "Starts in Nm" / "Live Now" from this prop, so a frozen

--- a/frontend/src/pages/VenuePage.jsx
+++ b/frontend/src/pages/VenuePage.jsx
@@ -103,7 +103,19 @@ export default function VenuePage() {
   // Feeds BandCard's "starting soon" minute math; a one-time snapshot is
   // enough here since these cards are read-only (no live add/remove UI to
   // keep in sync with a ticking clock).
-  const [currentTime] = useState(() => new Date())
+  const [currentTime, setCurrentTime] = useState(() => new Date())
+
+  // BandCard derives "Starts in Nm" / "Live Now" from this prop, so a frozen
+  // value strands a fan on a stale countdown -- and this is the page someone
+  // opens standing outside the venue. Same 60s cadence as App.jsx,
+  // EmbedPage.jsx and MySchedule.jsx.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentTime(new Date())
+    }, 60000)
+
+    return () => clearInterval(interval)
+  }, [])
 
   useEffect(() => {
     let active = true

--- a/frontend/src/pages/VenuePage.jsx
+++ b/frontend/src/pages/VenuePage.jsx
@@ -1,73 +1,92 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
-import { ArrowLeft, CalendarDays, Globe, MapPin, Navigation, TriangleAlert } from 'lucide-react'
+import { ArrowLeft, Globe, MapPin, Navigation } from 'lucide-react'
 import Footer from '../components/Footer'
 import ThemeToggle from '../components/ThemeToggle.jsx'
+import BandCard from '../components/BandCard'
 import { formatPerformanceDayLabel } from '../utils/timeFormat'
+import { prepareBands } from '../utils/bandUtils'
 import { fetchPublicJson } from '../utils/publicApi'
 import { trackPageView } from '../utils/metrics'
-import { buildBandProfileHref } from '../utils/bandProfileLink'
 import { safeExternalHref } from '../utils/urlSafety'
 import { buildDirectionsHref } from '../utils/directions'
 
-function PerformanceRow({ perf }) {
-  // #732 — functions/api/venues/[id].js already returns is_cancelled (row
-  // always included), but this row rendered it exactly like an ordinary
-  // performance. The visible "Cancelled" label is the accessible carrier
-  // (WCAG 1.4.1) -- strikethrough alone isn't announced by screen readers.
-  const isCancelled = Boolean(perf.is_cancelled)
-  // Computed once: the guard and the rendered value must be the same
-  // expression, or they can drift apart. Unlike EventTimeline this is NOT
-  // gated on the event being multi-day -- this row shows no other date, so on
-  // a single-day event the label is the only one present and suppressing it
-  // would remove information rather than redundancy.
+// Read-only performer card (#742). Selection (add-to-route) deliberately
+// isn't wired up here -- that pulls in scheduleStorage and the `end_date ||
+// date` staleness rule (see CLAUDE.md "Schedule Storage"), which is scope
+// this page doesn't need: a venue's lineup spans many events, so there is no
+// single event date to key staleness on. Tracked as a follow-up, not built.
+function VenuePerformerCard({ perf, venueName, currentTime }) {
+  // BandCard/prepareBands expect camelCase startTime/endTime and a `date`
+  // that is the FESTIVAL DAY this set belongs to -- performance_date, falling
+  // back to the event's start date (the #543 convention functions/api/venues/[id].js's
+  // own isPast/mapPerf already follow). prepareBands() applies the
+  // AFTER_MIDNIGHT_THRESHOLD_HOUR offset from that pair, exactly like every
+  // other schedule surface, so an after-midnight set (e.g. a 00:25 start)
+  // sorts and displays after -- not before -- the same evening's earlier sets.
+  const [band] = prepareBands([
+    {
+      id: perf.band_id,
+      name: perf.band_name,
+      // Feeds BandCard's non-interactive aria-label (`${name} at ${venue}`) --
+      // showVenue={false} below only hides the *visible* venue line, not this.
+      venue: venueName,
+      photo_url: perf.photo_url,
+      genre: perf.genre,
+      is_cancelled: perf.is_cancelled,
+      startTime: perf.start_time,
+      endTime: perf.end_time,
+      date: perf.performance_date || perf.event_date,
+    },
+  ])
+
+  // getTimeDescription (inside BandCard) can't distinguish same-week days at
+  // the same clock time -- during a 3-day event like Buddies Fest 2, three
+  // sets at 8 PM on three different nights all read as a bare "8:00 PM" with
+  // nothing to tell them apart. formatPerformanceDayLabel is the explicit,
+  // already-multi-day-aware carrier: it adds "(Day N)", suppresses itself on
+  // single-day events (#540/#541), and does NOT re-offset an after-midnight
+  // set's stored (already-previous-evening) date.
   const dayLabel = formatPerformanceDayLabel(perf)
+
   return (
-    <div className="rounded-lg border border-border bg-bg-purple/40 p-4">
-      {perf.band_name && (
-        <Link
-          to={buildBandProfileHref(perf.band_name)}
-          className={`font-display text-lg font-semibold transition-colors hover:text-accent-400 ${
-            isCancelled ? 'text-text-secondary' : 'text-text-primary'
-          }`}
-        >
-          {isCancelled ? <s>{perf.band_name}</s> : perf.band_name}
-        </Link>
+    <div>
+      <BandCard
+        band={band}
+        clickable={false}
+        showToggleButton={false}
+        showVenue={false}
+        eventSlug={perf.event_slug}
+        currentTime={currentTime}
+        dayLabel={dayLabel}
+      />
+      {/* A venue's lineup spans multiple events over time (e.g. Vol. 17 and
+          Buddies Fest 2 both play the same rooms) -- the day label alone
+          doesn't say WHICH event a past set belonged to. */}
+      {perf.event_name && (
+        <p className="mt-2 text-center text-xs text-text-tertiary">
+          {perf.event_slug ? (
+            <Link to={`/event/${perf.event_slug}`} className="hover:text-accent-400">
+              {perf.event_name}
+            </Link>
+          ) : (
+            perf.event_name
+          )}
+        </p>
       )}
-      {isCancelled && (
-        <span className="mt-1 inline-flex items-center gap-1.5 rounded-full bg-warning-500/25 px-2.5 py-1 text-xs font-semibold text-text-primary">
-          <TriangleAlert size={14} aria-hidden="true" />
-          Cancelled
-        </span>
-      )}
-      <p className="mt-1 flex flex-wrap items-center gap-2 text-sm text-text-tertiary">
-        {perf.event_slug ? (
-          <Link to={`/event/${perf.event_slug}`} className="hover:text-accent-400">
-            {perf.event_name}
-          </Link>
-        ) : (
-          <span>{perf.event_name}</span>
-        )}
-        {dayLabel && (
-          <span className="inline-flex items-center gap-1">
-            <CalendarDays size={13} aria-hidden="true" />
-            {dayLabel}
-          </span>
-        )}
-      </p>
     </div>
   )
 }
 
-function Section({ title, items }) {
+function Section({ title, items, venueName, currentTime }) {
   if (!items.length) return null
   return (
     <section className="mt-8">
       <h2 className="mb-3 font-display text-xl font-bold text-text-primary">{title}</h2>
-      <div className="space-y-3">
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {items.map(perf => (
-          <PerformanceRow key={perf.performance_id} perf={perf} />
+          <VenuePerformerCard key={perf.performance_id} perf={perf} venueName={venueName} currentTime={currentTime} />
         ))}
       </div>
     </section>
@@ -81,6 +100,10 @@ export default function VenuePage() {
   const [past, setPast] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  // Feeds BandCard's "starting soon" minute math; a one-time snapshot is
+  // enough here since these cards are read-only (no live add/remove UI to
+  // keep in sync with a ticking clock).
+  const [currentTime] = useState(() => new Date())
 
   useEffect(() => {
     let active = true
@@ -192,8 +215,8 @@ export default function VenuePage() {
               </p>
             )}
 
-            <Section title="Upcoming" items={upcoming} />
-            <Section title="Past shows" items={past} />
+            <Section title="Upcoming" items={upcoming} venueName={venue.name} currentTime={currentTime} />
+            <Section title="Past shows" items={past} venueName={venue.name} currentTime={currentTime} />
 
             {upcoming.length === 0 && past.length === 0 && (
               <p className="py-16 text-center text-text-secondary">No published performances at this venue yet.</p>

--- a/frontend/src/pages/__tests__/VenuePage.performerCards.test.jsx
+++ b/frontend/src/pages/__tests__/VenuePage.performerCards.test.jsx
@@ -1,0 +1,225 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import VenuePage from '../VenuePage.jsx'
+import { ThemeProvider } from '../../components/ThemeProvider.jsx'
+import { fetchPublicJson } from '../../utils/publicApi'
+
+vi.mock('../../utils/publicApi', () => ({ fetchPublicJson: vi.fn() }))
+
+function renderPage(id = '3') {
+  return render(
+    <ThemeProvider>
+      <HelmetProvider>
+        <MemoryRouter initialEntries={[`/venue/${id}`]}>
+          <Routes>
+            <Route path="/venue/:id" element={<VenuePage />} />
+          </Routes>
+        </MemoryRouter>
+      </HelmetProvider>
+    </ThemeProvider>
+  )
+}
+
+function perf(overrides = {}) {
+  return {
+    performance_id: 1,
+    start_time: '20:00',
+    end_time: '20:30',
+    performance_date: null,
+    is_cancelled: 0,
+    event_id: 55,
+    event_name: 'Buddies Fest 2',
+    event_slug: 'buddies-fest-2',
+    event_date: '2026-08-07',
+    event_end_date: '2026-08-09',
+    band_id: 9,
+    band_name: 'Test Band',
+    photo_url: null,
+    genre: null,
+    ...overrides,
+  }
+}
+
+// #742 — performer cards replace the old flat text list. Structural/content
+// assertions throughout (photo src, genre text, a formatted-time pattern,
+// distinct per-day labels) rather than "something rendered", per the repo's
+// vacuous-test defect class (see CLAUDE.md "Vacuous test defect class").
+describe('VenuePage — performer cards (#742)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders a photo, band name, genre pill, and a formatted time for a performance', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venue: { id: 3, name: 'Room 47', location: 'Waterloo, ON', address: null, website: null },
+      upcoming: [
+        perf({
+          band_name: 'Deer Fang',
+          photo_url: 'https://example.com/deer-fang.jpg',
+          genre: 'Post-Punk',
+        }),
+      ],
+      past: [],
+    })
+
+    const { container } = renderPage('3')
+    expect(await screen.findByRole('heading', { level: 1, name: 'Room 47' })).toBeInTheDocument()
+
+    expect(screen.getByText('Deer Fang')).toBeInTheDocument()
+    expect(screen.getByText('Post-Punk')).toBeInTheDocument()
+    expect(container.querySelector('img[src="https://example.com/deer-fang.jpg"]')).not.toBeNull()
+    // Read-only (#742): unlike a cancelled set (which BandCard already hides
+    // the toggle for on its own), this is a NORMAL, non-cancelled performance
+    // -- the only thing suppressing the add/remove button here is
+    // showToggleButton={false}. A cancelled-only fixture wouldn't prove this.
+    expect(screen.queryByRole('button', { name: /route/i })).toBeNull()
+    // getTimeDescription always renders a 12-hour clock time somewhere on the
+    // card, regardless of which branch (Today/this week/default) it lands in.
+    // Match the bare H:MM digits only, not an AM/PM suffix -- the ICU locale
+    // this suite runs under formats it as "8:00 p.m." (lowercase, periods),
+    // not "8:00 PM", so anchoring on the meridiem marker would be
+    // environment-dependent rather than a real assertion about the app.
+    expect(screen.getByText(/\d{1,2}:\d{2}/)).toBeInTheDocument()
+  })
+
+  it('renders no genre pill and no photo when the performance has neither', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venue: { id: 3, name: 'Room 47', location: 'Waterloo, ON', address: null, website: null },
+      upcoming: [perf({ band_name: 'Plain Band', photo_url: null, genre: null })],
+      past: [],
+    })
+
+    const { container } = renderPage('3')
+    expect(await screen.findByRole('heading', { level: 1, name: 'Room 47' })).toBeInTheDocument()
+
+    expect(screen.getByText('Plain Band')).toBeInTheDocument()
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  // Buddies Fest 2 is a 3-day event (Aug 7-9). Two sets at the SAME clock
+  // time on DIFFERENT days of that event must not read identically -- the
+  // exact ambiguity CLAUDE.md's after-midnight/multi-day invariants warn
+  // about. getTimeDescription alone can't tell them apart (both fall in the
+  // "this week" bucket and render a bare "8:00 PM"); the day label is what
+  // must carry the distinction.
+  it('shows a distinct per-set day label for two sets on different days of a multi-day event', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venue: { id: 3, name: 'Prohibition Warehouse', location: 'Waterloo, ON', address: null, website: null },
+      upcoming: [
+        perf({
+          performance_id: 1,
+          band_name: 'Day One Band',
+          performance_date: null, // day 1 -- NULL per the #543 convention, inherits event_date
+        }),
+        perf({
+          performance_id: 2,
+          band_name: 'Day Two Band',
+          performance_date: '2026-08-08', // day 2
+        }),
+      ],
+      past: [],
+    })
+
+    renderPage('3')
+    expect(await screen.findByRole('heading', { level: 1, name: 'Prohibition Warehouse' })).toBeInTheDocument()
+
+    expect(screen.getByText('Fri, Aug 7 (Day 1)')).toBeInTheDocument()
+    expect(screen.getByText('Sat, Aug 8 (Day 2)')).toBeInTheDocument()
+  })
+
+  // "Where's Shane?" plays 2026-08-08 at 00:25 during BF2 -- an
+  // after-midnight set that belongs to the PREVIOUS evening
+  // (AFTER_MIDNIGHT_THRESHOLD_HOUR = 6). Its performance_date is stored as
+  // the evening it belongs to (2026-08-07), per the repo-wide convention
+  // (CLAUDE.md "After-midnight band sorting"). The day label must reflect
+  // that evening, NOT the calendar date the clock happened to roll over to.
+  it('groups an after-midnight set with the PREVIOUS evening, not the calendar date of its start time', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venue: { id: 3, name: 'Prohibition Warehouse', location: 'Waterloo, ON', address: null, website: null },
+      upcoming: [
+        perf({
+          performance_id: 3,
+          band_name: "Where's Shane?",
+          start_time: '00:25',
+          end_time: '01:00',
+          performance_date: '2026-08-07', // the EVENING this set belongs to
+        }),
+      ],
+      past: [],
+    })
+
+    renderPage('3')
+    expect(await screen.findByRole('heading', { level: 1, name: 'Prohibition Warehouse' })).toBeInTheDocument()
+
+    expect(screen.getByText("Where's Shane?")).toBeInTheDocument()
+    expect(screen.getByText('Fri, Aug 7 (Day 1)')).toBeInTheDocument()
+    expect(screen.queryByText(/Aug 8/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Day 2/)).not.toBeInTheDocument()
+  })
+
+  // The "starting soon" pill is fed by the `currentTime` prop directly (not
+  // getCurrentDateTime()'s debug hook), so pinning the system clock is the
+  // only way to control it. Local-component Date construction throughout
+  // (never an explicit UTC offset) so the relative "15 minutes before" math
+  // holds regardless of the test runner's timezone -- matching the repo
+  // convention documented in timeFilter.test.js.
+  //
+  // This is the mutation-sensitive half of "multi-day sets show the correct
+  // per-set date": it proves the card's underlying startMs was computed from
+  // performance_date (2026-08-08), not event_date (2026-08-07). Using
+  // event_date would place the computed start 24h in the past relative to
+  // the pinned clock, and the pill would never appear.
+  it('computes a starting-soon countdown from performance_date, not the event start date', async () => {
+    // shouldAdvanceTime: real timers keep ticking (needed for findByRole's
+    // internal polling/microtask flushing after the mocked fetch resolves)
+    // while Date.now()/new Date() stay pinned to the value below.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date(2026, 7, 8, 19, 45, 0)) // Aug 8 2026, 19:45 local -- 15 min before the set below
+
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venue: { id: 3, name: 'Prohibition Warehouse', location: 'Waterloo, ON', address: null, website: null },
+      upcoming: [
+        perf({
+          performance_id: 4,
+          band_name: 'Soon Band',
+          start_time: '20:00',
+          end_time: '20:30',
+          event_date: '2026-08-07',
+          performance_date: '2026-08-08',
+        }),
+      ],
+      past: [],
+    })
+
+    renderPage('3')
+    expect(await screen.findByRole('heading', { level: 1, name: 'Prohibition Warehouse' })).toBeInTheDocument()
+
+    expect(screen.getByText(/Starts in 15m/)).toBeInTheDocument()
+  })
+
+  it('renders a cancelled set struck through inside the new card, not as a plain row', async () => {
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venue: { id: 3, name: 'Room 47', location: 'Waterloo, ON', address: null, website: null },
+      upcoming: [perf({ band_name: 'Cancelled Band', is_cancelled: 1 })],
+      past: [],
+    })
+
+    renderPage('3')
+    expect(await screen.findByRole('heading', { level: 1, name: 'Room 47' })).toBeInTheDocument()
+
+    expect(screen.getByText('Cancelled')).toBeInTheDocument()
+    expect(screen.getByText('Cancelled Band').closest('s')).not.toBeNull()
+    // The read-only card must not offer an add/remove toggle -- selection is
+    // explicitly out of scope for this page (#742).
+    expect(screen.queryByRole('button', { name: /route/i })).toBeNull()
+  })
+})

--- a/frontend/src/pages/__tests__/VenuePage.performerCards.test.jsx
+++ b/frontend/src/pages/__tests__/VenuePage.performerCards.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
@@ -84,6 +84,13 @@ describe('VenuePage — performer cards (#742)', () => {
     // not "8:00 PM", so anchoring on the meridiem marker would be
     // environment-dependent rather than a real assertion about the app.
     expect(screen.getByText(/\d{1,2}:\d{2}/)).toBeInTheDocument()
+
+    // A venue's lineup spans multiple events, so the event attribution is the
+    // only thing saying WHICH show a set belonged to. Assert the destination,
+    // not just the text -- a plain-text fallback renders when event_slug is
+    // absent, and that path would satisfy a text-only assertion.
+    const eventLink = screen.getByRole('link', { name: 'Buddies Fest 2' })
+    expect(eventLink).toHaveAttribute('href', '/event/buddies-fest-2')
   })
 
   it('renders no genre pill and no photo when the performance has neither', async () => {
@@ -108,6 +115,13 @@ describe('VenuePage — performer cards (#742)', () => {
   // "this week" bucket and render a bare "8:00 PM"); the day label is what
   // must carry the distinction.
   it('shows a distinct per-set day label for two sets on different days of a multi-day event', async () => {
+    // Pin the clock. These assert literal day-label strings, and
+    // formatPerformanceDayLabel is date-relative -- left on the real clock
+    // they would change meaning on Aug 7-8 2026, i.e. DURING Buddies Fest 2,
+    // the exact weekend this code ships for. A test that only passes before
+    // show day is worse than none.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date(2026, 7, 1, 12, 0, 0)) // Aug 1 2026 — within 2 weeks of the event
     fetchPublicJson.mockReset()
     fetchPublicJson.mockResolvedValue({
       venue: { id: 3, name: 'Prohibition Warehouse', location: 'Waterloo, ON', address: null, website: null },
@@ -140,6 +154,16 @@ describe('VenuePage — performer cards (#742)', () => {
   // (CLAUDE.md "After-midnight band sorting"). The day label must reflect
   // that evening, NOT the calendar date the clock happened to roll over to.
   it('groups an after-midnight set with the PREVIOUS evening, not the calendar date of its start time', async () => {
+    // Pinned for the same reason as the multi-day test above, but here the
+    // exact date matters. Pin EARLIER than two weeks before the set and this
+    // test fails -- getTimeDescription's >2-weeks fallback branch renders the
+    // raw +1-day-offset timestamp ("Aug 8") instead of the festival day
+    // ("Aug 7"). That is the open bug #689 Finding 1, not a venue-page
+    // defect. Aug 1 keeps the set inside the window fans actually view it in,
+    // so this asserts THIS page's behaviour rather than re-failing on a known
+    // timeFilter bug.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date(2026, 7, 1, 12, 0, 0)) // Aug 1 2026
     fetchPublicJson.mockReset()
     fetchPublicJson.mockResolvedValue({
       venue: { id: 3, name: 'Prohibition Warehouse', location: 'Waterloo, ON', address: null, website: null },
@@ -203,6 +227,45 @@ describe('VenuePage — performer cards (#742)', () => {
     expect(await screen.findByRole('heading', { level: 1, name: 'Prohibition Warehouse' })).toBeInTheDocument()
 
     expect(screen.getByText(/Starts in 15m/)).toBeInTheDocument()
+  })
+
+  // The countdown above is only correct at the instant of first render. This
+  // is the page a fan opens standing outside the venue and leaves open, so a
+  // `currentTime` captured once strands them on "Starts in 15m" long after
+  // the set began. Advancing the clock must move the card's state on.
+  it('refreshes the countdown while the page stays open', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date(2026, 7, 8, 19, 45, 0)) // 15 min before the set
+
+    fetchPublicJson.mockReset()
+    fetchPublicJson.mockResolvedValue({
+      venue: { id: 3, name: 'Prohibition Warehouse', location: 'Waterloo, ON', address: null, website: null },
+      upcoming: [
+        perf({
+          performance_id: 5,
+          band_name: 'Ticking Band',
+          start_time: '20:00',
+          end_time: '20:30',
+          event_date: '2026-08-07',
+          performance_date: '2026-08-08',
+        }),
+      ],
+      past: [],
+    })
+
+    renderPage('3')
+    expect(await screen.findByRole('heading', { level: 1, name: 'Prohibition Warehouse' })).toBeInTheDocument()
+    expect(screen.getByText(/Starts in 15m/)).toBeInTheDocument()
+
+    // Past the start time. Without the interval the card keeps rendering the
+    // stale countdown; with it, the set reads as live.
+    await act(async () => {
+      vi.setSystemTime(new Date(2026, 7, 8, 20, 5, 0))
+      await vi.advanceTimersByTimeAsync(60000)
+    })
+
+    expect(screen.queryByText(/Starts in 15m/)).not.toBeInTheDocument()
+    expect(screen.getByText(/Live Now/i)).toBeInTheDocument()
   })
 
   it('renders a cancelled set struck through inside the new card, not as a plain row', async () => {

--- a/functions/api/venues/[id].js
+++ b/functions/api/venues/[id].js
@@ -61,7 +61,9 @@ export async function onRequestGet(context) {
         e.end_date AS event_end_date,
         e.status AS event_status,
         bp.id AS band_id,
-        bp.name AS band_name
+        bp.name AS band_name,
+        bp.photo_url,
+        bp.genre
       FROM performances p
       JOIN events e ON e.id = p.event_id
       JOIN band_profiles bp ON bp.id = p.band_profile_id
@@ -112,6 +114,10 @@ export async function onRequestGet(context) {
       event_date: p.event_date,
       band_id: p.band_id,
       band_name: p.band_name,
+      // Performer-card prerequisites (#742): photo + genre, same fields the
+      // schedule surfaces already send BandCard.
+      photo_url: p.photo_url,
+      genre: p.genre,
     });
 
     return json(
@@ -124,6 +130,11 @@ export async function onRequestGet(context) {
           website: venue.website || null,
           instagram: venue.instagram || null,
           facebook: venue.facebook || null,
+          // #742 — the row already carries these (migrations 0043/0044); the
+          // hand-written projection below just never selected them. Same
+          // defect class as performance_date (#739 -> #741 -> #743), same file.
+          latitude: venue.latitude ?? null,
+          longitude: venue.longitude ?? null,
           performance_count: all.length,
           event_count: new Set(all.map((p) => p.event_id)).size,
         },

--- a/functions/api/venues/__tests__/venue-detail.test.js
+++ b/functions/api/venues/__tests__/venue-detail.test.js
@@ -234,3 +234,109 @@ describe("GET /api/venues/:id — multi-day ordering and per-set dates (#741)", 
     expect(payload.upcoming[0].event_end_date).toBe("2099-08-09");
   });
 });
+
+// #742 — correction to the issue's own "data gap" claim: latitude/longitude
+// were added by migrations 0043/0044 and are already selected by `SELECT *
+// FROM venues` at the top of this handler. What dropped them was the
+// hand-written projection a few lines down -- same defect shape as
+// performance_date (#739 -> #741 -> #743), same file, same root cause: the
+// row has the field, the projection never asked for it.
+describe("GET /api/venues/:id — coordinate projection (#742)", () => {
+  test("projects latitude/longitude when the row has them", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Room 47" });
+    rawDb.prepare("UPDATE venues SET latitude = ?, longitude = ? WHERE id = ?").run(43.466445, -80.522916, venue.id);
+
+    const response = await onRequestGet({ env, params: { id: String(venue.id) } });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.venue.latitude).toBe(43.466445);
+    expect(payload.venue.longitude).toBe(-80.522916);
+  });
+
+  test("projects null latitude/longitude for a venue that has neither", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "No Coordinates Venue" });
+
+    const response = await onRequestGet({ env, params: { id: String(venue.id) } });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.venue.latitude).toBeNull();
+    expect(payload.venue.longitude).toBeNull();
+  });
+});
+
+// #742 — performer-card prerequisite: the venue lineup query selected only
+// `bp.id AS band_id, bp.name AS band_name`, so a card built from this payload
+// had no photo and no genre pill to render.
+describe("GET /api/venues/:id — performer card fields (#742)", () => {
+  test("projects photo_url and genre on each performance, for both upcoming and past", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Prohibition Warehouse" });
+
+    const upcomingEvent = insertEvent(rawDb, {
+      name: "Card Fields Upcoming",
+      slug: "card-fields-upcoming",
+      date: "2099-01-01",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(upcomingEvent.id);
+    insertBand(rawDb, {
+      name: "Photogenic Band",
+      event_id: upcomingEvent.id,
+      venue_id: venue.id,
+      genre: "Punk",
+      photo_url: "https://example.com/photogenic.jpg",
+    });
+
+    const pastEvent = insertEvent(rawDb, {
+      name: "Card Fields Past",
+      slug: "card-fields-past",
+      date: "2001-01-01",
+    });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(pastEvent.id);
+    insertBand(rawDb, {
+      name: "Archived Photogenic Band",
+      event_id: pastEvent.id,
+      venue_id: venue.id,
+      genre: "Ska",
+      photo_url: "https://example.com/archived.jpg",
+    });
+
+    const response = await onRequestGet({ env, params: { id: String(venue.id) } });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(1);
+    expect(payload.upcoming[0].photo_url).toBe("https://example.com/photogenic.jpg");
+    expect(payload.upcoming[0].genre).toBe("Punk");
+    expect(payload.past).toHaveLength(1);
+    expect(payload.past[0].photo_url).toBe("https://example.com/archived.jpg");
+    expect(payload.past[0].genre).toBe("Ska");
+  });
+
+  test("projects null photo_url/genre for a band with neither set", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    const venue = insertVenue(rawDb, { name: "Blank Fields Venue" });
+    const event = insertEvent(rawDb, { name: "Blank Fields Event", slug: "blank-fields-event", date: "2099-01-01" });
+    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    insertBand(rawDb, { name: "Plain Band", event_id: event.id, venue_id: venue.id });
+
+    const response = await onRequestGet({ env, params: { id: String(venue.id) } });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upcoming).toHaveLength(1);
+    expect(payload.upcoming[0].photo_url).toBeNull();
+    expect(payload.upcoming[0].genre).toBeNull();
+  });
+});


### PR DESCRIPTION
Scoped subset of #742. Refs #742 (does not close it — static map deferred).

## Why this is pre-BF2 work

The venue page is what a fan opens deciding where to go, or standing outside trying to get in. **Buddies Fest 2 is in Tillsonburg across two sites ~450m apart**, so that page carries more weight this weekend than it ever did for the King St N crawl.

## 1. The projection fix — the `performance_date` bug class again

The issue body claims venues have no `latitude`/`longitude` columns and that a migration or geocoding pipeline is needed. **That is false**, and correcting it is most of the work:

- `migrations/0043` added the columns; `0044` seeded them. All 9 production venues have both.
- `functions/api/venues/[id].js:44` already does `SELECT * FROM venues`, so the row **already carried them**.
- The hand-written response projection simply never picked them up.

Same defect shape as `performance_date` (#739 → #741 → #743), in the **same file** — that sweep fixed the field it was named after and left these in the identical blind spot. Fix is two lines, no migration.

I asked for the whole projection to be audited against the table rather than just adding two fields. Result: no other gap worth adding — `contact_email` is deliberately role-gated, timestamps and `created_by_user_id` are internal, and the address parts are already synthesized into `address`/`location`. `phone` is an existing public/admin inconsistency, noted but not compounded here.

## 2. Performer cards

`VenuePage` rendered a flat text list. Now reuses `BandCard` (not a second card), read-only.

`BandCard` gains one **opt-in** `dayLabel` prop — `getTimeDescription` is date-blind within a festival week, so three sets at 8 PM on three nights of a multi-day event would read identically. Every existing caller is unaffected (`{dayLabel && …}`, undefined by default); callers on a single event already disambiguate via day tabs outside the card.

**Selection (add-to-route) is deliberately not wired up** — it pulls in `scheduleStorage` and the `end_date || date` staleness rule, and a venue's lineup spans many events so there is no single date to key staleness on. Follow-up, not built.

**Static map deliberately out of scope** — it needs a CSP change in `frontend/public/_headers`, and a CSP mistake breaks the page silently for every visitor. Wrong week. `_headers` is untouched.

## Test plan

- [x] `make gate` — exit 0. Backend **965**, frontend **928**, build green
- [x] `make review` (CodeRabbit) — 6 findings, then **no new findings**
- [x] lat/lng and `photo_url`/`genre` present in the payload
- [x] Multi-day: two sets at the same clock time on different days show distinct day labels
- [x] After-midnight: a 00:25 set groups with the **previous** evening (BF2 has one — *Where's Shane?*)
- [x] Cancelled sets still render struck-through with the visible "Cancelled" label (the #732 WCAG 1.4.1 carrier — verified preserved through the `BandCard` swap)
- [x] Countdown refreshes while the page stays open
- [x] Every assertion mutation-tested

## Review findings

**Fixed — `currentTime` never refreshed.** Captured once, so "Starts in 15m" froze forever on the page a fan opens outside a venue. Now ticks every 60s, matching `App.jsx`/`EmbedPage.jsx`/`MySchedule.jsx`. My first attempt shipped this **untested** — the mutation didn't fail, because the existing test pins the clock and never advances it. Added a test that advances past the set start and asserts the card moves to "Live Now"; removing the interval now fails it.

**Fixed — test clocks pinned.** Two day-label tests asserted literal date strings against the *real* clock, so they changed meaning on Aug 7–8 — during the festival. Plus the event-link destination and the `dayLabel` icon contract are now asserted.

**Not fixed, filed as #768 — DST-unsafe `prepareBands`.** `MS_PER_DAY` is 23 or 25 wall-clock hours across a transition. Real, but pre-existing, and `prepareBands` is the canonical after-midnight helper every schedule surface routes through. BF2 is August — nowhere near a transition, so it cannot fire. Not rewriting the app's most load-bearing time function two days before doors.

## One live bug confirmed on the way

Pinning the test clock earlier than two weeks before a set makes the after-midnight test fail: `getTimeDescription`'s >2-weeks fallback renders the raw +1-day-offset timestamp ("Aug 8") instead of the festival day ("Aug 7"). That is **#689 Finding 1**, now empirically confirmed reachable rather than theoretical. Clock pinned to Aug 1 so this suite tests the venue page rather than re-failing on a known `timeFilter` bug; commented in place.

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Venue schedules now display performances as responsive cards with band imagery, genres, event links, and festival-day labels.
  - Added calendar day indicators to performance cards when applicable.
  - Venue details now include available map coordinates.
  - Live countdowns update automatically and account for date, after-midnight, and cancelled performances.

- **Bug Fixes**
  - Improved handling of missing performance details and venue coordinates without displaying incorrect information.

- **Tests**
  - Added coverage for performer cards, day labels, countdown behaviour, cancellation styling, event links, and venue response data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->