### PR TITLE
fix(data): backfill Apple Music links and repair 5 wrong-artist links

### DIFF
--- a/scripts/backfill-apple-music-links.sql
+++ b/scripts/backfill-apple-music-links.sql
@@ -1,0 +1,106 @@
+-- Backfill apple_music links for artists that already had a Spotify link.
+--
+-- Run manually (this is data, not schema — it does NOT belong in migrations/,
+-- which auto-apply on deploy):
+--
+--   npx wrangler d1 execute settimes-production-db --remote \
+--     --file=scripts/backfill-apple-music-links.sql
+--
+-- Every statement is guarded on apple_music still being blank, so a re-run is
+-- a no-op and this can never clobber a link entered by hand in the meantime.
+--
+-- Identity was proven by DISCOGRAPHY MATCH against each artist's Bandcamp or
+-- Spotify releases, never by artist-name match alone — the same "existence is
+-- not identity" doctrine as scripts/probe-band-links.mjs. That mattered: an
+-- Apple name search returns 12 exact "Aversion" hits and 11 exact "Uppercut"
+-- hits, so a name-only pass would have written wrong links to live profiles.
+--
+-- URL shape follows the existing majority convention (63 of 74 rows):
+-- https://music.apple.com/ca/artist/<slug>/<id> — CA storefront, no ?uo=4
+-- affiliate suffix.
+--
+-- Deliberately NOT included:
+--   Ghost Factory (217) — verified absent from Apple Music. The only exact-name
+--     hit is an unrelated hip-hop artist, and their release "Socialist Trash"
+--     returns nothing. A blank field is correct here.
+--   GZ (68) — its existing SPOTIFY link resolves to a different artist
+--     ("THE OUTCAST"); pending owner confirmation of a rename. Untouched.
+
+-- BA Johnston — Hamilton. Proof: "Stairway to Hamilton", "Argos Suck",
+-- "Werewolves of London, Ontario" all present in Apple's catalog for this id.
+UPDATE band_profiles
+SET social_links = json_set(COALESCE(social_links, '{}'), '$.apple_music',
+      'https://music.apple.com/ca/artist/ba-johnston/287135498'),
+    updated_at = datetime('now')
+WHERE id = 31 AND TRIM(COALESCE(json_extract(social_links, '$.apple_music'), '')) = '';
+
+-- Aversion — Stratford ON. Proof: 4/4 vs aversionfc.bandcamp.com. Bandcamp's
+-- "JMBME" is the acronym of Apple's "Judge Me By My Enemies"; plus
+-- "Festival City EP", "Throwaway Kids", "End Days".
+UPDATE band_profiles
+SET social_links = json_set(COALESCE(social_links, '{}'), '$.apple_music',
+      'https://music.apple.com/ca/artist/aversion/1780235898'),
+    updated_at = datetime('now')
+WHERE id = 86 AND TRIM(COALESCE(json_extract(social_links, '$.apple_music'), '')) = '';
+
+-- Rhx34 — proof: 10/10 vs the Spotify discography already on file, including
+-- "LOVE_LETTER_FOR_YOU.TXT.vbs" and "the king of ur basement".
+UPDATE band_profiles
+SET social_links = json_set(COALESCE(social_links, '{}'), '$.apple_music',
+      'https://music.apple.com/ca/artist/rhx34/1733310855'),
+    updated_at = datetime('now')
+WHERE id = 82 AND TRIM(COALESCE(json_extract(social_links, '$.apple_music'), '')) = '';
+
+-- Rolodex Darko — Hamilton. Proof: "SLUT QUEEN" and
+-- "BLIND IN THE VALLEY OF SUICIDES" vs rolodexdarko.bandcamp.com.
+UPDATE band_profiles
+SET social_links = json_set(COALESCE(social_links, '{}'), '$.apple_music',
+      'https://music.apple.com/ca/artist/rolodex-darko/1588638207'),
+    updated_at = datetime('now')
+WHERE id = 85 AND TRIM(COALESCE(json_extract(social_links, '$.apple_music'), '')) = '';
+
+-- Uppercut — proof: 3/3 vs the Spotify discography already on file
+-- ("Sleepwalker", "All My Big Dawgs Go to Heaven", "Bond, Trauma Bond").
+-- Apple returns 11 unrelated exact-name "Uppercut" artists; this is the one.
+UPDATE band_profiles
+SET social_links = json_set(COALESCE(social_links, '{}'), '$.apple_music',
+      'https://music.apple.com/ca/artist/uppercut/1840778173'),
+    updated_at = datetime('now')
+WHERE id = 80 AND TRIM(COALESCE(json_extract(social_links, '$.apple_music'), '')) = '';
+
+-- Nova Doll — Barrie ON. Proof: "Denaturing", "California Sunshine",
+-- "Waydown" vs novadoll.bandcamp.com. (A second exact-name match is a
+-- house/electronica act — not this band.)
+UPDATE band_profiles
+SET social_links = json_set(COALESCE(social_links, '{}'), '$.apple_music',
+      'https://music.apple.com/ca/artist/nova-doll/1678067458'),
+    updated_at = datetime('now')
+WHERE id = 195 AND TRIM(COALESCE(json_extract(social_links, '$.apple_music'), '')) = '';
+
+-- Ship of Fools — Newmarket ON, punk. Proof: 4/4 vs sofpunk.bandcamp.com
+-- ("A Perfect Place for Harmony", "Broken Knuckles", "Status Quo",
+-- "The Basement Demos"). Found by searching the RELEASE title — the artist-name
+-- search surfaced an unrelated blues act instead.
+UPDATE band_profiles
+SET social_links = json_set(COALESCE(social_links, '{}'), '$.apple_music',
+      'https://music.apple.com/ca/artist/ship-of-fools/1252054276'),
+    updated_at = datetime('now')
+WHERE id = 193 AND TRIM(COALESCE(json_extract(social_links, '$.apple_music'), '')) = '';
+
+-- Working Girl — Hamilton, metal. Proof: 2/2 vs the Spotify discography
+-- already on file ("New Development" 2026, "Working Girl" 2024), genre and
+-- city both consistent with workinggirl.bandcamp.com.
+UPDATE band_profiles
+SET social_links = json_set(COALESCE(social_links, '{}'), '$.apple_music',
+      'https://music.apple.com/ca/artist/working-girl/1715549798'),
+    updated_at = datetime('now')
+WHERE id = 194 AND TRIM(COALESCE(json_extract(social_links, '$.apple_music'), '')) = '';
+
+-- Alert the Audience — Brantford ON. Proof: 3/4 vs
+-- alerttheaudience.bandcamp.com ("WE'LL DO IT LIVE!!!", "Here, I Made This",
+-- "This Is An EP").
+UPDATE band_profiles
+SET social_links = json_set(COALESCE(social_links, '{}'), '$.apple_music',
+      'https://music.apple.com/ca/artist/alert-the-audience/1417631689'),
+    updated_at = datetime('now')
+WHERE id = 105 AND TRIM(COALESCE(json_extract(social_links, '$.apple_music'), '')) = '';

--- a/scripts/fix-wrong-artist-links.sql
+++ b/scripts/fix-wrong-artist-links.sql
@@ -1,0 +1,89 @@
+-- Repair streaming links that point at the WRONG ARTIST (see issue #788).
+--
+-- Run manually (data, not schema — belongs in scripts/, never migrations/):
+--
+--   npx wrangler d1 execute settimes-production-db --remote \
+--     --file=scripts/fix-wrong-artist-links.sql
+--
+-- The audit flagged 6 links on 5 profiles; this patch repairs 5 on 4. GZ (68)
+-- is excluded on later evidence — see the note in the REMOVED section.
+--
+-- Found by auditing all 156 streaming links for identity rather than presence.
+-- hasField() in bandFields.js can only prove a link resolves to a real href;
+-- it cannot prove the href points at the right artist, so these were invisible
+-- to every existing check while live on public profile pages.
+--
+-- Three of the five pointed at OTHER BANDS IN THIS ROSTER (Dead Roots is 142,
+-- Dead Karma is 108, Avro Arrows is 186), and 132 + 186 shared a byte-identical
+-- Spotify id — the signature of row misalignment during a bulk entry pass.
+--
+-- Each statement is guarded on the known-wrong platform ID still being present,
+-- so a re-run is a no-op and a hand-fix made in the meantime is never clobbered.
+-- Guards match the ID substring, not the whole URL, because the stored Apple
+-- storefront prefix varies (/ca/, /us/, /kz/) across rows.
+--
+-- They use GLOB, not LIKE, deliberately. SQLite's LIKE is case-INSENSITIVE for
+-- ASCII, but Spotify and Apple ids are base62 and case-significant: a LIKE
+-- guard would also match a case-variant of the id, which is a different and
+-- perfectly valid id, and could clobber a link this patch never meant to touch.
+-- GLOB is case-sensitive. (No id contains *, ?, or [, so GLOB's wildcards are
+-- safe here.) Caught by CodeRabbit; there is a regression test for it.
+--
+-- A blank field is strictly better than a stranger's music: where no correct
+-- link could be proven, the key is REMOVED rather than guessed at. Those
+-- profiles will then show up correctly in the roster gap filter as missing.
+
+-- === REPLACED (correct links proven) ===
+
+-- Man Made Hill (67) — both links pointed at "Mark It Zero".
+-- Correct Apple id 497145490 proven 4/4 against manmadehill.bandcamp.com
+-- ("Delicious Logo", "Mirage Repair", "Mass Wasting", "Totally Regular"),
+-- Hamilton ON, genre Electronic. Spotify id confirmed via oEmbed title.
+UPDATE band_profiles
+SET social_links = json_set(social_links, '$.spotify',
+      'https://open.spotify.com/artist/1TujiBxIcuZG5m6hu52RNP'),
+    updated_at = datetime('now')
+WHERE id = 67 AND COALESCE(json_extract(social_links, '$.spotify'), '') GLOB '*57bkC3zB6VcK1K7AHIh4fd*';
+
+UPDATE band_profiles
+SET social_links = json_set(social_links, '$.apple_music',
+      'https://music.apple.com/ca/artist/man-made-hill/497145490'),
+    updated_at = datetime('now')
+WHERE id = 67 AND COALESCE(json_extract(social_links, '$.apple_music'), '') GLOB '*1540041962*';
+
+-- === REMOVED (no correct link could be proven) ===
+-- Each of these three HAS a correct apple_music link already on file; only the
+-- spotify key was wrong, so only that key is removed.
+
+-- GZ (68) is DELIBERATELY NOT TOUCHED.
+--
+-- Its spotify link resolves to "THE OUTCAST", which read as wrong until the
+-- follow-up sweep checked the rest of the row: GZ's own bio describes a
+-- "bilingual artist from the southern part of India", and THE OUTCAST's
+-- catalogue is Tamil ("Villayattam", "Immortal Sangham"). That is consistent
+-- with a rename, not a mis-paste — so the LINK is likely correct and the
+-- profile NAME is what's stale.
+--
+-- Removing a correct link would be a regression, and unlike the four below
+-- this row shows no sign of the bulk-entry misalignment (its instagram,
+-- genre and city are all self-consistent). Left for the owner to confirm.
+
+-- Dead Karma (108) — pointed at "DEAD ROOTS" (which is profile 142).
+UPDATE band_profiles
+SET social_links = json_remove(social_links, '$.spotify'),
+    updated_at = datetime('now')
+WHERE id = 108 AND COALESCE(json_extract(social_links, '$.spotify'), '') GLOB '*4FLg7ZoBc37HAokjDEEAKm*';
+
+-- Azathoth Entombed (132) — pointed at "Avro Arrows" (profile 186), which
+-- still holds this same id legitimately. Removing it here resolves the
+-- duplicate; 186 is left untouched.
+UPDATE band_profiles
+SET social_links = json_remove(social_links, '$.spotify'),
+    updated_at = datetime('now')
+WHERE id = 132 AND COALESCE(json_extract(social_links, '$.spotify'), '') GLOB '*1gG9HaBRUlgguK7KzSDRfo*';
+
+-- A Dallas Welcome (234) — pointed at "Dead Karma" (profile 108).
+UPDATE band_profiles
+SET social_links = json_remove(social_links, '$.spotify'),
+    updated_at = datetime('now')
+WHERE id = 234 AND COALESCE(json_extract(social_links, '$.spotify'), '') GLOB '*6oku69hBJT9zSgzBUdqT3y*';


### PR DESCRIPTION
## Summary

Two hand-run D1 data patches from an artist-profile pass. No application code changes.

1. **`scripts/backfill-apple-music-links.sql`** — 9 profiles had a Spotify link but no Apple Music link.
2. **`scripts/fix-wrong-artist-links.sql`** — an identity audit of all 156 streaming links found 6 links on 5 profiles pointing at a **completely different artist**, live on public pages. Repairs 5 on 4.

Closes #788

## Why this class was invisible

`hasField()` in `frontend/src/admin/utils/bandFields.js` proves a link *resolves to a real href* — never that the href is the **right artist**. A wrong link passes every existing check while being strictly worse than a blank field.

## Identity was proven, never assumed

Every link was verified by **discography match** against the artist's own Bandcamp or Spotify releases, following the "existence is not identity" doctrine in `scripts/probe-band-links.mjs`. That did real work: Apple returns **12** exact-name "Aversion" artists and **11** exact-name "Uppercut" artists, and the correct Ship of Fools was reachable only by searching a release title.

## Not independent typos

Three wrong links pointed at **other bands in this roster** (Dead Roots 142, Dead Karma 108, Avro Arrows 186), and profiles 132 + 186 held a byte-identical Spotify id — row misalignment during a bulk entry pass.

A follow-up sweep **bounded the blast radius to one column**: a whole-roster duplicate check across all 8 link fields found no other shared value anywhere, and each affected profile's genre, city, bio, bandcamp, instagram and facebook is self-consistent with its own band.

## One decision reversed by the sweep

**GZ (68)** was going to have its link removed as wrong. The sweep found GZ's own bio describes a *"bilingual artist from the southern part of India"* and THE OUTCAST's catalogue is Tamil. That is a **rename**, not a mis-paste — the link is likely correct and the profile *name* is stale. Removing it would have been a regression, so GZ is untouched pending owner confirmation.

## Test plan

- [x] Both patches verified against a seeded SQLite DB via `better-sqlite3` (18 + 20 assertions)
- [x] Correct rows only; sibling `spotify`/`bandcamp`/`instagram` keys preserved
- [x] Keys `json_remove`d, not blanked, so the roster gap filter sees them as missing
- [x] Avro Arrows (186), legitimate holder of the duplicated id, asserted untouched
- [x] `updated_at` space-separated, never ISO-`T` (SQLite invariant)
- [x] Re-runs are no-ops and never clobber a hand-entered value
- [x] All 9 backfilled URLs return HTTP 200
- [x] CodeRabbit clean after addressing its one finding
- [x] `npm run format:check` passes

## Review feedback addressed

CodeRabbit flagged the guards as case-insensitive. SQLite's `LIKE` ignores ASCII case, but Spotify/Apple ids are base62 and case-significant, so a guard could match a case-variant — a different, valid id — and clobber a link it was never meant to touch. All five guards now use case-sensitive `GLOB`, with a regression test seeding a case-flipped decoy. Mutation-checked: the decoy matches under `LIKE` (1) and not under `GLOB` (0), so the test discriminates.

## Deployment

These are **data, not schema** — they live in `scripts/` and are run by hand. They are NOT migrations and will not auto-apply on deploy:

```bash
npx wrangler d1 execute settimes-production-db --remote --file=scripts/backfill-apple-music-links.sql
npx wrangler d1 execute settimes-production-db --remote --file=scripts/fix-wrong-artist-links.sql
```

## Follow-ups (not in this PR)

- Correct Spotify links for the 3 profiles whose links were removed
- GZ rename confirmation → update `name`/`name_normalized`, or fix the link
- 9 profiles with ambiguous origins; 3 render as a bare `"ON"`
- Promote the identity audit to `scripts/` so this is one command, not a manual pass

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Added verified Apple Music links to nine existing artist profiles.
  * Corrected inaccurate Spotify and Apple Music links for an artist profile.
  * Removed unverified Spotify links from three profiles.
  * Preserved existing valid links and refreshed profile update timestamps where changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->