### PR TITLE
fix(profile): band photos crop to faces, and the hero Share button stays readable on light themes

### DIFF
--- a/frontend/src/admin/BandForm.jsx
+++ b/frontend/src/admin/BandForm.jsx
@@ -3,6 +3,7 @@ import PhotoUpload from './components/PhotoUpload'
 import RichTextEditor from './components/RichTextEditor'
 import { Input, Button, Tooltip } from '../components/ui'
 import Combobox from '../components/ui/Combobox'
+import { BAND_PHOTO_CROP } from '../utils/bandPhoto'
 import { Info } from 'lucide-react'
 import { FIELD_LIMITS } from '../utils/validation'
 import { DEFAULT_GENRES, getNormalizedGenreSuggestions } from '../utils/genres'
@@ -122,7 +123,11 @@ export default function BandForm({
         {isSchedulingExisting ? (
           <div className="sm:col-span-2 bg-white/5 border border-white/10 rounded-lg p-4 flex items-center gap-4 mb-2">
             {selectedProfile.photo_url ? (
-              <img src={selectedProfile.photo_url} alt="" className="w-16 h-16 rounded-full object-cover" />
+              <img
+                src={selectedProfile.photo_url}
+                alt=""
+                className={`w-16 h-16 rounded-full object-cover ${BAND_PHOTO_CROP}`}
+              />
             ) : (
               <div className="w-16 h-16 rounded-full bg-accent-500/20 flex items-center justify-center text-accent-400 text-xl font-bold">
                 {selectedProfile.name.charAt(0)}

--- a/frontend/src/admin/components/ArtistPicker.jsx
+++ b/frontend/src/admin/components/ArtistPicker.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
+import { BAND_PHOTO_CROP } from '../../utils/bandPhoto'
 
 export default function ArtistPicker({ artists, onSelect, onBulkSelect, onCancel, loading = false, venues = [] }) {
   const [query, setQuery] = useState('')
@@ -96,7 +97,7 @@ export default function ArtistPicker({ artists, onSelect, onBulkSelect, onCancel
                   <img
                     src={artist.photo_url}
                     alt=""
-                    className="w-9 h-9 rounded-full object-cover bg-white/10 shrink-0"
+                    className={`w-9 h-9 rounded-full object-cover bg-white/10 shrink-0 ${BAND_PHOTO_CROP}`}
                   />
                 ) : (
                   <div className="w-9 h-9 rounded-full bg-accent-500/20 flex items-center justify-center text-accent-400 font-bold shrink-0">

--- a/frontend/src/admin/components/PhotoUpload.jsx
+++ b/frontend/src/admin/components/PhotoUpload.jsx
@@ -1,6 +1,7 @@
 import { Image, LoaderCircle, Trash, Upload } from 'lucide-react'
 import { useState, useRef } from 'react'
 import { getAdminFormDataHeaders } from '../../utils/adminApi'
+import { BAND_PHOTO_CROP } from '../../utils/bandPhoto'
 
 /**
  * Downscale an image client-side via canvas before upload (#616 leanness
@@ -284,7 +285,10 @@ export default function PhotoUpload({
         {preview ? (
           /* Preview */
           <div className="relative h-full w-full group">
-            <img src={preview} alt="Band profile" className="w-full h-full object-cover" />
+            {/* Same crop as every public surface (BAND_PHOTO_CROP) — a preview
+                that framed the photo differently would be worse than none: it
+                would show an upload the fans never see. */}
+            <img src={preview} alt="Band profile" className={`w-full h-full object-cover ${BAND_PHOTO_CROP}`} />
 
             {/* Overlay with actions */}
             <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-4">

--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -2,6 +2,7 @@ import { CalendarDays, Plus, TriangleAlert, X, Zap } from 'lucide-react'
 import { memo } from 'react'
 import { Link } from 'react-router-dom'
 import { buildBandProfileHref } from '../utils/bandProfileLink'
+import { BAND_PHOTO_CROP } from '../utils/bandPhoto'
 import { getTimeDescription, isHappeningNow, isStartingSoon } from '../utils/timeFilter'
 import { formatTime } from '../utils/timeFormat'
 
@@ -95,7 +96,7 @@ function BandCard({
             src={band.photo_url}
             alt=""
             loading="lazy"
-            className={`h-16 w-16 rounded-full object-cover ring-2 ${onAmber ? 'ring-bg-navy/20' : 'ring-border'}`}
+            className={`h-16 w-16 rounded-full object-cover ring-2 ${BAND_PHOTO_CROP} ${onAmber ? 'ring-bg-navy/20' : 'ring-border'}`}
           />
         )}
         {startingSoon && (

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -15,6 +15,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useTransition 
 import { Link } from 'react-router-dom'
 import { fetchPublicJson } from '../utils/publicApi'
 import { buildBandProfileHref } from '../utils/bandProfileLink'
+import { BAND_PHOTO_CROP } from '../utils/bandPhoto'
 import { buildDirectionsHref } from '../utils/directions'
 import { formatPerformanceDayLabel, formatTimeRange, parseLocalDate } from '../utils/timeFormat'
 import { trackTicketClick } from '../utils/metrics'
@@ -574,7 +575,7 @@ function GenreDiscovery({ bands, eventSlug, eventDate }) {
                         <img
                           src={band.photo_url}
                           alt={band.name}
-                          className="w-full h-full object-cover"
+                          className={`w-full h-full object-cover ${BAND_PHOTO_CROP}`}
                           loading="lazy"
                         />
                       ) : (
@@ -993,7 +994,7 @@ function EventCard({
                             <img
                               src={band.photo_url}
                               alt={band.name}
-                              className="w-full h-full object-cover"
+                              className={`w-full h-full object-cover ${BAND_PHOTO_CROP}`}
                               loading="lazy"
                             />
                           </div>

--- a/frontend/src/pages/ArtistsPage.jsx
+++ b/frontend/src/pages/ArtistsPage.jsx
@@ -12,6 +12,7 @@ import {
   YouTubeIcon,
 } from '../components/ui/SocialIcons'
 import Footer from '../components/Footer'
+import { BAND_PHOTO_CROP } from '../utils/bandPhoto'
 import ThemeToggle from '../components/ThemeToggle.jsx'
 import { fetchPublicJson } from '../utils/publicApi'
 import { trackPageView, trackSocialClick } from '../utils/metrics'
@@ -69,7 +70,7 @@ function ArtistCard({ artist }) {
             src={artist.photo_url}
             alt=""
             loading="lazy"
-            className="h-16 w-16 shrink-0 rounded-full object-cover ring-2 ring-border"
+            className={`h-16 w-16 shrink-0 rounded-full object-cover ring-2 ring-border ${BAND_PHOTO_CROP}`}
           />
         ) : (
           <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-accent-500/20 text-2xl font-bold text-accent-400">

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -494,12 +494,22 @@ export default function BandProfilePage() {
                   the old placement floated awkwardly above the bio on mobile
                   and forced an empty column on desktop (Dre, 2026-07-17). */}
               <div className="absolute right-4 top-4">
+                {/* Fixed light-on-dark, NOT the theme tokens ShareButton
+                    defaults to. This instance sits over the band photo's dark
+                    scrim, which does not change with the theme — so on the two
+                    light themes the default `text-text-primary` renders
+                    near-black on a dark photo and all but disappears. Same
+                    reasoning as the `text-white` <h1> below it: over a dark
+                    photo scrim, theme-independent is correct. The no-photo
+                    branch further down keeps the themed default, because there
+                    the button really does sit on the theme surface. */}
                 <ShareButton
                   url={
                     typeof window !== 'undefined' ? `${window.location.origin}${window.location.pathname}` : undefined
                   }
                   title={profile.name}
                   text={`${profile.name} on SetTimes`}
+                  className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-white/30 bg-black/50 px-4 py-2 text-sm font-semibold text-white backdrop-blur-sm transition hover:bg-black/70 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-white"
                 />
               </div>
               <div className="absolute inset-x-0 bottom-0 p-6">

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -486,7 +486,12 @@ export default function BandProfilePage() {
               <img
                 src={profile.photo_url}
                 alt={profile.photo_alt_text || profile.name}
-                loading="lazy"
+                // This hero is the first thing on the page, so it is the LCP
+                // element — lazy-loading it defers the very resource the metric
+                // measures and pops it in late on slow connections. Same call,
+                // and same reasoning, as EventPosterThumbnail's inline variant.
+                loading="eager"
+                fetchPriority="high"
                 className={`h-full w-full object-cover opacity-60 ${BAND_PHOTO_CROP}`}
               />
               <div className="absolute inset-0 bg-linear-to-t from-black/85 via-black/35 to-transparent" />

--- a/frontend/src/pages/BandProfilePage.jsx
+++ b/frontend/src/pages/BandProfilePage.jsx
@@ -22,6 +22,7 @@ import {
 } from '../components/ui/SocialIcons'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { renderMarkdownToSafeHtml, stripMarkdownToText } from '../utils/markdown'
+import { BAND_PHOTO_CROP } from '../utils/bandPhoto'
 import { Helmet } from 'react-helmet-async'
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import BandFacts from '../components/BandFacts'
@@ -486,7 +487,7 @@ export default function BandProfilePage() {
                 src={profile.photo_url}
                 alt={profile.photo_alt_text || profile.name}
                 loading="lazy"
-                className="h-full w-full object-cover opacity-60"
+                className={`h-full w-full object-cover opacity-60 ${BAND_PHOTO_CROP}`}
               />
               <div className="absolute inset-0 bg-linear-to-t from-black/85 via-black/35 to-transparent" />
               {/* Page-level action lives in the header, not beside the bio —

--- a/frontend/src/utils/__tests__/bandPhoto.test.js
+++ b/frontend/src/utils/__tests__/bandPhoto.test.js
@@ -1,0 +1,61 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { BAND_PHOTO_CROP } from '../bandPhoto'
+
+const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+function jsxFiles(dir) {
+  const found = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '__tests__' || entry.name === 'node_modules') continue
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) found.push(...jsxFiles(full))
+    else if (entry.name.endsWith('.jsx')) found.push(full)
+  }
+  return found
+}
+
+describe('BAND_PHOTO_CROP', () => {
+  // Tailwind v4 scans source TEXT for whole class names and never evaluates
+  // template expressions, so a value assembled from parts generates no CSS and
+  // silently reverts to the centre crop. Nothing at runtime can detect that —
+  // the class name simply matches no rule. Only a source scan catches it.
+  it('is a complete literal class name in the source, not built from parts', () => {
+    const source = readFileSync(path.join(SRC, 'utils', 'bandPhoto.js'), 'utf8')
+    expect(source).toContain(`'${BAND_PHOTO_CROP}'`)
+    expect(source).not.toMatch(/BAND_PHOTO_CROP\s*=\s*[`'"].*\$\{/)
+  })
+
+  it('anchors above centre, or it would not fix anything', () => {
+    const percent = Number(BAND_PHOTO_CROP.match(/_(\d+)%\]$/)?.[1])
+    expect(percent).toBeGreaterThan(0)
+    expect(percent).toBeLessThan(50)
+  })
+
+  // The bug class: `object-cover` defaults to a CENTRE crop, which frames a
+  // portrait band photo on the midsections and cuts the faces out. It was live
+  // on eight surfaces at once, so fixing the reported one (the profile hero)
+  // would have left seven. This scan is what makes a ninth impossible.
+  it('is applied at every object-cover site that renders a band photo', () => {
+    const offenders = []
+
+    for (const file of jsxFiles(SRC)) {
+      const source = readFileSync(file, 'utf8')
+      if (!source.includes('object-cover')) continue
+
+      // Only band photos: an event poster or a decorative image has its own
+      // framing and must NOT be dragged to this anchor.
+      if (!/photo_url|\bpreview\b/.test(source)) continue
+
+      for (const [index, line] of source.split('\n').entries()) {
+        if (!line.includes('object-cover')) continue
+        if (line.includes('BAND_PHOTO_CROP')) continue
+        offenders.push(`${path.relative(SRC, file)}:${index + 1}`)
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/frontend/src/utils/__tests__/bandPhoto.test.js
+++ b/frontend/src/utils/__tests__/bandPhoto.test.js
@@ -28,10 +28,13 @@ describe('BAND_PHOTO_CROP', () => {
     expect(source).not.toMatch(/BAND_PHOTO_CROP\s*=\s*[`'"].*\$\{/)
   })
 
-  it('anchors above centre, or it would not fix anything', () => {
+  // Pinned exactly, not to a range. The value is a shared contract across
+  // eight surfaces, so drifting it to 40% would still be "above centre" while
+  // quietly putting the hero back on the midsections — the whole bug.
+  it('anchors at 25%, above centre', () => {
+    expect(BAND_PHOTO_CROP).toBe('object-[50%_25%]')
     const percent = Number(BAND_PHOTO_CROP.match(/_(\d+)%\]$/)?.[1])
-    expect(percent).toBeGreaterThan(0)
-    expect(percent).toBeLessThan(50)
+    expect(percent).toBe(25)
   })
 
   // The bug class: `object-cover` defaults to a CENTRE crop, which frames a

--- a/frontend/src/utils/bandPhoto.js
+++ b/frontend/src/utils/bandPhoto.js
@@ -1,0 +1,31 @@
+/**
+ * Where to anchor a band photo inside an `object-cover` frame.
+ *
+ * `object-cover` defaults to `object-position: 50% 50%`, which crops to the
+ * MIDDLE of the source. Band and press photos are overwhelmingly full-body
+ * group shots in portrait orientation, and every frame this app crops them
+ * into is wider than it is tall. The arithmetic is unkind: a 539x639 photo in
+ * the 3.5:1 profile hero shows only ~24% of the image height, and centred that
+ * window lands on the band's midsections — faces cropped out entirely.
+ *
+ * 25% from the top is the one anchor that is safe in every frame this app
+ * uses:
+ *
+ * - Wide hero + portrait source: the window is short, so 25% moves it up onto
+ *   the faces. `object-top` (0%) would overshoot into sky and cut faces in
+ *   half.
+ * - Square avatar + portrait source: the window is nearly as tall as the
+ *   source, so there is almost no travel and this clamps to roughly the top —
+ *   still better than centre.
+ * - Any landscape source: little or no vertical crop, so the value barely
+ *   matters and cannot make things worse.
+ *
+ * MUST stay a complete literal string. Tailwind v4 scans source *text* for
+ * whole class names and never evaluates template expressions, so building this
+ * from parts (`object-[50%_${pct}]`) generates no CSS and silently restores
+ * the centre crop. Same rule as the colour literals in
+ * `admin/utils/bandFields.js`; `__tests__/bandPhoto.test.js` scans the source
+ * to enforce it, and to catch a ninth `object-cover` site that forgets to
+ * import this.
+ */
+export const BAND_PHOTO_CROP = 'object-[50%_25%]'


### PR DESCRIPTION
## Summary

Two rendering defects on the band profile hero, both reported against **All My Senses** the day before Buddies Fest 2.

**1. Band photos cropped to the midsections.** `object-cover` defaults to `object-position: 50% 50%`. Band photos are overwhelmingly full-body portrait group shots, and every frame this app crops them into is wider than it is tall — so the centred window lands on the band's torsos and cuts the faces out entirely.

The arithmetic on the reported photo: a 539×639 source in the 3.5:1 hero exposes only ~24% of the image height. Centred, that window is y=243…396 of 639. The faces sit at y=110…190 — fully outside the crop.

`BAND_PHOTO_CROP` anchors at **25% from the top**, the one value that is safe in every frame here:

| Frame + source | Effect of 25% |
|---|---|
| Wide hero + portrait | Lifts the short window onto the faces — the fix |
| Square avatar + portrait | Window is nearly as tall as the source, so it barely travels and clamps near the top — still better than centre |
| Any landscape source | Little or no vertical crop; the value cannot make it worse |

`object-top` (0%) was rejected: it overshoots the hero into sky and beheads everyone.

**2. The hero Share button was unreadable on light themes.** It used `ShareButton`'s themed default (`bg-surface` / `text-text-primary`). Those tokens follow the theme; the surface underneath them does not — the hero scrim is `from-black/85` on all four themes. Result on `daybreak` / `silver-lining`: near-black text on a dark photo.

Closes #775

## What changed

| File | Change |
|------|--------|
| `utils/bandPhoto.js` | **New.** `BAND_PHOTO_CROP` — one literal, with the arithmetic that justifies 25% |
| `pages/BandProfilePage.jsx` | Hero crop; hero Share button pinned to fixed light-on-dark |
| `pages/ArtistsPage.jsx`, `components/BandCard.jsx` | 64px avatar crop |
| `components/EventTimeline.jsx` | Two frames — 64px thumb, 48px circle |
| `admin/components/PhotoUpload.jsx` | Upload preview crop |
| `admin/components/ArtistPicker.jsx`, `admin/BandForm.jsx` | Admin avatar crop |
| `utils/__tests__/bandPhoto.test.js` | **New.** Source-scanning guard |

## Two sweeps, both reported

**Crop:** live on **eight** surfaces. Fixing the reported one would have left seven. The admin upload preview is included deliberately — a preview framing the photo differently from the public page is worse than no preview, because it shows an upload the fans never see.

**Share button contrast:** exactly **one** instance. Both sibling candidates were already correct — the hero `<h1>` is fixed `text-white`, and `EventTimeline`'s selected-thumbnail overlay uses a solid `bg-accent-500` pill with `text-bg-navy`. Scoped to the over-photo button only; the no-photo branch keeps the themed default because there the button really does sit on the theme surface.

This is the rule CLAUDE.md already states — keep fixed colours "over a dark photo scrim" — so no doc change is needed.

## Security / correctness notes

None. CSS class names only. No request, response, handler, or schema is touched; `band_profiles.photo_url` is read-only at every edited site.

## Verification

- [x] Tests: 954 pass, 0 failures (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors — 2 pre-existing warnings in `AdminPanel.jsx`/`UserManagement.jsx`
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] **The class is real, not just typed:** built CSS contains `object-position:50% 25%`. This mattered — Tailwind v4 matches whole class names in source *text*, so a value assembled from parts would emit no CSS and silently restore the centre crop with nothing observable at runtime.
- [x] **The guard bites:** reverting one site fails it with `expected [ 'pages/ArtistsPage.jsx:73' ] to deeply equal []`. Restored and re-ran green.
- [x] `make review` (CodeRabbit) run pre-open; its one finding taken — the range assertion (`0 < n < 50`) let the shared value drift to 40%, still "above centre" while putting the hero back on the midsections. Now pinned exactly.

**Judgement call worth flagging:** 25% is a heuristic, not per-photo truth. It is right for group and press shots, which is what this roster is. A photo composed with faces low (a wide crowd shot, a seated portrait) would still crop imperfectly. The durable answer is an admin-settable focal point — filed as #776 rather than built the night before a show.

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized band and artist photo cropping across profiles, cards, timelines, scheduling, and upload previews.
  - Adjusted image positioning to keep subjects better framed and consistently visible.
  - Improved the photo hero share button with clearer contrast, spacing, sizing, and interaction states.

- **Tests**
  - Added coverage to verify consistent photo-cropping behaviour throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
