### PR TITLE
feat(admin): allow publishing an event with no lineup via explicit opt-in

### DIFF
--- a/frontend/src/admin/EventsTab.jsx
+++ b/frontend/src/admin/EventsTab.jsx
@@ -585,6 +585,26 @@ export default function EventsTab({
       refreshEvents()
       onEventsChange()
     } catch (err) {
+      // The publish endpoint reports this specific rejection via a
+      // machine-readable `code` (functions/api/admin/events/[id]/publish.js),
+      // not by matching `err.message` text -- so this stays correct even if
+      // the message copy changes later.
+      if (publish && err.details?.code === 'EMPTY_LINEUP') {
+        const confirmed = window.confirm(
+          `"${event.name}" has no bands yet. Publishing now will make the event page public immediately, showing "Lineup TBA" until a lineup is added. Continue?`
+        )
+        if (confirmed) {
+          try {
+            await eventsApi.setPublishState(event.id, true, { allowEmptyLineup: true })
+            showToast('Event published successfully!', 'success')
+            refreshEvents()
+            onEventsChange()
+          } catch (retryErr) {
+            showToast('Failed to publish event: ' + retryErr.message, 'error')
+          }
+        }
+        return
+      }
       showToast(`Failed to ${action} event: ` + err.message, 'error')
     }
   }

--- a/frontend/src/admin/__tests__/EventsTab.test.jsx
+++ b/frontend/src/admin/__tests__/EventsTab.test.jsx
@@ -1,0 +1,129 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import EventsTab from '../EventsTab'
+
+// EventsTab renders both a desktop <table> and a mobile card list
+// unconditionally (visibility is CSS-only), so any text/role query below
+// matches twice -- hence getAllByRole rather than getByRole (same pattern
+// as RosterTab.test.jsx).
+
+vi.mock('../../utils/adminApi', () => ({
+  eventsApi: {
+    setPublishState: vi.fn(),
+  },
+  bandsApi: {
+    getByEvent: vi.fn(),
+  },
+}))
+
+vi.mock('../../contexts/EventContext', () => ({
+  useEventContext: () => ({ refreshEvents: vi.fn() }),
+}))
+
+import { eventsApi } from '../../utils/adminApi'
+
+// Mirrors the response shape functions/api/admin/events/[id]/publish.js
+// returns for the zero-band guard: `code` is the machine-readable
+// discriminator the client keys off of, alongside the unchanged
+// error/message pair.
+function emptyLineupError() {
+  const message = 'Cannot publish event with no bands. Add at least one band first.'
+  const err = new Error(message)
+  err.status = 400
+  err.details = { error: 'Validation error', message, code: 'EMPTY_LINEUP' }
+  return err
+}
+
+const DRAFT_EVENT_NO_BANDS = {
+  id: 37,
+  name: 'Long Weekend Band Crawl Vol. 18',
+  slug: 'lwbc18',
+  date: '2026-10-11',
+  status: 'draft',
+  band_count: 0,
+}
+
+describe('EventsTab — publish without a lineup (empty-lineup override)', () => {
+  beforeEach(() => {
+    eventsApi.setPublishState.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('retries with allowEmptyLineup after the confirm, and the retry call carries the flag', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true) // both the generic confirm and the empty-lineup confirm say yes
+    eventsApi.setPublishState.mockRejectedValueOnce(emptyLineupError()).mockResolvedValueOnce({
+      success: true,
+      event: { ...DRAFT_EVENT_NO_BANDS, status: 'published' },
+      message: 'Event published successfully',
+    })
+
+    const showToast = vi.fn()
+    render(
+      <EventsTab
+        events={[DRAFT_EVENT_NO_BANDS]}
+        onEventsChange={vi.fn()}
+        showToast={showToast}
+        readOnly={false}
+        canArchiveEvents={true}
+      />
+    )
+
+    const publishButtons = screen.getAllByRole('button', { name: 'Publish' })
+    fireEvent.click(publishButtons[0])
+
+    await waitFor(() => expect(eventsApi.setPublishState).toHaveBeenCalledTimes(2))
+
+    // First call: the normal publish request, no override.
+    expect(eventsApi.setPublishState).toHaveBeenNthCalledWith(1, DRAFT_EVENT_NO_BANDS.id, true)
+    // Retry: exactly the flag, not resent as false-y noise.
+    expect(eventsApi.setPublishState).toHaveBeenNthCalledWith(2, DRAFT_EVENT_NO_BANDS.id, true, {
+      allowEmptyLineup: true,
+    })
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith('Event published successfully!', 'success'))
+  })
+
+  it('declining the empty-lineup confirm leaves the event unpublished and does not retry', async () => {
+    // First confirm ("Are you sure you want to publish this event?") says
+    // yes; second confirm (the empty-lineup-specific one) says no.
+    let confirmCallCount = 0
+    vi.spyOn(window, 'confirm').mockImplementation(() => {
+      confirmCallCount += 1
+      return confirmCallCount === 1
+    })
+    eventsApi.setPublishState.mockRejectedValueOnce(emptyLineupError())
+
+    const showToast = vi.fn()
+    render(
+      <EventsTab
+        events={[DRAFT_EVENT_NO_BANDS]}
+        onEventsChange={vi.fn()}
+        showToast={showToast}
+        readOnly={false}
+        canArchiveEvents={true}
+      />
+    )
+
+    const publishButtons = screen.getAllByRole('button', { name: 'Publish' })
+    fireEvent.click(publishButtons[0])
+
+    // Wait for both confirms to have fired (proves the empty-lineup branch
+    // was reached and the decline was read) before asserting nothing more
+    // happened.
+    await waitFor(() => expect(confirmCallCount).toBe(2))
+    await waitFor(() => expect(eventsApi.setPublishState).toHaveBeenCalledTimes(1))
+
+    // No retry -- exactly one call, never a second with the override flag.
+    expect(eventsApi.setPublishState).toHaveBeenCalledTimes(1)
+    // No success toast for a publish that never completed.
+    expect(showToast).not.toHaveBeenCalledWith('Event published successfully!', 'success')
+    expect(showToast).not.toHaveBeenCalledWith(expect.stringContaining('published successfully'), 'success')
+
+    // The button still reads "Publish" (draft), not "Unpublish" -- the event
+    // prop was never updated because the publish never went through.
+    expect(screen.getAllByRole('button', { name: 'Publish' }).length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/admin/__tests__/EventsTab.test.jsx
+++ b/frontend/src/admin/__tests__/EventsTab.test.jsx
@@ -86,6 +86,39 @@ describe('EventsTab — publish without a lineup (empty-lineup override)', () =>
     await waitFor(() => expect(showToast).toHaveBeenCalledWith('Event published successfully!', 'success'))
   })
 
+  it('surfaces an error toast when the override retry itself fails', async () => {
+    // The retry has its own catch block, which nothing else exercises: the
+    // happy-path test resolves the retry and the decline test never reaches
+    // it. Without this, a broken retry error path would fail silently -- the
+    // admin would click through the confirm and see nothing at all happen.
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    eventsApi.setPublishState
+      .mockRejectedValueOnce(emptyLineupError())
+      .mockRejectedValueOnce(new Error('Network request failed'))
+
+    const showToast = vi.fn()
+    render(
+      <EventsTab
+        events={[DRAFT_EVENT_NO_BANDS]}
+        onEventsChange={vi.fn()}
+        showToast={showToast}
+        readOnly={false}
+        canArchiveEvents={true}
+      />
+    )
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Publish' })[0])
+
+    await waitFor(() => expect(eventsApi.setPublishState).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith('Failed to publish event: Network request failed', 'error')
+    )
+
+    // A failed retry must not also claim success, and must not loop.
+    expect(showToast).not.toHaveBeenCalledWith('Event published successfully!', 'success')
+    expect(eventsApi.setPublishState).toHaveBeenCalledTimes(2)
+  })
+
   it('declining the empty-lineup confirm leaves the event unpublished and does not retry', async () => {
     // First confirm ("Are you sure you want to publish this event?") says
     // yes; second confirm (the empty-lineup-specific one) says no.

--- a/frontend/src/utils/__tests__/adminApi.test.js
+++ b/frontend/src/utils/__tests__/adminApi.test.js
@@ -54,3 +54,64 @@ describe('authApi.verifySession', () => {
     expect(window.localStorage.getItem('userEmail')).toBe('admin@test')
   })
 })
+
+describe('eventsApi.setPublishState', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    document.cookie = 'csrf_token=test-csrf-token; path=/'
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    document.cookie = 'csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
+  })
+
+  it('omits allowEmptyLineup from the request body when not passed', async () => {
+    const fetchMock = global.fetch
+    fetchMock.mockResolvedValue(
+      new globalThis.Response(JSON.stringify({ success: true, event: { id: 1, status: 'published' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    const { eventsApi } = await import('../adminApi.js')
+    await eventsApi.setPublishState(1, true)
+
+    const [, options] = fetchMock.mock.calls[0]
+    expect(JSON.parse(options.body)).toEqual({ publish: true })
+  })
+
+  it('omits allowEmptyLineup from the request body when explicitly false', async () => {
+    const fetchMock = global.fetch
+    fetchMock.mockResolvedValue(
+      new globalThis.Response(JSON.stringify({ success: true, event: { id: 1, status: 'draft' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    const { eventsApi } = await import('../adminApi.js')
+    await eventsApi.setPublishState(1, false, { allowEmptyLineup: false })
+
+    const [, options] = fetchMock.mock.calls[0]
+    expect(JSON.parse(options.body)).toEqual({ publish: false })
+  })
+
+  it('includes allowEmptyLineup: true in the request body when passed', async () => {
+    const fetchMock = global.fetch
+    fetchMock.mockResolvedValue(
+      new globalThis.Response(JSON.stringify({ success: true, event: { id: 1, status: 'published' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    const { eventsApi } = await import('../adminApi.js')
+    await eventsApi.setPublishState(1, true, { allowEmptyLineup: true })
+
+    const [, options] = fetchMock.mock.calls[0]
+    expect(JSON.parse(options.body)).toEqual({ publish: true, allowEmptyLineup: true })
+  })
+})

--- a/frontend/src/utils/__tests__/adminApi.test.js
+++ b/frontend/src/utils/__tests__/adminApi.test.js
@@ -114,4 +114,26 @@ describe('eventsApi.setPublishState', () => {
     const [, options] = fetchMock.mock.calls[0]
     expect(JSON.parse(options.body)).toEqual({ publish: true, allowEmptyLineup: true })
   })
+
+  // A truthy non-boolean must not reach the wire as `true`. The server rejects
+  // non-booleans, but it never sees this one: coercing here would hand it a
+  // literal `true` and open the empty-lineup guard on input written to be
+  // refused. Throwing before the request keeps the client from laundering an
+  // invalid value into a valid one.
+  it.each([['yes'], [1], [{}], [[]]])('rejects a truthy non-boolean allowEmptyLineup (%p)', async value => {
+    const fetchMock = global.fetch
+    fetchMock.mockResolvedValue(
+      new globalThis.Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    const { eventsApi } = await import('../adminApi.js')
+    await expect(eventsApi.setPublishState(1, true, { allowEmptyLineup: value })).rejects.toThrow(TypeError)
+
+    // The assertion that matters: no request was ever made, so the server had
+    // no chance to be handed a laundered `true`.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/utils/adminApi.js
+++ b/frontend/src/utils/adminApi.js
@@ -473,12 +473,18 @@ export const eventsApi = {
     return handleResponse(response)
   },
 
-  async setPublishState(eventId, publish) {
+  async setPublishState(eventId, publish, { allowEmptyLineup } = {}) {
+    const body = { publish }
+    // Only sent when true -- allowEmptyLineup:false is indistinguishable from
+    // omitting it server-side, so don't put it on every request.
+    if (allowEmptyLineup) {
+      body.allowEmptyLineup = true
+    }
     const response = await fetchWithCSRFRetry(`${API_BASE}/events/${eventId}/publish`, {
       method: 'POST',
       headers: getHeaders(),
       credentials: 'include',
-      body: JSON.stringify({ publish }),
+      body: JSON.stringify(body),
     })
     return handleResponse(response)
   },

--- a/frontend/src/utils/adminApi.js
+++ b/frontend/src/utils/adminApi.js
@@ -474,10 +474,19 @@ export const eventsApi = {
   },
 
   async setPublishState(eventId, publish, { allowEmptyLineup } = {}) {
+    // Throw rather than coerce. A truthy non-boolean ('yes', 1) reaching the
+    // old `if (allowEmptyLineup)` was LAUNDERED into a literal `true` on the
+    // wire, so the server's own non-boolean rejection never saw the bad value
+    // and the empty-lineup guard opened on input it was written to refuse.
+    // Failing loudly here surfaces the caller bug; silently not-sending would
+    // hide it behind a confusing "no bands" error instead.
+    if (allowEmptyLineup !== undefined && typeof allowEmptyLineup !== 'boolean') {
+      throw new TypeError('allowEmptyLineup must be a boolean')
+    }
     const body = { publish }
-    // Only sent when true -- allowEmptyLineup:false is indistinguishable from
-    // omitting it server-side, so don't put it on every request.
-    if (allowEmptyLineup) {
+    // Sent only when exactly true -- `false` is indistinguishable from
+    // omitting it server-side, so it stays off the request entirely.
+    if (allowEmptyLineup === true) {
       body.allowEmptyLineup = true
     }
     const response = await fetchWithCSRFRetry(`${API_BASE}/events/${eventId}/publish`, {

--- a/functions/api/admin/events/[id].js
+++ b/functions/api/admin/events/[id].js
@@ -619,6 +619,16 @@ export async function onRequestPut(context) {
           },
         );
       }
+      // Deliberately no band-count check here, unlike POST .../publish. This
+      // toggle carries no lineup requirement at all -- adding one would be a
+      // NEW restriction (this endpoint never had one), not a fix, and would
+      // make this route stricter than its sibling instead of matching it.
+      // POST .../publish is the guarded path, and its guard is bypassable via
+      // an explicit `allowEmptyLineup: true` on that endpoint (a supported
+      // "Lineup TBA" publish, e.g. announcing an event before booking is
+      // complete) -- don't "fix" the asymmetry by tightening this toggle;
+      // that would block the same workflow the other endpoint's override
+      // exists to allow.
       const nextStatus = event.status === "published" ? "draft" : "published";
       // Re-check status at write time: if a concurrent request archived this
       // event between the read above and this UPDATE, an unconditional write

--- a/functions/api/admin/events/[id]/publish.js
+++ b/functions/api/admin/events/[id]/publish.js
@@ -59,10 +59,25 @@ export async function onRequestPost(context) {
     }
 
     const body = await request.json().catch(() => ({}));
-    const { publish } = body;
+    const { publish, allowEmptyLineup } = body;
 
     if (typeof publish !== "boolean") {
       return new Response(JSON.stringify({ error: "Bad request", message: "publish must be a boolean" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // allowEmptyLineup is an explicit opt-in to publish an event with zero
+    // booked performances. "Lineup TBA" is a supported published state
+    // (EventTimeline.jsx renders it for exactly this case), and announcing
+    // an event before the lineup is booked -- to start accruing SEO runway,
+    // e.g. -- is an intentional workflow, not an oversight the guard below
+    // should categorically block. Validated the same way `publish` is
+    // validated above: reject a non-boolean rather than coercing a truthy
+    // string into an unlock.
+    if (allowEmptyLineup !== undefined && typeof allowEmptyLineup !== "boolean") {
+      return new Response(JSON.stringify({ error: "Bad request", message: "allowEmptyLineup must be a boolean" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
@@ -90,11 +105,16 @@ export async function onRequestPost(context) {
         .bind(eventId)
         .first();
 
-      if (bandCount.count === 0) {
+      if (bandCount.count === 0 && !allowEmptyLineup) {
+        // `code` is additive -- `error`/`message` stay byte-for-byte identical
+        // to the pre-override guard so existing callers see no behaviour
+        // change. It exists so the admin UI can detect this specific
+        // rejection and offer the override without string-matching `message`.
         return new Response(
           JSON.stringify({
             error: "Validation error",
             message: "Cannot publish event with no bands. Add at least one band first.",
+            code: "EMPTY_LINEUP",
           }),
           {
             status: 400,

--- a/functions/api/admin/events/__tests__/events.test.js
+++ b/functions/api/admin/events/__tests__/events.test.js
@@ -1088,6 +1088,111 @@ describe("Event API - handler integration", () => {
   });
 });
 
+// The empty-lineup guard above (bandCount.count === 0) blocks a real
+// workflow: announcing an event before its lineup is booked, so the page
+// starts accruing SEO runway early. "Lineup TBA" is a supported rendering
+// state (EventTimeline.jsx), so the guard must stay bypassable via an
+// explicit opt-in rather than an unconditional block.
+describe("Publish endpoint: allowEmptyLineup override", () => {
+  it("0 bands + no flag rejects publish and leaves the event in draft (persisted state)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+    const ev = insertEvent(rawDb, { name: "NoFlagNoBands", slug: "no-flag-no-bands" });
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/publish`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ publish: true }),
+    });
+
+    const res = await publishHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Validation error");
+    expect(data.message).toBe("Cannot publish event with no bands. Add at least one band first.");
+    expect(data.code).toBe("EMPTY_LINEUP");
+
+    // Rejecting must not half-apply -- confirm the row was never touched.
+    const row = rawDb.prepare("SELECT status FROM events WHERE id = ?").get(ev.id);
+    expect(row.status).toBe("draft");
+  });
+
+  it("0 bands + allowEmptyLineup: true publishes the event", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+    const ev = insertEvent(rawDb, { name: "OverrideNoBands", slug: "override-no-bands" });
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/publish`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ publish: true, allowEmptyLineup: true }),
+    });
+
+    const res = await publishHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.event.status).toBe("published");
+
+    const row = rawDb.prepare("SELECT status FROM events WHERE id = ?").get(ev.id);
+    expect(row.status).toBe("published");
+  });
+
+  it("0 bands + allowEmptyLineup: 'yes' (non-boolean) rejects with 400, event stays draft", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+    const ev = insertEvent(rawDb, { name: "BadFlagType", slug: "bad-flag-type" });
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/publish`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ publish: true, allowEmptyLineup: "yes" }),
+    });
+
+    const res = await publishHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(400);
+
+    // A truthy string must not silently unlock the guard -- the row must
+    // never have been published.
+    const row = rawDb.prepare("SELECT status FROM events WHERE id = ?").get(ev.id);
+    expect(row.status).toBe("draft");
+  });
+
+  it("publish: false + allowEmptyLineup: true unpublishes normally -- the flag is a no-op on unpublish", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+    const ev = insertEvent(rawDb, { name: "UnpublishWithFlag", slug: "unpublish-with-flag", status: "published" });
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/publish`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ publish: false, allowEmptyLineup: true }),
+    });
+
+    const res = await publishHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.event.status).toBe("draft");
+  });
+
+  it("an event WITH bands still publishes with no flag (no regression)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+    const ev = insertEvent(rawDb, { name: "HasBandsNoFlag", slug: "has-bands-no-flag" });
+    insertBand(rawDb, { name: "Regression Band", event_id: ev.id });
+
+    const request = new Request(`https://example.test/api/admin/events/${ev.id}/publish`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "editor" },
+      body: JSON.stringify({ publish: true }),
+    });
+
+    const res = await publishHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.event.status).toBe("published");
+  });
+});
+
 describe("Event duplication atomicity (P0-B2)", () => {
   it("cleans up newly created event if performance copy fails", async () => {
     const rawDb = createTestDB();


### PR DESCRIPTION
## Summary

Lets an event be published before its lineup is booked, via an explicit opt-in. This unblocks announcing **Long Weekend Band Crawl Vol. 18** (event 37, 2026-10-11, currently `draft` with 0 performances) so it starts accruing SEO runway now rather than after the lineup is confirmed.

Not claimed as closing #804 — that issue is the inverse gap (create-as-`published` bypassing the check) and stays open.

## The bug

```
EventTimeline.jsx:861   renders "Lineup TBA" for an upcoming event with no lineup   (3 tests)
publish.js:88           forbids ever reaching that state
```

The API refused to create the state the UI was built and tested for. Hitting Publish on Vol. 18 returned:

> Failed to publish event: Cannot publish event with no bands. Add at least one band first.

The guard was also **not** a real invariant: the `PUT` publish-toggle in `functions/api/admin/events/[id].js` has no band check at all, so an empty event was already publishable by another route.

## Approach — opt-in, not removal

The guard's accident-prevention value is real; only the inability to override it was the bug. So:

- `publish: true`, 0 bands, **no flag** → the existing 400, with `error`/`message` **byte-for-byte unchanged**. No behaviour change for any existing caller.
- `publish: true`, 0 bands, `allowEmptyLineup: true` → publishes.
- A non-boolean `allowEmptyLineup` is rejected, not coerced — a truthy string must not silently unlock the guard.
- The flag is inert on `publish: false`.

The 400 body gains an **additive** `code: "EMPTY_LINEUP"` so the client detects this specific rejection without string-matching `message` (which would silently break the moment the copy changes). `handleResponse` already exposes the parsed body as `error.details`, so no new plumbing was needed.

The admin UI catches it, confirms — *"…has no bands yet. Publishing now will make the event page public immediately, showing 'Lineup TBA' until a lineup is added."* — and retries **exactly once** with the flag.

The PUT toggle is deliberately left alone (adding a check there would be a new restriction, not a fix); it gains a comment so nobody "fixes" the asymmetry later and breaks the announcement flow.

## Test plan

- [x] `make gate` green — **1119 backend + 996 frontend**, lint, format, build
- [x] Backend: no-flag rejection (asserting the row is *still* `draft`, not just the status code), flag publishes, non-boolean rejected, flag inert on unpublish, event-with-bands unaffected
- [x] Frontend: retry carries the flag, decline does not retry, and the retry's own failure surfaces an error toast
- [x] Every new test proven non-vacuous by mutation, including two run independently of the implementer:
  - `newStatus = publish || allowEmptyLineup` (flag leaking into the unpublish direction) → fails exactly the "flag is a no-op on unpublish" test
  - replacing the retry's `showToast` with a no-op → fails exactly the retry-failure test

## Notes

One honest finding from the mutation pass, recorded rather than hidden: the "flag not passed" assertion in `adminApi.test.js` does **not**, on its own, catch a regression that always includes `allowEmptyLineup`, because `JSON.stringify` drops `undefined`-valued keys. It is the companion "explicitly false" test that actually pins the `if (allowEmptyLineup)` guard. Both are needed together.

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events without scheduled performers can now be published after confirming an empty lineup.
  * Publishing clearly identifies when an empty lineup requires confirmation.
  * Invalid empty-lineup options are rejected with an appropriate validation message.

* **Bug Fixes**
  * Improved handling and notifications for failed publication retries.
  * Declining confirmation no longer retries publication or reports success.
  * Events with performers continue to publish normally without requiring additional confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->