### PR TITLE
perf(api): cut the cache TTL on endpoints that change during a show

### DIFF
--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -1,4 +1,5 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
+import { CACHE_SHOW_CRITICAL } from "../../../utils/cacheHeaders.js";
 import { normalizeBandName } from "../../../utils/bandName.js";
 import { safeReflectSocialLinks } from "../../../utils/validation.js";
 import { eventLocalFestivalToday } from "../../../utils/eventDay.js";
@@ -306,7 +307,7 @@ export async function onRequestGet(context) {
       status: 200,
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, max-age=300",
+        "Cache-Control": CACHE_SHOW_CRITICAL,
       },
     });
   } catch (error) {

--- a/functions/api/events/[id]/details.js
+++ b/functions/api/events/[id]/details.js
@@ -1,4 +1,5 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
+import { CACHE_SHOW_CRITICAL } from "../../../utils/cacheHeaders.js";
 import { normalizeHttpUrl, validateId } from "../../../utils/validation.js";
 
 /**
@@ -159,7 +160,7 @@ export async function onRequestGet(context) {
         status: 200,
         headers: {
           "Content-Type": "application/json",
-          "Cache-Control": "public, max-age=300",
+          "Cache-Control": CACHE_SHOW_CRITICAL,
         },
       },
     );

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -228,7 +228,12 @@ describe("Timeline API - Optimized JOIN Queries", () => {
       const response = await onRequestGet(mockContext);
 
       expect(response.headers.get("Content-Type")).toBe("application/json");
-      expect(response.headers.get("Cache-Control")).toBe("public, max-age=300");
+      // Pinned to the literal, not to the imported constant: asserting a
+      // constant equals itself would pass no matter what the value became.
+      // The TTL is the point — this endpoint drives "Happening Now", so a set
+      // cancelled mid-show must not stay visible for five minutes. If someone
+      // raises max-age here, this test is the thing that should stop them.
+      expect(response.headers.get("Cache-Control")).toBe("public, max-age=60, stale-while-revalidate=300");
     });
 
     it("should return 200 status on success", async () => {

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -233,7 +233,11 @@ describe("Timeline API - Optimized JOIN Queries", () => {
       // The TTL is the point — this endpoint drives "Happening Now", so a set
       // cancelled mid-show must not stay visible for five minutes. If someone
       // raises max-age here, this test is the thing that should stop them.
-      expect(response.headers.get("Cache-Control")).toBe("public, max-age=60, stale-while-revalidate=300");
+      expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+      // And it must not acquire stale-while-revalidate: inside the SWR window a
+      // cache serves the STALE body and revalidates async (RFC 5861), so a fan
+      // opening the page once would still see a cancelled set as playing.
+      expect(response.headers.get("Cache-Control")).not.toMatch(/stale-while-revalidate/);
     });
 
     it("should return 200 status on success", async () => {

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -1,4 +1,5 @@
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
+import { CACHE_SHOW_CRITICAL } from "../../utils/cacheHeaders.js";
 import { normalizeHttpUrl } from "../../utils/validation.js";
 import { eventLocalToday, eventLocalFestivalToday, eventLocalClock } from "../../utils/eventDay.js";
 
@@ -528,7 +529,7 @@ export async function onRequestGet(context) {
       status: 200,
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, max-age=300", // Cache for 5 minutes
+        "Cache-Control": CACHE_SHOW_CRITICAL,
       },
     });
   } catch (error) {

--- a/functions/api/venues/[id].js
+++ b/functions/api/venues/[id].js
@@ -5,6 +5,7 @@
 // archived events). Gated by PUBLIC_DATA_PUBLISH_ENABLED.
 
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
+import { CACHE_SHOW_CRITICAL } from "../../utils/cacheHeaders.js";
 import { validateId } from "../../utils/validation.js";
 import { eventLocalFestivalToday } from "../../utils/eventDay.js";
 
@@ -142,7 +143,7 @@ export async function onRequestGet(context) {
         past: all.filter(isPast).map(mapPerf),
       },
       200,
-      { "Cache-Control": "public, max-age=300" },
+      { "Cache-Control": CACHE_SHOW_CRITICAL },
     );
   } catch (error) {
     console.error("Error fetching venue:", error);

--- a/functions/utils/cacheHeaders.js
+++ b/functions/utils/cacheHeaders.js
@@ -1,0 +1,35 @@
+/**
+ * Cache-Control values for public GET responses.
+ *
+ * Two tiers, split by one question: **can this change while a show is running?**
+ *
+ * During an event the operator cancels sets, moves times, and swaps venues from
+ * the admin (see docs/SHOW_DAY_RUNBOOK.md). Every second of TTL on a response
+ * that carries live show state is a second a fan can be standing at the wrong
+ * venue. These endpoints all sat at 300s while `api/schedule.js` — the busiest
+ * of them — had already been dropped to 60s and made env-tunable. That gap was
+ * an oversight, not a decision.
+ *
+ * `stale-while-revalidate` is what makes the shorter TTL cheap: past 60s the
+ * client still paints instantly from cache and refreshes in the background, so
+ * a correction lands within about a minute without the origin taking a
+ * thundering-herd of blocking revalidations.
+ *
+ * Note these are currently **browser** caches, not edge ones — Cloudflare
+ * returns `cf-cache-status: DYNAMIC` for Pages Functions responses, so nothing
+ * is held at the edge. Shortening the TTL therefore costs no CDN efficiency; it
+ * only narrows the window a single client can hold a stale copy.
+ */
+
+/**
+ * Anything rendering live show state: what is on now, what is next, set times,
+ * cancellations, venue assignments.
+ */
+export const CACHE_SHOW_CRITICAL = "public, max-age=60, stale-while-revalidate=300";
+
+/**
+ * Browse and discovery surfaces that do not change mid-show — event lists,
+ * artist and venue indexes, aggregate stats. A stale minute here costs nothing,
+ * so these keep the longer TTL.
+ */
+export const CACHE_BROWSE = "public, max-age=300";

--- a/functions/utils/cacheHeaders.js
+++ b/functions/utils/cacheHeaders.js
@@ -10,22 +10,30 @@
  * of them — had already been dropped to 60s and made env-tunable. That gap was
  * an oversight, not a decision.
  *
- * `stale-while-revalidate` is what makes the shorter TTL cheap: past 60s the
- * client still paints instantly from cache and refreshes in the background, so
- * a correction lands within about a minute without the origin taking a
- * thundering-herd of blocking revalidations.
+ * **No `stale-while-revalidate` here, deliberately.** It is the obvious thing
+ * to reach for and it is wrong for this purpose. Inside the SWR window a cache
+ * serves the STALE response and revalidates asynchronously (RFC 5861), so the
+ * fresh body only reaches the *next* request. A fan who opens the page once —
+ * which is the normal case — would still read the cancelled set as playing, and
+ * `max-age=60, stale-while-revalidate=300` would let that happen for up to 360s:
+ * worse than the 300s this change exists to fix. Plain `max-age` blocks and
+ * returns fresh data instead. SWR optimises latency; the goal here is freshness,
+ * and the two pull in opposite directions.
+ *
+ * The 60s also matches `api/schedule.js`, which already defaults there.
  *
  * Note these are currently **browser** caches, not edge ones — Cloudflare
  * returns `cf-cache-status: DYNAMIC` for Pages Functions responses, so nothing
  * is held at the edge. Shortening the TTL therefore costs no CDN efficiency; it
- * only narrows the window a single client can hold a stale copy.
+ * only narrows the window a single client can hold a stale copy, and the extra
+ * revalidations land on an origin that was already serving every request.
  */
 
 /**
  * Anything rendering live show state: what is on now, what is next, set times,
  * cancellations, venue assignments.
  */
-export const CACHE_SHOW_CRITICAL = "public, max-age=60, stale-while-revalidate=300";
+export const CACHE_SHOW_CRITICAL = "public, max-age=60";
 
 /**
  * Browse and discovery surfaces carrying no live performance state — event

--- a/functions/utils/cacheHeaders.js
+++ b/functions/utils/cacheHeaders.js
@@ -28,8 +28,13 @@
 export const CACHE_SHOW_CRITICAL = "public, max-age=60, stale-while-revalidate=300";
 
 /**
- * Browse and discovery surfaces that do not change mid-show — event lists,
- * artist and venue indexes, aggregate stats. A stale minute here costs nothing,
- * so these keep the longer TTL.
+ * Browse and discovery surfaces carrying no live performance state — event
+ * lists, artist and venue indexes, aggregate-only stats. A stale minute here
+ * costs nothing, so these keep the longer TTL.
+ *
+ * "Stats" alone is not the test: `api/bands/stats/[name].js` is named for its
+ * aggregates but also returns upcoming and past performances, cancellations and
+ * venue assignments, so it belongs to CACHE_SHOW_CRITICAL. Any response that
+ * carries live performance state does, whatever it is called.
  */
 export const CACHE_BROWSE = "public, max-age=300";


### PR DESCRIPTION
## Summary

A set cancelled or moved mid-show could stay on fans' screens for up to **five minutes**.

Every public endpoint carrying live show state was `max-age=300`, while `api/schedule.js` — the busiest of them — had already been dropped to 60s and made env-tunable via `SCHEDULE_CACHE_TTL_SECONDS`. That gap was an oversight, not a decision.

Found while diagnosing a report that artist link edits "weren't instant". The links turned out to be fine — the data was correct in D1 and served correctly — but the same 300s TTL sat on the endpoints that matter on show day, with Buddies Fest 2 tomorrow.

## What changed

Four endpoints move from `max-age=300` to `max-age=60`:

| Endpoint | Why it's show-critical |
|---|---|
| `events/timeline` | "Happening Now" / up next |
| `events/[id]/details` | lineup and set times |
| `venues/[id]` | which acts are at this venue |
| `bands/stats/[name]` | the artist profile page's own source |

**No `stale-while-revalidate`, deliberately** (caught by Copilot review). It is the reflex reach for "shorter TTL without more origin load" and it is wrong here: inside the SWR window a cache serves the *stale* body and revalidates asynchronously (RFC 5861), so the fresh response only reaches the *next* request. A fan opening the page once would still read a cancelled set as playing — and `max-age=60, stale-while-revalidate=300` permits that for up to 360s, longer than the 300s this PR exists to fix. Plain `max-age=60` blocks and returns fresh data at t=61s. SWR optimises latency; this needs freshness.

**It costs no CDN efficiency at all.** Cloudflare returns `cf-cache-status: DYNAMIC` for Pages Functions responses, so nothing was being held at the edge in the first place — verified against production. This only narrows how long a single client can hold a stale copy.

## Deliberately NOT changed

Sweeping all 20 `Cache-Control` sites mattered more than fixing the two I first noticed:

- **Browse surfaces** (events list, artists, venues index, public stats, `ssrMeta`) stay at 300s — they don't change mid-show.
- **`ical` (3600) and `recap` (3600)** stay — calendar clients poll on their own schedule, and a recap is of a finished event.
- **`s/[slug].js` (300)** stays. It's the HTML shell carrying OG meta for social crawlers, not show data — and the share *data* endpoint it loads sets no `Cache-Control` at all, so a fan reopening a shared link already gets fresh performances.

The value lives in **one shared constant** rather than a fifth literal, so the tiers can't drift apart the way these four drifted from `schedule.js`.

## Security / correctness notes

None. Response headers only — no body, status, route, query, or schema changes. No auth or data-integrity surface touched.

## Verification

- [x] Tests: 965 pass, 6 todo, 0 failures (`npm test`)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`)
- [x] Build: N/A — no frontend change
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] Verified against production that these endpoints return `cf-cache-status: DYNAMIC`, so the "no CDN cost" claim is measured rather than assumed
- [x] `make review` (CodeRabbit) run pre-open; its finding taken

**The timeline test caught this change by asserting the old value** — which is what a good test should do. Updated to pin the new one, deliberately to the *literal* rather than the imported constant: asserting a constant equals itself would pass whatever the value became. That test is now the tripwire for all four endpoints, since they share the constant.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved freshness for live event, band, timeline, and venue information.
  * Live responses now refresh after 60 seconds without serving stale content, helping keep time-sensitive details accurate.
  * Browse and discovery responses continue to use a five-minute cache period.
* **Tests**
  * Updated cache behaviour checks to reflect the new live-data refresh policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
