### PR TITLE
fix(events): stop offering to expand a lineup that does not exist

### DIFF
--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -967,7 +967,13 @@ function EventCard({
           </div>
         )}
 
-        {!expanded && featuredBands.length === 0 && (
+        {/* Only offer the hint when expanding would actually load something.
+            `featuredBands` is empty both when a lineup exists but hasn't been
+            fetched yet AND when the event has no lineup at all — gating on
+            allBandCount separates them. Without it a not-yet-booked event
+            reads "Lineup TBA" and then invites you to expand for the lineup it
+            just said doesn't exist; expanding loads nothing. */}
+        {!expanded && featuredBands.length === 0 && allBandCount > 0 && (
           <div className="mt-4 pt-4 border-t border-border">
             <p className="text-text-tertiary text-sm">Expand to load performers and venues.</p>
           </div>

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -1035,6 +1035,44 @@ describe('EventTimeline empty lineup and between-seasons states', () => {
     // The zero-count stat this replaces would have rendered its own "Bands"
     // label (plural, since 0 !== 1) right next to the numeral.
     expect(screen.queryByText('Bands')).not.toBeInTheDocument()
+    // ...and it must not then invite the fan to expand for the lineup it just
+    // said does not exist. Expanding a 0-band event loads nothing.
+    expect(screen.queryByText('Expand to load performers and venues.')).not.toBeInTheDocument()
+  })
+
+  it('still offers the expand hint when the event has a lineup that is not loaded yet', async () => {
+    // The complement of the assertion above: `featuredBands` is empty here too
+    // (the collapsed card carries no band rows), but band_count proves there is
+    // something to load — so the hint is correct and must survive. Without this,
+    // the fix could be "delete the hint entirely" and still look green.
+    stubTimeline({
+      now: [],
+      upcoming: [
+        {
+          id: 2,
+          name: 'Booked Fest',
+          slug: 'booked-fest',
+          date: '2026-10-11',
+          status: 'published',
+          venues: [],
+          bands: [],
+          band_count: 12,
+          venue_count: 3,
+          ticket_url: null,
+        },
+      ],
+      past: [],
+    })
+
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Booked Fest')).toBeInTheDocument()
+    expect(screen.getByText('Expand to load performers and venues.')).toBeInTheDocument()
+    expect(screen.queryByText('Lineup TBA')).not.toBeInTheDocument()
   })
 
   it('omits the lineup stat entirely for a past event with no recorded bands', async () => {


### PR DESCRIPTION
## Summary

A published event with no lineup rendered **"Lineup TBA"** and then, directly beneath it, **"Expand to load performers and venues."** Expanding loads nothing — the card advertised a lineup it had just said wasn't booked.

Live on Vol. 18 since it was published.

## Cause

The hint was gated only on `featuredBands.length === 0`. That is true in **two different situations**:

1. a lineup exists but the collapsed card hasn't fetched it yet — hint is correct
2. the event has no lineup at all — hint is nonsense

Gating on `allBandCount` separates them. One condition:

```diff
-{!expanded && featuredBands.length === 0 && (
+{!expanded && featuredBands.length === 0 && allBandCount > 0 && (
```

## Why two tests

The obvious over-fix — deleting the hint outright — also satisfies "no hint on a 0-band event". One test would have passed against a worse fix.

The second covers the complement: an event with `band_count: 12` and no loaded band rows still shows the hint, because there genuinely is something to load.

## Test plan

- [x] `make gate` green — **1119 backend + 1001 frontend**, lint, format, build
- [x] Mutation-verified **in both directions**:
  - revert the guard (restore the bug) → fails the "Lineup TBA" test only
  - delete the hint entirely (over-fix) → fails the new complement only
  - neither test catches both alone, which is why both exist

## Note

The commit message says "1002 frontend"; the correct figure is **1001**, as above. Caught after pushing and not worth a history rewrite to correct one digit.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event lineup messaging so events without performers display “Lineup TBA” without an invitation to expand.
  * Events with performers still show the option to load the lineup.

* **Tests**
  * Added coverage to verify lineup messaging for events with and without performers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->