### PR TITLE
fix(schedule): advance a local calendar day, not a fixed 24h, across DST

### DIFF
--- a/frontend/src/components/LiveContextBar.jsx
+++ b/frontend/src/components/LiveContextBar.jsx
@@ -261,6 +261,10 @@ function LiveContextBar({
     if (lifecycle.label !== 'Upcoming' || !eventData?.date) return null
     const eventDateObj = new Date(eventData.date + 'T00:00:00')
     const nowDate = currentTime instanceof Date ? currentTime : new Date(+currentTime)
+    // Safe across DST despite the raw division below (#768): the LOCAL Y/M/D
+    // fields are read first, then reprojected through Date.UTC — a UTC day is
+    // always exactly 86,400,000ms by definition, so the subtraction is exact
+    // and never sees the 23h/25h local-day variation a DST transition causes.
     const eventDay = Date.UTC(eventDateObj.getFullYear(), eventDateObj.getMonth(), eventDateObj.getDate())
     const todayDay = Date.UTC(nowDate.getFullYear(), nowDate.getMonth(), nowDate.getDate())
     return Math.ceil((eventDay - todayDay) / 86400000)

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -22,7 +22,8 @@ import {
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { HIGHLIGHTED_BANDS, getHighlightMessage } from '../config/highlights.jsx'
 import { copyToClipboard } from '../utils/clipboard'
-import { addLocalDays, dayNumberMapFromDays, formatFestivalDate, orderedFestivalDays } from '../utils/festivalDays'
+import { dayNumberMapFromDays, formatFestivalDate, orderedFestivalDays } from '../utils/festivalDays'
+import { prepareBands } from '../utils/bandUtils'
 import { formatTimeRange } from '../utils/timeFormat'
 import { useFestivalDayFilter } from '../hooks/useFestivalDayFilter'
 import BandCard from './BandCard'
@@ -160,34 +161,16 @@ function MySchedule({
   )
 
   const highlightedBandIds = useMemo(() => new Set(HIGHLIGHTED_BANDS), [])
-  const normalizedBands = useMemo(() => {
-    return dayFilteredBands.map(band => {
-      const parsedStartMs = Date.parse(`${band.date}T${band.startTime}:00`)
-      const parsedEndMs = Date.parse(`${band.date}T${band.endTime}:00`)
-      const startMs =
-        Number.isFinite(band.startMs) && band.startMs > 0
-          ? band.startMs
-          : Number.isNaN(parsedStartMs)
-            ? 0
-            : parsedStartMs
-
-      let endMs =
-        Number.isFinite(band.endMs) && band.endMs > 0 ? band.endMs : Number.isNaN(parsedEndMs) ? 0 : parsedEndMs
-
-      if (startMs > 0 && endMs > 0 && endMs < startMs) {
-        // Advance the LOCAL CALENDAR DATE, not a fixed 24h — see addLocalDays'
-        // doc comment in festivalDays.js (#768). Sibling of the same fix in
-        // bandUtils.js's prepareBands().
-        endMs = addLocalDays(endMs, 1)
-      }
-
-      return {
-        ...band,
-        startMs,
-        endMs,
-      }
-    })
-  }, [dayFilteredBands])
+  // Delegate to prepareBands rather than re-deriving startMs/endMs here.
+  // CLAUDE.md's after-midnight invariant requires every consumer to apply the
+  // same offset or delegate to prepareBands; the previous local normalization
+  // did the endMs overnight wrap but NOT the sub-6-AM offset, so any band
+  // arriving without a precomputed startMs would have sorted to the top of the
+  // schedule instead of the end. App.jsx already prepares these bands, so this
+  // is idempotent in production (prepareBands recomputes from date/startTime/
+  // endTime and never reads startMs) — it closes the latent hole in the
+  // fallback path and removes the duplicated arithmetic (#768).
+  const normalizedBands = useMemo(() => prepareBands(dayFilteredBands), [dayFilteredBands])
 
   // Calculate time until/since a band
   const getTimeStatus = band => {

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -22,7 +22,7 @@ import {
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { HIGHLIGHTED_BANDS, getHighlightMessage } from '../config/highlights.jsx'
 import { copyToClipboard } from '../utils/clipboard'
-import { dayNumberMapFromDays, formatFestivalDate, orderedFestivalDays } from '../utils/festivalDays'
+import { addLocalDays, dayNumberMapFromDays, formatFestivalDate, orderedFestivalDays } from '../utils/festivalDays'
 import { formatTimeRange } from '../utils/timeFormat'
 import { useFestivalDayFilter } from '../hooks/useFestivalDayFilter'
 import BandCard from './BandCard'
@@ -161,8 +161,6 @@ function MySchedule({
 
   const highlightedBandIds = useMemo(() => new Set(HIGHLIGHTED_BANDS), [])
   const normalizedBands = useMemo(() => {
-    const oneDayMs = 24 * 60 * 60 * 1000
-
     return dayFilteredBands.map(band => {
       const parsedStartMs = Date.parse(`${band.date}T${band.startTime}:00`)
       const parsedEndMs = Date.parse(`${band.date}T${band.endTime}:00`)
@@ -177,7 +175,10 @@ function MySchedule({
         Number.isFinite(band.endMs) && band.endMs > 0 ? band.endMs : Number.isNaN(parsedEndMs) ? 0 : parsedEndMs
 
       if (startMs > 0 && endMs > 0 && endMs < startMs) {
-        endMs += oneDayMs
+        // Advance the LOCAL CALENDAR DATE, not a fixed 24h — see addLocalDays'
+        // doc comment in festivalDays.js (#768). Sibling of the same fix in
+        // bandUtils.js's prepareBands().
+        endMs = addLocalDays(endMs, 1)
       }
 
       return {

--- a/frontend/src/utils/__tests__/bandUtils.test.js
+++ b/frontend/src/utils/__tests__/bandUtils.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { afterAll, beforeAll, describe, it, expect } from 'vitest'
 import { prepareBands } from '../bandUtils'
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -161,5 +161,97 @@ describe('prepareBands — multi-day festival-day support (#538)', () => {
     const [day1Late] = prepareBands([makeBand('01:00', '02:00', '2026-08-02')])
     const [day2Late] = prepareBands([makeBand('01:00', '02:00', '2026-08-03')])
     expect(day2Late.startMs - day1Late.startMs).toBe(DAY_MS)
+  })
+})
+
+// #768: prepareBands' after-midnight offset must advance the LOCAL CALENDAR
+// DATE (via addLocalDays in festivalDays.js), not a fixed 24h/86,400,000ms —
+// a local day is 23h/25h across a DST transition, so a flat millisecond add
+// lands on the wrong wall-clock time, and sometimes the wrong calendar date,
+// for a transition-night after-midnight set. Ground-truth values below were
+// derived by running the actual Date arithmetic under TZ=America/Toronto
+// (not hand-computed), then cross-checked against the values CodeRabbit
+// derived in issue #768.
+//
+// This repo has no prior convention for pinning a test's timezone, so these
+// tests set process.env.TZ directly (scoped to this describe block, restored
+// in afterAll) rather than introducing one. That makes the DST assertions
+// deterministic regardless of the machine or CI runner's default TZ.
+describe('prepareBands — DST-safe after-midnight offset (#768)', () => {
+  let originalTz
+
+  beforeAll(() => {
+    originalTz = process.env.TZ
+    process.env.TZ = 'America/Toronto'
+  })
+
+  afterAll(() => {
+    process.env.TZ = originalTz
+  })
+
+  it('regression: ordinary (non-transition) dates are unchanged by the DST-safe offset', () => {
+    const [band] = prepareBands([makeBand('01:00', '02:00', '2026-08-02')])
+    const baseStart = Date.parse('2026-08-02T01:00:00')
+    const baseEnd = Date.parse('2026-08-02T02:00:00')
+    expect(band.startMs).toBe(baseStart + DAY_MS)
+    expect(band.endMs).toBe(baseEnd + DAY_MS)
+  })
+
+  it('fall back (2026-11-01): a 00:25 after-midnight set lands Nov 2 00:25 EST, not Nov 1 23:25 EST', () => {
+    // Toronto falls back 02:00 EDT -> 01:00 EST on 2026-11-01. Verified via
+    // `TZ=America/Toronto node`: the broken `+= MS_PER_DAY` implementation
+    // produces "Sun Nov 01 2026 23:25:00 GMT-0500" — wrong hour AND wrong
+    // calendar day.
+    const [band] = prepareBands([makeBand('00:25', '01:10', '2026-11-01')])
+
+    expect(new Date(band.startMs).toString()).toContain('Mon Nov 02 2026 00:25:00 GMT-0500')
+
+    const brokenStartMs = Date.parse('2026-11-01T00:25:00') + DAY_MS
+    expect(band.startMs).not.toBe(brokenStartMs)
+  })
+
+  it('spring forward (2027-03-14): a 00:25 after-midnight set lands Mar 15 00:25 EDT, not Mar 15 01:25 EDT', () => {
+    // Toronto springs forward 02:00 EST -> 03:00 EDT on 2027-03-14. Verified
+    // via `TZ=America/Toronto node`: the broken `+= MS_PER_DAY`
+    // implementation produces "Mon Mar 15 2027 01:25:00 GMT-0400" — wrong
+    // hour (calendar date happens to still be correct for this input).
+    const [band] = prepareBands([makeBand('00:25', '01:10', '2027-03-14')])
+
+    expect(new Date(band.startMs).toString()).toContain('Mon Mar 15 2027 00:25:00 GMT-0400')
+
+    const brokenStartMs = Date.parse('2027-03-14T00:25:00') + DAY_MS
+    expect(band.startMs).not.toBe(brokenStartMs)
+  })
+
+  it('non-existent local time edge: an after-midnight set that lands in the spring-forward gap normalizes forward by the gap size (intentional)', () => {
+    // A 02:30 set belonging to the 2027-03-13 evening lineup (hour 2 < the
+    // AFTER_MIDNIGHT_THRESHOLD_HOUR of 6) is offset forward one calendar day
+    // to 2027-03-14 — but 02:00-02:59 does not exist that day, because
+    // Toronto's clocks jump straight from 02:00 to 03:00. `addLocalDays`
+    // (via `Date#setDate`) normalizes this forward by the size of the gap
+    // (to 03:30 EDT) rather than throwing, the same way the wall clock
+    // itself behaves that night. This is pinned as deliberate, not left as
+    // incidental engine behavior (#768).
+    const [band] = prepareBands([makeBand('02:30', '03:15', '2027-03-13')])
+
+    expect(new Date(band.startMs).toString()).toContain('Sun Mar 14 2027 03:30:00 GMT-0400')
+    // Sanity: matches direct construction of the same nonexistent local time.
+    expect(band.startMs).toBe(new Date(2027, 2, 14, 2, 30, 0).getTime())
+  })
+
+  it('overnight-wrap (endMs < startMs) on the spring-forward transition day itself is also DST-safe', () => {
+    // An evening set on the transition day (2027-03-14 23:30) ending just
+    // after midnight (00:20, parsed on the same calendar date so it is
+    // BEFORE startMs) triggers the `endMs < startMs` wrap at the bottom of
+    // prepareBands — a genuine sibling of the after-midnight offset above,
+    // using the same addLocalDays helper. Verified via `TZ=America/Toronto
+    // node`: the broken `+= MS_PER_DAY` implementation produces "Mon Mar 15
+    // 2027 01:20:00 GMT-0400" — one hour late.
+    const [band] = prepareBands([makeBand('23:30', '00:20', '2027-03-14')])
+
+    expect(new Date(band.endMs).toString()).toContain('Mon Mar 15 2027 00:20:00 GMT-0400')
+
+    const brokenEndMs = Date.parse('2027-03-14T00:20:00') + DAY_MS
+    expect(band.endMs).not.toBe(brokenEndMs)
   })
 })

--- a/frontend/src/utils/__tests__/bandUtils.test.js
+++ b/frontend/src/utils/__tests__/bandUtils.test.js
@@ -186,7 +186,12 @@ describe('prepareBands — DST-safe after-midnight offset (#768)', () => {
   })
 
   afterAll(() => {
-    process.env.TZ = originalTz
+    // process.env coerces to string, so assigning an undefined originalTz
+    // would leave the literal 'undefined' as the TZ for every later test in
+    // this process — an invalid zone, on exactly the machines that don't set
+    // TZ (CI). Delete the key instead of assigning it back.
+    if (originalTz === undefined) delete process.env.TZ
+    else process.env.TZ = originalTz
   })
 
   it('regression: ordinary (non-transition) dates are unchanged by the DST-safe offset', () => {

--- a/frontend/src/utils/__tests__/festivalDays.test.js
+++ b/frontend/src/utils/__tests__/festivalDays.test.js
@@ -239,7 +239,12 @@ describe('addLocalDays (#768 — DST-safe day offset)', () => {
   })
 
   afterAll(() => {
-    process.env.TZ = originalTz
+    // process.env coerces to string, so assigning an undefined originalTz
+    // would leave the literal 'undefined' as the TZ for every later test in
+    // this process — an invalid zone, on exactly the machines that don't set
+    // TZ (CI). Delete the key instead of assigning it back.
+    if (originalTz === undefined) delete process.env.TZ
+    else process.env.TZ = originalTz
   })
 
   it('is a no-op-equivalent to +24h on an ordinary (non-transition) date — no regression to the 99% case', () => {

--- a/frontend/src/utils/__tests__/festivalDays.test.js
+++ b/frontend/src/utils/__tests__/festivalDays.test.js
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import {
+  addLocalDays,
   dayNumberByDate,
   dayNumberMapFromDays,
   formatFestivalDate,
@@ -218,5 +219,81 @@ describe('isMultiDay', () => {
 
   it('is false for empty input', () => {
     expect(isMultiDay([])).toBe(false)
+  })
+})
+
+// #768: addLocalDays must advance the LOCAL CALENDAR DATE, not a fixed
+// 86,400,000ms — a local day is 23h/25h across a DST transition, so a flat
+// millisecond add lands on the wrong wall-clock time (and sometimes the
+// wrong calendar date). These tests pin process.env.TZ to America/Toronto
+// so the DST assertions are deterministic regardless of the machine/CI TZ —
+// this repo has no prior TZ-pinning convention for tests, so the pin is
+// scoped to this describe block and restored afterward rather than added
+// globally to src/test/setup.js.
+describe('addLocalDays (#768 — DST-safe day offset)', () => {
+  let originalTz
+
+  beforeAll(() => {
+    originalTz = process.env.TZ
+    process.env.TZ = 'America/Toronto'
+  })
+
+  afterAll(() => {
+    process.env.TZ = originalTz
+  })
+
+  it('is a no-op-equivalent to +24h on an ordinary (non-transition) date — no regression to the 99% case', () => {
+    const ms = Date.parse('2026-08-02T01:00:00')
+    const DAY_MS = 24 * 60 * 60 * 1000
+    expect(addLocalDays(ms, 1)).toBe(ms + DAY_MS)
+  })
+
+  it('fall back (2026-11-01): keeps 00:25 wall-clock time and lands on the correct next calendar day', () => {
+    // Toronto falls back 02:00 EDT -> 01:00 EST on 2026-11-01. A 00:25 set
+    // belonging to the Nov 1 evening lineup must land Nov 2 00:25 EST — the
+    // fixed +24h add instead produces Nov 1 23:25 EST (wrong hour AND wrong
+    // calendar day; asserted as the "broken" comparison below).
+    const startMs = Date.parse('2026-11-01T00:25:00')
+    const result = addLocalDays(startMs, 1)
+
+    expect(new Date(result).toString()).toContain('Nov 02 2026 00:25:00')
+    expect(new Date(result).toString()).toContain('GMT-0500')
+
+    const broken = startMs + 24 * 60 * 60 * 1000
+    expect(result).not.toBe(broken)
+  })
+
+  it('spring forward (2027-03-14): keeps 00:25 wall-clock time and lands on the correct next calendar day', () => {
+    // Toronto springs forward 02:00 EST -> 03:00 EDT on 2027-03-14. A 00:25 set
+    // belonging to the Mar 14 evening lineup must land Mar 15 00:25 EDT — the
+    // fixed +24h add instead produces Mar 15 01:25 EDT (wrong hour).
+    const startMs = Date.parse('2027-03-14T00:25:00')
+    const result = addLocalDays(startMs, 1)
+
+    expect(new Date(result).toString()).toContain('Mar 15 2027 00:25:00')
+    expect(new Date(result).toString()).toContain('GMT-0400')
+
+    const broken = startMs + 24 * 60 * 60 * 1000
+    expect(result).not.toBe(broken)
+  })
+
+  it('non-existent local time edge: stepping into the spring-forward gap normalizes forward by the gap size (intentional)', () => {
+    // 2027-03-13 02:30 is an ordinary after-midnight set (belongs to the Mar 13
+    // evening lineup, before the transition). Advancing it by one local
+    // calendar day lands on 2027-03-14 02:30 — a wall-clock time that never
+    // occurs, because Toronto's clocks jump straight from 02:00 to 03:00 that
+    // night. setDate() normalizes this forward by the size of the gap (to
+    // 03:30 EDT) rather than throwing, matching how the wall clock itself
+    // behaves that night. This is deliberately pinned as correct, not left as
+    // incidental engine behavior (#768).
+    const startMs = Date.parse('2027-03-13T02:30:00')
+    const result = addLocalDays(startMs, 1)
+
+    expect(new Date(result).toString()).toContain('Mar 14 2027 03:30:00')
+    expect(new Date(result).toString()).toContain('GMT-0400')
+
+    // Sanity: matches direct construction of the same nonexistent local time.
+    const direct = new Date(2027, 2, 14, 2, 30, 0)
+    expect(result).toBe(direct.getTime())
   })
 })

--- a/frontend/src/utils/bandUtils.js
+++ b/frontend/src/utils/bandUtils.js
@@ -1,6 +1,5 @@
-import { AFTER_MIDNIGHT_THRESHOLD_HOUR } from './festivalDays'
+import { AFTER_MIDNIGHT_THRESHOLD_HOUR, addLocalDays } from './festivalDays'
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000
 // Times starting before AFTER_MIDNIGHT_THRESHOLD_HOUR are treated as after-midnight sets
 // of the event night, so they sort after same-day evening sets rather than appearing at
 // the top of the schedule. Canonical definition lives in festivalDays.js (#550).
@@ -27,13 +26,17 @@ export function prepareBands(list) {
     if (!Number.isNaN(startMs)) {
       const startHour = parseInt(String(band.startTime ?? '').split(':')[0], 10)
       if (Number.isFinite(startHour) && startHour < AFTER_MIDNIGHT_THRESHOLD_HOUR) {
-        startMs += MS_PER_DAY
-        if (!Number.isNaN(endMs)) endMs += MS_PER_DAY
+        // Advance the LOCAL CALENDAR DATE, not a fixed 24h — a local day is
+        // 23h/25h across a DST transition, so a flat millisecond add lands on
+        // the wrong wall-clock time (and sometimes the wrong calendar date)
+        // for an after-midnight set on a transition night (#768).
+        startMs = addLocalDays(startMs, 1)
+        if (!Number.isNaN(endMs)) endMs = addLocalDays(endMs, 1)
       }
     }
 
     if (!Number.isNaN(startMs) && !Number.isNaN(endMs) && endMs < startMs) {
-      endMs += MS_PER_DAY
+      endMs = addLocalDays(endMs, 1)
     }
 
     return {

--- a/frontend/src/utils/festivalDays.js
+++ b/frontend/src/utils/festivalDays.js
@@ -22,8 +22,9 @@
  * This is the single canonical definition (#550) — every consumer imports
  * it rather than re-encoding `6`:
  * - `frontend/src/utils/bandUtils.js` (`prepareBands`) offsets sub-6-AM
- *   start times by `MS_PER_DAY` so they sort after the same evening's
- *   earlier sets rather than at the top of the schedule.
+ *   start times by one local calendar day (`addLocalDays`, below) so they
+ *   sort after the same evening's earlier sets rather than at the top of
+ *   the schedule.
  * - `frontend/src/admin/utils/timeUtils.js` derives
  *   `AFTER_MIDNIGHT_THRESHOLD_MINUTES` (`AFTER_MIDNIGHT_THRESHOLD_HOUR * 60`)
  *   from this for its own minutes-based offset (`adjustForMidnight`).
@@ -154,4 +155,38 @@ export function resolveActiveFestivalDay({ days, dayParam, todayStr, startDate =
   }
 
   return 1
+}
+
+/**
+ * Advances a LOCAL epoch-ms timestamp by `days` local calendar days — NOT a
+ * fixed `days * 86_400_000`. A local day is 23h or 25h across a DST
+ * transition (spring-forward / fall-back), so a flat millisecond add lands
+ * on the wrong wall-clock time, and sometimes the wrong calendar date, for
+ * any after-midnight set on a transition night (#768).
+ *
+ * `setDate()` walks the calendar and re-resolves the UTC offset for the
+ * landing date, so it is DST-correct by construction. This is the same
+ * technique `SharePreviewPage.jsx`'s `sortKey()` already uses (stepping
+ * backward across the boundary) — see the comment there for the reasoning;
+ * this is that pattern's forward-stepping, shared home so `bandUtils.js`
+ * and `MySchedule.jsx` don't each re-derive it.
+ *
+ * Spring-forward edge case: advancing into the 2:00–2:59 AM hour on the
+ * night clocks jump forward lands on a local time that does not exist.
+ * `setDate()` normalizes it forward by the size of the gap (e.g. 2:30 AM ->
+ * 3:30 AM) rather than throwing — the same normalization a wall clock
+ * itself performs on that night. That is treated as correct here, not an
+ * accident of the engine: an after-midnight set is deliberately re-anchored
+ * to the previous evening's day, and the exact minute a non-existent
+ * wall-clock time resolves to is a one-night-a-year edge no fan-facing
+ * surface distinguishes. Pinned by a test in `bandUtils.test.js`.
+ *
+ * @param {number} ms - epoch milliseconds
+ * @param {number} days - number of local calendar days to advance (may be negative)
+ * @returns {number} new epoch milliseconds
+ */
+export function addLocalDays(ms, days) {
+  const d = new Date(ms)
+  d.setDate(d.getDate() + days)
+  return d.getTime()
 }

--- a/frontend/src/utils/timeFormat.js
+++ b/frontend/src/utils/timeFormat.js
@@ -76,6 +76,12 @@ export function formatPerformanceDayLabel(performance) {
     return dateLabel
   }
 
+  // Math.round (not Math.floor, not a bare division) is load-bearing: across a
+  // DST transition the true elapsed time between two local midnights is 23h or
+  // 25h, not exactly MS_PER_DAY, so the raw quotient drifts by a fraction of a
+  // day. Rounding absorbs that fraction; it would take roughly a dozen
+  // *accumulated* transitions in one event to flip the rounding, and no
+  // festival spans anywhere close to that (#768).
   const dayOffset = Math.round((perfDay.getTime() - eventStart.getTime()) / MS_PER_DAY)
   const dayNumber = dayOffset + 1
 


### PR DESCRIPTION
## Summary

`prepareBands()` offsets after-midnight sets (before 6 AM) by one day so they sort after the evening lineup. That offset was a flat `+= 86_400_000`. A local calendar day is 23h or 25h across a DST transition, so the flat add lands on the wrong wall-clock time — and, on fall-back, on the wrong calendar day entirely.

`addLocalDays()` steps the local calendar via `Date#setDate()` instead, which re-resolves the UTC offset. Verified in `America/Toronto`:

| Transition | A 00:25 set rendered as | Should be |
|---|---|---|
| Fall back (Nov 1 2026 evening) | `Nov 1, 11:25 PM EST` | `Nov 2, 12:25 AM EST` |
| Spring forward (Mar 14 2027 evening) | `1:25 AM EDT` | `12:25 AM EDT` |

The fall-back case is the bad one: wrong hour *and* wrong calendar day, so the set sorts back into the middle of the evening lineup instead of at the end.

Closes #768

## What changed

| File | Change |
|------|--------|
| `utils/festivalDays.js` | New `addLocalDays(ms, days)` — the canonical DST-safe day step, alongside `AFTER_MIDNIGHT_THRESHOLD_HOUR` |
| `utils/bandUtils.js` | Three call sites converted (after-midnight start, after-midnight end, overnight end-wrap); `MS_PER_DAY` removed |
| `components/MySchedule.jsx` | Hand-rolled normalization replaced with `prepareBands()` — see below |
| `utils/timeFormat.js` | Comment only: why `Math.round` on the day-offset division is load-bearing |
| `components/LiveContextBar.jsx` | Comment only: why the `Date.UTC()` reprojection is already DST-immune |
| `utils/__tests__/*.test.js` | DST cases with `TZ` pinned to `America/Toronto` |

### The sibling sweep found a live bug

`MySchedule` normalized its own bands rather than calling `prepareBands`, and its copy did the overnight end-wrap but **not** the sub-6-AM start offset — the invariant this repo has fixed four times. It was unreachable in production (`App.jsx:210` prepares bands before `App.jsx:875` renders `MySchedule`), so nothing was broken today, but it was a re-entry point for the bug class.

Replaced with `prepareBands(dayFilteredBands)`. Safe because `prepareBands` reads only `band.date`/`startTime`/`endTime` and never `startMs`, so it is idempotent on already-prepared bands. Net −20 lines.

### Two lookalikes that are correct, and now say so

`timeFormat.js` divides by `MS_PER_DAY` and `LiveContextBar.jsx` subtracts raw epoch ms — both look like the same defect. Neither is: `Math.round` absorbs the ±1h drift (it would take ~12 accumulated transitions in one event to flip), and `Date.UTC()` reprojects to a plane where a day is exactly 86,400,000 ms. Both got a comment so a future sweep doesn't "fix" them into breaking.

## Security / correctness notes

None. Presentation-layer date arithmetic only — no auth, no data mutation, no schema change.

## Verification

- [x] Tests: 960 pass, 0 failures (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors (`npm run lint`) — 2 pre-existing warnings in `AdminPanel.jsx`/`UserManagement.jsx`, confirmed pre-existing by stashing
- [x] Format check: clean (`cd frontend && npm run format:check`)
- [x] Build: green (`npm run build --prefix frontend`)
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] **Non-vacuity proven:** reverted `bandUtils.js` to `+= 86400000` and re-ran — exactly 3 tests failed, with exactly the wrong values in the table above. Restored and re-ran green.
- [x] `make review` (CodeRabbit) run pre-open; all 3 findings taken

**Known limitation, stated rather than hidden:** the spring-forward *gap* test (a set whose +1 day lands on a wall-clock time that doesn't exist, e.g. 02:30 → 03:30) is **structurally vacuous** — for a value in the gap, both the flat add and the calendar step resolve to the same UTC instant. It is kept to pin the roll-forward behaviour, but it carries no proof of the fix.

Not swept: the `setUTCDate` sites in `functions/` (`api/feeds/ical.js`, `event/[slug].js`, `api/admin/events/wizard.js`). Deliberate UTC stepping, out of scope here.

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schedule and festival-day handling across daylight-saving time changes.
  * Corrected overnight and after-midnight event times to preserve local calendar dates.
  * Normalized nonexistent local times during spring-forward transitions.

* **Tests**
  * Added coverage for daylight-saving transitions, overnight scheduling, and local-date calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->