### PR TITLE
fix(events): refuse to create an event already published

### DIFF
--- a/frontend/src/admin/EventFormModal.jsx
+++ b/frontend/src/admin/EventFormModal.jsx
@@ -666,7 +666,15 @@ export default function EventFormModal({ isOpen, onClose, event = null, onSave, 
                   className="w-full min-h-[44px] px-4 py-2 rounded bg-bg-navy text-white border border-gray-600 focus:border-accent-500 focus:outline-hidden focus:ring-1 focus:ring-accent-500"
                 >
                   <option value="draft">Draft</option>
-                  <option value="published">Published</option>
+                  {/*
+                    Create offers no `Published`: the server rejects it (#804).
+                    A brand-new event has no performances yet, so creating it
+                    published would always be a silent empty-lineup publish,
+                    skipping the confirm that POST .../publish shows. Create as
+                    a draft, then publish -- that path still supports a
+                    "Lineup TBA" publish, it just asks first.
+                  */}
+                  {isEditing && <option value="published">Published</option>}
                   {!isEditing && canCreateArchived && <option value="archived">Archived</option>}
                 </select>
               )}

--- a/frontend/src/admin/__tests__/eventFormStatusOptions.test.js
+++ b/frontend/src/admin/__tests__/eventFormStatusOptions.test.js
@@ -33,13 +33,17 @@ describe('EventFormModal status options — #804', () => {
     // the JSX and pass no matter what the markup does.
     const code = source.replace(/\/\*[\s\S]*?\*\//g, '')
 
-    const publishedOption = code.match(/.*<option value="published">.*/)
-    expect(publishedOption, 'expected a published <option> to exist for the edit form').not.toBeNull()
+    // Match ALL occurrences, not just the first. A non-global `.match()` reads
+    // only match #1, so a second, unconditional `<option value="published">`
+    // added later would sail past a guard that inspected just that one — the
+    // regression this test exists to catch, reintroduced silently.
+    const publishedOptions = [...code.matchAll(/.*<option value="published">.*/g)]
+    expect(publishedOptions, 'expected exactly one published <option>, for the edit form only').toHaveLength(1)
 
-    // The line must be conditional on isEditing. An unconditional
+    // That sole option must be conditional on isEditing. An unconditional
     // `<option value="published">` is the #804 regression.
     expect(
-      publishedOption[0],
+      publishedOptions[0][0],
       'the Published option must be gated on isEditing — an unconditional one lets the create form build a request the server now rejects (#804)'
     ).toMatch(/isEditing\s*&&/)
   })

--- a/frontend/src/admin/__tests__/eventFormStatusOptions.test.js
+++ b/frontend/src/admin/__tests__/eventFormStatusOptions.test.js
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Durable guard for #804 — the create form must not offer `Published`.
+ *
+ * POST /api/admin/events rejects `status: "published"` outright, because a
+ * just-created event has zero performances and would therefore always be a
+ * silent empty-lineup publish, skipping the confirm that POST .../publish
+ * shows. This asserts the UI can't build that rejected request in the first
+ * place, so the two halves can't drift apart.
+ *
+ * Deliberately a SOURCE SCAN rather than a render test, following the
+ * `bandFields.test.js` precedent. EventFormModal.jsx is ~700 lines and
+ * otherwise untested; importing it to assert three `<option>` lines would drop
+ * all of its uncovered lines into the coverage denominator and push the global
+ * ratchet (statements 57 / branches 50 / functions 60 / lines 58 in
+ * vitest.config.js) toward failing — the trap where adding a test makes CI red.
+ * Reading the file as text costs nothing and cannot regress coverage.
+ */
+describe('EventFormModal status options — #804', () => {
+  const currentFile = fileURLToPath(import.meta.url)
+  // Resolved via node:path rather than `new URL(relative, import.meta.url)`,
+  // matching bandFields.test.js.
+  const modalPath = path.join(path.dirname(currentFile), '../EventFormModal.jsx')
+  const source = readFileSync(modalPath, 'utf8')
+
+  it('gates the Published option on isEditing so create cannot offer it', () => {
+    // Strip block comments first: the explanatory comment above the option
+    // mentions `Published`, and an unstripped scan would match that instead of
+    // the JSX and pass no matter what the markup does.
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, '')
+
+    const publishedOption = code.match(/.*<option value="published">.*/)
+    expect(publishedOption, 'expected a published <option> to exist for the edit form').not.toBeNull()
+
+    // The line must be conditional on isEditing. An unconditional
+    // `<option value="published">` is the #804 regression.
+    expect(
+      publishedOption[0],
+      'the Published option must be gated on isEditing — an unconditional one lets the create form build a request the server now rejects (#804)'
+    ).toMatch(/isEditing\s*&&/)
+  })
+
+  it('still offers Archived on create for admins (historical back-fill must keep working)', () => {
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, '')
+    const archivedOption = code.match(/.*<option value="archived">.*/)
+
+    expect(archivedOption, 'expected an archived <option>').not.toBeNull()
+    // HistoricalImportModal back-fills past editions as `archived`; #804 must
+    // not have collaterally removed that path.
+    expect(archivedOption[0]).toMatch(/!isEditing\s*&&\s*canCreateArchived/)
+  })
+})

--- a/functions/api/admin/events.js
+++ b/functions/api/admin/events.js
@@ -170,6 +170,37 @@ export async function onRequestPost(context) {
       );
     }
 
+    // Publication must go through POST /api/admin/events/:id/publish, which is
+    // the only route that asks before putting a lineup-less event in front of
+    // the public (400 EMPTY_LINEUP, overridable with an explicit
+    // `allowEmptyLineup: true` -- the supported "Lineup TBA" publish).
+    //
+    // Creating straight into `published` is the one path where that prompt can
+    // never fire: the row is born with zero performances, so a create-as-
+    // published is ALWAYS an empty-lineup publish, silently. The admin create
+    // form offered `Published` in a dropdown next to `Draft`, so one mis-click
+    // put a half-configured event on the public site and in the sitemap (#804).
+    //
+    // This is deliberately NOT the same as the "tighten every status writer"
+    // fix that `events/[id].js` rejects in its PUT-toggle comment. That comment
+    // argues against making the toggle STRICTER than its guarded sibling; this
+    // routes creation TOWARD that sibling. `draft` and `archived` stay allowed
+    // -- archived is historical back-fill (HistoricalImportModal) and carries
+    // no live-lineup requirement.
+    if (status === "published") {
+      return new Response(
+        JSON.stringify({
+          error: "Validation error",
+          message: "Create the event as a draft, then publish it. Publishing checks the lineup first.",
+          code: "CREATE_AS_PUBLISHED",
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
     // Validate date is not in past (unless status is archived for retroactive
     // events). "Today" must be the events' Toronto-local day, not the Worker's
     // UTC day: new Date() components on Cloudflare are UTC, which roll to

--- a/functions/api/admin/events/__tests__/events.test.js
+++ b/functions/api/admin/events/__tests__/events.test.js
@@ -104,6 +104,81 @@ describe("Event API - handler integration", () => {
     expect(data.event.slug).toBe("integration-event");
   });
 
+  // #804: publication has to go through POST .../publish, the only route that
+  // asks before putting a lineup-less event in front of the public. A created
+  // row has zero performances by construction, so create-as-published is always
+  // a silent empty-lineup publish.
+  //
+  // These assert on what the fix CHANGES -- whether the row reaches the DB --
+  // not merely on the status code. A test that only checked `res.status` would
+  // still pass if the handler returned 400 *after* inserting.
+  it("onRequestPost refuses to create an event already published, and writes nothing", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+    const request = new Request("https://example.test/api/admin/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Sneaky Published Event",
+        slug: "sneaky-published-event",
+        date: "2099-10-11",
+        status: "published",
+      }),
+    });
+
+    const res = await eventsHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.code).toBe("CREATE_AS_PUBLISHED");
+
+    // The real assertion: the event must not exist at all.
+    const stored = rawDb.prepare("SELECT id FROM events WHERE slug = ?").get("sneaky-published-event");
+    expect(stored).toBeUndefined();
+  });
+
+  it("onRequestPost still creates a draft event (the fix must not block the normal path)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+    const request = new Request("https://example.test/api/admin/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Draft Event",
+        slug: "draft-event",
+        date: "2099-10-11",
+        status: "draft",
+      }),
+    });
+
+    const res = await eventsHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(201);
+    const stored = rawDb.prepare("SELECT status FROM events WHERE slug = ?").get("draft-event");
+    expect(stored.status).toBe("draft");
+  });
+
+  // Guards the trap called out in #804: rejecting every non-draft status on
+  // create would silently break HistoricalImportModal, which back-fills past
+  // editions as `archived`. Archived carries no live-lineup requirement.
+  it("onRequestPost still creates an archived event for an admin (historical back-fill)", async () => {
+    const rawDb = createTestDB();
+    const env = { DB: createDBEnv(rawDb) };
+    const request = new Request("https://example.test/api/admin/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-role": "admin" },
+      body: JSON.stringify({
+        name: "Historical Edition",
+        slug: "historical-edition",
+        date: "2020-08-02",
+        status: "archived",
+      }),
+    });
+
+    const res = await eventsHandler.onRequestPost({ request, env });
+    expect(res.status).toBe(201);
+    const stored = rawDb.prepare("SELECT status FROM events WHERE slug = ?").get("historical-edition");
+    expect(stored.status).toBe("archived");
+  });
+
   it("accepts an event dated the Toronto-local today even after UTC has rolled over", async () => {
     // Regression for the #568 bug class in the create path: the past-date guard
     // must use the events' Toronto-local day, not the Worker's UTC day. At


### PR DESCRIPTION
## Summary

`POST /api/admin/events` accepted `status: "published"` and persisted it. That is the one path where the empty-lineup prompt can **never** fire: the row is born with zero performances, so a create-as-published is *always* an empty-lineup publish, silently. The admin create form offered `Published` in a dropdown beside `Draft`, so one mis-click put a half-configured event on the public site and in the sitemap.

Publication now goes through `POST .../publish` — the only route that asks first (`400 EMPTY_LINEUP`, overridable with an explicit `allowEmptyLineup: true`).

Closes #804

## What changed

| File | Change |
|------|--------|
| `functions/api/admin/events.js` | Reject `status: "published"` on create → `400` with `code: "CREATE_AS_PUBLISHED"`. `draft` and `archived` still allowed |
| `frontend/src/admin/EventFormModal.jsx` | Gate the `Published` option on `isEditing`, so the create form cannot build the now-rejected request |
| `functions/api/admin/events/__tests__/events.test.js` | 3 tests: rejection writes nothing; draft still works; archived still works |
| `frontend/src/admin/__tests__/eventFormStatusOptions.test.js` | New source-scan guard on the option gating |

## Security / correctness notes

**This is a footgun fix, not a security fix — and deliberately not a claim that empty published events are invalid.** They are supported: "Lineup TBA" is an intentional workflow for announcing an event before booking completes (`publish.js:71-78`), which is why the guard there has an explicit override.

The subtle part is that `events/[id].js:622-631` already **rejects** the "tighten every status writer" approach:

> …don't "fix" the asymmetry by tightening this toggle; that would block the same workflow the other endpoint's override exists to allow.

That comment argues against making the toggle **stricter than its guarded sibling**. This change routes creation **toward** that sibling — the opposite move — and preserves the capability: create as draft, then publish, and the "Lineup TBA" confirm still lets it through. One extra click, no lost workflow.

`archived` stays allowed on create. That is the trap #804 called out: forcing every new event to `draft` would silently break `HistoricalImportModal`, which back-fills past editions as `archived`. A test now pins that.

### Sibling sweep — every path that can write `status = 'published'`

| Path | Band check? | Action |
|------|-------------|--------|
| `events.js` POST (create) | none | **fixed here** |
| `events/[id].js` PATCH | none | **left alone → filed as #821** |
| `events/[id].js` PUT toggle | none, *documented as deliberate* | left alone by design |
| `events/[id]/publish.js` | yes (+ override) | unchanged, the guarded path |
| `events/[id]/archive.js` | n/a — writes `archived` | unchanged |

Two notes on the sweep method:

- **The create path is invisible to the grep `CLAUDE.md` prescribes.** That doc says to grep `UPDATE events` to find the four status writers. Create is an `INSERT`, so it never appears — which is precisely why this bug survived. Worth remembering the next time that sweep is run.
- **PATCH is now #821.** CodeRabbit flagged it on this PR and my own sweep found it independently. I did *not* widen this PR to cover it: the PUT-toggle comment above makes "should PATCH be tightened?" a real design question rather than an obvious yes, and it should be answered deliberately rather than incidentally. #821 lays out three options with a recommendation.

## Verification

- [x] Tests: **1127 backend** (110 files, was 1124) + **1003 frontend** (89 files, was 1001) pass, 0 failures
- [x] ESLint: backend 0 errors; frontend 0 errors (2 pre-existing warnings in `AdminPanel.jsx` / `UserManagement.jsx`, unrelated)
- [x] Format check: clean, both stacks
- [x] Build: green
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] Manual smoke: covered by mutation testing below, which is stronger than a click-through here

**Both new guards are mutation-proven, not assumed.** A passing test proves nothing until it has failed for the right reason:

- Disabling the server guard (`if (false && status === "published")`) fails **exactly** the new rejection test — `expected 201 to be 400` — while the draft and archived tests stay green.
- Removing the `isEditing` gate fails **exactly** the source-scan test.

The backend test asserts the row **never reaches the DB**, not merely the status code: a test checking only `res.status` would still pass if the handler returned 400 *after* inserting.

**Why the frontend guard is a source scan rather than a render test:** `EventFormModal.jsx` is ~700 lines and otherwise untested. Importing it to assert three `<option>` lines would drop all of its uncovered lines into the coverage denominator and push the global ratchet (statements 57 / branches 50 / functions 60 / lines 58) toward failing — the trap where adding a test turns CI red. It follows the `bandFields.test.js` precedent, and strips block comments before matching so the explanatory comment above the option can't satisfy the assertion vacuously.

All gate steps were run **bare with real exit codes**, not through a pipe — a piped gate reports `tail`'s status, not `make`'s.

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - New events can no longer be created directly with a Published status.
  - Events must be created as Drafts before they can be published.
  - Draft and permitted Archived event creation remain available.
  - Editing existing events continues to support the Published status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->