### PR TITLE
fix(admin): freeze the roster's identity and action columns

### DIFF
--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -678,13 +678,26 @@ export default function RosterTab({ showToast, readOnly = false }) {
                 <thead className="bg-bg-navy/50 border-b border-accent-500/20">
                   <tr>
                     {!readOnly && (
-                      <th className="px-4 py-3 w-12 text-center align-middle">
-                        <input
-                          type="checkbox"
-                          className="cursor-pointer h-5 w-5 align-middle"
-                          onChange={e => handleSelectAll(e.target.checked)}
-                          checked={effectiveSelectedIds.size === filteredBands.length && filteredBands.length > 0}
-                        />
+                      <th className="sticky left-0 z-10 bg-bg-navy px-3 py-3 w-12 text-center align-middle">
+                        {/* The w-6 box is load-bearing, not decoration: it is what
+                            makes this column exactly the 3rem that `left-12` pins
+                            the Name column to. `w-12` alone does NOT survive —
+                            the table overflows its container, so the auto layout
+                            algorithm squeezes every column to its MINIMUM CONTENT
+                            width and discards the preferred width. Min-content
+                            here is the checkbox (20px) plus px-3 (24px) = 44px,
+                            which left a 4px sliver between the two frozen columns
+                            with the scrolling table visible through it. 24px + 24px
+                            lands on 48px exactly. Measured in a browser; jsdom has
+                            no layout and cannot catch a regression here. */}
+                        <div className="flex w-6 justify-center">
+                          <input
+                            type="checkbox"
+                            className="cursor-pointer h-5 w-5 align-middle"
+                            onChange={e => handleSelectAll(e.target.checked)}
+                            checked={effectiveSelectedIds.size === filteredBands.length && filteredBands.length > 0}
+                          />
+                        </div>
                       </th>
                     )}
                     <FilterableHeader
@@ -697,6 +710,12 @@ export default function RosterTab({ showToast, readOnly = false }) {
                       onToggleFilter={toggleFilterPanel}
                       triggerRef={filterRefs.name}
                       renderColumnFilterPanel={renderColumnFilterPanel}
+                      // Name is always the first sticky column after the (optional)
+                      // checkbox column -- its left offset must match the checkbox
+                      // column's actual rendered width (w-12 = 3rem) only when that
+                      // column exists. Hardcoding left-12 unconditionally would leave
+                      // a gap (or worse, overlap) when readOnly hides the checkbox.
+                      stickyClassName={`sticky z-10 bg-bg-navy ${readOnly ? 'left-0' : 'left-12'}`}
                     />
                     <FilterableHeader
                       sortKey="origin"
@@ -788,85 +807,118 @@ export default function RosterTab({ showToast, readOnly = false }) {
                       renderColumnFilterPanel={renderColumnFilterPanel}
                     />
                     {!readOnly && (
-                      <th className="px-4 py-3 text-right text-white font-semibold whitespace-nowrap align-middle">
+                      <th className="sticky right-0 z-10 bg-bg-navy px-3 py-3 text-right text-white font-semibold whitespace-nowrap align-middle">
                         Actions
                       </th>
                     )}
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-accent-500/10">
-                  {sortedBands.map(band => (
-                    <tr
-                      key={band.id}
-                      className={`hover:bg-bg-navy/30 transition-colors ${selectedIds.has(band.id) ? 'bg-blue-900/30' : ''}`}
-                    >
-                      {!readOnly && (
-                        <td className="px-4 py-3 text-center align-middle">
-                          <input
-                            type="checkbox"
-                            className="cursor-pointer h-5 w-5 align-middle"
-                            checked={selectedIds.has(band.id)}
-                            onChange={e => handleSelect(band.id, e.target.checked)}
-                          />
-                        </td>
-                      )}
-                      <td className="px-4 py-3 text-white font-medium">
-                        <div className="flex items-center gap-2">
-                          <a
-                            href={`/band/${band.band_profile_id || band.id?.toString().replace('profile_', '')}`}
-                            className="text-accent-400 hover:underline"
-                            target="_blank"
-                            rel="noreferrer"
+                  {sortedBands.map(band => {
+                    // Sticky cells (checkbox, Name, Actions) are opaque by necessity
+                    // (see below), which means they can't just inherit the <tr>'s own
+                    // translucent hover/selected background -- non-sticky cells would
+                    // show through a transparent sticky cell as the table scrolls
+                    // horizontally underneath it. Each sticky cell gets its own opaque
+                    // base (bg-bg-purple, matching the table's resting background) plus
+                    // an absolutely-positioned ::before tint layer (before:-z-10 keeps
+                    // it behind the cell's real content) driven by `group-hover:` (the
+                    // <tr> below carries `group`) and this row's own selected flag --
+                    // that's two independent translucent layers that can't both live on
+                    // one `background-color`, so this splits them across the cell's own
+                    // paint and the pseudo-element's. No `relative` here -- every caller
+                    // already applies `sticky`, which is itself a positioned element and
+                    // so already provides the containing block the `before:absolute`
+                    // pseudo needs; stacking `relative` alongside `sticky` on the same
+                    // element would leave the winner to Tailwind's internal class
+                    // ordering rather than source order, risking silently breaking the
+                    // sticky positioning entirely.
+                    const isSelected = selectedIds.has(band.id)
+                    const stickyCellClassName = `bg-bg-purple before:absolute before:inset-0 before:-z-10 before:content-[''] before:transition-colors group-hover:before:bg-bg-navy/30 ${isSelected ? 'before:bg-blue-900/30' : ''}`
+                    return (
+                      <tr
+                        key={band.id}
+                        className={`group hover:bg-bg-navy/30 transition-colors ${isSelected ? 'bg-blue-900/30' : ''}`}
+                      >
+                        {!readOnly && (
+                          <td
+                            className={`sticky left-0 z-10 px-3 py-3 w-12 text-center align-middle ${stickyCellClassName}`}
                           >
-                            {band.name}
-                          </a>
-                          {isInactive(band) && <InactiveBadge />}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-white/70">{formatOrigin(band) || '-'}</td>
-                      <td className="px-4 py-3 text-white/70">{band.genre || '-'}</td>
-                      <td className="px-4 py-3 text-white/70">{band.next_event_name || '-'}</td>
-                      <td className="px-4 py-3 text-white/70">{band.last_event_name || '-'}</td>
-                      <td className="px-4 py-3 text-white/70">
-                        <span
-                          className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold ${
-                            isInactive(band) ? 'bg-gray-700 text-white/80' : 'bg-emerald-600/20 text-emerald-200'
-                          }`}
-                        >
-                          {isInactive(band) ? 'Inactive' : 'Active'}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3">
-                        <SocialLinksIcons band={band} />
-                      </td>
-                      <td className="px-4 py-3 text-white/70">{band.contact_email || '-'}</td>
-                      <td className="px-4 py-3 text-right text-white/70">
-                        {band.follower_count > 0 ? (
-                          <span className="inline-flex items-center rounded-full bg-accent-500/15 px-2 py-1 text-xs font-semibold text-accent-300">
-                            {band.follower_count}
-                          </span>
-                        ) : (
-                          <span className="text-white/30">0</span>
+                            {/* Must match the header's w-6 box — see the comment
+                                there. Both cells share one column, so a mismatch
+                                reopens the 4px gap. */}
+                            <div className="flex w-6 justify-center">
+                              <input
+                                type="checkbox"
+                                className="cursor-pointer h-5 w-5 align-middle"
+                                checked={isSelected}
+                                onChange={e => handleSelect(band.id, e.target.checked)}
+                              />
+                            </div>
+                          </td>
                         )}
-                      </td>
-                      {!readOnly && (
-                        <td className="px-4 py-3 flex justify-end gap-2">
-                          <button
-                            onClick={() => startEdit(band)}
-                            className="px-4 py-2 min-h-[44px] bg-amber-700 hover:bg-amber-800 text-white rounded text-sm"
-                          >
-                            Edit
-                          </button>
-                          <button
-                            onClick={() => handleDelete(band.id, band.name)}
-                            className="px-4 py-2 min-h-[44px] bg-red-600 hover:bg-red-700 text-white rounded text-sm"
-                          >
-                            Delete
-                          </button>
+                        <td
+                          className={`sticky ${readOnly ? 'left-0' : 'left-12'} z-10 px-3 py-3 text-white font-medium ${stickyCellClassName}`}
+                        >
+                          <div className="flex items-center gap-2">
+                            <a
+                              href={`/band/${band.band_profile_id || band.id?.toString().replace('profile_', '')}`}
+                              className="text-accent-400 hover:underline"
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              {band.name}
+                            </a>
+                            {isInactive(band) && <InactiveBadge />}
+                          </div>
                         </td>
-                      )}
-                    </tr>
-                  ))}
+                        <td className="px-3 py-3 text-white/70">{formatOrigin(band) || '-'}</td>
+                        <td className="px-3 py-3 text-white/70">{band.genre || '-'}</td>
+                        <td className="px-3 py-3 text-white/70 max-w-[10rem]">{band.next_event_name || '-'}</td>
+                        <td className="px-3 py-3 text-white/70 max-w-[10rem]">{band.last_event_name || '-'}</td>
+                        <td className="px-3 py-3 text-white/70">
+                          <span
+                            className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold ${
+                              isInactive(band) ? 'bg-gray-700 text-white/80' : 'bg-emerald-600/20 text-emerald-200'
+                            }`}
+                          >
+                            {isInactive(band) ? 'Inactive' : 'Active'}
+                          </span>
+                        </td>
+                        <td className="px-3 py-3">
+                          <SocialLinksIcons band={band} />
+                        </td>
+                        <td className="px-3 py-3 text-white/70">{band.contact_email || '-'}</td>
+                        <td className="px-3 py-3 text-right text-white/70">
+                          {band.follower_count > 0 ? (
+                            <span className="inline-flex items-center rounded-full bg-accent-500/15 px-2 py-1 text-xs font-semibold text-accent-300">
+                              {band.follower_count}
+                            </span>
+                          ) : (
+                            <span className="text-white/30">0</span>
+                          )}
+                        </td>
+                        {!readOnly && (
+                          <td className={`sticky right-0 z-10 px-3 py-3 ${stickyCellClassName}`}>
+                            <div className="flex justify-end gap-2">
+                              <button
+                                onClick={() => startEdit(band)}
+                                className="px-4 py-2 min-h-[44px] bg-amber-700 hover:bg-amber-800 text-white rounded text-sm"
+                              >
+                                Edit
+                              </button>
+                              <button
+                                onClick={() => handleDelete(band.id, band.name)}
+                                className="px-4 py-2 min-h-[44px] bg-red-600 hover:bg-red-700 text-white rounded text-sm"
+                              >
+                                Delete
+                              </button>
+                            </div>
+                          </td>
+                        )}
+                      </tr>
+                    )
+                  })}
                 </tbody>
               </table>
             </div>

--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -614,7 +614,13 @@ export default function RosterTab({ showToast, readOnly = false }) {
 
       {/* Bulk Actions */}
       {!readOnly && effectiveSelectedIds.size > 0 && (
-        <div className="bg-bg-navy/80 p-4 rounded border border-accent-500/30 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sticky top-20 z-10 backdrop-blur-md">
+        /* z-20, not z-10: the frozen columns below are z-10 and come LATER in
+           DOM order, so on an equal z-index they would win the paint order and
+           cover this bar's action select and Apply button exactly when a
+           selection is active. Nothing isolates the two subtrees — the table
+           wrapper's `overflow-hidden` does not create a stacking context. Keep
+           this strictly above the sticky cells. */
+        <div className="bg-bg-navy/80 p-4 rounded border border-accent-500/30 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sticky top-20 z-20 backdrop-blur-md">
           <span className="text-white font-medium">
             {effectiveSelectedIds.size} selected
             {hiddenSelectedCount > 0 && (

--- a/frontend/src/admin/RosterTab.jsx
+++ b/frontend/src/admin/RosterTab.jsx
@@ -693,6 +693,7 @@ export default function RosterTab({ showToast, readOnly = false }) {
                         <div className="flex w-6 justify-center">
                           <input
                             type="checkbox"
+                            aria-label="Select all visible artists"
                             className="cursor-pointer h-5 w-5 align-middle"
                             onChange={e => handleSelectAll(e.target.checked)}
                             checked={effectiveSelectedIds.size === filteredBands.length && filteredBands.length > 0}
@@ -850,6 +851,7 @@ export default function RosterTab({ showToast, readOnly = false }) {
                             <div className="flex w-6 justify-center">
                               <input
                                 type="checkbox"
+                                aria-label={`Select ${band.name}`}
                                 className="cursor-pointer h-5 w-5 align-middle"
                                 checked={isSelected}
                                 onChange={e => handleSelect(band.id, e.target.checked)}

--- a/frontend/src/admin/__tests__/RosterTab.test.jsx
+++ b/frontend/src/admin/__tests__/RosterTab.test.jsx
@@ -722,7 +722,7 @@ describe('RosterTab — bulk actions scope to visible rows (#711)', () => {
     // Select all 3 bands (no filter)
     const selectAllCheckbox = screen
       .getAllByRole('checkbox')
-      .find(cb => cb.parentElement.parentElement === screen.getAllByRole('row')[0])
+      .find(cb => cb.closest('tr') === screen.getAllByRole('row')[0])
     fireEvent.click(selectAllCheckbox)
     expect(screen.getAllByText(/3 selected/)).toBeDefined()
 
@@ -807,7 +807,7 @@ describe('RosterTab — bulk actions scope to visible rows (#711)', () => {
     // Select all 3
     const selectAllCheckbox = screen
       .getAllByRole('checkbox')
-      .find(cb => cb.parentElement.parentElement === screen.getAllByRole('row')[0])
+      .find(cb => cb.closest('tr') === screen.getAllByRole('row')[0])
     fireEvent.click(selectAllCheckbox)
 
     // Apply filter that hides 1 row
@@ -830,7 +830,7 @@ describe('RosterTab — bulk actions scope to visible rows (#711)', () => {
     // Select all 3
     const selectAllCheckbox = screen
       .getAllByRole('checkbox')
-      .find(cb => cb.parentElement.parentElement === screen.getAllByRole('row')[0])
+      .find(cb => cb.closest('tr') === screen.getAllByRole('row')[0])
     fireEvent.click(selectAllCheckbox)
 
     // Apply filter
@@ -979,5 +979,107 @@ describe('RosterTab — mobile Filters button', () => {
 
     // Assert no duplicates: Set size must equal array length
     expect(ids.length).toBe(new Set(ids).size)
+  })
+})
+
+// #772 — the desktop table's intrinsic width exceeds the container, so it
+// scrolls horizontally. Without pinning, scrolling right to reach Actions
+// takes Name out of view -- a row with a live Delete button and no visible
+// artist name. `getByRole('columnheader'/'row')` only matches the desktop
+// <table> (the mobile branch is div-based with no table roles), so these
+// selectors are unambiguous without the getAllBy*/queryAllBy* workaround
+// the rest of this file needs.
+describe('RosterTab — sticky identity + actions columns (#772)', () => {
+  it('pins the Name header to the right of the checkbox column (left-12) and Actions to the right edge', async () => {
+    bandsApi.getAll.mockResolvedValue({ bands: [ACTIVE_BAND, INACTIVE_BAND] })
+    render(<RosterTab showToast={vi.fn()} />)
+    await screen.findAllByText('Active Aardvarks')
+
+    const nameHeader = screen.getByRole('columnheader', { name: /^Name/ })
+    expect(nameHeader.className).toMatch(/\bsticky\b/)
+    expect(nameHeader.className).toMatch(/\bleft-12\b/)
+    expect(nameHeader.className).not.toMatch(/\bleft-0\b/)
+
+    const actionsHeader = screen.getByRole('columnheader', { name: 'Actions' })
+    expect(actionsHeader.className).toMatch(/\bsticky\b/)
+    expect(actionsHeader.className).toMatch(/\bright-0\b/)
+  })
+
+  it('readOnly: Name sticks to the left edge (left-0) since there is no checkbox column, and Actions is absent', async () => {
+    bandsApi.getAll.mockResolvedValue({ bands: [ACTIVE_BAND] })
+    render(<RosterTab showToast={vi.fn()} readOnly />)
+    await screen.findAllByText('Active Aardvarks')
+
+    // No checkbox column in read-only mode -- Name is the first column.
+    const headerRow = screen.getAllByRole('row')[0]
+    expect(headerRow.querySelector('input[type="checkbox"]')).toBeNull()
+
+    const nameHeader = screen.getByRole('columnheader', { name: /^Name/ })
+    expect(nameHeader.className).toMatch(/\bsticky\b/)
+    expect(nameHeader.className).toMatch(/\bleft-0\b/)
+    expect(nameHeader.className).not.toMatch(/\bleft-12\b/)
+
+    // Actions only renders when !readOnly.
+    expect(screen.queryByRole('columnheader', { name: 'Actions' })).toBeNull()
+  })
+
+  it('gives the body Name cell a sticky, opaque background so the artist stays identifiable while scrolled', async () => {
+    bandsApi.getAll.mockResolvedValue({ bands: [ACTIVE_BAND] })
+    render(<RosterTab showToast={vi.fn()} />)
+    await screen.findAllByText('Active Aardvarks')
+
+    // The mobile card list renders a same-named link too -- narrow to the
+    // one living inside a <td> (the desktop table).
+    const nameLink = screen
+      .getAllByRole('link', { name: 'Active Aardvarks' })
+      .map(el => el.closest('td'))
+      .find(Boolean)
+    expect(nameLink).not.toBeNull()
+    expect(nameLink.className).toMatch(/\bsticky\b/)
+    expect(nameLink.className).toMatch(/\bleft-12\b/)
+    expect(nameLink.className).toMatch(/\bbg-bg-purple\b/)
+  })
+
+  it('gives the body Actions cell a sticky right-0 position, and moves the flex layout off the <td> onto an inner wrapper', async () => {
+    bandsApi.getAll.mockResolvedValue({ bands: [ACTIVE_BAND] })
+    render(<RosterTab showToast={vi.fn()} />)
+    await screen.findAllByText('Active Aardvarks')
+
+    const editButton = screen
+      .getAllByRole('button', { name: 'Edit' })
+      .map(el => el.closest('td'))
+      .find(Boolean)
+    expect(editButton).not.toBeNull()
+    expect(editButton.className).toMatch(/\bsticky\b/)
+    expect(editButton.className).toMatch(/\bright-0\b/)
+    // The <td> itself must NOT carry `flex` -- that was the bug (#772):
+    // display:flex on a <td> drops it out of the table layout algorithm and
+    // fights sticky positioning. The flex wrapper is an inner <div> instead.
+    expect(editButton.className).not.toMatch(/(?:^|\s)flex(?:\s|$)/)
+    expect(editButton.querySelector(':scope > div.flex')).not.toBeNull()
+  })
+
+  // Sticky cells are opaque (bg-bg-purple) so scrolled content can't show
+  // through, which means the row's own translucent hover/selected
+  // background-color can't just paint on the cell directly -- the fix
+  // splits it onto a `before:` pseudo-element tint layer instead. This
+  // proves the selected half of that split actually toggles per-row.
+  it('the sticky Name cell carries the selected-tint class only once its row is selected', async () => {
+    bandsApi.getAll.mockResolvedValue({ bands: [ACTIVE_BAND] })
+    render(<RosterTab showToast={vi.fn()} />)
+    await screen.findAllByText('Active Aardvarks')
+
+    const getNameCell = () =>
+      screen
+        .getAllByRole('link', { name: 'Active Aardvarks' })
+        .map(el => el.closest('td'))
+        .find(Boolean)
+
+    expect(getNameCell().className).not.toMatch(/before:bg-blue-900\/30/)
+
+    const bodyRow = screen.getAllByRole('row').find(r => r.textContent.includes('Active Aardvarks'))
+    fireEvent.click(bodyRow.querySelector('input[type="checkbox"]'))
+
+    expect(getNameCell().className).toMatch(/before:bg-blue-900\/30/)
   })
 })

--- a/frontend/src/admin/__tests__/RosterTab.test.jsx
+++ b/frontend/src/admin/__tests__/RosterTab.test.jsx
@@ -720,9 +720,13 @@ describe('RosterTab — bulk actions scope to visible rows (#711)', () => {
     await screen.findAllByText('Band A')
 
     // Select all 3 bands (no filter)
-    const selectAllCheckbox = screen
-      .getAllByRole('checkbox')
-      .find(cb => cb.closest('tr') === screen.getAllByRole('row')[0])
+    // Query by accessible name rather than walking the DOM to the header row:
+    // a structural walk silently yields undefined when the markup shifts (a
+    // wrapper div was enough to break it), and fireEvent then fails with
+    // "please provide a DOM element" instead of naming the real problem. The
+    // mobile card list's select-all is named "Select all", so this is
+    // unambiguous.
+    const selectAllCheckbox = screen.getByRole('checkbox', { name: 'Select all visible artists' })
     fireEvent.click(selectAllCheckbox)
     expect(screen.getAllByText(/3 selected/)).toBeDefined()
 
@@ -805,9 +809,13 @@ describe('RosterTab — bulk actions scope to visible rows (#711)', () => {
     await screen.findAllByText('Band A')
 
     // Select all 3
-    const selectAllCheckbox = screen
-      .getAllByRole('checkbox')
-      .find(cb => cb.closest('tr') === screen.getAllByRole('row')[0])
+    // Query by accessible name rather than walking the DOM to the header row:
+    // a structural walk silently yields undefined when the markup shifts (a
+    // wrapper div was enough to break it), and fireEvent then fails with
+    // "please provide a DOM element" instead of naming the real problem. The
+    // mobile card list's select-all is named "Select all", so this is
+    // unambiguous.
+    const selectAllCheckbox = screen.getByRole('checkbox', { name: 'Select all visible artists' })
     fireEvent.click(selectAllCheckbox)
 
     // Apply filter that hides 1 row
@@ -828,9 +836,13 @@ describe('RosterTab — bulk actions scope to visible rows (#711)', () => {
     await screen.findAllByText('Band A')
 
     // Select all 3
-    const selectAllCheckbox = screen
-      .getAllByRole('checkbox')
-      .find(cb => cb.closest('tr') === screen.getAllByRole('row')[0])
+    // Query by accessible name rather than walking the DOM to the header row:
+    // a structural walk silently yields undefined when the markup shifts (a
+    // wrapper div was enough to break it), and fireEvent then fails with
+    // "please provide a DOM element" instead of naming the real problem. The
+    // mobile card list's select-all is named "Select all", so this is
+    // unambiguous.
+    const selectAllCheckbox = screen.getByRole('checkbox', { name: 'Select all visible artists' })
     fireEvent.click(selectAllCheckbox)
 
     // Apply filter
@@ -1045,18 +1057,24 @@ describe('RosterTab — sticky identity + actions columns (#772)', () => {
     render(<RosterTab showToast={vi.fn()} />)
     await screen.findAllByText('Active Aardvarks')
 
-    const editButton = screen
+    const actionsCell = screen
       .getAllByRole('button', { name: 'Edit' })
       .map(el => el.closest('td'))
       .find(Boolean)
-    expect(editButton).not.toBeNull()
-    expect(editButton.className).toMatch(/\bsticky\b/)
-    expect(editButton.className).toMatch(/\bright-0\b/)
+    expect(actionsCell).not.toBeNull()
+    expect(actionsCell.className).toMatch(/\bsticky\b/)
+    expect(actionsCell.className).toMatch(/\bright-0\b/)
     // The <td> itself must NOT carry `flex` -- that was the bug (#772):
     // display:flex on a <td> drops it out of the table layout algorithm and
     // fights sticky positioning. The flex wrapper is an inner <div> instead.
-    expect(editButton.className).not.toMatch(/(?:^|\s)flex(?:\s|$)/)
-    expect(editButton.querySelector(':scope > div.flex')).not.toBeNull()
+    expect(actionsCell.className).not.toMatch(/(?:^|\s)flex(?:\s|$)/)
+    // Walk children directly rather than querySelector(':scope > …') — :scope
+    // support varies across DOM implementations, and this asserts the same
+    // thing without depending on it.
+    const flexWrapper = Array.from(actionsCell.children).find(
+      child => child.tagName === 'DIV' && child.classList.contains('flex')
+    )
+    expect(flexWrapper).toBeDefined()
   })
 
   // Sticky cells are opaque (bg-bg-purple) so scrolled content can't show

--- a/frontend/src/admin/components/FilterableHeader.jsx
+++ b/frontend/src/admin/components/FilterableHeader.jsx
@@ -51,11 +51,22 @@ export default function FilterableHeader({
   onToggleFilter,
   triggerRef,
   renderColumnFilterPanel,
+  stickyClassName = '',
 }) {
+  // Sticky columns (Name, pinned to the left edge of the roster's horizontal
+  // scroll container -- #772) need `position: sticky` plus an opaque
+  // background and z-index instead of the default `relative` (which exists
+  // only to anchor the filter dropdown panel below). `sticky` is itself a
+  // valid containing block for the panel's `absolute` positioning, so this
+  // is a full replacement, never both at once -- stacking two `position`
+  // utilities on one element leaves the winner to Tailwind's internal class
+  // ordering rather than source order, and if `relative` won the column
+  // would silently stop sticking.
+  const positionClassName = stickyClassName || 'relative'
   const thClassName =
     align === 'right'
-      ? 'relative px-4 py-3 text-right text-white font-semibold whitespace-nowrap align-middle'
-      : 'relative px-4 py-3 text-left text-white font-semibold whitespace-nowrap align-middle'
+      ? `${positionClassName} px-3 py-3 text-right text-white font-semibold whitespace-nowrap align-middle`
+      : `${positionClassName} px-3 py-3 text-left text-white font-semibold whitespace-nowrap align-middle`
   const wrapperClassName = align === 'right' ? 'flex items-center justify-end gap-1' : 'flex items-center gap-1'
 
   return (
@@ -92,4 +103,5 @@ FilterableHeader.propTypes = {
   onToggleFilter: PropTypes.func.isRequired,
   triggerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
   renderColumnFilterPanel: PropTypes.func.isRequired,
+  stickyClassName: PropTypes.string,
 }


### PR DESCRIPTION
## Summary

The Global Artist Roster renders 11 columns in a container narrower than they need, so the table scrolled horizontally and **Actions** and **Followers** sat off-screen.

The reported symptom was the scrolling. The dangerous part was the consequence: scrolling right to reach Actions took the **Name** column with it, leaving a row with a red **Delete** button and nothing on screen to say which artist it belonged to.

This pins the checkbox + Name columns to the left edge and Actions to the right, so identity and actions are both always visible at any width. Mobile is untouched — `md:hidden` renders a card list, not this table.

Closes #772

## What changed

| File | Change |
|------|--------|
| `admin/RosterTab.jsx` | Sticky left (checkbox + Name) and sticky right (Actions); `flex` moved off the `<td>`; `px-4`→`px-3`; event-name columns capped; accessible names on the selection checkboxes |
| `admin/components/FilterableHeader.jsx` | New `stickyClassName` prop, replacing `relative` rather than stacking with it |
| `admin/__tests__/RosterTab.test.jsx` | 5 new tests; 3 brittle selectors retired |

## The translucent-background problem

Sticky cells are transparent by default, so the scrolling table shows through them. Both row-state backgrounds — `hover:bg-bg-navy/30` and selected `bg-blue-900/30` — are **translucent**, and one element gets one `background-color`, so they cannot simply be layered onto an opaque base.

Each sticky cell paints an opaque `bg-bg-purple` base and carries the state tint on a `::before` layer driven by the row's `group`. The cells already set `z-10`, so `position: sticky` + a real `z-index` establishes a stacking context — which is what makes `before:-z-10` paint *above* the cell's own background but *below* its text. `relative` is deliberately never stacked alongside `sticky`; two position utilities on one element leaves the winner to Tailwind's class ordering, and if `relative` won the column would silently stop sticking.

## The 4px gap only a browser could find

`w-12` on the checkbox column does **not** hold. The table overflows its container, so the auto layout algorithm squeezes every column to its **minimum content width** and discards the preferred width. The column measured **44px** (checkbox 20px + `px-3` 24px) while Name stayed pinned at `left-12` = **48px** — leaving a 4px sliver between the two frozen columns with the scrolling table visible through it.

Probing that seam in a real browser returned `"Brantford, ON"` — content from a column that was supposed to be underneath.

Wrapping the checkbox in a `w-6` box makes min-content 24+24 = exactly the 48px `left-12` assumes. Measured before and after:

| | checkbox col | gap | element at the seam |
|---|---|---|---|
| Before | 44px | **4px** | `TD | Brantford, ON` (scrolling) |
| After | 48px | **0px** | `Alert the Audience` (frozen) |

`min-w-12` was tried first and does nothing — min-width does not override the minimum-content squeeze here.

**jsdom has no layout, so no unit test can catch this class.** It was found by rendering the real compiled CSS in Chrome. That is called out in a comment at the site, since the next person to touch the padding will reopen it.

## Security / correctness notes

None. Presentational — no auth, no request/response shape, no schema change.

## Verification

- [x] Tests: 956 pass, 0 failures (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors — 2 pre-existing warnings in `AdminPanel.jsx`/`UserManagement.jsx`
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] **Browser-verified**: sticky offsets, gap closure, and the `::before` tint measured against the real compiled CSS, not just asserted in jsdom
- [x] `make review` (CodeRabbit) run pre-open; its finding taken — the selection checkboxes had no accessible name

**Three brittle selectors retired.** The existing tests walked `parentElement.parentElement` from checkbox to row and broke the moment a wrapper appeared. `closest('tr')` is depth-independent and cannot break the same way.

**Scope note:** a wider admin a11y sweep is warranted but deliberately not in this PR — filed as #777, because the obvious regex for it is wrong (`<input[^>]*>` is truncated by the `>` in any `onChange={e => …}`, so it reports already-labelled checkboxes as unlabelled). That needs a JSX-aware check.

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved roster table navigation with frozen selection, Name, and Actions columns during horizontal scrolling.
  * Added clearer hover and selected-row highlighting with consistent sticky-cell backgrounds.
  * Improved checkbox alignment and spacing across table headers and rows.
  * Preserved roster details, badges, links, contact information, follower counts, and row actions.
  * Enhanced read-only layout behaviour for the roster table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->