### PR TITLE
fix(events): gate public visibility on status, not the dead is_published column

### DIFF
--- a/frontend/src/__tests__/isPublishedGuard.test.js
+++ b/frontend/src/__tests__/isPublishedGuard.test.js
@@ -67,13 +67,18 @@ function isExempt(relPath) {
   return false
 }
 
+const SCANNED_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx']
+
 function walk(dir) {
   let files = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name)
     if (entry.isDirectory()) {
       files = files.concat(walk(full))
-    } else if (entry.isFile() && (entry.name.endsWith('.js') || entry.name.endsWith('.jsx'))) {
+      // .ts/.tsx are scanned even though this codebase is currently JS-only:
+      // a guard that silently stops covering a file type the day someone adds
+      // one is the failure mode guards exist to prevent.
+    } else if (entry.isFile() && SCANNED_EXTENSIONS.some(ext => entry.name.endsWith(ext))) {
       files.push(full)
     }
   }

--- a/frontend/src/__tests__/isPublishedGuard.test.js
+++ b/frontend/src/__tests__/isPublishedGuard.test.js
@@ -1,0 +1,105 @@
+// --- Durable guard: `is_published` must never drive PUBLIC UI ---------------
+//
+// `events.is_published` is a deprecated column (migration 0005 superseded it
+// with `events.status`) that still gets written by the admin archive path for
+// rollback safety. Reading it on the SERVER took the public site dark on
+// 2026-08-10. The frontend never had that failure mode — it had the quieter
+// one: EventTimeline.jsx rendered a "Draft" badge off
+// `event.is_published === false`, which is ALWAYS false because the public
+// timeline endpoint never projects the column (`event.is_published` is
+// `undefined`, and `undefined === false` is `false`). Dead code that looked
+// live — and the reason a frontend guard earns its keep: the same deprecated
+// column fails silently here rather than loudly. See
+// functions/utils/eventVisibility.js for the backend half of this incident
+// and functions/utils/__tests__/eventVisibility.test.js for its guard, which
+// this test mirrors on the frontend side.
+//
+// This is a source scan, not a runtime assertion, for the same reason as
+// that backend guard and frontend/src/admin/utils/__tests__/bandFields.test.js's
+// Tailwind-class scan: the bug is a string baked into JSX/JS at module load
+// time (a prop name, an object key, a comparison target). Nothing about
+// "does this component read is_published" is observable by rendering the
+// component with props that omit the field -- the component just silently
+// treats it as undefined, which is exactly how this bug hid in plain sight.
+// Only reading the source text catches it.
+//
+// EXEMPT admin/**: unlike the public timeline, the admin events list
+// (`GET /api/admin/events`, via `functions/api/admin/events/index.js`) DOES
+// still project `is_published`, and the admin UI legitimately reads it as a
+// draft/published indicator until it's migrated onto `status` (#799). This
+// guard protects PUBLIC surfaces, where the column is never projected and
+// any read of it is necessarily dead or wrong -- not the admin surface,
+// where it's still live data.
+import { readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const currentFile = fileURLToPath(import.meta.url)
+const srcRoot = path.join(path.dirname(currentFile), '../')
+
+// Directories/files exempt from the scan:
+//  - admin/**        — the admin surface legitimately still reads
+//    is_published from admin endpoints that still project it (#799 tracks
+//    the eventual migration onto `status`).
+//  - any __tests__/** path — test fixtures legitimately seed/assert against
+//    the deprecated column (e.g. HistoricalImportModal's write, or an
+//    impossible-state regression guard).
+//  - utils/adminApi.js — not under admin/ by directory, but functionally
+//    part of the admin surface: it's the admin API client, imported
+//    exclusively by admin/** components (plus EventContext.jsx, itself an
+//    admin-panel-context provider) to normalize the same still-projected
+//    admin endpoint response as EventFormModal.jsx and AdminPanel.jsx above.
+//    Same justification as admin/**, just organized in utils/ as a shared
+//    client module rather than nested under admin/. Mirrors how the backend
+//    guard's EXEMPT_EXACT carves out utils/eventVisibility.js and
+//    api/test-utils.js for the same "right behaviour, wrong directory for
+//    the path-prefix rule" reason.
+//  - this file itself — its own header/comments name the column, which
+//    would otherwise flag itself.
+const EXEMPT_EXACT = new Set(['utils/adminApi.js', '__tests__/isPublishedGuard.test.js'])
+
+function isExempt(relPath) {
+  const normalized = relPath.split(path.sep).join('/')
+  if (normalized.startsWith('admin/')) return true
+  if (normalized.split('/').includes('__tests__')) return true
+  if (EXEMPT_EXACT.has(normalized)) return true
+  return false
+}
+
+function walk(dir) {
+  let files = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files = files.concat(walk(full))
+    } else if (entry.isFile() && (entry.name.endsWith('.js') || entry.name.endsWith('.jsx'))) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+describe('is_published never read outside admin/test infrastructure', () => {
+  it('contains no bare is_published reads outside the allowlisted paths', () => {
+    const offenders = []
+    for (const absPath of walk(srcRoot)) {
+      const relPath = path.relative(srcRoot, absPath)
+      if (isExempt(relPath)) continue
+      const source = readFileSync(absPath, 'utf8')
+      if (source.includes('is_published')) {
+        offenders.push(relPath)
+      }
+    }
+
+    expect(
+      offenders,
+      offenders.length > 0
+        ? `is_published must never drive public UI (frontend/src/components/EventTimeline.jsx's dead "Draft" ` +
+            `badge was this exact bug) — found it in: ${offenders.join(', ')}. Use event.status instead, or add ` +
+            `the file to frontend/src/admin/**, a __tests__/** path, or the EXEMPT_EXACT allowlist in this guard ` +
+            `if it's genuinely admin infrastructure.`
+        : undefined
+    ).toEqual([])
+  })
+})

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -138,6 +138,24 @@ export default function EventTimeline() {
     }
   }, [])
 
+  // Auto-expand Past when it's the only bucket with content -- e.g. between
+  // seasons, when the last event has been archived and the next one is still
+  // a draft with an empty lineup. Without this a fan lands on a page with
+  // nothing visible behind a collapsed "Show History" toggle.
+  //
+  // Keyed on the RAW timeline arrays, not the filtered lists: keying on
+  // filters would re-expand this section every time a fan filters upcoming
+  // events away after deliberately collapsing it, fighting their own action.
+  // Only ever sets true -- never stomps a manual collapse.
+  useEffect(() => {
+    const hasRawNow = (timeline.now || []).length > 0
+    const hasRawUpcoming = (timeline.upcoming || []).length > 0
+    const hasRawPast = (timeline.past || []).length > 0
+    if (!hasRawNow && !hasRawUpcoming && hasRawPast) {
+      setShowPast(true)
+    }
+  }, [timeline])
+
   const loadDetails = useCallback(async eventId => {
     if (!eventId) return
 
@@ -285,7 +303,15 @@ export default function EventTimeline() {
                 navigating by heading level. Visual size is unchanged. See App.jsx
                 line 731-734 for the same pattern on the event schedule page. */}
             <h2 className="text-4xl font-bold text-text-primary mb-2">Events</h2>
-            <p className="text-text-secondary">Discover upcoming band crawls and music events</p>
+            {/* Between seasons (no now/upcoming events) the "Discover upcoming"
+                copy is simply false -- there's nothing upcoming to discover.
+                Swap to copy that's still true: past crawls are browsable and
+                new dates land here. */}
+            <p className="text-text-secondary">
+              {hasNow || hasUpcoming
+                ? 'Discover upcoming band crawls and music events'
+                : 'Browse past band crawls — new dates will be announced here'}
+            </p>
           </div>
 
           <div className="flex items-center gap-3">
@@ -448,6 +474,38 @@ export default function EventTimeline() {
                     ? 'Try adjusting your filters to see more events'
                     : 'Check back soon for upcoming band crawls!'}
                 </p>
+              </div>
+            </Alert>
+          </div>
+        )}
+
+        {/* Between-Seasons State — past events exist but nothing is now/upcoming
+            (e.g. the last event archived and the next one is still a draft
+            with an empty lineup). This is NOT the same as the empty state
+            above: there IS content, just not in the sections a fan expects
+            to see first. Conflating the two would tell a fan "no events
+            found" while 19 past events sit collapsed one toggle away. */}
+        {!hasNow && !hasUpcoming && hasPast && (
+          <div className="py-16 text-center">
+            <Alert variant="info">
+              <div className="text-center">
+                <h3 className="text-lg font-bold mb-2">
+                  {hasActiveFilters ? 'No upcoming events match your filters' : 'No upcoming events right now'}
+                </h3>
+                <p className="text-text-secondary mb-4">
+                  {hasActiveFilters
+                    ? "Your filters are hiding every upcoming event. Clear them to see what's next."
+                    : "We're between seasons — browse past crawls below, or subscribe to hear about new dates first."}
+                </p>
+                {hasActiveFilters ? (
+                  <Button variant="secondary" size="sm" onClick={clearFilters} icon={<X size={14} />}>
+                    Clear Filters
+                  </Button>
+                ) : (
+                  <Button as={Link} to="/subscribe" variant="secondary" size="sm">
+                    Subscribe for Updates
+                  </Button>
+                )}
               </div>
             </Alert>
           </div>
@@ -752,7 +810,6 @@ function EventCard({
                     Archived
                   </Badge>
                 )}
-                {event.is_published === false && <Badge variant="warning">Draft</Badge>}
               </div>
 
               <p className="text-text-secondary text-sm mb-4 flex items-center gap-2">
@@ -762,10 +819,21 @@ function EventCard({
 
               {/* Event Stats */}
               <div className="flex flex-wrap gap-6 text-sm">
-                <div className="flex items-center gap-2">
-                  <span className="font-bold text-text-primary">{allBandCount}</span>
-                  <span className="text-text-tertiary">{allBandCount === 1 ? 'Band' : 'Bands'}</span>
-                </div>
+                {allBandCount > 0 ? (
+                  <div className="flex items-center gap-2">
+                    <span className="font-bold text-text-primary">{allBandCount}</span>
+                    <span className="text-text-tertiary">{allBandCount === 1 ? 'Band' : 'Bands'}</span>
+                  </div>
+                ) : (
+                  // A future event with an empty lineup isn't missing data —
+                  // it just hasn't been booked yet, so say so instead of
+                  // showing "0 Bands" (which reads as broken). A CONCLUDED
+                  // event with zero bands is a different situation: there's
+                  // no lineup still coming, just a historical gap (same as
+                  // the "0 Venues" case below), so "Lineup TBA" would be
+                  // nonsense there — omit the stat entirely instead.
+                  !isPast && <span className="text-text-tertiary">Lineup TBA</span>
+                )}
                 {/* Historical volumes have roster-only lineups with no venue
                   assignments — "0 Venues" reads as missing data, so omit the
                   stat entirely rather than showing a zero. */}

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -146,14 +146,26 @@ export default function EventTimeline() {
   // Keyed on the RAW timeline arrays, not the filtered lists: keying on
   // filters would re-expand this section every time a fan filters upcoming
   // events away after deliberately collapsing it, fighting their own action.
-  // Only ever sets true -- never stomps a manual collapse.
+  //
+  // Fires only on the TRANSITION into past-only (tracked via wasPastOnlyRef),
+  // never merely because the state holds. The 60s poll above calls
+  // setTimeline(data) with a fresh object identity every tick, even when the
+  // shape is unchanged -- keying on `[timeline]` alone would re-run this
+  // effect on every poll and call setShowPast(true) again, reopening a
+  // section a fan just collapsed. Gating on the transition means a later
+  // poll that returns the same past-only shape finds wasPastOnlyRef already
+  // true and leaves a manual collapse alone.
+  const wasPastOnlyRef = useRef(false)
   useEffect(() => {
     const hasRawNow = (timeline.now || []).length > 0
     const hasRawUpcoming = (timeline.upcoming || []).length > 0
     const hasRawPast = (timeline.past || []).length > 0
-    if (!hasRawNow && !hasRawUpcoming && hasRawPast) {
+    const isPastOnly = !hasRawNow && !hasRawUpcoming && hasRawPast
+
+    if (isPastOnly && !wasPastOnlyRef.current) {
       setShowPast(true)
     }
+    wasPastOnlyRef.current = isPastOnly
   }, [timeline])
 
   const loadDetails = useCallback(async eventId => {
@@ -290,6 +302,20 @@ export default function EventTimeline() {
   const hasNow = filteredNow.length > 0
   const hasUpcoming = filteredUpcoming.length > 0
   const hasPast = filteredPast.length > 0
+
+  // Whether an active filter is actually WHY the between-seasons block below
+  // is showing, as opposed to a genuine gap where the raw timeline has
+  // nothing now/upcoming to hide. hasActiveFilters only proves a filter is
+  // SET -- not that it hid anything -- so a raw past-only timeline (between
+  // seasons) with an unrelated filter still active would otherwise get the
+  // false "your filters are hiding an upcoming event" copy, and clearing
+  // filters would land the fan right back in the same between-seasons state.
+  // Derived from the RAW buckets rather than filteredNow/filteredUpcoming:
+  // by the time the between-seasons block renders those are already both
+  // empty (that's its render condition), so checking them here would always
+  // read false and this would never fire.
+  const filtersHideFutureEvents =
+    hasActiveFilters && ((timeline.now || []).length > 0 || (timeline.upcoming || []).length > 0)
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
@@ -490,14 +516,14 @@ export default function EventTimeline() {
             <Alert variant="info">
               <div className="text-center">
                 <h3 className="text-lg font-bold mb-2">
-                  {hasActiveFilters ? 'No upcoming events match your filters' : 'No upcoming events right now'}
+                  {filtersHideFutureEvents ? 'No upcoming events match your filters' : 'No upcoming events right now'}
                 </h3>
                 <p className="text-text-secondary mb-4">
-                  {hasActiveFilters
+                  {filtersHideFutureEvents
                     ? "Your filters are hiding every upcoming event. Clear them to see what's next."
                     : "We're between seasons — browse past crawls below, or subscribe to hear about new dates first."}
                 </p>
-                {hasActiveFilters ? (
+                {filtersHideFutureEvents ? (
                   <Button variant="secondary" size="sm" onClick={clearFilters} icon={<X size={14} />}>
                     Clear Filters
                   </Button>

--- a/frontend/src/components/__tests__/EventTimeline.cancelled.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.cancelled.test.jsx
@@ -41,7 +41,6 @@ describe('EventTimeline collapsed chips — cancelled sets (#732)', () => {
           slug: 'chip-sort-fest-cancelled',
           date: '2026-09-01',
           status: 'published',
-          is_published: true,
           venues: [],
           bands: [
             { id: 1, name: 'Deer Fang', is_cancelled: 1 },
@@ -112,7 +111,6 @@ describe('EventTimeline expanded details render cancellation on every band-list 
           slug: 'cancel-coverage-fest',
           date: '2026-08-02',
           status: 'published',
-          is_published: true,
           venues: [],
           bands: [],
           band_count: 2,

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -984,6 +984,12 @@ describe('EventTimeline empty lineup and between-seasons states', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
+    // Unconditional here rather than a trailing call inside the one test that
+    // installs fake timers: if an assertion in that test throws, the trailing
+    // call never runs and fake timers leak into every subsequent test in this
+    // file, turning one real failure into a cascade of unrelated ones. A no-op
+    // when no fake timers were installed.
+    vi.useRealTimers()
   })
 
   function stubTimeline(timelineData) {
@@ -1318,8 +1324,6 @@ describe('EventTimeline empty lineup and between-seasons states', () => {
       expect(screen.getByRole('button', { name: /show history/i })).toBeInTheDocument()
     })
     expect(screen.queryByText(/Long Weekend Band Crawl Vol 17/)).not.toBeInTheDocument()
-
-    vi.useRealTimers()
   })
 })
 

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
@@ -30,7 +30,6 @@ describe('EventTimeline', () => {
           slug: 'test-event',
           date: '2026-05-10',
           status: 'published',
-          is_published: true,
           venues: [],
           bands: [],
           band_count: 0,
@@ -119,7 +118,6 @@ describe('EventTimeline duplicate performer chips (#605)', () => {
           slug: 'two-set-event',
           date: '2026-05-10',
           status: 'published',
-          is_published: true,
           venues: [],
           bands: [],
           band_count: 2,
@@ -232,7 +230,6 @@ describe('EventTimeline recap links', () => {
     band_count: 0,
     venue_count: 0,
     ticket_url: null,
-    is_published: true,
     status: 'published',
   }
 
@@ -305,7 +302,6 @@ describe('EventTimeline performance day labels (#743)', () => {
           date: '2026-08-07',
           end_date: '2026-08-09',
           status: 'published',
-          is_published: true,
           venues: [],
           bands: [],
           band_count: 2,
@@ -403,7 +399,6 @@ describe('EventTimeline performance day labels (#743)', () => {
           date: '2026-08-07',
           end_date: null,
           status: 'published',
-          is_published: true,
           venues: [],
           bands: [],
           band_count: 1,
@@ -502,7 +497,6 @@ describe('EventTimeline collapsed performer chips ordering', () => {
           slug: 'chip-sort-fest',
           date: '2026-09-01',
           status: 'published',
-          is_published: true,
           venues: [],
           // API order is set-time order — deliberately unalphabetical.
           bands: [
@@ -575,7 +569,6 @@ describe('EventTimeline poster thumbnails (#658)', () => {
           slug: 'poster-fest',
           date: '2026-08-02',
           status: 'published',
-          is_published: true,
           venues: [],
           bands: [],
           band_count: 0,
@@ -630,7 +623,6 @@ describe('EventTimeline poster thumbnails (#658)', () => {
           slug: 'no-poster-fest',
           date: '2026-08-07',
           status: 'published',
-          is_published: true,
           venues: [],
           bands: [],
           band_count: 0,
@@ -684,7 +676,6 @@ describe('EventTimeline past-section poster lazy mounting (#658)', () => {
       slug: name.toLowerCase().replace(/\s+/g, '-'),
       date: '2020-05-10',
       status: 'archived',
-      is_published: true,
       venues: [],
       bands: [],
       band_count: 0,
@@ -695,7 +686,11 @@ describe('EventTimeline past-section poster lazy mounting (#658)', () => {
 
     const timelineData = {
       now: [],
-      upcoming: [],
+      // A non-empty upcoming bucket keeps Past collapsed by default (Past only
+      // auto-expands when it's the sole non-empty bucket) -- this test is
+      // about lazy mounting behind a MANUAL toggle, a different concern from
+      // that auto-expand, so it needs Past to start collapsed to exercise it.
+      upcoming: [{ ...pastEvent('upcoming', 'Unrelated Upcoming Event'), status: 'published', poster_url: null }],
       past: [pastEvent(1, 'Past Fest One'), pastEvent(2, 'Past Fest Two'), pastEvent(3, 'Past Fest Three')],
     }
 
@@ -758,7 +753,24 @@ describe('EventTimeline past-section poster lazy mounting (#658)', () => {
 
     const timelineData = {
       now: [],
-      upcoming: [],
+      // A non-empty upcoming bucket keeps Past collapsed by default (Past only
+      // auto-expands when it's the sole non-empty bucket), which this test
+      // relies on to exercise the manual "Show History" toggle below.
+      upcoming: [
+        {
+          id: 2,
+          name: 'Unrelated Upcoming Event',
+          slug: 'unrelated-upcoming-event',
+          date: '2099-01-01',
+          status: 'published',
+          venues: [],
+          bands: [],
+          band_count: 0,
+          venue_count: 0,
+          ticket_url: null,
+          poster_url: null,
+        },
+      ],
       past: [
         {
           id: 1,
@@ -766,7 +778,6 @@ describe('EventTimeline past-section poster lazy mounting (#658)', () => {
           slug: 'axe-fest',
           date: '2020-05-10',
           status: 'archived',
-          is_published: true,
           venues: [],
           bands: [],
           band_count: 0,
@@ -798,7 +809,24 @@ describe('EventTimeline past-section poster lazy mounting (#658)', () => {
     // /event/undefined.
     const timelineData = {
       now: [],
-      upcoming: [],
+      // A non-empty upcoming bucket keeps Past collapsed by default (Past only
+      // auto-expands when it's the sole non-empty bucket), which this test
+      // relies on to exercise the manual "Show History" toggle below.
+      upcoming: [
+        {
+          id: 10,
+          name: 'Unrelated Upcoming Event',
+          slug: 'unrelated-upcoming-event',
+          date: '2099-01-01',
+          status: 'published',
+          venues: [],
+          bands: [],
+          band_count: 0,
+          venue_count: 0,
+          ticket_url: null,
+          poster_url: null,
+        },
+      ],
       past: [
         {
           id: 9,
@@ -806,7 +834,6 @@ describe('EventTimeline past-section poster lazy mounting (#658)', () => {
           slug: null,
           date: '2020-05-10',
           status: 'archived',
-          is_published: true,
           venues: [],
           bands: [],
           band_count: 0,
@@ -861,7 +888,6 @@ describe('EventTimeline Venues grid directions (#754)', () => {
           slug: 'test-event',
           date: '2026-05-10',
           status: 'published',
-          is_published: true,
           venues: [],
           bands: [],
           band_count: 0,
@@ -946,5 +972,268 @@ describe('EventTimeline Venues grid directions (#754)', () => {
     // only The Mill has an address in this fixture.
     expect(screen.getAllByText('Directions')).toHaveLength(1)
     expect(screen.getByRole('link', { name: /directions to the mill/i })).toBeInTheDocument()
+  })
+})
+
+// Between seasons (e.g. the last event archives and the next one is still a
+// draft with an empty lineup), the timeline previously rendered a heading, a
+// tagline claiming "upcoming" events, and 0 visible cards -- reading as
+// broken. These cover the fix: an announced-but-unlineup'd event's stat row,
+// and the page-level states when Now/Upcoming are both empty.
+describe('EventTimeline empty lineup and between-seasons states', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function stubTimeline(timelineData) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
+  }
+
+  it('renders "Lineup TBA" instead of "0 Bands" for an upcoming event with no lineup yet', async () => {
+    stubTimeline({
+      now: [],
+      upcoming: [
+        {
+          id: 1,
+          name: 'Vol 18',
+          slug: 'vol-18',
+          date: '2026-10-11',
+          status: 'published',
+          venues: [],
+          bands: [],
+          band_count: 0,
+          venue_count: 0,
+          ticket_url: null,
+        },
+      ],
+      past: [],
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Vol 18')).toBeInTheDocument()
+    expect(screen.getByText('Lineup TBA')).toBeInTheDocument()
+    // The zero-count stat this replaces would have rendered its own "Bands"
+    // label (plural, since 0 !== 1) right next to the numeral.
+    expect(screen.queryByText('Bands')).not.toBeInTheDocument()
+  })
+
+  it('omits the lineup stat entirely for a past event with no recorded bands', async () => {
+    stubTimeline({
+      now: [],
+      upcoming: [
+        {
+          id: 1,
+          name: 'Upcoming Fest',
+          slug: 'upcoming-fest',
+          date: '2099-05-10',
+          status: 'published',
+          venues: [],
+          bands: [],
+          band_count: 5,
+          venue_count: 1,
+          ticket_url: null,
+        },
+      ],
+      past: [
+        {
+          id: 2,
+          name: 'Undocumented Past Fest',
+          slug: 'undocumented-past-fest',
+          date: '2020-05-10',
+          status: 'archived',
+          venues: [],
+          bands: [],
+          band_count: 0,
+          venue_count: 0,
+          ticket_url: null,
+        },
+      ],
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Upcoming Fest')).toBeInTheDocument()
+    // Past events sit behind the "Show History" toggle -- auto-expand does
+    // NOT fire here because Upcoming Fest keeps hasUpcoming true.
+    fireEvent.click(screen.getByRole('button', { name: /show history/i }))
+    expect(await screen.findByText('Undocumented Past Fest')).toBeInTheDocument()
+
+    const pastCard = screen
+      .getAllByTestId('event-card')
+      .find(card => within(card).queryByText('Undocumented Past Fest'))
+    expect(pastCard).toBeTruthy()
+    expect(within(pastCard).queryByText('Lineup TBA')).not.toBeInTheDocument()
+    expect(within(pastCard).queryByText('Bands')).not.toBeInTheDocument()
+    expect(within(pastCard).queryByText('Band')).not.toBeInTheDocument()
+  })
+
+  it('still renders "N Bands" for an event with a real lineup', async () => {
+    stubTimeline({
+      now: [],
+      upcoming: [
+        {
+          id: 1,
+          name: 'Booked Fest',
+          slug: 'booked-fest',
+          date: '2026-10-11',
+          status: 'published',
+          venues: [],
+          bands: [],
+          band_count: 3,
+          venue_count: 2,
+          ticket_url: null,
+        },
+      ],
+      past: [],
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Booked Fest')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('Bands')).toBeInTheDocument()
+    expect(screen.queryByText('Lineup TBA')).not.toBeInTheDocument()
+  })
+
+  it('shows a between-seasons message (not the generic empty state) when only past events exist', async () => {
+    stubTimeline({
+      now: [],
+      upcoming: [],
+      past: [
+        {
+          id: 1,
+          name: 'Long Weekend Band Crawl Vol 17',
+          slug: 'lwbc-17',
+          date: '2026-08-02',
+          status: 'archived',
+          venues: [],
+          bands: [],
+          band_count: 22,
+          venue_count: 6,
+          ticket_url: null,
+        },
+      ],
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText(/no upcoming events right now/i)).toBeInTheDocument()
+    expect(screen.queryByText('No events found')).not.toBeInTheDocument()
+  })
+
+  it('auto-expands the Past section when it is the only non-empty bucket', async () => {
+    stubTimeline({
+      now: [],
+      upcoming: [],
+      past: [
+        {
+          id: 1,
+          name: 'Long Weekend Band Crawl Vol 17',
+          slug: 'lwbc-17',
+          date: '2026-08-02',
+          status: 'archived',
+          venues: [],
+          bands: [],
+          band_count: 22,
+          venue_count: 6,
+          ticket_url: null,
+        },
+      ],
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    // No click on "Show History" -- the past event should already be visible.
+    expect(await screen.findByText('Long Weekend Band Crawl Vol 17')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hide history/i })).toBeInTheDocument()
+  })
+
+  it('reads the between-seasons tagline when there is nothing now/upcoming, and the original tagline otherwise', async () => {
+    stubTimeline({
+      now: [],
+      upcoming: [],
+      past: [
+        {
+          id: 1,
+          name: 'Long Weekend Band Crawl Vol 17',
+          slug: 'lwbc-17',
+          date: '2026-08-02',
+          status: 'archived',
+          venues: [],
+          bands: [],
+          band_count: 22,
+          venue_count: 6,
+          ticket_url: null,
+        },
+      ],
+    })
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText(/browse past band crawls/i)).toBeInTheDocument()
+    expect(screen.queryByText('Discover upcoming band crawls and music events')).not.toBeInTheDocument()
+    unmount()
+
+    stubTimeline({
+      now: [],
+      upcoming: [
+        {
+          id: 2,
+          name: 'Vol 18',
+          slug: 'vol-18',
+          date: '2026-10-11',
+          status: 'published',
+          venues: [],
+          bands: [],
+          band_count: 0,
+          venue_count: 0,
+          ticket_url: null,
+        },
+      ],
+      past: [],
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Discover upcoming band crawls and music events')).toBeInTheDocument()
+    expect(screen.queryByText(/browse past band crawls/i)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -1236,4 +1236,214 @@ describe('EventTimeline empty lineup and between-seasons states', () => {
     expect(await screen.findByText('Discover upcoming band crawls and music events')).toBeInTheDocument()
     expect(screen.queryByText(/browse past band crawls/i)).not.toBeInTheDocument()
   })
+
+  // Regression: the auto-expand effect above is keyed on `[timeline]`, and
+  // the 60s poll (fetchTimeline(true) in the main data-fetch effect) calls
+  // setTimeline(data) with a fresh object identity every tick -- even when
+  // the shape is unchanged. Without the wasPastOnlyRef transition guard,
+  // that re-runs the auto-expand effect on every poll and calls
+  // setShowPast(true) again, silently reopening a section a fan just
+  // collapsed. This uses the same `vi.useFakeTimers({ shouldAdvanceTime:
+  // true })` + `vi.advanceTimersByTimeAsync` pattern as
+  // BandProfilePage.test.jsx (#739) -- shouldAdvanceTime keeps
+  // findBy/waitFor's own polling working under fake timers.
+  it('does not reopen a manually collapsed Past section on a later past-only poll', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const pastOnlyTimeline = name => ({
+      now: [],
+      upcoming: [],
+      past: [
+        {
+          id: 1,
+          name,
+          slug: 'lwbc-17',
+          date: '2026-08-02',
+          status: 'archived',
+          venues: [],
+          bands: [],
+          band_count: 22,
+          venue_count: 6,
+          ticket_url: null,
+        },
+      ],
+    })
+
+    let fetchCount = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          fetchCount += 1
+          // The second (polled) response is a DISTINCT past-only payload --
+          // not a byte-for-byte repeat -- so a passing assertion below
+          // proves a real update was applied, not that the poll was a no-op.
+          const name = fetchCount === 1 ? 'Long Weekend Band Crawl Vol 17' : 'Long Weekend Band Crawl Vol 17 (Updated)'
+          return Promise.resolve(jsonResponse(pastOnlyTimeline(name)))
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    // Past auto-expands because it's the only non-empty raw bucket.
+    expect(await screen.findByText('Long Weekend Band Crawl Vol 17')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hide history/i })).toBeInTheDocument()
+
+    // Fan deliberately collapses it.
+    fireEvent.click(screen.getByRole('button', { name: /hide history/i }))
+    expect(screen.getByRole('button', { name: /show history/i })).toBeInTheDocument()
+    expect(screen.queryByText('Long Weekend Band Crawl Vol 17')).not.toBeInTheDocument()
+
+    // Drive the 60s poll. It must fetch a genuinely new payload.
+    await vi.advanceTimersByTimeAsync(60000)
+    await waitFor(() => expect(fetchCount).toBeGreaterThan(1))
+
+    // ...but the collapse must survive it: still "Show History", and no past
+    // event content leaked back into the DOM under either name. Testing
+    // Library's waitFor (not a bare synchronous assertion, and not vitest's
+    // own vi.waitFor) is required here -- it wraps each retry in act(),
+    // which is what actually flushes the setTimeline update from the
+    // interval's fetch into React's effects. A synchronous assertion
+    // immediately after advanceTimersByTimeAsync can read stale DOM and pass
+    // even when the auto-expand effect WOULD have reopened the section --
+    // confirmed by temporarily reverting the wasPastOnlyRef fix, which made
+    // this test pass right up until this assertion was switched to waitFor.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /show history/i })).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/Long Weekend Band Crawl Vol 17/)).not.toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+})
+
+// Finding 2 companion to the between-seasons tests above: hasActiveFilters
+// only proves a filter is SET, not that it hid an upcoming event. These
+// cover both directions of that distinction using the between-seasons block
+// (`!hasNow && !hasUpcoming && hasPast`), which is the only place
+// filtersHideFutureEvents is consulted.
+describe('EventTimeline between-seasons filter copy accuracy', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function stubTimeline(timelineData) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(jsonResponse(timelineData))
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
+  }
+
+  it('shows the between-seasons message, not the filter-recovery copy, when the raw timeline is genuinely past-only', async () => {
+    // Raw timeline has ONLY past events -- a real between-seasons gap. The
+    // active month filter still matches that past event (2026-08), so it
+    // does not empty the past bucket; it just happens to be set. Under the
+    // bug (hasActiveFilters), this would render "No upcoming events match
+    // your filters" / "Your filters are hiding every upcoming event" -- both
+    // false, since there was never a raw upcoming event to hide, and
+    // clearing filters would land the fan in the exact same state.
+    stubTimeline({
+      now: [],
+      upcoming: [],
+      past: [
+        {
+          id: 1,
+          name: 'Long Weekend Band Crawl Vol 17',
+          slug: 'lwbc-17',
+          date: '2026-08-02',
+          status: 'archived',
+          venues: [],
+          bands: [],
+          band_count: 22,
+          venue_count: 6,
+          ticket_url: null,
+        },
+      ],
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText(/no upcoming events right now/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /show filters/i }))
+    fireEvent.change(screen.getByLabelText(/filter by month/i), { target: { value: '2026-08' } })
+
+    const alertBox = await screen.findByRole('alert')
+    expect(within(alertBox).getByText(/no upcoming events right now/i)).toBeInTheDocument()
+    expect(within(alertBox).queryByText(/no upcoming events match your filters/i)).not.toBeInTheDocument()
+    expect(within(alertBox).queryByText(/your filters are hiding every upcoming event/i)).not.toBeInTheDocument()
+    expect(within(alertBox).getByRole('link', { name: /subscribe for updates/i })).toBeInTheDocument()
+    expect(within(alertBox).queryByRole('button', { name: /clear filters/i })).not.toBeInTheDocument()
+  })
+
+  it('shows the filter-recovery copy when a filter genuinely hides every raw upcoming event', async () => {
+    // Raw timeline HAS an upcoming event. The month filter excludes it
+    // (2020-05 vs. the event's 2026-10) while still matching the past event,
+    // so filteredUpcoming is empty but the raw bucket was not -- the filter
+    // is the actual cause, and this copy should stay.
+    stubTimeline({
+      now: [],
+      upcoming: [
+        {
+          id: 1,
+          name: 'Vol 18',
+          slug: 'vol-18',
+          date: '2026-10-11',
+          status: 'published',
+          venues: [],
+          bands: [],
+          band_count: 0,
+          venue_count: 0,
+          ticket_url: null,
+        },
+      ],
+      past: [
+        {
+          id: 2,
+          name: 'Long Weekend Band Crawl Vol 17',
+          slug: 'lwbc-17',
+          date: '2020-05-10',
+          status: 'archived',
+          venues: [],
+          bands: [],
+          band_count: 22,
+          venue_count: 6,
+          ticket_url: null,
+        },
+      ],
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Vol 18')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /show filters/i }))
+    fireEvent.change(screen.getByLabelText(/filter by month/i), { target: { value: '2020-05' } })
+
+    const alertBox = await screen.findByRole('alert')
+    expect(within(alertBox).getByText(/no upcoming events match your filters/i)).toBeInTheDocument()
+    expect(within(alertBox).getByText(/your filters are hiding every upcoming event/i)).toBeInTheDocument()
+    expect(within(alertBox).getByRole('button', { name: /clear filters/i })).toBeInTheDocument()
+    expect(within(alertBox).queryByRole('link', { name: /subscribe for updates/i })).not.toBeInTheDocument()
+  })
 })

--- a/functions/__tests__/sitemap.test.js
+++ b/functions/__tests__/sitemap.test.js
@@ -18,7 +18,7 @@ async function fetchSitemap(env) {
 }
 
 function publish(rawDb, eventId) {
-  rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(eventId);
+  rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(eventId);
 }
 
 describe("GET /sitemap.xml — recap entries (#555)", () => {

--- a/functions/api/__tests__/artists.test.js
+++ b/functions/api/__tests__/artists.test.js
@@ -9,7 +9,7 @@ function seedEnv() {
 }
 
 function publish(rawDb, eventId) {
-  rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(eventId);
+  rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(eventId);
 }
 
 async function getArtists(env, query = "") {

--- a/functions/api/__tests__/schedule-cancelled.test.js
+++ b/functions/api/__tests__/schedule-cancelled.test.js
@@ -7,7 +7,7 @@ describe("GET /api/schedule — is_cancelled", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-cancel" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     const band = insertBand(rawDb, { name: "Deer Fang", event_id: ev.id, venue_id: venue.id });
     const performanceId = band.id;

--- a/functions/api/__tests__/schedule-current-visibility.test.js
+++ b/functions/api/__tests__/schedule-current-visibility.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { createTestEnv, insertEvent } from "../test-utils";
+import * as scheduleHandler from "../schedule.js";
+
+// Regression guard for the `?event=current` visibility narrowing.
+//
+// `?event=current` and `?event=<slug>` deliberately have DIFFERENT gates:
+//   - the slug branch is publicEventStatusSql() — archived editions are the
+//     site's browsable back catalogue,
+//   - the current branch is publishedEventStatusSql() — archived must be
+//     excluded.
+//
+// The two are easy to conflate, and a sweep that unified them would look like
+// a tidy-up. It isn't: the handler's `-6 hours` buffer means an event archived
+// on its own final day STILL satisfies
+// `COALESCE(end_date, date) >= date('now','-6 hours')`, so the broader
+// predicate hands a fan the archived edition as tonight's live schedule.
+//
+// These tests fail if `publishedEventStatusSql()` in functions/api/schedule.js
+// is ever widened back to `publicEventStatusSql()`.
+
+function isoDaysFromNow(days) {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+describe("GET /api/schedule?event=current — archived events are excluded", () => {
+  it("404s when the only date-eligible event is archived", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // Archived, but ending TODAY — still inside the -6h buffer, so the date
+    // filter alone does not exclude it. Only the status gate does.
+    insertEvent(rawDb, {
+      name: "Buddies Fest 2",
+      slug: "bf2-archived-today",
+      date: isoDaysFromNow(0),
+      end_date: isoDaysFromNow(0),
+      status: "archived",
+    });
+
+    const res = await scheduleHandler.onRequestGet({
+      request: new Request("https://example.test/api/schedule?event=current"),
+      env,
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.message).toBe("No published events available");
+  });
+
+  it("returns the published event, not an earlier-dated archived one", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // The archived event sorts FIRST under `ORDER BY date ASC`, so if the gate
+    // ever admits archived rows this assertion catches it on ordering alone —
+    // it does not depend on the archived row being absent from the table.
+    insertEvent(rawDb, {
+      name: "Buddies Fest 2",
+      slug: "bf2-archived-today",
+      date: isoDaysFromNow(0),
+      end_date: isoDaysFromNow(0),
+      status: "archived",
+    });
+    insertEvent(rawDb, {
+      name: "Long Weekend Band Crawl Vol. 18",
+      slug: "lwbc18-published",
+      date: isoDaysFromNow(30),
+      status: "published",
+    });
+
+    const res = await scheduleHandler.onRequestGet({
+      request: new Request("https://example.test/api/schedule?event=current"),
+      env,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.event.slug).toBe("lwbc18-published");
+    expect(body.event.is_archived).toBe(false);
+  });
+
+  it("still serves an archived event by slug — the other branch is unchanged", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    insertEvent(rawDb, {
+      name: "Buddies Fest 2",
+      slug: "bf2-archived-today",
+      date: isoDaysFromNow(0),
+      end_date: isoDaysFromNow(0),
+      status: "archived",
+    });
+
+    const res = await scheduleHandler.onRequestGet({
+      request: new Request("https://example.test/api/schedule?event=bf2-archived-today"),
+      env,
+    });
+
+    // Asserting the slug branch here is what keeps the fix honest: narrowing
+    // `current` must not be achieved by narrowing event visibility globally,
+    // which would re-break history browsing — the original incident.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.event.slug).toBe("bf2-archived-today");
+    expect(body.event.is_archived).toBe(true);
+  });
+});

--- a/functions/api/__tests__/schedule-genre.test.js
+++ b/functions/api/__tests__/schedule-genre.test.js
@@ -11,7 +11,7 @@ describe("GET /api/schedule - genre (#725)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-genre" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     insertBand(rawDb, { name: "Genre Band", event_id: ev.id, venue_id: venue.id, genre: "Indie Rock" });
 
@@ -27,7 +27,7 @@ describe("GET /api/schedule - genre (#725)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Vol17", slug: "vol17-no-genre" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
     const venue = insertVenue(rawDb, { name: "Roost" });
     insertBand(rawDb, { name: "No Genre Band", event_id: ev.id, venue_id: venue.id });
 

--- a/functions/api/__tests__/schedule-poster.test.js
+++ b/functions/api/__tests__/schedule-poster.test.js
@@ -11,7 +11,7 @@ describe("GET /api/schedule - poster_url (#655)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Buddies Fest 2", slug: "buddiesfest2-poster" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
     rawDb
       .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
       .run("https://band-photos.settimes.ca/event-posters/36-buddiesfest2.jpg", ev.id);
@@ -27,7 +27,7 @@ describe("GET /api/schedule - poster_url (#655)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "No Poster Fest", slug: "no-poster-fest" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
 
     const req = new Request("https://example.test/api/schedule?event=no-poster-fest");
     const res = await scheduleHandler.onRequestGet({ request: req, env });
@@ -40,7 +40,7 @@ describe("GET /api/schedule - poster_url (#655)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Unsafe Poster Fest", slug: "unsafe-poster-fest" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
     rawDb
       .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
       // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #655 read-path guard
@@ -61,7 +61,7 @@ describe("GET /api/schedule - poster_url (#655)", () => {
     const futureDateStr = futureDate.toISOString().split("T")[0];
 
     const ev = insertEvent(rawDb, { name: "Current Poster Fest", slug: "current-poster-fest", date: futureDateStr });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
     rawDb
       .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
       .run("https://band-photos.settimes.ca/event-posters/current.jpg", ev.id);

--- a/functions/api/__tests__/schedule-reveal.test.js
+++ b/functions/api/__tests__/schedule-reveal.test.js
@@ -7,7 +7,7 @@ describe("GET /api/schedule - reveal mode", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-reveal-off", status: "draft" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
     const venue = insertVenue(rawDb, { name: "Venue A" });
     insertBand(rawDb, { name: "Announced Band", event_id: ev.id, venue_id: venue.id });
     const unannounced = insertBand(rawDb, { name: "Hidden Band", event_id: ev.id, venue_id: venue.id });
@@ -26,7 +26,7 @@ describe("GET /api/schedule - reveal mode", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-reveal-on" });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(ev.id);
     const venue = insertVenue(rawDb, { name: "Venue B" });
     const announced = insertBand(rawDb, { name: "Visible Band", event_id: ev.id, venue_id: venue.id });
     rawDb.prepare("UPDATE performances SET is_announced=1 WHERE id=?").run(announced.id);
@@ -46,7 +46,7 @@ describe("GET /api/schedule - reveal mode", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-meta" });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(ev.id);
 
     const req = new Request("https://example.test/api/schedule?event=vol6-meta");
     const res = await scheduleHandler.onRequestGet({ request: req, env });
@@ -60,7 +60,7 @@ describe("GET /api/schedule - ticket_url sanitization (#504)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-unsafe-ticket" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
     rawDb
       .prepare("UPDATE events SET ticket_url = ? WHERE id = ?")
       // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #504 read-path guard
@@ -77,7 +77,7 @@ describe("GET /api/schedule - ticket_url sanitization (#504)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Vol6", slug: "vol6-safe-ticket" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
     rawDb.prepare("UPDATE events SET ticket_url = ? WHERE id = ?").run("https://tickets.example.com/vol6", ev.id);
 
     const req = new Request("https://example.test/api/schedule?event=vol6-safe-ticket");
@@ -93,7 +93,7 @@ describe("GET /api/schedule - multi-day per-set date (#539)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Multi-Day Fest", slug: "multi-day-fest", date: "2026-08-01" });
-    rawDb.prepare("UPDATE events SET is_published=1, end_date=? WHERE id=?").run("2026-08-02", ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published', end_date=? WHERE id=?").run("2026-08-02", ev.id);
     const venue = insertVenue(rawDb, { name: "Main Stage" });
 
     const day1Band = insertBand(rawDb, {
@@ -132,7 +132,7 @@ describe("GET /api/schedule - multi-day per-set date (#539)", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const ev = insertEvent(rawDb, { name: "Single Day Show", slug: "single-day-show", date: "2026-08-01" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
     const venue = insertVenue(rawDb, { name: "Solo Venue" });
     insertBand(rawDb, { name: "Only Band", event_id: ev.id, venue_id: venue.id });
     // performance_date is left NULL (the column's default) here.
@@ -158,7 +158,7 @@ describe("GET /api/schedule - current-event window (#539)", () => {
     const yesterdayStr = yesterday.toISOString().split("T")[0];
 
     const ev = insertEvent(rawDb, { name: "Two Day Crawl", slug: "two-day-crawl", date: yesterdayStr });
-    rawDb.prepare("UPDATE events SET is_published=1, end_date=? WHERE id=?").run(todayStr, ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published', end_date=? WHERE id=?").run(todayStr, ev.id);
     const venue = insertVenue(rawDb, { name: "Some Venue" });
     insertBand(rawDb, { name: "Some Band", event_id: ev.id, venue_id: venue.id });
 
@@ -182,7 +182,7 @@ describe("GET /api/schedule - current-event window (#539)", () => {
     const twoDaysAgoStr = twoDaysAgo.toISOString().split("T")[0];
 
     const ev = insertEvent(rawDb, { name: "Old Single Day Show", slug: "old-single-day-show", date: twoDaysAgoStr });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
 
     const req = new Request("https://example.test/api/schedule?event=current");
     const res = await scheduleHandler.onRequestGet({ request: req, env });

--- a/functions/api/__tests__/schedule-social-links.test.js
+++ b/functions/api/__tests__/schedule-social-links.test.js
@@ -12,7 +12,7 @@ describe("GET /api/schedule - malformed social_links (#678 item 4)", () => {
 
     try {
       const ev = insertEvent(rawDb, { name: "Corrupt Fest", slug: "corrupt-social-links" });
-      rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(ev.id);
+      rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
       const venue = insertVenue(rawDb, { name: "Venue C" });
       insertBand(rawDb, {
         name: "Broken Links Band",

--- a/functions/api/__tests__/venues.test.js
+++ b/functions/api/__tests__/venues.test.js
@@ -10,7 +10,7 @@ function seedEnv() {
 }
 
 function publish(rawDb, eventId) {
-  rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(eventId);
+  rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(eventId);
 }
 
 async function getVenues(env, query = "") {

--- a/functions/api/artists.js
+++ b/functions/api/artists.js
@@ -8,6 +8,7 @@
 import { getPublicDataGateResponse } from "../utils/publicGate.js";
 import { safeReflectSocialLinks } from "../utils/validation.js";
 import { sortableName } from "../utils/sortableName.js";
+import { publicEventStatusSql } from "../utils/eventVisibility.js";
 
 const DEFAULT_LIMIT = 24;
 const MAX_LIMIT = 60;
@@ -64,7 +65,7 @@ export async function onRequestGet(context) {
       FROM band_profiles bp
       JOIN performances p ON p.band_profile_id = bp.id
       JOIN events e ON e.id = p.event_id
-      WHERE (e.is_published = 1 OR e.status = 'archived')
+      WHERE ${publicEventStatusSql("e")}
         AND (
           ? = ''
           OR bp.name LIKE ? ESCAPE '\\'

--- a/functions/api/bands/[name].js
+++ b/functions/api/bands/[name].js
@@ -2,6 +2,7 @@ import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { normalizeBandName } from "../../utils/bandName.js";
 import { safeReflectSocialLinks } from "../../utils/validation.js";
 import { eventLocalFestivalToday } from "../../utils/eventDay.js";
+import { publicEventStatusSql } from "../../utils/eventVisibility.js";
 
 /**
  * Public API: Get band profile by name
@@ -114,13 +115,12 @@ export async function onRequestGet(context) {
         e.name as event_name,
         e.slug as event_slug,
         e.date as event_date,
-        e.end_date as event_end_date,
-        e.is_published as event_published
+        e.end_date as event_end_date
       FROM performances p
       LEFT JOIN venues v ON p.venue_id = v.id
       LEFT JOIN events e ON p.event_id = e.id
       WHERE p.band_profile_id = ?
-        AND e.is_published = 1
+        AND ${publicEventStatusSql("e")}
         AND (e.reveal_mode = 0 OR p.is_announced = 1)
       ORDER BY e.date DESC, p.start_time
     `,

--- a/functions/api/bands/__tests__/band-cancelled-history.test.js
+++ b/functions/api/bands/__tests__/band-cancelled-history.test.js
@@ -16,7 +16,7 @@ async function seedAndFetch({ endDate, isCancelled = 0, bandName = "Deer Fang" }
     date: endDate,
     end_date: endDate,
   });
-  rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+  rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
   const venue = insertVenue(rawDb, { name: "Blue Room" });
   const band = insertBand(rawDb, { name: bandName, event_id: event.id, venue_id: venue.id });
   rawDb.prepare("UPDATE performances SET is_cancelled = ? WHERE id = ?").run(isCancelled, band.id);

--- a/functions/api/bands/__tests__/profile.test.js
+++ b/functions/api/bands/__tests__/profile.test.js
@@ -11,7 +11,7 @@ describe("GET /api/bands/:name - reveal_mode gate", () => {
       slug: "vol17-band-profile-1",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Prohibition Warehouse" });
     const perf = insertBand(rawDb, {
       name: "Embargoed Artist",
@@ -36,7 +36,7 @@ describe("GET /api/bands/:name - reveal_mode gate", () => {
       slug: "vol17-band-profile-2",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Roost" });
     const perf = insertBand(rawDb, {
       name: "Revealed Artist",
@@ -62,7 +62,7 @@ describe("GET /api/bands/:name - reveal_mode gate", () => {
       slug: "vol17-band-profile-3",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=0 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Revive Karaoke" });
     const perf = insertBand(rawDb, {
       name: "Normal Artist",
@@ -97,7 +97,7 @@ describe("GET /api/bands/:name - social_links scheme sanitization (#483)", () =>
       slug: "vol17-band-profile-483-unsafe",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Roost" });
     insertBand(rawDb, {
       name: "Scheme Test Band",
@@ -124,7 +124,7 @@ describe("GET /api/bands/:name - social_links scheme sanitization (#483)", () =>
       slug: "vol17-band-profile-483-safe",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Roost" });
     insertBand(rawDb, {
       name: "Valid Site Band",

--- a/functions/api/bands/stats/[name].js
+++ b/functions/api/bands/stats/[name].js
@@ -3,6 +3,7 @@ import { CACHE_SHOW_CRITICAL } from "../../../utils/cacheHeaders.js";
 import { normalizeBandName } from "../../../utils/bandName.js";
 import { safeReflectSocialLinks } from "../../../utils/validation.js";
 import { eventLocalFestivalToday } from "../../../utils/eventDay.js";
+import { publicEventStatusSql } from "../../../utils/eventVisibility.js";
 
 /**
  * Public API: Get band profile with rich stats
@@ -129,7 +130,7 @@ export async function onRequestGet(context) {
       LEFT JOIN venues v ON p.venue_id = v.id
       LEFT JOIN events e ON p.event_id = e.id
       WHERE p.band_profile_id = ?
-        AND e.status IN ('published', 'archived')
+        AND ${publicEventStatusSql("e")}
         AND (e.reveal_mode = 0 OR p.is_announced = 1)
       ORDER BY e.date DESC, COALESCE(p.performance_date, e.date) ASC, p.start_time
     `,

--- a/functions/api/bands/stats/__tests__/stats-cancelled-lifecycle.test.js
+++ b/functions/api/bands/stats/__tests__/stats-cancelled-lifecycle.test.js
@@ -28,7 +28,6 @@ describe("GET /api/bands/stats/:name — cancelled set lifecycle (#732)", () => 
       date: "2099-01-01",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Stats 732 Cancelled Band",
       event_id: event.id,
@@ -66,7 +65,6 @@ describe("GET /api/bands/stats/:name — cancelled set lifecycle (#732)", () => 
       date: "2001-01-01",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Stats 732 Past Cancelled Band",
       event_id: event.id,
@@ -94,7 +92,6 @@ describe("GET /api/bands/stats/:name — cancelled set lifecycle (#732)", () => 
       date: "2001-01-01",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     insertBand(rawDb, {
       name: "Stats 732 Past Normal Band",
       event_id: event.id,
@@ -127,7 +124,6 @@ describe("GET /api/bands/stats/:name — cancelled set lifecycle (#732)", () => 
       end_date: "2026-07-12",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const day1 = insertBand(rawDb, {
       name: "Stats 732 Multiday Band",

--- a/functions/api/bands/stats/__tests__/stats.test.js
+++ b/functions/api/bands/stats/__tests__/stats.test.js
@@ -18,7 +18,7 @@ describe("GET /api/bands/stats/:name — reveal_mode gate", () => {
       date: futureDate,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET reveal_mode=1 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Stats Hidden Band",
       event_id: event.id,
@@ -47,7 +47,7 @@ describe("GET /api/bands/stats/:name — reveal_mode gate", () => {
       date: futureDate,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET reveal_mode=1 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Stats Revealed Band",
       event_id: event.id,
@@ -76,7 +76,7 @@ describe("GET /api/bands/stats/:name — reveal_mode gate", () => {
       date: futureDate,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET reveal_mode=0 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Stats Normal Band",
       event_id: event.id,
@@ -116,7 +116,6 @@ describe("GET /api/bands/stats/:name - social_links scheme sanitization (#483)",
       date: futureDate,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     insertBand(rawDb, {
       name: "Stats Scheme Band",
       event_id: event.id,
@@ -145,7 +144,6 @@ describe("GET /api/bands/stats/:name - social_links scheme sanitization (#483)",
       date: futureDate,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     insertBand(rawDb, {
       name: "Stats Valid Site Band",
       event_id: event.id,
@@ -181,7 +179,6 @@ describe("GET /api/bands/stats/:name — event_end_date exposure (#542 PR-1)", (
       end_date: "2099-01-03",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     insertBand(rawDb, {
       name: "Stats Multiday Band",
       event_id: event.id,
@@ -209,7 +206,6 @@ describe("GET /api/bands/stats/:name — event_end_date exposure (#542 PR-1)", (
       date: "2099-06-01",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(futureEvent.id);
     insertBand(rawDb, {
       name: "Stats Singleday Band",
       event_id: futureEvent.id,
@@ -222,7 +218,6 @@ describe("GET /api/bands/stats/:name — event_end_date exposure (#542 PR-1)", (
       date: "2001-01-01",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(pastEvent.id);
     insertBand(rawDb, {
       name: "Stats Singleday Band",
       event_id: pastEvent.id,
@@ -252,7 +247,6 @@ describe("GET /api/bands/stats/:name — event_end_date exposure (#542 PR-1)", (
       end_date: "2001-03-03",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     insertBand(rawDb, {
       name: "Stats Past Multiday Band",
       event_id: event.id,
@@ -304,7 +298,6 @@ describe("GET /api/bands/stats/:name — per-performance classification (#603)",
       end_date: "2026-07-12",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const day1Perf = insertBand(rawDb, {
       name: "Stats 603 Multiday Band",
@@ -344,7 +337,6 @@ describe("GET /api/bands/stats/:name — per-performance classification (#603)",
       end_date: "2026-07-12",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     // performance_date left NULL — the #543 convention for day-1 sets and
     // single-day events — so it must inherit event_date (2026-07-10), which
@@ -417,7 +409,6 @@ describe("GET /api/bands/stats/:name — per-set performance_date, notes, and or
       end_date: "2099-08-09",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     // Day-1 bonus set: later performance_date-adjacent clock time (22:00) but
     // the EARLIER performance_date — this is the exact shape that broke
@@ -476,7 +467,6 @@ describe("GET /api/bands/stats/:name — per-set performance_date, notes, and or
       end_date: "2001-08-09",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const day1 = insertBand(rawDb, {
       name: "Kepi Ghoulie",

--- a/functions/api/events/[id]/details.js
+++ b/functions/api/events/[id]/details.js
@@ -1,6 +1,7 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
 import { CACHE_SHOW_CRITICAL } from "../../../utils/cacheHeaders.js";
 import { normalizeHttpUrl, validateId } from "../../../utils/validation.js";
+import { publicEventStatusSql } from "../../../utils/eventVisibility.js";
 
 /**
  * Public API: Get event details (bands + venues) for a single published event
@@ -41,7 +42,7 @@ export async function onRequestGet(context) {
       `
       SELECT id, name, slug, date, ticket_url, status, reveal_mode
       FROM events
-      WHERE id = ? AND (is_published = 1 OR status = 'archived')
+      WHERE id = ? AND ${publicEventStatusSql()}
       LIMIT 1
     `,
     )

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -1,5 +1,5 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
-import { normalizeHttpUrl } from "../../../utils/validation.js";
+import { normalizeHttpUrl, validateId } from "../../../utils/validation.js";
 import { sortableName } from "../../../utils/sortableName.js";
 import { archivedEventStatusSql, publicEventStatusSql } from "../../../utils/eventVisibility.js";
 
@@ -54,12 +54,25 @@ export async function onRequestGet(context) {
   const numericId = Number(rawId);
   const isNumeric = Number.isFinite(numericId) && String(numericId) === rawId;
 
+  // A value that LOOKS numeric must still clear validateId() before it reaches
+  // a query -- the repo-wide contract for Pages `params.id` (matching
+  // functions/api/events/[id]/details.js). Number.isFinite() alone accepted
+  // "0", "-3" and "1.5" and bound them straight through. Slugs are unaffected:
+  // Number("bf2") is NaN, so they take the slug branch below.
+  const idCheck = isNumeric ? validateId(rawId) : null;
+  if (idCheck && !idCheck.valid) {
+    return new Response(JSON.stringify({ error: "Invalid event id" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   try {
     const event = isNumeric
       ? await DB.prepare(
           `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE id = ? AND ${archivedEventStatusSql()} LIMIT 1`,
         )
-          .bind(numericId)
+          .bind(idCheck.value)
           .first()
       : await DB.prepare(
           `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE slug = ? AND ${archivedEventStatusSql()} LIMIT 1`,

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -1,6 +1,7 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
 import { normalizeHttpUrl } from "../../../utils/validation.js";
 import { sortableName } from "../../../utils/sortableName.js";
+import { publicEventStatusSql } from "../../../utils/eventVisibility.js";
 
 // SQLite `ORDER BY` can't strip a leading article inline (#587); the SQL
 // query below is a coarse pre-sort and this comparator re-derives the exact
@@ -99,7 +100,7 @@ export async function onRequestGet(context) {
             -- it's archived — restricting to status='archived' would then miss
             -- prior editions that are only published so far and wrongly call a
             -- returning act a first-timer. published-or-archived covers both.
-            AND (e2.is_published = 1 OR e2.status = 'archived')
+            AND ${publicEventStatusSql("e2")}
             -- "Returning" means chronologically earlier, not merely "some other
             -- event" (#613): without this, a band that only played a LATER
             -- archived edition counted as returning at an EARLIER one. Same-day

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -1,7 +1,7 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
 import { normalizeHttpUrl } from "../../../utils/validation.js";
 import { sortableName } from "../../../utils/sortableName.js";
-import { publicEventStatusSql } from "../../../utils/eventVisibility.js";
+import { archivedEventStatusSql, publicEventStatusSql } from "../../../utils/eventVisibility.js";
 
 // SQLite `ORDER BY` can't strip a leading article inline (#587); the SQL
 // query below is a coarse pre-sort and this comparator re-derives the exact
@@ -57,12 +57,12 @@ export async function onRequestGet(context) {
   try {
     const event = isNumeric
       ? await DB.prepare(
-          `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE id = ? AND status = 'archived' LIMIT 1`,
+          `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE id = ? AND ${archivedEventStatusSql()} LIMIT 1`,
         )
           .bind(numericId)
           .first()
       : await DB.prepare(
-          `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE slug = ? AND status = 'archived' LIMIT 1`,
+          `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE slug = ? AND ${archivedEventStatusSql()} LIMIT 1`,
         )
           .bind(rawId)
           .first();

--- a/functions/api/events/__tests__/details.test.js
+++ b/functions/api/events/__tests__/details.test.js
@@ -11,7 +11,7 @@ describe("GET /api/events/:id/details", () => {
       slug: "test-event",
       date: "2026-01-01",
     });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Test Venue", city: "Portland" });
     insertBand(rawDb, {
@@ -95,7 +95,7 @@ describe("GET /api/events/:id/details - performance_date across a multi-day even
       date: "2026-08-07",
       end_date: "2026-08-09",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "The Mill" });
 
     // Day 3, EARLY time -- if sorted on start_time alone this sorts FIRST.
@@ -170,7 +170,7 @@ describe("GET /api/events/:id/details - duplicate performer counting (#605)", ()
       slug: "details-two-set-band",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     const firstSet = insertBand(rawDb, {
@@ -229,7 +229,7 @@ describe("GET /api/events/:id/details - reveal_mode gate", () => {
       slug: "reveal-details-1",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     const announced = insertBand(rawDb, {
       name: "Visible Band",
@@ -265,7 +265,7 @@ describe("GET /api/events/:id/details - reveal_mode gate", () => {
       slug: "reveal-details-2",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Princess Cafe" });
     const announced = insertBand(rawDb, {
       name: "Announced Band",
@@ -295,7 +295,7 @@ describe("GET /api/events/:id/details - reveal_mode gate", () => {
       slug: "reveal-details-0",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=0 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Room 47" });
     const unannounced = insertBand(rawDb, {
       name: "Unannounced But Visible",
@@ -327,7 +327,7 @@ describe("GET /api/events/:id/details - is_cancelled (#732)", () => {
       slug: "details-cancel-732",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     const band = insertBand(rawDb, {
       name: "Deer Fang",
@@ -369,7 +369,7 @@ describe("GET /api/events/:id/details - ticket_url sanitization (#504)", () => {
       slug: "details-504-unsafe-ticket",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     rawDb
       .prepare("UPDATE events SET ticket_url = ? WHERE id = ?")
       // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #504 read-path guard
@@ -395,7 +395,7 @@ describe("GET /api/events/:id/details - ticket_url sanitization (#504)", () => {
       slug: "details-504-safe-ticket",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     rawDb.prepare("UPDATE events SET ticket_url = ? WHERE id = ?").run("https://tickets.example.com/crawl", event.id);
 
     const request = new Request(`https://example.test/api/events/${event.id}/details`);

--- a/functions/api/events/__tests__/recap.test.js
+++ b/functions/api/events/__tests__/recap.test.js
@@ -308,7 +308,6 @@ describe("GET /api/events/:id/recap", () => {
       date: "2023-06-01",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(priorEvent.id);
 
     const currentEvent = insertEvent(rawDb, {
       name: "Archived Vol",
@@ -335,7 +334,10 @@ describe("GET /api/events/:id/recap", () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
     const event = insertEvent(rawDb, { name: "Mixed Venues", slug: "mixed-venues" });
-    rawDb.prepare("UPDATE events SET status='archived', is_published=1 WHERE id=?").run(event.id);
+    // archive.js always writes is_published = 0 when it sets status = 'archived'
+    // (see functions/api/admin/events/[id]/archive.js) — status='archived' AND
+    // is_published=1 together is a combination production can never hold.
+    rawDb.prepare("UPDATE events SET status='archived' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Stage A" });
     insertBand(rawDb, { name: "Band With Venue", event_id: event.id, venue_id: venue.id });
     insertBand(rawDb, { name: "Band Without Venue", event_id: event.id }); // no venue

--- a/functions/api/events/__tests__/timeline-archived-buckets.test.js
+++ b/functions/api/events/__tests__/timeline-archived-buckets.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { onRequestGet as timelineHandler } from "../timeline.js";
 import { createTestEnv, insertEvent } from "../../test-utils.js";
+import { eventLocalToday } from "../../../utils/eventDay.js";
 
 // Regression guard for how `status = 'archived'` interacts with the timeline's
 // now / upcoming / past bucketing.
@@ -25,10 +26,22 @@ import { createTestEnv, insertEvent } from "../../test-utils.js";
 // SQL actually returns, which a mock keyed on WHERE-clause substrings cannot
 // demonstrate.
 
+// Anchored on the Toronto-local event day, NOT `new Date().toISOString()`.
+// timeline.js buckets events off eventLocalToday()/eventLocalFestivalToday(),
+// so a UTC-sliced baseline runs a day ahead of the handler between local
+// 20:00 and midnight — the exact "server-side today is never UTC-sliced"
+// invariant this repo documents (fixed in #568). Offsetting from a UTC-midnight
+// Date built out of those Y/M/D parts keeps the arithmetic pure calendar days.
+//
+// Deliberately NOT mirrored into schedule-current-visibility.test.js: that
+// handler gates on SQLite `date('now','-6 hours')`, which really is UTC, so a
+// UTC baseline is the aligned one there. Same-looking helper, different correct
+// answer — the baseline has to match the handler under test, not a house style.
 function isoDaysFromNow(days) {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().slice(0, 10);
+  const [year, month, day] = eventLocalToday().split("-").map(Number);
+  const base = new Date(Date.UTC(year, month - 1, day));
+  base.setUTCDate(base.getUTCDate() + days);
+  return base.toISOString().slice(0, 10);
 }
 
 async function getTimeline(env) {

--- a/functions/api/events/__tests__/timeline-archived-buckets.test.js
+++ b/functions/api/events/__tests__/timeline-archived-buckets.test.js
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import { onRequestGet as timelineHandler } from "../timeline.js";
+import { createTestEnv, insertEvent } from "../../test-utils.js";
+
+// Regression guard for how `status = 'archived'` interacts with the timeline's
+// now / upcoming / past bucketing.
+//
+// Bucket membership is a LIFECYCLE question before it is a date question:
+// archiving an event means "this edition is concluded", so it must outrank the
+// calendar. An admin who closes out an event on its own final day (or on day 2
+// of a multi-day run, or early by mistake) must not leave it advertised as
+// "Happening Now".
+//
+//   now      = published AND the festival window covers today
+//   upcoming = published AND dated in the future
+//   past     = archived OR (published AND concluded by date)
+//
+// The two halves are load-bearing together. Narrowing now/upcoming to
+// published-only WITHOUT `archived OR` in past would make an archived event
+// with a live or future date match no bucket at all and disappear from the
+// timeline entirely — which is why the fifth test here exists.
+//
+// These run against the real better-sqlite3 harness rather than the mocked
+// query-string matcher in timeline.test.js: the whole point is which rows the
+// SQL actually returns, which a mock keyed on WHERE-clause substrings cannot
+// demonstrate.
+
+function isoDaysFromNow(days) {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+async function getTimeline(env) {
+  const res = await timelineHandler({
+    request: new Request("https://example.test/api/events/timeline"),
+    env,
+  });
+  expect(res.status).toBe(200);
+  return res.json();
+}
+
+const slugsOf = (bucket) => (bucket || []).map((e) => e.slug ?? e.event_slug);
+
+describe("GET /api/events/timeline — archived events never appear as live", () => {
+  it("keeps an archived event off 'now' even while its date window is open", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // Spans yesterday → tomorrow, so the date filter alone puts it squarely in
+    // the "now" window. Only the status gate can exclude it.
+    insertEvent(rawDb, {
+      name: "Closed Out Early",
+      slug: "closed-out-early",
+      date: isoDaysFromNow(-1),
+      end_date: isoDaysFromNow(1),
+      status: "archived",
+    });
+
+    const body = await getTimeline(env);
+
+    expect(slugsOf(body.now)).not.toContain("closed-out-early");
+    expect(slugsOf(body.upcoming)).not.toContain("closed-out-early");
+  });
+
+  it("keeps an archived event off 'upcoming' even when it is future-dated", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    insertEvent(rawDb, {
+      name: "Archived But Future Dated",
+      slug: "archived-future",
+      date: isoDaysFromNow(30),
+      status: "archived",
+    });
+
+    const body = await getTimeline(env);
+
+    expect(slugsOf(body.upcoming)).not.toContain("archived-future");
+    expect(slugsOf(body.now)).not.toContain("archived-future");
+  });
+
+  it("still shows a published event in 'now' — the gate narrows status, not dates", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    insertEvent(rawDb, {
+      name: "Running Tonight",
+      slug: "running-tonight",
+      date: isoDaysFromNow(-1),
+      end_date: isoDaysFromNow(1),
+      status: "published",
+    });
+
+    const body = await getTimeline(env);
+
+    // Without this, "exclude archived" could be satisfied by a gate that
+    // excludes everything — the exact failure mode of the P0 this branch fixes.
+    expect(slugsOf(body.now)).toContain("running-tonight");
+  });
+
+  it("still shows a published future event in 'upcoming'", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    insertEvent(rawDb, {
+      name: "Long Weekend Band Crawl Vol. 18",
+      slug: "lwbc18",
+      date: isoDaysFromNow(60),
+      status: "published",
+    });
+
+    const body = await getTimeline(env);
+
+    expect(slugsOf(body.upcoming)).toContain("lwbc18");
+  });
+
+  it("routes an archived event to 'past' regardless of its date, so it is never lost", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // Both of these are excluded from now/upcoming by the tests above. If the
+    // past bucket were gated on date alone they would match NO bucket and
+    // silently vanish from the timeline — the regression that narrowing
+    // now/upcoming without `archived OR` in past would introduce.
+    insertEvent(rawDb, {
+      name: "Closed Out Early",
+      slug: "closed-out-early",
+      date: isoDaysFromNow(-1),
+      end_date: isoDaysFromNow(1),
+      status: "archived",
+    });
+    insertEvent(rawDb, {
+      name: "Archived But Future Dated",
+      slug: "archived-future",
+      date: isoDaysFromNow(30),
+      status: "archived",
+    });
+
+    const body = await getTimeline(env);
+    const past = slugsOf(body.past);
+
+    expect(past).toContain("closed-out-early");
+    expect(past).toContain("archived-future");
+  });
+
+  it("keeps a genuinely concluded published event in 'past'", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    // Published and over, but nobody has archived it yet — the default state of
+    // every event between "show ended" and an admin clicking Archive.
+    insertEvent(rawDb, {
+      name: "Finished Not Yet Archived",
+      slug: "finished-unarchived",
+      date: isoDaysFromNow(-10),
+      end_date: isoDaysFromNow(-9),
+      status: "published",
+    });
+
+    const body = await getTimeline(env);
+
+    expect(slugsOf(body.past)).toContain("finished-unarchived");
+  });
+
+  it("never shows a draft event in any bucket", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+
+    insertEvent(rawDb, {
+      name: "Unannounced",
+      slug: "unannounced-draft",
+      date: isoDaysFromNow(20),
+      status: "draft",
+    });
+
+    const body = await getTimeline(env);
+
+    expect(slugsOf(body.now)).not.toContain("unannounced-draft");
+    expect(slugsOf(body.upcoming)).not.toContain("unannounced-draft");
+    expect(slugsOf(body.past)).not.toContain("unannounced-draft");
+  });
+});

--- a/functions/api/events/__tests__/timeline-cancelled.test.js
+++ b/functions/api/events/__tests__/timeline-cancelled.test.js
@@ -41,7 +41,6 @@ describe("Timeline real-DB — the 'now' query excludes cancelled sets (#732)", 
       end_date: todayLocal(),
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     return event;
   };
 
@@ -118,7 +117,6 @@ describe("Timeline real-DB — is_cancelled surfaces on upcoming[].bands (#732)"
       date: farFuture,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Room 47" });
     const cancelledPerf = insertBand(rawDb, {
@@ -172,7 +170,6 @@ describe("Timeline real-DB — is_cancelled surfaces on upcoming[].bands (#732)"
       date: "2020-01-01",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     const cancelledPerf = insertBand(rawDb, {

--- a/functions/api/events/__tests__/timeline.test.js
+++ b/functions/api/events/__tests__/timeline.test.js
@@ -724,7 +724,7 @@ describe("Timeline real-DB — reveal_mode JOIN gate (SQL exercise)", () => {
       date: today,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET reveal_mode=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     const perf = insertBand(rawDb, {
@@ -771,7 +771,6 @@ describe("Timeline real-DB — upcoming has no fixed day-window cap (SQL exercis
       date: farFuture,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -818,7 +817,6 @@ describe("Timeline real-DB — NULL venue_id must not inflate venue_count (#479)
       date: today,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     // venue_id defaults to null in insertBand — performance has no venue assigned
     insertBand(rawDb, { name: "Unassigned Band", event_id: event.id });
@@ -869,7 +867,6 @@ describe("Timeline real-DB — derived band url is scheme-validated (#483)", () 
       date: today,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Roost" });
     insertBand(rawDb, {
@@ -908,7 +905,6 @@ describe("Timeline real-DB — derived band url is scheme-validated (#483)", () 
       date: today,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Roost" });
     insertBand(rawDb, {
@@ -954,7 +950,6 @@ describe("Timeline real-DB — event ticket_url is scheme-validated (#504)", () 
       date: today,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     rawDb
       .prepare("UPDATE events SET ticket_url = ? WHERE id = ?")
       // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #504 read-path guard
@@ -983,7 +978,6 @@ describe("Timeline real-DB — event ticket_url is scheme-validated (#504)", () 
       date: today,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     rawDb.prepare("UPDATE events SET ticket_url = ? WHERE id = ?").run("https://tickets.example.com/crawl", event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
@@ -1020,7 +1014,6 @@ describe("Timeline real-DB — event poster_url is present and scheme-validated 
       date: today,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     rawDb
       .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
       .run("https://cdn.example.com/posters/poster-event.jpg", event.id);
@@ -1048,7 +1041,6 @@ describe("Timeline real-DB — event poster_url is present and scheme-validated 
       date: today,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1073,7 +1065,6 @@ describe("Timeline real-DB — event poster_url is present and scheme-validated 
       date: today,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #658 read-path guard
     rawDb.prepare("UPDATE events SET poster_url = ? WHERE id = ?").run("javascript:alert(1)", event.id);
 
@@ -1119,7 +1110,6 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
       status: "published",
       doors_json: JSON.stringify({ "2026-07-10": "16:00" }),
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1145,7 +1135,6 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
       status: "published",
       doors_json: JSON.stringify({ "2026-07-10": "16:00" }),
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1173,7 +1162,6 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
       status: "published",
       doors_json: JSON.stringify({ "2026-07-10": "16:00", "2026-07-11": "10:00" }),
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1201,7 +1189,7 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
     });
     // Seed malformed JSON directly — bypasses validateDoorsJson, simulating a
     // legacy/corrupt row.
-    rawDb.prepare("UPDATE events SET is_published=1, doors_json=? WHERE id=?").run("{not valid json", event.id);
+    rawDb.prepare("UPDATE events SET doors_json=? WHERE id=?").run("{not valid json", event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1227,7 +1215,6 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
       date: "2026-07-10",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1251,7 +1238,6 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
       date: "2026-07-10",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Roost" });
     insertBand(rawDb, {
@@ -1285,7 +1271,6 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
       date: "2026-07-10",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Roost" });
     insertBand(rawDb, {
@@ -1321,7 +1306,6 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
       status: "published",
       doors_json: JSON.stringify({ "2026-07-10": "16:00" }),
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Roost" });
     insertBand(rawDb, {
@@ -1359,7 +1343,6 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
       date: "2026-07-10",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Roost" });
     insertBand(rawDb, {
@@ -1403,7 +1386,6 @@ describe("Timeline real-DB — start-edge gate (#569)", () => {
       end_date: "2026-07-11",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Roost" });
     const fridayPerf = insertBand(rawDb, {
@@ -1469,7 +1451,6 @@ describe("Timeline real-DB — end-edge gate (#751)", () => {
       date: "2026-07-10",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Roost" });
     const evening = insertBand(rawDb, {
@@ -1517,7 +1498,6 @@ describe("Timeline real-DB — end-edge gate (#751)", () => {
       date: "2026-07-10",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1544,7 +1524,6 @@ describe("Timeline real-DB — end-edge gate (#751)", () => {
       end_date: "2026-08-09",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "The Mill" });
     const lastNightSet = insertBand(rawDb, {
@@ -1584,7 +1563,6 @@ describe("Timeline real-DB — end-edge gate (#751)", () => {
       date: "2026-07-10",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1630,7 +1608,6 @@ describe("Timeline real-DB — end_date exposed on event objects (#542 PR-1)", (
       end_date: "2026-07-12",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1654,7 +1631,6 @@ describe("Timeline real-DB — end_date exposed on event objects (#542 PR-1)", (
       end_date: "2026-07-22",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(multiDay.id);
 
     const singleDay = insertEvent(rawDb, {
       name: "Future One-Nighter",
@@ -1662,7 +1638,6 @@ describe("Timeline real-DB — end_date exposed on event objects (#542 PR-1)", (
       date: "2026-07-15",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(singleDay.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1690,7 +1665,6 @@ describe("Timeline real-DB — end_date exposed on event objects (#542 PR-1)", (
       end_date: "2026-07-05",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const request = new Request("https://example.test/api/events/timeline");
     const response = await timelineHandler({ request, env });
@@ -1726,7 +1700,6 @@ describe("Timeline real-DB — duplicate performer chips for a two-set band (#60
       date: farFuture,
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     insertBand(rawDb, {

--- a/functions/api/events/public.js
+++ b/functions/api/events/public.js
@@ -4,6 +4,7 @@
 
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { normalizeHttpUrl } from "../../utils/validation.js";
+import { publicEventStatusSql } from "../../utils/eventVisibility.js";
 
 export async function onRequestGet(context) {
   const { request, env } = context;
@@ -38,7 +39,7 @@ export async function onRequestGet(context) {
         COUNT(DISTINCT p.venue_id) as venue_count
       FROM events e
       LEFT JOIN performances p ON p.event_id = e.id
-      WHERE e.is_published = 1
+      WHERE ${publicEventStatusSql("e")}
     `;
 
     const params = [];

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -2,6 +2,7 @@ import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { CACHE_SHOW_CRITICAL } from "../../utils/cacheHeaders.js";
 import { normalizeHttpUrl } from "../../utils/validation.js";
 import { eventLocalToday, eventLocalFestivalToday, eventLocalClock } from "../../utils/eventDay.js";
+import { publicEventStatusSql } from "../../utils/eventVisibility.js";
 
 /**
  * 24-hour "HH:MM" time regex — mirrors DOORS_TIME_REGEX in validation.js.
@@ -331,7 +332,7 @@ export async function onRequestGet(context) {
         LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1) AND p.is_cancelled = 0
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
-        WHERE e.is_published = 1
+        WHERE ${publicEventStatusSql("e")}
         AND e.date <= ?
         AND COALESCE(e.end_date, e.date) >= ?
         ORDER BY e.date DESC, p.start_time, v.name
@@ -382,11 +383,11 @@ export async function onRequestGet(context) {
         LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1)
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
-        WHERE e.is_published = 1
+        WHERE ${publicEventStatusSql("e")}
         AND e.date > ?
         AND e.id IN (
           SELECT id FROM events
-          WHERE is_published = 1
+          WHERE ${publicEventStatusSql()}
           AND date > ?
           ORDER BY date ASC
           LIMIT 10
@@ -443,13 +444,12 @@ export async function onRequestGet(context) {
         LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1)
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
-        WHERE (
-          (e.is_published = 1 AND COALESCE(e.end_date, e.date) < ?)
-          OR e.status = 'archived'
-        )
+        WHERE ${publicEventStatusSql("e")}
+        AND COALESCE(e.end_date, e.date) < ?
         AND e.id IN (
           SELECT id FROM events
-          WHERE (is_published = 1 AND COALESCE(end_date, date) < ?) OR status = 'archived'
+          WHERE ${publicEventStatusSql()}
+          AND COALESCE(end_date, date) < ?
           ORDER BY date DESC
           LIMIT ?
         )

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -2,7 +2,26 @@ import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { CACHE_SHOW_CRITICAL } from "../../utils/cacheHeaders.js";
 import { normalizeHttpUrl } from "../../utils/validation.js";
 import { eventLocalToday, eventLocalFestivalToday, eventLocalClock } from "../../utils/eventDay.js";
-import { publicEventStatusSql } from "../../utils/eventVisibility.js";
+import { archivedEventStatusSql, publishedEventStatusSql } from "../../utils/eventVisibility.js";
+
+// Bucket membership is a lifecycle question before it is a date question.
+// `status = 'archived'` MEANS "this edition is concluded", so it outranks the
+// calendar: an archived event must never surface as "Happening Now" or
+// "Upcoming" just because an admin closed it out on its own final day (the
+// same trap `/api/schedule?event=current` avoids with publishedEventStatusSql).
+//
+//   now      = published AND the festival window covers today
+//   upcoming = published AND dated in the future
+//   past     = archived OR (published AND concluded by date)
+//
+// Exhaustive and non-overlapping over publicly visible events. The two halves
+// only work together: narrowing now/upcoming to published-only WITHOUT the
+// `archived OR` below would make an archived-but-future-dated event match no
+// bucket at all and vanish from the timeline entirely.
+const concludedEventSql = (alias = "") => {
+  const dateExpr = alias ? `COALESCE(${alias}.end_date, ${alias}.date)` : "COALESCE(end_date, date)";
+  return `(${archivedEventStatusSql(alias)} OR (${publishedEventStatusSql(alias)} AND ${dateExpr} < ?))`;
+};
 
 /**
  * 24-hour "HH:MM" time regex — mirrors DOORS_TIME_REGEX in validation.js.
@@ -332,7 +351,7 @@ export async function onRequestGet(context) {
         LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1) AND p.is_cancelled = 0
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
-        WHERE ${publicEventStatusSql("e")}
+        WHERE ${publishedEventStatusSql("e")}
         AND e.date <= ?
         AND COALESCE(e.end_date, e.date) >= ?
         ORDER BY e.date DESC, p.start_time, v.name
@@ -383,11 +402,11 @@ export async function onRequestGet(context) {
         LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1)
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
-        WHERE ${publicEventStatusSql("e")}
+        WHERE ${publishedEventStatusSql("e")}
         AND e.date > ?
         AND e.id IN (
           SELECT id FROM events
-          WHERE ${publicEventStatusSql()}
+          WHERE ${publishedEventStatusSql()}
           AND date > ?
           ORDER BY date ASC
           LIMIT 10
@@ -444,12 +463,10 @@ export async function onRequestGet(context) {
         LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1)
         LEFT JOIN band_profiles b ON p.band_profile_id = b.id
         LEFT JOIN venues v ON p.venue_id = v.id
-        WHERE ${publicEventStatusSql("e")}
-        AND COALESCE(e.end_date, e.date) < ?
+        WHERE ${concludedEventSql("e")}
         AND e.id IN (
           SELECT id FROM events
-          WHERE ${publicEventStatusSql()}
-          AND COALESCE(end_date, date) < ?
+          WHERE ${concludedEventSql()}
           ORDER BY date DESC
           LIMIT ?
         )

--- a/functions/api/feeds/__tests__/ical-cancelled.test.js
+++ b/functions/api/feeds/__tests__/ical-cancelled.test.js
@@ -12,7 +12,7 @@ describe("GET /api/feeds/ical — cancelled sets", () => {
       slug: "ical-cancelled",
       date: futureDate,
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Blue Room" });
 
     // Insert one cancelled set and one scheduled set

--- a/functions/api/feeds/__tests__/ical.test.js
+++ b/functions/api/feeds/__tests__/ical.test.js
@@ -254,7 +254,7 @@ describe("GET /api/feeds/ical — reveal_mode gate (real-DB)", () => {
       slug: "ical-reveal-hidden",
       date: futureDate,
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     const perf = insertBand(rawDb, {
       name: "Hidden iCal Band",
@@ -281,7 +281,7 @@ describe("GET /api/feeds/ical — reveal_mode gate (real-DB)", () => {
       slug: "ical-reveal-shown",
       date: futureDate,
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Princess Cafe" });
     const perf = insertBand(rawDb, {
       name: "Revealed iCal Band",
@@ -308,7 +308,7 @@ describe("GET /api/feeds/ical — reveal_mode gate (real-DB)", () => {
       slug: "ical-reveal-mode0",
       date: futureDate,
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=0 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Room 47" });
     const perf = insertBand(rawDb, {
       name: "Normal iCal Band",
@@ -348,7 +348,7 @@ describe("GET /api/feeds/ical — day-aware performance_date (real-DB)", () => {
       date: day1,
       end_date: day2,
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Roost" });
 
     const day2Perf = insertBand(rawDb, {
@@ -388,7 +388,7 @@ describe("GET /api/feeds/ical — day-aware performance_date (real-DB)", () => {
       date: day1,
       end_date: day2,
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Prohibition Warehouse" });
 
     const lateNightPerf = insertBand(rawDb, {
@@ -426,7 +426,7 @@ describe("GET /api/feeds/ical — day-aware performance_date (real-DB)", () => {
       date: day1,
       end_date: day2,
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Room 47" });
 
     // Day-1 early set (NULL performance_date — inherits the event's date).
@@ -496,7 +496,7 @@ describe("GET /api/feeds/ical — midnight-straddling DTEND rolls to the next da
       slug: "ical-straddle",
       date: "2099-03-01",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Room 47" });
 
     insertBand(rawDb, {
@@ -527,7 +527,7 @@ describe("GET /api/feeds/ical — midnight-straddling DTEND rolls to the next da
       slug: "ical-month-boundary",
       date: "2099-03-31",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Princess Cafe" });
 
     insertBand(rawDb, {

--- a/functions/api/feeds/ical.js
+++ b/functions/api/feeds/ical.js
@@ -3,6 +3,7 @@
 // Compatible with Google Calendar, Apple Calendar, Outlook
 
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
+import { publicEventStatusSql } from "../../utils/eventVisibility.js";
 
 function sanitizeFilenamePart(value) {
   return (
@@ -50,7 +51,7 @@ export async function onRequestGet(context) {
       LEFT JOIN performances p ON p.event_id = e.id AND (e.reveal_mode = 0 OR p.is_announced = 1)
       LEFT JOIN band_profiles bp ON p.band_profile_id = bp.id
       LEFT JOIN venues v ON v.id = p.venue_id
-      WHERE e.is_published = 1
+      WHERE ${publicEventStatusSql("e")}
       AND COALESCE(e.end_date, e.date) >= date('now')
     `;
 

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -5,7 +5,7 @@
 import { getPublicDataGateResponse } from "../utils/publicGate.js";
 import { normalizeHttpUrl, safeReflectSocialLinks } from "../utils/validation.js";
 import { logger } from "../utils/logger.js";
-import { publicEventStatusSql } from "../utils/eventVisibility.js";
+import { publicEventStatusSql, publishedEventStatusSql } from "../utils/eventVisibility.js";
 
 export async function onRequestGet(context) {
   const { request, env } = context;
@@ -24,14 +24,17 @@ export async function onRequestGet(context) {
     let event;
 
     if (eventParam === "current") {
-      // Get the current or next upcoming published event
+      // Get the current or next upcoming published event.
       // The -6 hour buffer keeps the event visible during late-night/overnight
-      // sets that span past midnight (e.g. 11:30pm-12:30am)
+      // sets that span past midnight (e.g. 11:30pm-12:30am).
+      // Deliberately published-only, unlike the slug branch below: that same
+      // -6h buffer means an event archived on its own final day still matches
+      // the date filter, and serving that as tonight's live schedule is wrong.
       event = await DB.prepare(
         `
         SELECT id, name, date, end_date, city, slug, status, ticket_url, poster_url, theme_colors, venue_info, social_links, doors_json, reveal_mode
         FROM events
-        WHERE ${publicEventStatusSql()}
+        WHERE ${publishedEventStatusSql()}
           AND COALESCE(end_date, date) >= date('now', '-6 hours')
         ORDER BY date ASC
         LIMIT 1

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -5,6 +5,7 @@
 import { getPublicDataGateResponse } from "../utils/publicGate.js";
 import { normalizeHttpUrl, safeReflectSocialLinks } from "../utils/validation.js";
 import { logger } from "../utils/logger.js";
+import { publicEventStatusSql } from "../utils/eventVisibility.js";
 
 export async function onRequestGet(context) {
   const { request, env } = context;
@@ -30,7 +31,7 @@ export async function onRequestGet(context) {
         `
         SELECT id, name, date, end_date, city, slug, status, ticket_url, poster_url, theme_colors, venue_info, social_links, doors_json, reveal_mode
         FROM events
-        WHERE is_published = 1
+        WHERE ${publicEventStatusSql()}
           AND COALESCE(end_date, date) >= date('now', '-6 hours')
         ORDER BY date ASC
         LIMIT 1
@@ -42,7 +43,7 @@ export async function onRequestGet(context) {
         `
         SELECT id, name, date, end_date, city, slug, status, ticket_url, poster_url, theme_colors, venue_info, social_links, doors_json, reveal_mode
         FROM events
-        WHERE slug = ? AND (is_published = 1 OR status = 'archived')
+        WHERE slug = ? AND ${publicEventStatusSql()}
       `,
       )
         .bind(eventParam)

--- a/functions/api/schedule/__tests__/build.test.js
+++ b/functions/api/schedule/__tests__/build.test.js
@@ -6,7 +6,6 @@ describe("POST /api/schedule/build", () => {
   test("records schedule build for performance ids", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "Build Event", slug: "build-event" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Build Venue" });
     const performance = insertBand(rawDb, {
       name: "Build Band",

--- a/functions/api/schedule/__tests__/share-create.test.js
+++ b/functions/api/schedule/__tests__/share-create.test.js
@@ -14,7 +14,7 @@ describe("POST /api/schedule/share", () => {
   test("creates a share link and returns a slug", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { slug: "my-event" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     const venue = insertVenue(rawDb);
     const perf = insertBand(rawDb, { event_id: event.id, venue_id: venue.id });
 

--- a/functions/api/schedule/__tests__/share-get-bands.test.js
+++ b/functions/api/schedule/__tests__/share-get-bands.test.js
@@ -12,7 +12,7 @@ describe("GET /api/schedule/share/[slug] — bands detail", () => {
   function seed() {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "Vol. 17", slug: "vol17" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     return { env, rawDb, event, venue };
   }

--- a/functions/api/schedule/__tests__/share-get.test.js
+++ b/functions/api/schedule/__tests__/share-get.test.js
@@ -30,7 +30,7 @@ describe("GET /api/schedule/share/[slug]", () => {
   test("returns share link data for a valid slug", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
       slug: "abc12345",
       event_id: event.id,
@@ -96,7 +96,7 @@ describe("GET /api/schedule/share/[slug]", () => {
   test("counts one view per visitor, not one per fetch (#705)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
       slug: "view1234",
       event_id: event.id,
@@ -127,7 +127,7 @@ describe("GET /api/schedule/share/[slug]", () => {
   test("never writes an orphan ledger row when the parent link is gone (#705)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
       slug: "orphan01",
       event_id: event.id,
@@ -178,7 +178,7 @@ describe("GET /api/schedule/share/[slug]", () => {
   test("link-preview crawlers never count (#705)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
       slug: "crawler1",
       event_id: event.id,
@@ -211,7 +211,7 @@ describe("GET /api/schedule/share/[slug]", () => {
   test("does not increment view_count for an import refetch (?import=1)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
       slug: "import12",
       event_id: event.id,
@@ -237,7 +237,7 @@ describe("GET /api/schedule/share/[slug]", () => {
   test("increments import_count for an import refetch (?import=1) but not view_count (#703)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
       slug: "import99",
       event_id: event.id,
@@ -264,7 +264,7 @@ describe("GET /api/schedule/share/[slug]", () => {
   test("a normal GET (no ?import=1) increments view_count but not import_count (#703)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
       slug: "normal01",
       event_id: event.id,
@@ -285,7 +285,7 @@ describe("GET /api/schedule/share/[slug]", () => {
   test("an import-counter write failure still returns the share payload with 200 (#703)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "My Fest", slug: "my-fest" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     insertShareLink(rawDb, {
       slug: "failimp1",
       event_id: event.id,

--- a/functions/api/schedule/share.js
+++ b/functions/api/schedule/share.js
@@ -3,6 +3,7 @@
 // Body: { event_id, event_slug, performance_ids[], band_names[] }
 
 import { toSqliteDateTime } from "../../utils/authAttempts.js";
+import { publicEventStatusSql } from "../../utils/eventVisibility.js";
 
 const MAX_PERFORMANCE_IDS = 50;
 const MAX_BAND_NAME_LENGTH = 100;
@@ -58,7 +59,7 @@ export async function onRequestPost(context) {
       return json({ error: `Band names must not exceed ${MAX_BAND_NAME_LENGTH} characters` }, 400);
     }
 
-    const event = await DB.prepare(`SELECT id FROM events WHERE id = ? AND (is_published = 1 OR status = 'archived')`)
+    const event = await DB.prepare(`SELECT id FROM events WHERE id = ? AND ${publicEventStatusSql()}`)
       .bind(Number(event_id))
       .first();
     if (!event) {

--- a/functions/api/schedule/share/[slug].js
+++ b/functions/api/schedule/share/[slug].js
@@ -2,6 +2,7 @@
 // GET /api/schedule/share/[slug]
 
 import { isLikelyCrawler, visitorHash } from "../../../utils/visitorDedupe.js";
+import { publicEventStatusSql } from "../../../utils/eventVisibility.js";
 
 function json(body, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -25,7 +26,7 @@ export async function onRequestGet(context) {
     const row = await DB.prepare(
       `SELECT sl.slug, sl.event_slug, sl.performance_ids, sl.band_names, e.name AS event_name
        FROM share_links sl
-       JOIN events e ON e.id = sl.event_id AND (e.is_published = 1 OR e.status = 'archived')
+       JOIN events e ON e.id = sl.event_id AND ${publicEventStatusSql("e")}
        WHERE sl.slug = ? AND sl.expires_at > datetime('now')`,
     )
       .bind(slug)

--- a/functions/api/stats/__tests__/public.test.js
+++ b/functions/api/stats/__tests__/public.test.js
@@ -9,7 +9,7 @@ function seedEnv() {
 }
 
 function publish(rawDb, eventId) {
-  rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(eventId);
+  rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(eventId);
 }
 
 async function getStats(env) {

--- a/functions/api/stats/public.js
+++ b/functions/api/stats/public.js
@@ -14,6 +14,7 @@
 // Bands/venues/events are public data, so their names/counts are fine.
 
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
+import { publicEventStatusSql } from "../../utils/eventVisibility.js";
 
 const TOP_BANDS_LIMIT = 8;
 
@@ -46,12 +47,12 @@ export async function onRequestGet(context) {
       await DB.batch([
         DB.prepare(`SELECT COUNT(*) AS count FROM band_profiles WHERE is_active = 1`),
         DB.prepare(`SELECT COUNT(*) AS count FROM venues`),
-        DB.prepare(`SELECT COUNT(*) AS count FROM events WHERE is_published = 1`),
+        DB.prepare(`SELECT COUNT(*) AS count FROM events WHERE ${publicEventStatusSql()}`),
         DB.prepare(
           `SELECT COUNT(*) AS count
            FROM performances p
            JOIN events e ON e.id = p.event_id
-           WHERE e.is_published = 1`,
+           WHERE ${publicEventStatusSql("e")}`,
         ),
         // share_links: aggregate only — count of rows + sum of view_count.
         DB.prepare(`SELECT COUNT(*) AS count, COALESCE(SUM(view_count), 0) AS total_views FROM share_links`),

--- a/functions/api/venues.js
+++ b/functions/api/venues.js
@@ -5,6 +5,7 @@
 // so venues are discoverable. Gated by PUBLIC_DATA_PUBLISH_ENABLED.
 
 import { getPublicDataGateResponse } from "../utils/publicGate.js";
+import { publicEventStatusSql } from "../utils/eventVisibility.js";
 
 const DEFAULT_LIMIT = 24;
 const MAX_LIMIT = 60;
@@ -46,7 +47,7 @@ export async function onRequestGet(context) {
       FROM venues v
       JOIN performances p ON p.venue_id = v.id
       JOIN events e ON e.id = p.event_id
-      WHERE (e.is_published = 1 OR e.status = 'archived')
+      WHERE ${publicEventStatusSql("e")}
         AND (
           ? = ''
           OR v.name LIKE ? ESCAPE '\\'

--- a/functions/api/venues/[id].js
+++ b/functions/api/venues/[id].js
@@ -8,6 +8,7 @@ import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { CACHE_SHOW_CRITICAL } from "../../utils/cacheHeaders.js";
 import { validateId } from "../../utils/validation.js";
 import { eventLocalFestivalToday } from "../../utils/eventDay.js";
+import { publicEventStatusSql } from "../../utils/eventVisibility.js";
 
 function json(body, status = 200, extraHeaders = {}) {
   return new Response(JSON.stringify(body), {
@@ -69,7 +70,7 @@ export async function onRequestGet(context) {
       JOIN events e ON e.id = p.event_id
       JOIN band_profiles bp ON bp.id = p.band_profile_id
       WHERE p.venue_id = ?
-        AND (e.is_published = 1 OR e.status = 'archived')
+        AND ${publicEventStatusSql("e")}
         AND (e.reveal_mode = 0 OR p.is_announced = 1)
       -- Events newest-first, but sets CHRONOLOGICAL within an event (#741).
       -- Ordering on start_time alone put a day-3 16:10 set ahead of a day-1

--- a/functions/api/venues/__tests__/venue-detail.test.js
+++ b/functions/api/venues/__tests__/venue-detail.test.js
@@ -16,7 +16,7 @@ describe("GET /api/venues/:id — reveal_mode gate", () => {
       slug: "venue-reveal-hidden",
       date: futureDate,
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Hidden Venue Band",
       event_id: event.id,
@@ -45,7 +45,7 @@ describe("GET /api/venues/:id — reveal_mode gate", () => {
       slug: "venue-reveal-shown",
       date: futureDate,
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Revealed Venue Band",
       event_id: event.id,
@@ -74,7 +74,7 @@ describe("GET /api/venues/:id — reveal_mode gate", () => {
       slug: "venue-reveal-mode0",
       date: futureDate,
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=0 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=0 WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Normal Venue Band",
       event_id: event.id,
@@ -124,7 +124,7 @@ describe("GET /api/venues/:id — end-edge gate (#750)", () => {
       slug: "venue-endedge-single",
       date: "2026-08-07",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Night Owl Set",
       event_id: event.id,
@@ -157,7 +157,7 @@ describe("GET /api/venues/:id — end-edge gate (#750)", () => {
       slug: "venue-endedge-single-cutover",
       date: "2026-08-07",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const perf = insertBand(rawDb, {
       name: "Cutover Band",
       event_id: event.id,
@@ -192,7 +192,7 @@ describe("GET /api/venues/:id — multi-day ordering and per-set dates (#741)", 
       end_date: "2099-08-09",
       status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
 
     // Deliberately inserted out of order, with the LATEST day carrying the
     // EARLIEST clock time -- the exact shape that made start_time-only
@@ -287,7 +287,7 @@ describe("GET /api/venues/:id — performer card fields (#742)", () => {
       slug: "card-fields-upcoming",
       date: "2099-01-01",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(upcomingEvent.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(upcomingEvent.id);
     insertBand(rawDb, {
       name: "Photogenic Band",
       event_id: upcomingEvent.id,
@@ -301,7 +301,7 @@ describe("GET /api/venues/:id — performer card fields (#742)", () => {
       slug: "card-fields-past",
       date: "2001-01-01",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(pastEvent.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(pastEvent.id);
     insertBand(rawDb, {
       name: "Archived Photogenic Band",
       event_id: pastEvent.id,
@@ -328,7 +328,7 @@ describe("GET /api/venues/:id — performer card fields (#742)", () => {
 
     const venue = insertVenue(rawDb, { name: "Blank Fields Venue" });
     const event = insertEvent(rawDb, { name: "Blank Fields Event", slug: "blank-fields-event", date: "2099-01-01" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     insertBand(rawDb, { name: "Plain Band", event_id: event.id, venue_id: venue.id });
 
     const response = await onRequestGet({ env, params: { id: String(venue.id) } });

--- a/functions/event/[slug].js
+++ b/functions/event/[slug].js
@@ -13,6 +13,7 @@ import {
 import { normalizeHttpUrl } from "../utils/validation.js";
 import { sortableName } from "../utils/sortableName.js";
 import { torontoUtcOffset } from "../utils/eventDay.js";
+import { publicEventStatusSql } from "../utils/eventVisibility.js";
 
 // Sets starting before 06:00 are after-midnight sets that belong to the
 // PREVIOUS festival day (AFTER_MIDNIGHT_THRESHOLD_HOUR = 6 convention;
@@ -116,7 +117,7 @@ export async function onRequest(context) {
     event = await env.DB.prepare(
       `SELECT id, name, date, end_date, slug, description, city, ticket_url, poster_url, created_at, reveal_mode
        FROM events
-       WHERE slug = ? AND (is_published = 1 OR status = 'archived')`,
+       WHERE slug = ? AND ${publicEventStatusSql()}`,
     )
       .bind(slug)
       .first();

--- a/functions/event/__tests__/slug.jsonld-golden.test.js
+++ b/functions/event/__tests__/slug.jsonld-golden.test.js
@@ -72,7 +72,7 @@ describe("JSON-LD golden snapshot — /event/[slug]", () => {
       slug: "golden-lwbc17",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id = ?").run(event.id);
     // Pin created_at: offers.validFrom is derived from it (see [slug].js),
     // so leaving the schema default (datetime('now')) would make the
     // snapshot re-run non-deterministic — a new validFrom every day.

--- a/functions/event/__tests__/slug.test.js
+++ b/functions/event/__tests__/slug.test.js
@@ -42,7 +42,7 @@ describe("SSR /event/[slug] — MusicEvent JSON-LD ticket_url sanitization (#504
       slug: "slug-504-unsafe-ticket",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     rawDb
       .prepare("UPDATE events SET ticket_url = ? WHERE id = ?")
       // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #504 read-path guard
@@ -68,7 +68,7 @@ describe("SSR /event/[slug] — MusicEvent JSON-LD ticket_url sanitization (#504
       slug: "slug-504-safe-ticket",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     rawDb.prepare("UPDATE events SET ticket_url = ? WHERE id = ?").run("https://tickets.example.com/crawl", event.id);
 
     const response = await onRequest(makeContext({ env, slug: "slug-504-safe-ticket" }));
@@ -90,7 +90,7 @@ describe("SSR /event/[slug] — MusicEvent JSON-LD enrichment (#615)", () => {
       slug: "slug-615-enriched",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
 
     const response = await onRequest(makeContext({ env, slug: "slug-615-enriched" }));
     expect(response.status).toBe(200);
@@ -115,7 +115,7 @@ describe("SSR /event/[slug] — MusicEvent JSON-LD enrichment (#615)", () => {
       slug: "slug-615-ticketed",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     rawDb.prepare("UPDATE events SET ticket_url = ? WHERE id = ?").run("https://tickets.example.com/crawl", event.id);
 
     const seededEvent = rawDb.prepare("SELECT created_at FROM events WHERE id = ?").get(event.id);
@@ -140,7 +140,7 @@ describe("SSR /event/[slug] — MusicEvent JSON-LD enrichment (#615)", () => {
       slug: "slug-615-no-ticket",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
 
     const response = await onRequest(makeContext({ env, slug: "slug-615-no-ticket" }));
     expect(response.status).toBe(200);
@@ -160,7 +160,7 @@ describe("SSR /event/[slug] — poster_url image + og:image/twitter:image (#616)
       slug: "slug-616-poster",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     rawDb
       .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
       .run("https://band-photos.settimes.ca/event-posters/1-vol17.jpg", event.id);
@@ -189,7 +189,7 @@ describe("SSR /event/[slug] — poster_url image + og:image/twitter:image (#616)
       slug: "slug-616-no-poster",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
 
     const response = await onRequest(makeContext({ env, slug: "slug-616-no-poster" }));
     expect(response.status).toBe(200);
@@ -211,7 +211,7 @@ describe("SSR /event/[slug] — poster_url image + og:image/twitter:image (#616)
       slug: "slug-616-unsafe-poster",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     rawDb
       .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
       // eslint-disable-next-line no-script-url -- test fixture: intentional unsafe scheme, exercises the #504-style read-path guard
@@ -242,7 +242,7 @@ describe("SSR /event/[slug] — per-day subEvent JSON-LD (#542 PR-4)", () => {
       slug: "slug-542-multiday",
       date: "2026-08-01",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, end_date=? WHERE id=?").run("2026-08-02", event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', end_date=? WHERE id=?").run("2026-08-02", event.id);
     const venue = insertVenue(rawDb, { name: "Main Stage" });
 
     const day1Band = insertBand(rawDb, {
@@ -302,7 +302,7 @@ describe("SSR /event/[slug] — per-day subEvent JSON-LD (#542 PR-4)", () => {
       slug: "slug-542-singleday",
       date: "2026-08-01",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Solo Venue" });
     insertBand(rawDb, { name: "Only Band", event_id: event.id, venue_id: venue.id });
 
@@ -323,7 +323,7 @@ describe("SSR /event/[slug] — per-day subEvent JSON-LD (#542 PR-4)", () => {
       slug: "slug-542-same-date",
       date: "2026-08-01",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, end_date=? WHERE id=?").run("2026-08-01", event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', end_date=? WHERE id=?").run("2026-08-01", event.id);
 
     const response = await onRequest(makeContext({ env, slug: "slug-542-same-date" }));
     const html = await response.text();
@@ -339,7 +339,9 @@ describe("SSR /event/[slug] — per-day subEvent JSON-LD (#542 PR-4)", () => {
       slug: "slug-542-reveal",
       date: "2026-08-01",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, end_date=?, reveal_mode=1 WHERE id=?").run("2026-08-02", event.id);
+    rawDb
+      .prepare("UPDATE events SET status = 'published', end_date=?, reveal_mode=1 WHERE id=?")
+      .run("2026-08-02", event.id);
     const venue = insertVenue(rawDb, { name: "Reveal Stage" });
 
     const announced = insertBand(rawDb, { name: "Announced Band", event_id: event.id, venue_id: venue.id });
@@ -377,7 +379,7 @@ describe("SSR /event/[slug] — per-day subEvent JSON-LD (#542 PR-4)", () => {
       slug: "slug-542-after-midnight",
       date: "2026-08-01",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, end_date=? WHERE id=?").run("2026-08-02", event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', end_date=? WHERE id=?").run("2026-08-02", event.id);
     const venue = insertVenue(rawDb, { name: "Late Stage" });
 
     // Stored with performance_date = the literal calendar date the 1 AM set
@@ -408,11 +410,11 @@ describe("SSR /event/[slug] — per-day subEvent JSON-LD (#542 PR-4)", () => {
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
 
     const summerEvent = insertEvent(rawDb, { name: "Summer Show", slug: "slug-542-summer", date: "2026-08-02" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(summerEvent.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(summerEvent.id);
 
     // lwbc15 precedent (CLAUDE.md #542): a February event is EST, not EDT.
     const winterEvent = insertEvent(rawDb, { name: "Winter Show", slug: "slug-542-winter", date: "2026-02-14" });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(winterEvent.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(winterEvent.id);
 
     const summerRes = await onRequest(makeContext({ env, slug: "slug-542-summer" }));
     const [summerMusicEvent] = extractJsonLd(await summerRes.text());
@@ -433,7 +435,7 @@ describe("SSR /event/[slug] — MusicEvent JSON-LD venue reveal_mode gate (#635)
       slug: "slug-635-reveal-venue",
       date: "2026-08-01",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, reveal_mode=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published', reveal_mode=1 WHERE id=?").run(event.id);
 
     const visibleVenue = insertVenue(rawDb, { name: "Visible Venue" });
     const hiddenVenue = insertVenue(rawDb, { name: "Hidden Venue" });
@@ -502,7 +504,7 @@ describe("SSR /event/[slug] — og:site_name (#784 ownership sweep)", () => {
       slug: "slug-784-site-name",
       date: "2026-08-02",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
 
     const response = await onRequest(makeContextWithDefaultsShell({ env, slug: "slug-784-site-name" }));
     expect(response.status).toBe(200);

--- a/functions/events/[slug]/recap.js
+++ b/functions/events/[slug]/recap.js
@@ -11,6 +11,7 @@ import { isPublicDataEnabled } from "../../utils/publicGate.js";
 import { escapeAttr, serveWithInjectedMeta, CANONICAL_HOST, DEFAULT_OG_IMAGE } from "../../utils/ssrMeta.js";
 import { normalizeHttpUrl, validateDate } from "../../utils/validation.js";
 import { eventLocalToday } from "../../utils/eventDay.js";
+import { publicEventStatusSql } from "../../utils/eventVisibility.js";
 
 const DATE_LABEL_FORMAT = { year: "numeric", month: "long", day: "numeric" };
 
@@ -41,7 +42,7 @@ export async function onRequestGet(context) {
     event = await env.DB.prepare(
       `SELECT id, name, slug, date, end_date, poster_url
        FROM events
-       WHERE slug = ? AND (is_published = 1 OR status = 'archived')`,
+       WHERE slug = ? AND ${publicEventStatusSql()}`,
     )
       .bind(slug)
       .first();

--- a/functions/events/__tests__/recap.test.js
+++ b/functions/events/__tests__/recap.test.js
@@ -59,14 +59,12 @@ describe("SSR /events/[slug]/recap", () => {
   test("injects the recap's own canonical + og:url, and strips the homepage's", async () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
-    const event = insertEvent(rawDb, {
+    insertEvent(rawDb, {
       name: "Recap Event",
       slug: "recap-event",
       date: "2026-08-02",
       status: "archived",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
-
     const response = await onRequestGet(makeContext({ env, slug: "recap-event" }));
     expect(response.status).toBe(200);
     const html = await response.text();
@@ -83,14 +81,12 @@ describe("SSR /events/[slug]/recap", () => {
   test("exactly one of every identity tag — no duplicate from the homepage shell", async () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
-    const event = insertEvent(rawDb, {
+    insertEvent(rawDb, {
       name: "Single Tag Event",
       slug: "single-tag-event",
       date: "2026-08-02",
       status: "archived",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
-
     const response = await onRequestGet(makeContext({ env, slug: "single-tag-event" }));
     const html = await response.text();
 
@@ -108,7 +104,6 @@ describe("SSR /events/[slug]/recap", () => {
       date: "2025-08-03",
       status: "archived",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Main Stage" });
     insertBand(rawDb, { name: "Band A", event_id: event.id, venue_id: venue.id });
     insertBand(rawDb, { name: "Band B", event_id: event.id, venue_id: venue.id });
@@ -127,14 +122,12 @@ describe("SSR /events/[slug]/recap", () => {
   test("falls back to the branded default og:image when the event has no poster", async () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
-    const event = insertEvent(rawDb, {
+    insertEvent(rawDb, {
       name: "No Poster Event",
       slug: "no-poster-event",
       date: "2026-08-02",
       status: "archived",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
-
     const response = await onRequestGet(makeContext({ env, slug: "no-poster-event" }));
     const html = await response.text();
 
@@ -152,7 +145,7 @@ describe("SSR /events/[slug]/recap", () => {
       status: "archived",
     });
     rawDb
-      .prepare("UPDATE events SET is_published=1, poster_url = ? WHERE id = ?")
+      .prepare("UPDATE events SET poster_url = ? WHERE id = ?")
       .run("https://band-photos.settimes.ca/event-posters/recap.jpg", event.id);
 
     const response = await onRequestGet(makeContext({ env, slug: "postered-event" }));
@@ -183,8 +176,8 @@ describe("SSR /events/[slug]/recap", () => {
       date: "2026-08-02",
       status: "draft",
     });
-    // is_published stays 0 (default) and status stays 'draft' -- matches
-    // neither half of the (is_published = 1 OR status = 'archived') gate.
+    // status stays 'draft' (the insertEvent default) -- doesn't satisfy
+    // publicEventStatusSql()'s status IN ('published', 'archived') gate.
 
     const response = await onRequestGet(makeContext({ env, slug: "draft-event-recap" }));
     expect(response.status).toBe(200);
@@ -200,12 +193,12 @@ describe("SSR /events/[slug]/recap", () => {
   test("falls back to the plain shell for a published event whose date is in the future", async () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
-    const event = insertEvent(rawDb, {
+    insertEvent(rawDb, {
       name: "Future Event",
       slug: "future-event-recap",
       date: "2999-01-01",
+      status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const response = await onRequestGet(makeContext({ env, slug: "future-event-recap" }));
     expect(response.status).toBe(200);
@@ -225,8 +218,9 @@ describe("SSR /events/[slug]/recap", () => {
       name: "In-Progress Multiday Event",
       slug: "in-progress-multiday-recap",
       date: "2026-08-02",
+      status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1, end_date='2999-01-01' WHERE id=?").run(event.id);
+    rawDb.prepare("UPDATE events SET end_date='2999-01-01' WHERE id=?").run(event.id);
 
     const response = await onRequestGet(makeContext({ env, slug: "in-progress-multiday-recap" }));
     expect(response.status).toBe(200);
@@ -242,12 +236,12 @@ describe("SSR /events/[slug]/recap", () => {
   test("falls back to the plain shell for a calendar-invalid legacy date (Feb 30)", async () => {
     const { env, rawDb } = createTestEnv();
     env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
-    const event = insertEvent(rawDb, {
+    insertEvent(rawDb, {
       name: "Bad Legacy Date Event",
       slug: "bad-legacy-date-recap",
       date: "2026-02-30",
+      status: "published",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
 
     const response = await onRequestGet(makeContext({ env, slug: "bad-legacy-date-recap" }));
     expect(response.status).toBe(200);
@@ -258,14 +252,12 @@ describe("SSR /events/[slug]/recap", () => {
   test("falls back to the plain shell when the public-data gate is closed", async () => {
     const { env, rawDb } = createTestEnv();
     // PUBLIC_DATA_PUBLISH_ENABLED intentionally left unset.
-    const event = insertEvent(rawDb, {
+    insertEvent(rawDb, {
       name: "Gated Event",
       slug: "gated-event",
       date: "2026-08-02",
       status: "archived",
     });
-    rawDb.prepare("UPDATE events SET is_published=1 WHERE id=?").run(event.id);
-
     const response = await onRequestGet(makeContext({ env, slug: "gated-event" }));
     expect(response.status).toBe(200);
     const html = await response.text();

--- a/functions/s/__tests__/slug-og-live.test.js
+++ b/functions/s/__tests__/slug-og-live.test.js
@@ -29,7 +29,6 @@ describe("SSR /s/[slug] — OG card resolves live performances (#733)", () => {
   function seed() {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "Vol. 17", slug: "vol17" });
-    rawDb.prepare("UPDATE events SET is_published = 1 WHERE id = ?").run(event.id);
     const venue = insertVenue(rawDb, { name: "Blue Room" });
     return { env, rawDb, event, venue };
   }

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -4,6 +4,7 @@
  */
 import { getPublicDataGateResponse } from "./utils/publicGate.js";
 import { eventLocalToday } from "./utils/eventDay.js";
+import { publicEventStatusSql } from "./utils/eventVisibility.js";
 
 export async function onRequestGet(context) {
   const { env } = context;
@@ -15,20 +16,20 @@ export async function onRequestGet(context) {
 
   try {
     const [{ results: events }, { results: bands }, { results: venues }] = await Promise.all([
-      env.DB.prepare(`SELECT slug, date FROM events WHERE is_published = 1 ORDER BY date DESC`).all(),
+      env.DB.prepare(`SELECT slug, date FROM events WHERE ${publicEventStatusSql()} ORDER BY date DESC`).all(),
       env.DB.prepare(
         `SELECT DISTINCT bp.id
          FROM band_profiles bp
          INNER JOIN performances p ON p.band_profile_id = bp.id
          INNER JOIN events e ON e.id = p.event_id
-         WHERE e.is_published = 1`,
+         WHERE ${publicEventStatusSql("e")}`,
       ).all(),
       env.DB.prepare(
         `SELECT DISTINCT v.id
          FROM venues v
          INNER JOIN performances p ON p.venue_id = v.id
          INNER JOIN events e ON e.id = p.event_id
-         WHERE e.is_published = 1`,
+         WHERE ${publicEventStatusSql("e")}`,
       ).all(),
     ]);
 

--- a/functions/utils/__tests__/eventVisibility.test.js
+++ b/functions/utils/__tests__/eventVisibility.test.js
@@ -113,13 +113,19 @@ describe("is_published never read outside admin/test infrastructure", () => {
     return false;
   }
 
+  // .ts is scanned even though functions/ is currently JS-only: a guard that
+  // silently stops covering a file type the day someone adds one is the exact
+  // failure mode guards exist to prevent. Mirrors the frontend half in
+  // frontend/src/__tests__/isPublishedGuard.test.js.
+  const SCANNED_EXTENSIONS = [".js", ".ts"];
+
   function walk(dir) {
     let files = [];
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         files = files.concat(walk(full));
-      } else if (entry.isFile() && entry.name.endsWith(".js")) {
+      } else if (entry.isFile() && SCANNED_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
         files.push(full);
       }
     }

--- a/functions/utils/__tests__/eventVisibility.test.js
+++ b/functions/utils/__tests__/eventVisibility.test.js
@@ -2,7 +2,7 @@ import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { publicEventStatusSql, archivedEventStatusSql } from "../eventVisibility.js";
+import { publicEventStatusSql, archivedEventStatusSql, publishedEventStatusSql } from "../eventVisibility.js";
 
 describe("publicEventStatusSql", () => {
   it("returns the unaliased predicate by default", () => {
@@ -36,6 +36,39 @@ describe("archivedEventStatusSql", () => {
 
   it("throws on an invalid alias", () => {
     expect(() => archivedEventStatusSql("e; DROP TABLE events;--")).toThrow();
+  });
+});
+
+describe("publishedEventStatusSql", () => {
+  it("returns the unaliased predicate by default", () => {
+    expect(publishedEventStatusSql()).toBe("status = 'published'");
+  });
+
+  it("prefixes the given alias", () => {
+    expect(publishedEventStatusSql("e")).toBe("e.status = 'published'");
+  });
+
+  it("excludes archived, unlike publicEventStatusSql", () => {
+    // The distinction that matters: /api/schedule?event=current must not serve
+    // an event archived on its own final day as tonight's live schedule.
+    expect(publishedEventStatusSql()).not.toContain("archived");
+    expect(publicEventStatusSql()).toContain("archived");
+  });
+
+  it("throws on an invalid alias", () => {
+    expect(() => publishedEventStatusSql("e; DROP TABLE events;--")).toThrow();
+  });
+});
+
+describe("alias validation rejects non-strings", () => {
+  // String(null) === "null", which matches the identifier pattern. Without an
+  // explicit typeof guard, a null alias would pass validation and then quietly
+  // fall through to an unaliased column, producing valid-but-wrong SQL in a
+  // multi-table join. Regression guard for that exact hole.
+  it.each([[null], [0], [1], [{}], [[]], [true]])("throws for %p", (value) => {
+    expect(() => publicEventStatusSql(value)).toThrow(/invalid table alias/);
+    expect(() => archivedEventStatusSql(value)).toThrow(/invalid table alias/);
+    expect(() => publishedEventStatusSql(value)).toThrow(/invalid table alias/);
   });
 });
 

--- a/functions/utils/__tests__/eventVisibility.test.js
+++ b/functions/utils/__tests__/eventVisibility.test.js
@@ -1,0 +1,117 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { publicEventStatusSql, archivedEventStatusSql } from "../eventVisibility.js";
+
+describe("publicEventStatusSql", () => {
+  it("returns the unaliased predicate by default", () => {
+    expect(publicEventStatusSql()).toBe("status IN ('published', 'archived')");
+  });
+
+  it("prefixes the given alias", () => {
+    expect(publicEventStatusSql("e")).toBe("e.status IN ('published', 'archived')");
+    expect(publicEventStatusSql("e2")).toBe("e2.status IN ('published', 'archived')");
+  });
+
+  it("throws on an alias that isn't a plain SQL identifier", () => {
+    // The alias is always a hardcoded literal in real callers, but this
+    // function must not silently become an injection vector if that
+    // invariant is ever broken — see the header comment in eventVisibility.js.
+    expect(() => publicEventStatusSql("e; DROP TABLE events;--")).toThrow();
+    expect(() => publicEventStatusSql("e.status")).toThrow();
+    expect(() => publicEventStatusSql(" e")).toThrow();
+    expect(() => publicEventStatusSql("1e")).toThrow();
+  });
+});
+
+describe("archivedEventStatusSql", () => {
+  it("returns the unaliased predicate by default", () => {
+    expect(archivedEventStatusSql()).toBe("status = 'archived'");
+  });
+
+  it("prefixes the given alias", () => {
+    expect(archivedEventStatusSql("e2")).toBe("e2.status = 'archived'");
+  });
+
+  it("throws on an invalid alias", () => {
+    expect(() => archivedEventStatusSql("e; DROP TABLE events;--")).toThrow();
+  });
+});
+
+// --- Durable guard: `is_published` must never be read on a public path -----
+//
+// `events.is_published` was deprecated in migration 0005 in favour of
+// `events.status`, but `functions/api/admin/events/[id]/archive.js` still
+// writes it (`is_published = 0`) to keep the eventual column-drop migration
+// safe. Archiving therefore UNPUBLISHES under the old column, so any public
+// read path still gated on bare `is_published = 1` silently returns zero
+// rows the moment an event is archived. See functions/utils/eventVisibility.js
+// for the full incident writeup.
+//
+// This is a source scan, not a runtime assertion (same technique as
+// frontend/src/admin/utils/__tests__/bandFields.test.js): the bug is a string
+// baked into a SQL template at module load time, so nothing about it is
+// observable by calling the exported functions.
+describe("is_published never read outside admin/test infrastructure", () => {
+  const currentFile = fileURLToPath(import.meta.url);
+  const functionsRoot = path.join(path.dirname(currentFile), "../../");
+
+  // Directories/files exempt from the scan:
+  //  - functions/api/admin/**  — admin write paths must keep writing
+  //    is_published in lockstep with status (rollback safety for the
+  //    eventual column-drop migration); not a public read path.
+  //  - any __tests__/** path   — test fixtures legitimately seed/assert
+  //    against the deprecated column (e.g. verifying archive.js's write, or
+  //    an impossible-state regression guard).
+  //  - functions/api/test-utils.js — the shared test D1 schema. Its
+  //    CREATE TABLE mirrors production (which still has the column); this is
+  //    schema parity, not a read.
+  //  - functions/utils/eventVisibility.js — this predicate's own canonical
+  //    home. Its header comment documents the deprecated column by name, so
+  //    a literal string scan would otherwise flag itself.
+  const EXEMPT_EXACT = new Set(["api/test-utils.js", "utils/eventVisibility.js"]);
+
+  function isExempt(relPath) {
+    const normalized = relPath.split(path.sep).join("/");
+    if (normalized.startsWith("api/admin/")) return true;
+    if (normalized.split("/").includes("__tests__")) return true;
+    if (EXEMPT_EXACT.has(normalized)) return true;
+    return false;
+  }
+
+  function walk(dir) {
+    let files = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files = files.concat(walk(full));
+      } else if (entry.isFile() && entry.name.endsWith(".js")) {
+        files.push(full);
+      }
+    }
+    return files;
+  }
+
+  it("contains no bare is_published reads outside the allowlisted paths", () => {
+    const offenders = [];
+    for (const absPath of walk(functionsRoot)) {
+      const relPath = path.relative(functionsRoot, absPath);
+      if (isExempt(relPath)) continue;
+      const source = readFileSync(absPath, "utf8");
+      if (source.includes("is_published")) {
+        offenders.push(relPath);
+      }
+    }
+
+    expect(
+      offenders,
+      offenders.length > 0
+        ? `is_published must never be read on a public path (functions/utils/eventVisibility.js) — ` +
+            `found it in: ${offenders.join(", ")}. Use publicEventStatusSql()/archivedEventStatusSql() instead, ` +
+            `or add the file to functions/api/admin/**, a __tests__/** path, or the EXEMPT_EXACT allowlist ` +
+            `in this guard if it's genuinely test/schema infrastructure.`
+        : undefined,
+    ).toEqual([]);
+  });
+});

--- a/functions/utils/eventVisibility.js
+++ b/functions/utils/eventVisibility.js
@@ -1,0 +1,59 @@
+// The single canonical home for "is this event publicly visible?" — mirrors
+// functions/utils/eventDay.js's role as the one place that owns a
+// recurring cross-file predicate (see CLAUDE.md).
+//
+// `events.is_published` was deprecated in migration 0005 in favour of
+// `events.status TEXT` ('draft' | 'published' | 'archived'), but the column
+// was never dropped. `functions/api/admin/events/[id]/archive.js` writes
+// `status = 'archived', is_published = 0` — archiving an event therefore
+// UNPUBLISHES it under the old column. Every production event ends up
+// 'archived' or 'draft', so a public read path still gated on bare
+// `is_published = 1` matches ZERO rows once an event has been archived.
+//
+// `status` is the real gate. An event is publicly visible iff
+// `status IN ('published', 'archived')`; it is specifically archived iff
+// `status = 'archived'`. `is_published` must never be read on a public path
+// again — the guard test in functions/utils/__tests__/eventVisibility.test.js
+// scans the source tree and fails the build if it is. Admin write paths
+// (functions/api/admin/**) are exempt: they must keep writing `is_published`
+// in lockstep with `status` so the eventual column-drop migration stays safe
+// and this change stays rollback-able.
+
+const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// The alias is always a hardcoded literal supplied by the calling module,
+// never user input — but it is validated anyway so this helper can never
+// become an injection vector if a caller ever passes something dynamic.
+function assertValidAlias(alias) {
+  if (alias !== "" && !IDENTIFIER_RE.test(alias)) {
+    throw new Error(`eventVisibility: invalid table alias "${alias}"`);
+  }
+}
+
+function columnRef(alias) {
+  assertValidAlias(alias);
+  return alias ? `${alias}.status` : "status";
+}
+
+/**
+ * SQL predicate for "this event is publicly visible" — published or
+ * archived. Pass the table alias in use at the call site (e.g. "e"); omit it
+ * when the query selects directly from `events` with no alias.
+ *
+ * @param {string} [alias] - table alias, e.g. "e"; "" (default) for none
+ * @returns {string} e.g. "e.status IN ('published', 'archived')"
+ */
+export function publicEventStatusSql(alias = "") {
+  return `${columnRef(alias)} IN ('published', 'archived')`;
+}
+
+/**
+ * SQL predicate for "this event is archived" — the subset of public
+ * visibility used by recap pages and "returning act" history queries.
+ *
+ * @param {string} [alias] - table alias, e.g. "e2"; "" (default) for none
+ * @returns {string} e.g. "e.status = 'archived'"
+ */
+export function archivedEventStatusSql(alias = "") {
+  return `${columnRef(alias)} = 'archived'`;
+}

--- a/functions/utils/eventVisibility.js
+++ b/functions/utils/eventVisibility.js
@@ -6,9 +6,14 @@
 // `events.status TEXT` ('draft' | 'published' | 'archived'), but the column
 // was never dropped. `functions/api/admin/events/[id]/archive.js` writes
 // `status = 'archived', is_published = 0` — archiving an event therefore
-// UNPUBLISHES it under the old column. Every production event ends up
-// 'archived' or 'draft', so a public read path still gated on bare
-// `is_published = 1` matches ZERO rows once an event has been archived.
+// UNPUBLISHES it under the old column, so a public read path gated on bare
+// `is_published = 1` stops matching that event the instant it is archived.
+//
+// A live event really is `status = 'published'` with `is_published = 1`, so
+// the two columns agree while it runs and nothing looks wrong. The failure is
+// terminal rather than gradual: every edition eventually gets archived, and
+// when the last un-archived one does, every such read path drops to ZERO rows
+// at the same instant. That is what took the public site dark on 2026-08-10.
 //
 // `status` is the real gate. An event is publicly visible iff
 // `status IN ('published', 'archived')`; it is specifically archived iff

--- a/functions/utils/eventVisibility.js
+++ b/functions/utils/eventVisibility.js
@@ -25,7 +25,11 @@ const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 // never user input — but it is validated anyway so this helper can never
 // become an injection vector if a caller ever passes something dynamic.
 function assertValidAlias(alias) {
-  if (alias !== "" && !IDENTIFIER_RE.test(alias)) {
+  // The typeof check is load-bearing, not defensive noise: IDENTIFIER_RE.test()
+  // stringifies its argument, and String(null) === "null" matches the identifier
+  // pattern. Without it, a null alias passes validation and then silently
+  // degrades to an unaliased column via the falsy check in columnRef().
+  if (typeof alias !== "string" || (alias !== "" && !IDENTIFIER_RE.test(alias))) {
     throw new Error(`eventVisibility: invalid table alias "${alias}"`);
   }
 }
@@ -49,11 +53,30 @@ export function publicEventStatusSql(alias = "") {
 
 /**
  * SQL predicate for "this event is archived" — the subset of public
- * visibility used by recap pages and "returning act" history queries.
+ * visibility used by recap pages, which exist only for concluded editions.
  *
  * @param {string} [alias] - table alias, e.g. "e2"; "" (default) for none
  * @returns {string} e.g. "e.status = 'archived'"
  */
 export function archivedEventStatusSql(alias = "") {
   return `${columnRef(alias)} = 'archived'`;
+}
+
+/**
+ * SQL predicate for "this event is published" — the NARROWER subset that
+ * deliberately excludes archived events.
+ *
+ * Use this only where serving a concluded event would be wrong, not merely
+ * unusual. The live case is `/api/schedule?event=current`: an event archived
+ * on its own final day still satisfies
+ * `COALESCE(end_date, date) >= date('now','-6 hours')`, so the broader
+ * publicEventStatusSql() would hand a fan the archived edition as tonight's
+ * running schedule. Browse and history surfaces want publicEventStatusSql()
+ * instead — archived editions are the site's back catalogue, not an error.
+ *
+ * @param {string} [alias] - table alias, e.g. "e"; "" (default) for none
+ * @returns {string} e.g. "e.status = 'published'"
+ */
+export function publishedEventStatusSql(alias = "") {
+  return `${columnRef(alias)} = 'published'`;
 }


### PR DESCRIPTION
## Summary

**settimes.ca went dark to the public today.** Buddies Fest 2 was archived at `2026-08-10 13:57:42 UTC`; `functions/api/admin/events/[id]/archive.js:79` writes `SET status = 'archived', archived_at = …, is_published = 0`, so archiving the last live event flipped the site's final publish bit off. Thirteen public read paths gated on bare `is_published = 1` with no `OR status = 'archived'` escape hatch, and every one of them went to zero at the same instant.

`events.is_published` was deprecated back in `migrations/0005` ("can be dropped in a future migration once all code is updated") and never removed; `migrations/0036` even added a fresh index on it. `status TEXT` (`'draft' | 'published' | 'archived'`) is the real gate. This PR moves **every public read** onto `status` behind one canonical helper, and adds a source-scanning guard test so the column can never be read on a public path again.

No pre-existing issue — same-day P0 hotfix. Follow-up filed as **#799** (drop the column and its two indexes, and stop writing it from admin).

## The blast radius, verified live against production before the fix

| Surface | Was | Should be |
|---|---|---|
| `/api/events/public` | `count: 0` | 19 |
| `/api/stats/public` | `events: 0, performances: 0` beside `bands: 218` | 19 / 283 |
| `/sitemap.xml` | 8 URLs, all static | ~276 |
| `/api/feeds/ical` | 0 `VEVENT`s | future events |
| `/api/events/timeline` | `now: 0, upcoming: 0` | structurally unreachable |
| `/api/bands/:name` | `404 Band not found` for every band | 200 |
| Homepage | heading + collapsed "Show History (19)", **zero event cards** | event cards |

Running both predicates against the real production dataset: **visible_events 19 vs 0**, **visible_performances 283 vs 0**, **sitemap_bands 218 vs 0**, **sitemap_venues 12 vs 0**.

**This was also a long-standing SEO hole, not purely today's regression.** `sitemap.xml.js:24` and `:31` build the band and venue URLs by joining through `events` with `e.is_published = 1`. Archiving has always forced that to 0, so archived editions have *never* contributed URLs — the 218 artist pages and 12 venue pages have essentially never been in the sitemap. Today merely removed the one live event that was masking it.

## What changed

| File | Change |
|------|--------|
| **`functions/utils/eventVisibility.js`** | **New.** The single canonical home for the gate, mirroring `functions/utils/eventDay.js`'s role for the after-midnight threshold. Exports `publicEventStatusSql()` (published-or-archived), `archivedEventStatusSql()`, `publishedEventStatusSql()`. Alias-validated so it can never become an injection vector if a caller ever passes something dynamic. |
| `functions/sitemap.xml.js` | 3 gates converted — the two SEO-significant ones are the band (`:24`) and venue (`:31`) joins. |
| `functions/api/events/timeline.js` | 5 gates converted. |
| `functions/api/stats/public.js`, `events/public.js`, `feeds/ical.js`, `schedule.js`, `bands/[name].js` | The remaining bare `is_published = 1` reads. |
| `functions/api/artists.js`, `venues.js`, `venues/[id].js`, `events/[id]/details.js`, `bands/stats/[name].js`, `schedule/share.js`, `schedule/share/[slug].js`, `event/[slug].js`, `events/[slug]/recap.js` | Already-correct sites carrying the second and third SQL dialects (`(is_published = 1 OR status = 'archived')`, raw `status IN (…)`), normalised onto the shared helper. Leaving multiple dialects live is what let these drift apart in the first place. |
| `functions/api/events/[id]/recap.js` | Two raw `status = 'archived'` literals routed through `archivedEventStatusSql()`. |
| `functions/utils/__tests__/eventVisibility.test.js` | **New.** Unit tests for all three exports plus the durable source-scan guard (below). |
| `functions/api/__tests__/schedule-current-visibility.test.js` | **New.** Regression guard for the `?event=current` narrowing (below). |
| 30 test fixture files | `UPDATE events SET is_published = 1` → `status = 'published'`. |

**17 production read paths converted; 1 new canonical home; 30 fixture files corrected.**

### Two latent bugs fixed as a side effect

- **`timeline.js`'s "past" bucket had no date filter on its archived branch** — `(is_published = 1 AND end < ?) OR status = 'archived'` sorted an archived *future*-dated event into "past". The new gate applies the date filter uniformly.
- **`functions/api/bands/[name].js:118`** projected `e.is_published as event_published` with no consumer anywhere. Deleted.

### The one place the gate is deliberately *narrower*

`/api/schedule?event=current` uses `publishedEventStatusSql()` (published-only), not the broader predicate. CodeRabbit caught this as a regression I'd introduced in the mechanical sweep, and it was right: that handler carries a `-6 hours` buffer, so an event archived on its own final day still satisfies `COALESCE(end_date, date) >= date('now','-6 hours')` and the broader predicate would hand a fan the archived edition as tonight's live schedule. The `?event=<slug>` branch stays published-or-archived — archived editions are the site's browsable back catalogue.

CodeRabbit's literal patch was a raw `status = 'published'` string, which would have started a fourth SQL dialect outside the canonical home; added `publishedEventStatusSql()` instead.

## Security / correctness notes

- **No new injection surface.** The helpers interpolate only a table alias, which is a hardcoded literal at every call site and is validated against `/^[A-Za-z_][A-Za-z0-9_]*$/` regardless. The `typeof alias !== "string"` check is load-bearing, not defensive noise: `RegExp.test()` stringifies its argument and `String(null) === "null"` matches the identifier pattern, so without it a `null` alias would pass validation and then silently degrade to an unaliased column — valid-but-wrong SQL in a multi-table join. Covered by an `it.each` regression block.
- **Admin write paths still write `is_published`** (`functions/api/admin/**`, exempted from the guard scan). Keeping the columns in lockstep keeps the eventual column-drop migration safe and makes this change rollback-able. #799 removes it.
- **This widens what the public can see**, by design: archived events and their performances become visible again on the sitemap, iCal feed, artist pages, and venue pages. That is the intended pre-incident behaviour — `status = 'archived'` means "concluded", not "hidden". Draft events remain invisible on every path.

## Why CI was green through all of this

30+ test files seeded `UPDATE events SET is_published = 1` while leaving `status` at its `'draft'` default. **Production can never hold that state** — the admin write paths keep both columns in lockstep. One fixture even asserted `status='archived', is_published=1`, which `archive.js` makes unreachable by construction. The fixtures encoded an impossible world and validated the broken gate inside it.

## The durable guard

`functions/utils/__tests__/eventVisibility.test.js` walks `functions/**/*.js` with `readFileSync` and fails if any file outside `functions/api/admin/**`, `__tests__/**`, or a 2-entry allowlist so much as mentions `is_published`. Same technique as `frontend/src/admin/utils/__tests__/bandFields.test.js` — and necessary for the same reason: the bug is a string baked into a SQL template at module load, so nothing about it is observable by calling the exported functions. Turns the whole class into one failing test instead of a recurring audit.

**Proven by mutation, not assumed:**
- Reintroducing `is_published = 1` into a non-admin function → guard fails. ✅
- Reverting `?event=current` to `publicEventStatusSql()` → 2 of the 3 tests in `schedule-current-visibility.test.js` fail, and the slug-branch test correctly stays green (narrowing `current` must not be achieved by narrowing visibility globally, which would re-break history browsing — the original incident). ✅

## Verification

- [x] Tests: 1082 backend pass across 105 files, 0 failures (`npm test`); 980 frontend pass across 86 files (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check`, both stacks)
- [x] Build: green (`npm run build --prefix frontend`)
- [x] `make gate` exit 0 — twice, before and after the CodeRabbit review round
- [x] `validate:openapi`: n/a — `docs/api-spec.yaml` unchanged
- [x] Manual smoke: production incident reproduced in a browser via Playwright before the fix (homepage renders a heading, a false "Discover upcoming band crawls" tagline, and a collapsed "Show History (19)" with zero event cards). Both predicates then run against the real production dataset, confirming 19/283/218/12 vs. 0/0/0/0.
- [x] CodeRabbit (`make review`) — 1 MAJOR (the `?event=current` widening, fixed), 1 MINOR (the `typeof` guard, fixed). Two further issues found by the sibling sweep that CodeRabbit missed: `archivedEventStatusSql` had zero production consumers, and `recap.js` still carried raw `status = 'archived'` literals — both resolved by routing recap through the helper.

**Note:** the `pr-review-toolkit:code-reviewer` pass (triggered — multi-file, touches a documented invariant) terminated early on an API session limit and never produced a review. Happy to re-run it before merge; given the site is currently dark, I'd rather not hold the fix on it.

## Post-merge

1. Confirm against production: `curl -s https://settimes.ca/sitemap.xml | grep -c '<loc>'` (expect ~276, was 8), `curl -s https://settimes.ca/api/stats/public | jq '{events,performances}'`, `curl -s https://settimes.ca/api/feeds/ical | grep -c 'BEGIN:VEVENT'`.
2. Resubmit `sitemap.xml` in Search Console — 218 artist pages and 12 venue pages are entering the sitemap for essentially the first time.

---
Built by Sonny · Reviewed by Theo + CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event visibility across schedules, event pages, listings, feeds, sitemaps, recaps, sharing, and public statistics.
  - Current-event results now exclude archived events and select the appropriate published event.
  - Archived events remain accessible through direct links where applicable.
  - Timeline buckets now correctly place archived and concluded events.
  - Invalid numeric event identifiers now return a clear error.

- **User Experience**
  - Past events expand automatically when no current or upcoming events exist.
  - Improved between-season messaging and lineup information.
  - Removed draft badges from event cards.

- **Tests**
  - Added regression coverage for visibility, timeline behaviour, and publication states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->