### PR TITLE
fix(recap): make sitemap, SSR and the recap API agree on "concluded"

### DIFF
--- a/functions/__tests__/recapGatingConsistency.test.js
+++ b/functions/__tests__/recapGatingConsistency.test.js
@@ -110,6 +110,21 @@ describe("#787 — sitemap, SSR and the recap API agree on whether a recap exist
     expect(await allThree(env)).toEqual({ sitemap: true, ssr: true, api: true });
   });
 
+  it("archived but future-dated: all three serve it", async () => {
+    // The case my first pass missed, caught by CodeRabbit and Codex
+    // independently. concludedEventSql treats archived as concluded regardless
+    // of date (lifecycle outranks the calendar, #800), and an admin can produce
+    // this by archiving an event early. SSR carried a SECOND, redundant
+    // `lastDay >= eventLocalToday()` check that re-decided conclusion locally
+    // and returned the shell here, while the API and sitemap said yes.
+    //
+    // The exact three-way disagreement this whole file exists to prevent --
+    // which is why "all three agree" beats "each path is individually correct".
+    const env = seed({ date: isoDaysFromNow(30), status: "archived" });
+
+    expect(await allThree(env)).toEqual({ sitemap: true, ssr: true, api: true });
+  });
+
   it("published but still in the future: none of the three serve it", async () => {
     const env = seed({ date: isoDaysFromNow(30), status: "published" });
 

--- a/functions/__tests__/recapGatingConsistency.test.js
+++ b/functions/__tests__/recapGatingConsistency.test.js
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { onRequestGet as sitemapHandler } from "../sitemap.xml.js";
+import { onRequestGet as recapApiHandler } from "../api/events/[id]/recap.js";
+import { onRequestGet as recapSsrHandler } from "../events/[slug]/recap.js";
+import { createTestEnv, insertEvent } from "../api/test-utils.js";
+import { eventLocalToday } from "../utils/eventDay.js";
+
+// #787 — three paths decide whether an event's recap page exists, and they used
+// to disagree:
+//
+//   sitemap.xml.js            publicEventStatusSql() + a JS `date < today` compare
+//   events/[slug]/recap.js    publicEventStatusSql() -- no date check at all
+//   api/events/[id]/recap.js  archivedEventStatusSql() -- narrower than both
+//
+// A published, past, NOT-YET-ARCHIVED event therefore got a sitemap URL and full
+// SSR identity meta while the data API behind the page 404'd: an indexable
+// soft-404. Archiving is an admin housekeeping click that lags the event's real
+// end -- Buddies Fest 2 sat unarchived for three days after it finished.
+//
+// THE DRIFT IS THE BUG, so a per-path test cannot catch it: each path was
+// self-consistent and individually defensible. Every case below drives all
+// three handlers against one seeded database and asserts they return the same
+// answer. That is the only assertion shape that fails when they diverge.
+
+const SLUG = "gatecheck";
+
+// Anchored on the Toronto-local event day, never `new Date().toISOString()`,
+// which is UTC-sliced and runs a day ahead of the handlers between local 20:00
+// and midnight (the #568 invariant). Offsetting from a UTC-midnight Date built
+// out of those Y/M/D parts keeps the arithmetic pure calendar days. Same
+// approach as functions/api/events/__tests__/timeline-archived-buckets.test.js.
+function isoDaysFromNow(days) {
+  const [year, month, day] = eventLocalToday().split("-").map(Number);
+  const base = new Date(Date.UTC(year, month - 1, day));
+  base.setUTCDate(base.getUTCDate() + days);
+  return base.toISOString().slice(0, 10);
+}
+
+const STUB_HTML = `<!doctype html><html><head>
+    <meta name="description" content="Homepage description" />
+    <title>SetTimes</title>
+  </head><body><div id="root"></div></body></html>`;
+
+function withAssets(env) {
+  env.ASSETS = {
+    fetch: async () => new Response(STUB_HTML, { status: 200, headers: { "content-type": "text/html" } }),
+  };
+  return env;
+}
+
+/** Does the sitemap advertise this event's recap URL? */
+async function sitemapAdvertisesRecap(env) {
+  const res = await sitemapHandler({ request: new Request("https://settimes.ca/sitemap.xml"), env });
+  const xml = await res.text();
+  return xml.includes(`https://settimes.ca/events/${SLUG}/recap`);
+}
+
+/** Does SSR inject real recap meta, or fall through to the bare SPA shell? */
+async function ssrServesRecapMeta(env) {
+  const res = await recapSsrHandler({
+    request: new Request(`https://settimes.ca/events/${SLUG}/recap`),
+    env,
+    params: { slug: SLUG },
+  });
+  const html = await res.text();
+  // The stub shell carries the homepage description and no recap canonical; an
+  // injected response strips that default and adds the recap URL.
+  return html.includes(`https://settimes.ca/events/${SLUG}/recap`) && !html.includes("Homepage description");
+}
+
+/** Does the JSON API the page renders from return the recap? */
+async function apiServesRecap(env) {
+  const res = await recapApiHandler({
+    request: new Request(`https://settimes.ca/api/events/${SLUG}/recap`),
+    env,
+    params: { id: SLUG },
+  });
+  return res.status === 200;
+}
+
+async function allThree(env) {
+  return {
+    sitemap: await sitemapAdvertisesRecap(env),
+    ssr: await ssrServesRecapMeta(env),
+    api: await apiServesRecap(env),
+  };
+}
+
+function seed(overrides) {
+  const { env, rawDb } = createTestEnv();
+  env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+  insertEvent(rawDb, { name: "Gate Check", slug: SLUG, ...overrides });
+  return withAssets(env);
+}
+
+describe("#787 — sitemap, SSR and the recap API agree on whether a recap exists", () => {
+  it("published and concluded: all three serve it", async () => {
+    // THE #787 CASE. Ended 10 days ago and nobody has archived it yet -- the
+    // default state of every event between "show over" and an admin clicking
+    // Archive. Against the unfixed code the API alone said no.
+    const env = seed({ date: isoDaysFromNow(-11), end_date: isoDaysFromNow(-10), status: "published" });
+
+    expect(await allThree(env)).toEqual({ sitemap: true, ssr: true, api: true });
+  });
+
+  it("archived and concluded: all three serve it", async () => {
+    // Today's normal case. Present so the fix cannot be "make everything no".
+    const env = seed({ date: isoDaysFromNow(-11), end_date: isoDaysFromNow(-10), status: "archived" });
+
+    expect(await allThree(env)).toEqual({ sitemap: true, ssr: true, api: true });
+  });
+
+  it("published but still in the future: none of the three serve it", async () => {
+    const env = seed({ date: isoDaysFromNow(30), status: "published" });
+
+    expect(await allThree(env)).toEqual({ sitemap: false, ssr: false, api: false });
+  });
+
+  it("draft and concluded: none of the three serve it", async () => {
+    // Concluded by date, but never public. Visibility still gates everything.
+    const env = seed({ date: isoDaysFromNow(-11), end_date: isoDaysFromNow(-10), status: "draft" });
+
+    expect(await allThree(env)).toEqual({ sitemap: false, ssr: false, api: false });
+  });
+
+  it("multi-day event mid-festival: none of the three serve it", async () => {
+    // Started yesterday, ends tomorrow. The sitemap used to compare the START
+    // date, so it advertised a recap for a festival still in progress -- BLR3
+    // (Jul 10-12) would have had a live recap URL on the 11th and 12th.
+    // COALESCE(end_date, date) is what makes this false.
+    const env = seed({ date: isoDaysFromNow(-1), end_date: isoDaysFromNow(1), status: "published" });
+
+    expect(await allThree(env)).toEqual({ sitemap: false, ssr: false, api: false });
+  });
+
+  it("single-day event running today: none of the three serve it", async () => {
+    // NULL end_date, so COALESCE falls back to `date`. Guards that fallback --
+    // an event is not "concluded" on the day it runs.
+    const env = seed({ date: isoDaysFromNow(0), status: "published" });
+
+    expect(await allThree(env)).toEqual({ sitemap: false, ssr: false, api: false });
+  });
+});

--- a/functions/api/events/[id]/recap.js
+++ b/functions/api/events/[id]/recap.js
@@ -1,7 +1,8 @@
 import { getPublicDataGateResponse } from "../../../utils/publicGate.js";
 import { normalizeHttpUrl, validateId } from "../../../utils/validation.js";
 import { sortableName } from "../../../utils/sortableName.js";
-import { archivedEventStatusSql, publicEventStatusSql } from "../../../utils/eventVisibility.js";
+import { concludedEventSql, publicEventStatusSql } from "../../../utils/eventVisibility.js";
+import { eventLocalFestivalToday } from "../../../utils/eventDay.js";
 
 // SQLite `ORDER BY` can't strip a leading article inline (#587); the SQL
 // query below is a coarse pre-sort and this comparator re-derives the exact
@@ -67,21 +68,35 @@ export async function onRequestGet(context) {
     });
   }
 
+  // A recap exists iff the event is publicly visible AND concluded (#787) --
+  // NOT `status = 'archived'` alone. Archiving is an admin housekeeping click
+  // that can lag the event's real end by days (BF2 sat unarchived for three),
+  // and gating on it made this API 404 for a published, finished event whose
+  // recap URL the sitemap already advertised and whose SSR meta
+  // functions/events/[slug]/recap.js already served -- an indexable soft-404.
+  // All three paths now ask the same question the same way.
+  //
+  // concludedEventSql() embeds one `?`, bound AFTER the id/slug below. The
+  // value must be eventLocalFestivalToday(): an event ending at 2 AM is still
+  // running, so the festival day steps back below the 6 AM threshold rather
+  // than declaring it over at midnight.
+  const concludedBy = eventLocalFestivalToday();
+
   try {
     const event = isNumeric
       ? await DB.prepare(
-          `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE id = ? AND ${archivedEventStatusSql()} LIMIT 1`,
+          `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE id = ? AND ${concludedEventSql()} LIMIT 1`,
         )
-          .bind(idCheck.value)
+          .bind(idCheck.value, concludedBy)
           .first()
       : await DB.prepare(
-          `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE slug = ? AND ${archivedEventStatusSql()} LIMIT 1`,
+          `SELECT id, name, slug, date, end_date, poster_url FROM events WHERE slug = ? AND ${concludedEventSql()} LIMIT 1`,
         )
-          .bind(rawId)
+          .bind(rawId, concludedBy)
           .first();
 
     if (!event) {
-      return new Response(JSON.stringify({ error: "Event not found or not archived" }), {
+      return new Response(JSON.stringify({ error: "Event not found or has not concluded" }), {
         status: 404,
         headers: { "Content-Type": "application/json" },
       });

--- a/functions/api/events/timeline.js
+++ b/functions/api/events/timeline.js
@@ -2,7 +2,7 @@ import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { CACHE_SHOW_CRITICAL } from "../../utils/cacheHeaders.js";
 import { normalizeHttpUrl } from "../../utils/validation.js";
 import { eventLocalToday, eventLocalFestivalToday, eventLocalClock } from "../../utils/eventDay.js";
-import { archivedEventStatusSql, publishedEventStatusSql } from "../../utils/eventVisibility.js";
+import { concludedEventSql, publishedEventStatusSql } from "../../utils/eventVisibility.js";
 
 // Bucket membership is a lifecycle question before it is a date question.
 // `status = 'archived'` MEANS "this edition is concluded", so it outranks the
@@ -12,16 +12,16 @@ import { archivedEventStatusSql, publishedEventStatusSql } from "../../utils/eve
 //
 //   now      = published AND the festival window covers today
 //   upcoming = published AND dated in the future
-//   past     = archived OR (published AND concluded by date)
+//   past     = concludedEventSql() -- archived, or published and over
 //
 // Exhaustive and non-overlapping over publicly visible events. The two halves
 // only work together: narrowing now/upcoming to published-only WITHOUT the
-// `archived OR` below would make an archived-but-future-dated event match no
-// bucket at all and vanish from the timeline entirely.
-const concludedEventSql = (alias = "") => {
-  const dateExpr = alias ? `COALESCE(${alias}.end_date, ${alias}.date)` : "COALESCE(end_date, date)";
-  return `(${archivedEventStatusSql(alias)} OR (${publishedEventStatusSql(alias)} AND ${dateExpr} < ?))`;
-};
+// `archived OR` inside concludedEventSql would make an archived-but-future-
+// dated event match no bucket at all and vanish from the timeline entirely.
+//
+// concludedEventSql lives in functions/utils/eventVisibility.js since #787,
+// once the recap paths needed the identical answer: "has this edition ended?"
+// must not be spelled two ways -- that drift IS the defect #787 fixes.
 
 /**
  * 24-hour "HH:MM" time regex — mirrors DOORS_TIME_REGEX in validation.js.

--- a/functions/events/[slug]/recap.js
+++ b/functions/events/[slug]/recap.js
@@ -1,16 +1,22 @@
 // CF Pages Function: serve /events/[slug]/recap with server-rendered meta for
 // crawlers. Distinct from /event/[slug] (singular) -- this is the ARCHIVE
-// recap page (frontend/src/pages/EventRecapPage.jsx), reachable once an
-// event's date is past (functions/sitemap.xml.js emits it there). Modeled on
-// functions/event/[slug].js: same D1 lookup shape, same published-event gate,
-// same fallback discipline (gate closed / not found / DB error -> the SPA
-// shell via env.ASSETS.fetch so the page still renders client-side). See
+// recap page (frontend/src/pages/EventRecapPage.jsx), reachable once an event
+// has CONCLUDED: archived, or published with its last day elapsed. That is
+// concludedEventSql() (functions/utils/eventVisibility.js), the single
+// predicate shared with GET /api/events/:id/recap and functions/sitemap.xml.js
+// so all three agree on which events have a recap (#787). Note "concluded" is
+// not "date is past" -- an archived event counts regardless of date, because
+// lifecycle outranks the calendar (#800).
+//
+// Modeled on functions/event/[slug].js: same D1 lookup shape, same fallback
+// discipline (gate closed / not found / DB error -> the SPA shell via
+// env.ASSETS.fetch so the page still renders client-side). See
 // functions/utils/ssrMeta.js for the full SSR-injection rationale.
 
 import { isPublicDataEnabled } from "../../utils/publicGate.js";
 import { escapeAttr, serveWithInjectedMeta, CANONICAL_HOST, DEFAULT_OG_IMAGE } from "../../utils/ssrMeta.js";
 import { normalizeHttpUrl, validateDate } from "../../utils/validation.js";
-import { eventLocalToday, eventLocalFestivalToday } from "../../utils/eventDay.js";
+import { eventLocalFestivalToday } from "../../utils/eventDay.js";
 import { concludedEventSql } from "../../utils/eventVisibility.js";
 
 const DATE_LABEL_FORMAT = { year: "numeric", month: "long", day: "numeric" };
@@ -58,25 +64,29 @@ export async function onRequestGet(context) {
   }
   if (!event) return env.ASSETS.fetch(request);
 
-  // This route claims to be the ARCHIVE recap (see file header) -- the
-  // published/archived gate above says nothing about whether the event has
-  // actually happened yet. Without this check, a direct request for a
-  // future published event would get recap-specific meta ("recap for X on
-  // <date>") for a show that hasn't played, ahead of the sitemap ever
-  // listing it there. end_date || date mirrors the multi-day convention
-  // elsewhere (CLAUDE.md, scheduleStorage) -- a multi-day event isn't over
-  // until its LAST day has passed, not its first.
+  // NOT a second conclusion gate (#787). "Has this edition ended?" is answered
+  // once, by concludedEventSql() in the query above -- the same predicate, with
+  // the same bind value, that the recap API and the sitemap use.
   //
-  // `date`/`end_date` are TEXT columns with no DB-level format constraint, so
-  // a legacy row can hold a syntactically-YYYY-MM-DD but calendar-invalid
-  // value (e.g. "2026-02-30"). A plain typeof/string check doesn't catch
-  // that, and a lexicographic compare against an out-of-range day can still
-  // resolve either way -- validateDate() (validation.js) does real
-  // month-length/leap-year validation, same helper the write-side event form
-  // uses, so an invalid legacy date falls back to the shell rather than
-  // risking a wrong-signed comparison (CodeRabbit, #784 follow-up).
+  // This used to also compare `lastDay >= eventLocalToday()`, which quietly
+  // re-decided conclusion here and disagreed with the shared predicate for an
+  // ARCHIVED, FUTURE-DATED event: concludedEventSql treats archived as
+  // concluded regardless of date (lifecycle outranks the calendar, #800), so
+  // the API returned 200 and the sitemap advertised the URL while SSR alone
+  // fell back to the shell. An admin can produce that state by archiving an
+  // event early. It also used eventLocalToday() where the predicate uses
+  // eventLocalFestivalToday() -- two different "todays" for one question.
+  //
+  // What survives is an OUTPUT-SANITY guard, not a visibility rule:
+  // `date`/`end_date` are TEXT with no DB-level format constraint, so a legacy
+  // row can hold a syntactically-YYYY-MM-DD but calendar-invalid value (e.g.
+  // "2026-02-30"). validateDate() does real month-length/leap-year checking
+  // (the same helper the write-side event form uses), so rather than emit
+  // "recap for X on <impossible date>" into canonical/og:title we fall back to
+  // the shell (CodeRabbit, #784 follow-up). Corrupt data, not an unpublished
+  // or unfinished event.
   const lastDay = event.end_date || event.date;
-  if (!validateDate(lastDay).valid || lastDay >= eventLocalToday()) {
+  if (!validateDate(lastDay).valid) {
     return env.ASSETS.fetch(request);
   }
 

--- a/functions/events/[slug]/recap.js
+++ b/functions/events/[slug]/recap.js
@@ -10,8 +10,8 @@
 import { isPublicDataEnabled } from "../../utils/publicGate.js";
 import { escapeAttr, serveWithInjectedMeta, CANONICAL_HOST, DEFAULT_OG_IMAGE } from "../../utils/ssrMeta.js";
 import { normalizeHttpUrl, validateDate } from "../../utils/validation.js";
-import { eventLocalToday } from "../../utils/eventDay.js";
-import { publicEventStatusSql } from "../../utils/eventVisibility.js";
+import { eventLocalToday, eventLocalFestivalToday } from "../../utils/eventDay.js";
+import { concludedEventSql } from "../../utils/eventVisibility.js";
 
 const DATE_LABEL_FORMAT = { year: "numeric", month: "long", day: "numeric" };
 
@@ -39,12 +39,18 @@ export async function onRequestGet(context) {
 
   let event;
   try {
+    // Publicly visible AND concluded (#787). This gate previously checked
+    // visibility only, so SSR would happily emit canonical/og:url/title for the
+    // recap of an event that had not happened yet, while
+    // GET /api/events/:id/recap -- which the page renders from -- returned
+    // nothing. Identical predicate and identical bind value as that API and as
+    // the sitemap: the drift between the three IS the bug.
     event = await env.DB.prepare(
       `SELECT id, name, slug, date, end_date, poster_url
        FROM events
-       WHERE slug = ? AND ${publicEventStatusSql()}`,
+       WHERE slug = ? AND ${concludedEventSql()}`,
     )
-      .bind(slug)
+      .bind(slug, eventLocalFestivalToday())
       .first();
   } catch (err) {
     console.error("SSR event recap lookup failed:", slug, err);

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -3,8 +3,8 @@
  * Includes all published events and band profiles with at least one published performance.
  */
 import { getPublicDataGateResponse } from "./utils/publicGate.js";
-import { eventLocalToday } from "./utils/eventDay.js";
-import { publicEventStatusSql } from "./utils/eventVisibility.js";
+import { eventLocalFestivalToday } from "./utils/eventDay.js";
+import { concludedEventSql, publicEventStatusSql } from "./utils/eventVisibility.js";
 
 export async function onRequestGet(context) {
   const { env } = context;
@@ -16,7 +16,22 @@ export async function onRequestGet(context) {
 
   try {
     const [{ results: events }, { results: bands }, { results: venues }] = await Promise.all([
-      env.DB.prepare(`SELECT slug, date FROM events WHERE ${publicEventStatusSql()} ORDER BY date DESC`).all(),
+      // `is_concluded` is computed in SQL by the SAME predicate the recap API
+      // and the recap SSR route use, rather than re-derived in JS here (#787).
+      // Deriving it separately is exactly how the three drifted apart: this
+      // file compared `date` -- the START date -- so a multi-day edition got a
+      // recap URL emitted from day 2 onward, mid-festival (BLR3, Jul 10-12,
+      // would have had one live on the 11th and 12th). concludedEventSql uses
+      // COALESCE(end_date, date), which fixes that as a side effect.
+      env.DB.prepare(
+        `SELECT slug, date, end_date,
+                CASE WHEN ${concludedEventSql()} THEN 1 ELSE 0 END AS is_concluded
+         FROM events
+         WHERE ${publicEventStatusSql()}
+         ORDER BY date DESC`,
+      )
+        .bind(eventLocalFestivalToday())
+        .all(),
       env.DB.prepare(
         `SELECT DISTINCT bp.id
          FROM band_profiles bp
@@ -76,10 +91,9 @@ export async function onRequestGet(context) {
   </url>`,
     ];
 
-    // YYYY-MM-DD lexicographic comparison — never new Date('YYYY-MM-DD'),
-    // which UTC-parses and drifts a day (documented repo invariant).
-    const today = eventLocalToday();
-
+    // The recap cutoff used to be a JS date compare against eventLocalToday()
+    // here. It now rides on `is_concluded` from the shared SQL predicate (#787)
+    // so this file cannot drift from the recap API and SSR route again.
     for (const event of events) {
       rows.push(`  <url>
     <loc>https://settimes.ca/event/${event.slug}</loc>
@@ -89,11 +103,13 @@ export async function onRequestGet(context) {
   </url>`);
       // Past editions also get their recap page (#555) — a content-rich page
       // that was previously reachable only by typing the URL. Recaps only
-      // exist once the event has happened, so future events are excluded.
-      if (event.date < today) {
+      // exist once the event has concluded, and `is_concluded` comes from the
+      // shared predicate in SQL above (#787) rather than a local date compare,
+      // so this agrees with the recap API and SSR route by construction.
+      if (event.is_concluded) {
         rows.push(`  <url>
     <loc>https://settimes.ca/events/${event.slug}/recap</loc>
-    <lastmod>${event.date}</lastmod>
+    <lastmod>${event.end_date || event.date}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>`);

--- a/functions/utils/eventVisibility.js
+++ b/functions/utils/eventVisibility.js
@@ -123,6 +123,12 @@ export function publishedEventStatusSql(alias = "") {
  * @returns {string} e.g. "(status = 'archived' OR (status = 'published' AND COALESCE(end_date, date) < ?))"
  */
 export function concludedEventSql(alias = "") {
+  // Validate BEFORE interpolating. The two helpers below would throw on a bad
+  // alias anyway, but `dateExpr` is built first, so `${alias}` would already
+  // have stringified the argument -- running a custom toString() on a hostile
+  // object before any guard fired. Every other path in this module validates
+  // ahead of interpolation (see columnRef); this one now matches.
+  assertValidAlias(alias);
   const dateExpr = alias ? `COALESCE(${alias}.end_date, ${alias}.date)` : "COALESCE(end_date, date)";
   return `(${archivedEventStatusSql(alias)} OR (${publishedEventStatusSql(alias)} AND ${dateExpr} < ?))`;
 }

--- a/functions/utils/eventVisibility.js
+++ b/functions/utils/eventVisibility.js
@@ -85,3 +85,44 @@ export function archivedEventStatusSql(alias = "") {
 export function publishedEventStatusSql(alias = "") {
   return `${columnRef(alias)} = 'published'`;
 }
+
+/**
+ * SQL predicate for "this event has concluded" — archived (any date), or
+ * published with its LAST day already elapsed. Promoted here from
+ * `functions/api/events/timeline.js`, where it powers the `past` bucket,
+ * once a second consumer (recap + sitemap gating, #787) needed the exact
+ * same answer (the #550 precedent: unify a duplicated predicate when a
+ * second consumer appears, not before).
+ *
+ * Lifecycle outranks the calendar: `status = 'archived'` MEANS "this edition
+ * is concluded", so an archived event counts as concluded regardless of its
+ * date — the same trap `/api/schedule?event=current` avoids in the other
+ * direction with publishedEventStatusSql(). Without the `archived OR` half,
+ * an event archived early (before its own date) would satisfy neither "not
+ * concluded" nor the archived branch and vanish from any bucket built on
+ * this predicate.
+ *
+ * A recap exists iff an event is publicly visible AND concluded — nothing
+ * more, nothing less. Gating recap visibility (or a sitemap recap URL) on
+ * anything narrower, such as `status = 'archived'` alone, produces a soft-404:
+ * an indexable URL / full SSR identity meta for an event whose JSON data API
+ * still 404s, because archiving is an admin housekeeping click that can lag
+ * the event's actual end by days.
+ *
+ * Embeds exactly ONE unbound `?` for the date comparison — the caller MUST
+ * bind one parameter for it, and that value MUST be
+ * `eventLocalFestivalToday()` (functions/utils/eventDay.js), never
+ * `eventLocalToday()`. An event ending at 2 AM is still running: the festival
+ * day steps back a calendar day below AFTER_MIDNIGHT_THRESHOLD_HOUR (6 AM) so
+ * a still-airing after-midnight set is never treated as concluded. Every
+ * consumer of this predicate must answer "is this event over?" with the same
+ * value the timeline's past bucket uses for itself, or two call sites drift
+ * back into disagreeing (the exact defect #787 fixes).
+ *
+ * @param {string} [alias] - table alias, e.g. "e"; "" (default) for none
+ * @returns {string} e.g. "(status = 'archived' OR (status = 'published' AND COALESCE(end_date, date) < ?))"
+ */
+export function concludedEventSql(alias = "") {
+  const dateExpr = alias ? `COALESCE(${alias}.end_date, ${alias}.date)` : "COALESCE(end_date, date)";
+  return `(${archivedEventStatusSql(alias)} OR (${publishedEventStatusSql(alias)} AND ${dateExpr} < ?))`;
+}


### PR DESCRIPTION
## Summary

Three code paths decided whether an event's recap page exists, and they disagreed:

| Path | Gate before |
|---|---|
| `functions/sitemap.xml.js` (emits the URL) | `publicEventStatusSql()` + a JS `date < today` compare |
| `functions/events/[slug]/recap.js` (SSR meta) | `publicEventStatusSql()` — **no date check at all** |
| `functions/api/events/[id]/recap.js` (the data API the page renders from) | `archivedEventStatusSql()` — **narrower than both** |

A **published, past, not-yet-archived** event therefore got a sitemap URL and full SSR identity meta (canonical, `og:url`, `<title>`) while the data API behind it 404'd — an indexable soft-404. That isn't an exotic state; it's the *default* one between "show over" and an admin clicking Archive. **Buddies Fest 2 sat in it for three days.**

Closes #787

## #800 armed this rather than causing it

Worth being precise, since I originally expected to close #787 as unreachable. Before #800, `is_published = 1` matched nothing, so the sitemap emitted **zero** recap URLs and the soft-404 had no way to fire. Restoring the sitemap made it live — dormant today only because all 19 past events happen to be archived. **It would have fired when Vol. 18 concludes on 2026-10-11.**

## The fix

All three paths now use one predicate, `concludedEventSql()`, **promoted out of `timeline.js` into `functions/utils/eventVisibility.js`**.

That promotion follows the repo's own #550 rule — unify a duplicated predicate when a **second** consumer appears, not before. Recap + sitemap are that second consumer.

The important property: it is *the same predicate the timeline's `past` bucket uses*. So a recap can't go live while the homepage still says "Happening Now" — fixing one disagreement without opening a new one.

All three bind `eventLocalFestivalToday()`, never `eventLocalToday()`: an event ending at 2 AM is still running, so the festival day steps back below the 6 AM threshold rather than declaring it over at midnight.

## Second defect, same block

`sitemap.xml.js` compared `event.date` — the **start** date — so a multi-day edition got its recap URL emitted **from day 2 onward, mid-festival**. BLR3 (Jul 10–12) would have had a live recap URL on the 11th and 12th, while the show was still running.

The sitemap now computes `is_concluded` **in SQL** from the shared predicate rather than re-deriving it in JS. That fixes the multi-day bug via `COALESCE(end_date, date)` *and* removes the mechanism that let the three drift apart to begin with. Recap `<lastmod>` also moves to `end_date || date`.

## Tested by consistency, not per-path

The drift **is** the bug, and each path was individually self-consistent and defensible — so no per-path test can see it. `functions/__tests__/recapGatingConsistency.test.js` drives all three handlers against one seeded database and asserts they return the same answer, across six shapes: published+concluded, archived+concluded, published+future, draft+concluded, multi-day mid-festival, and single-day running today.

**Mutation-verified, not assumed:**
- reverting the API to archived-only → fails *exactly* "published and concluded" ✅
- reverting the sitemap to the start-date compare → fails *exactly* "multi-day event mid-festival" ✅

## Security / correctness notes

This **widens** what the recap API serves: a published, concluded, unarchived event now returns 200 instead of 404. That is the intended pre-existing contract the sitemap and SSR already assumed. It simultaneously **narrows** SSR, which previously would emit recap meta for an event that hadn't happened. Draft events remain invisible on all three paths — visibility still gates everything.

## Flagged, not fixed

`archivedEventStatusSql` now has no consumer outside `concludedEventSql`, which uses it internally. Kept and still exported — it's a tested primitive of the visibility vocabulary — but this is the **second** time it has been left without an external caller. Say the word if you'd rather it be un-exported.

## Verification

- [x] `make gate` exit 0 — backend **107 files / 1098 tests**, frontend **87 / 990**
- [x] ESLint 0 errors; format check clean; build green
- [x] Mutation-verified both defects (above)
- [x] No existing fixture needed changing — the widening is compatible with archived-event fixtures, and no recap test seeded a future event
- [x] `validate:openapi`: n/a — `docs/api-spec.yaml` unchanged
- [ ] Manual smoke: deferred to post-merge production check (`/events/{slug}/recap` for a concluded edition, plus sitemap recap-URL count)

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Event recaps now appear consistently across the sitemap, recap pages, and recap API.
  - Published events become eligible for recaps once their effective end date has passed, without requiring archival status.
  - Future, draft, active multi-day, and same-day events remain excluded until appropriate.
  - Recap sitemap links now use the event’s end date for more accurate update information.
  - Improved messaging when an event has not yet concluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->