### PR TITLE
fix(home): space the browse links so the arrow stops touching the next icon

### DIFF
--- a/frontend/src/pages/EventsPage.jsx
+++ b/frontend/src/pages/EventsPage.jsx
@@ -80,20 +80,31 @@ export default function EventsPage() {
               <span className="text-accent-500">Set</span>Times
             </h1>
             <p className="text-lg text-accent-400">Discover · Plan · Experience</p>
-            <Link
-              to="/artists"
-              className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-accent-400 transition-colors hover:text-accent-300"
-            >
-              <Users size={15} aria-hidden="true" /> Browse all artists
-              <ArrowRight size={12} aria-hidden="true" />
-            </Link>
-            <Link
-              to="/venues"
-              className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-accent-400 transition-colors hover:text-accent-300"
-            >
-              <MapPin size={15} aria-hidden="true" /> Browse venues
-              <ArrowRight size={12} aria-hidden="true" />
-            </Link>
+            {/* One flex row owning the space BETWEEN the links, rather than two
+                inline-flex siblings separated only by collapsed JSX whitespace.
+                That whitespace is a single space (~4px) while each link's own
+                gap-1.5 is 6px — so the space between the groups was smaller
+                than the space inside them, and the first link's arrow read as
+                belonging to the second link's pin. gap-x-5 (20px) puts the
+                grouping the right way round. flex-wrap + gap-y keeps them
+                readable if they wrap on a narrow screen, which the old inline
+                layout handled badly (mt-3 applied to each link separately). */}
+            <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2">
+              <Link
+                to="/artists"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-accent-400 transition-colors hover:text-accent-300"
+              >
+                <Users size={15} aria-hidden="true" /> Browse all artists
+                <ArrowRight size={12} aria-hidden="true" />
+              </Link>
+              <Link
+                to="/venues"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-accent-400 transition-colors hover:text-accent-300"
+              >
+                <MapPin size={15} aria-hidden="true" /> Browse venues
+                <ArrowRight size={12} aria-hidden="true" />
+              </Link>
+            </div>
           </div>
           <ThemeToggle />
         </div>


### PR DESCRIPTION
## Summary

On the home page header, `Browse all artists →` ran into `Browse venues`, so the first link's arrow read as belonging to the second link's pin icon.

Looks like a spacing preference; it's a grouping bug:

| | |
|---|---|
| Gap **inside** each link (`gap-1.5`) | **6px** |
| Gap **between** the two links | **~4px** — collapsed JSX whitespace |

The links were adjacent `inline-flex` siblings with nothing owning the space between them, so the only separation was the single space in the source. That inverts the proximity rule — elements in different groups sat closer than elements within a group — so the eye binds the arrow to the wrong link.

## What changed

| File | Change |
|------|--------|
| `pages/EventsPage.jsx` | Both links wrapped in one `flex flex-wrap items-center gap-x-5 gap-y-2` row; `mt-3` moved from each link to the wrapper |

`gap-x-5` (20px) against the 6px internal gap restores the grouping. `flex-wrap` + `gap-y-2` also fixes the narrow-screen case, where two inline elements each carrying `mt-3` wrapped without consistent vertical rhythm.

## Sweep

Scanned `frontend/src` for adjacent `inline-flex` `<Link>` siblings relying on collapsed whitespace for separation. **Only instance.**

## Security / correctness notes

None. Layout markup only — both `to` targets (`/artists`, `/venues`), all link text and icons unchanged. One file, nothing in `functions/`.

## Verification

- [x] Tests: 968 pass, 0 failures (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [ ] **Manual smoke: not done — please eyeball the 20px spacing.** Reasoned from the measurements above, not observed; a local hook blocked the browser check. 20px is a judgement call and may want to be tighter.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and alignment for artist and venue navigation links.
  * Navigation links now wrap more cleanly across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->