### PR TITLE
docs(claude): adopt the ponytail efficiency ladder as doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,27 @@ The mechanical form is usually one grep. "Which files select `p.start_time` but 
 
 Prefer a durable guard over a repeat audit: a source-scanning test (as `bandFields.test.js` does for Tailwind class literals) collapses a whole bug class into one failing test.
 
+### The efficiency ladder — before you write
+
+Adapted from the [ponytail](https://github.com/DietrichGebert/ponytail) ruleset. Before writing code, stop at the first rung that applies:
+
+1. **YAGNI** — does this need to exist at all?
+2. **Reuse** — does it already exist here? (`functions/utils/`, `frontend/src/utils/`, the `bandFields.js` registry, `prepareBands`)
+3. **Standard library / platform** — does JS, Web Crypto, or D1 already do it? (see the PBKDF2 and TOTP invariants — this repo has repeatedly chosen the platform primitive over a dependency)
+4. **Existing dependency** — does something already in `package.json` solve it?
+5. **One line** — can it be one line?
+6. **Minimum working code** — only then.
+
+Deletion over addition. Boring over clever. Fewest files that work.
+
+**The ladder runs after you understand the problem, not instead of it.** Trace the real flow end-to-end first. A short diff that patches a symptom is worse than a longer one that fixes the cause — the ladder ranks *solutions to the actual problem*; it does not rank problems by how cheap they are to make disappear. It defers to the debugging discipline, always.
+
+**The ladder governs the fix. It does not govern the sweep.** The sibling sweep and its durable guard test are *requested work* — part of the definition of done for any bug fix — never speculative additions for rung 1 to eliminate. And on the merits: one source-scanning test that retires a bug class permanently is less total work than re-running that sweep by hand on every future PR. **The guard is the lazy option**, not the expensive one.
+
+Never lazy about: understanding, input validation, error handling that prevents data loss, security, accessibility, theme-token correctness, or anything explicitly asked for.
+
+> Adopted as doctrine only — the ponytail plugin itself was evaluated and **not installed** (2026-08-06). Its hard rules ("no boilerplate that wasn't asked for", "shortest working diff wins") cut against the sweep discipline above, and its benchmark is n=4 on Haiku 4.5. Take the ladder, skip the install; don't re-litigate.
+
 ---
 
 ## Agent Delegation Workflow (standing default)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,9 @@ Deletion over addition. Boring over clever. Fewest files that work.
 
 **The ladder governs the fix. It does not govern the sweep.** The sibling sweep and its durable guard test are *requested work* — part of the definition of done for any bug fix — never speculative additions for rung 1 to eliminate. And on the merits: one source-scanning test that retires a bug class permanently is less total work than re-running that sweep by hand on every future PR. **The guard is the lazy option**, not the expensive one.
 
-Never lazy about: understanding, input validation, error handling that prevents data loss, security, accessibility, theme-token correctness, or anything explicitly asked for.
+Never be lazy about understanding, input validation, error handling that prevents data loss, security, accessibility, theme-token correctness, or anything explicitly asked for.
 
-> Adopted as doctrine only — the ponytail plugin itself was evaluated and **not installed** (2026-08-06). Its hard rules ("no boilerplate that wasn't asked for", "shortest working diff wins") cut against the sweep discipline above, and its benchmark is n=4 on Haiku 4.5. Take the ladder, skip the install; don't re-litigate.
+> Adopted as doctrine only — the ponytail plugin itself was evaluated and **not installed** (2026-08-06). Its hard rules ("no boilerplate that wasn't asked for", "shortest working diff wins") cut against the sweep discipline above, and its benchmark is n=4 on Haiku 4.5. Take the ladder, skip the installation; don't re-litigate.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a 21-line "efficiency ladder" section to `CLAUDE.md`, adapted from [ponytail](https://github.com/DietrichGebert/ponytail) (~97k stars) — a viral minimality ruleset for AI coding agents. The ladder itself is good: YAGNI → reuse → stdlib/platform → existing dependency → one line → minimum working code.

**The plugin was deliberately NOT installed.** Its hard rules ("no boilerplate that wasn't asked for", "shortest working diff wins", "fewest files possible") cut directly against this repo's sweep-for-siblings discipline. An agent holding both would resolve the tension toward the freshly-injected ruleset and produce a one-file fix plus a skipped sweep *with a citation to justify it* — the `performance_date` failure (#739 → #741 → #743) with extra steps.

Closes nothing — this is doctrine, filed for the record so the decision isn't re-litigated.

## What changed

| File | Change |
|------|--------|
| `CLAUDE.md` | New "### The efficiency ladder — before you write" section under "Sweep for siblings" |

The conflict is resolved by **reframe, not exemption**: the sibling sweep and its guard test are *requested work* — part of the definition of done for a bug fix — never speculative additions for rung 1 to eliminate. And on the merits, one source-scanning test that retires a bug class permanently is less total work than re-running that sweep by hand on every future PR. **The guard is the lazy option.**

An exemption list grows and gets argued around; a scope definition doesn't.

## Why not just install it

Its benchmark is **n=4, Haiku 4.5, one FastAPI+React repo** (reproducible via promptfoo, to their credit). Haiku over-generates boilerplate, making it the friendliest possible test subject — the reported 54%/22%/20%/27% deltas won't transfer to Opus/Sonnet. And this repo's context is already rule-dense; a 14th partially-contradictory ruleset buys incoherence, not efficiency.

## Security / correctness notes

None. Documentation only.

## Verification

- [x] Tests: N/A — no code changed
- [x] ESLint: N/A — no JS changed
- [x] Format check: N/A — no npm script or CI workflow includes `.md` (root and frontend format globs are js/jsx/json/css only). `CLAUDE.md` already fails a manual `prettier --check` on `main`; running `--write` on it would reflow the entire file into a huge unrelated diff for zero gate benefit.
- [x] Build: N/A
- [x] `validate:openapi`: N/A
- [x] Manual: rendered the section on GitHub to confirm the table and blockquote render

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for choosing efficient, minimal implementation approaches before writing code.
  - Documented expectations for tracing problems end to end, addressing related bug classes, and adding durable safeguards.
  - Clarified exceptions where thorough handling remains required, including validation, errors, security, accessibility, themes, and explicitly requested work.
  - Recorded the evaluation of an optional plugin, which was not installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->