### PR TITLE
a11y(admin): name the two unlabelled LineupTab desktop-table checkboxes

### DIFF
--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -874,6 +874,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
                               className="h-5 w-5 cursor-pointer"
                               onChange={e => handleSelectAll(e.target.checked)}
                               checked={selectedIds.size === filteredBands.length && filteredBands.length > 0}
+                              aria-label="Select all bands"
                             />
                           </th>
                         )}
@@ -970,6 +971,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
                                   className="h-5 w-5 cursor-pointer"
                                   checked={selectedIds.has(band.id)}
                                   onChange={e => handleSelect(band.id, e.target.checked)}
+                                  aria-label={`Select ${band.name}`}
                                 />
                               </td>
                             )}


### PR DESCRIPTION
## Summary

`LineupTab`'s **desktop table** had two checkboxes with no accessible name — a select-all in a `<th>` and a per-row one in a `<td>`. A screen reader announced them as a bare "checkbox", with nothing to tell one row from the next.

This is the same defect class CodeRabbit caught in `RosterTab`'s desktop table during #772. The **mobile card** variants were always fine: they wrap the input in a `<label>` carrying the band name. That is precisely why the desktop ones were missed — you can't wrap a table cell's checkbox in a label containing the row content.

Refs #777, #823

## What changed

| File | Change |
|------|--------|
| `frontend/src/admin/LineupTab.jsx` | select-all → `aria-label="Select all bands"`; per-row → ``aria-label={`Select ${band.name}`}`` |

Naming the row **entity** matters. `aria-label="Select"` announces identically on every row, which is no more useful than silence when moving down a table. Matches the existing good example in `components/ArtistPicker.jsx`.

## Security / correctness notes

None. Two added attributes, no behaviour, styling, or layout change.

### Sibling sweep

Bug class: *a checkbox under `frontend/src/admin/` with no accessible name.* Checked every `type="checkbox"` in the tree — **9 production sites**:

| Site | State |
|------|-------|
| `AdminLogin.jsx:242` | already correct — `<label>` "Remember this device for 30 days" |
| `EventsTab.jsx:1067` | already correct — `<label>` "Show Archived" |
| `components/UserFormModal.jsx:251` | already correct — `<label>` "Active" |
| `RosterTab.jsx:938`, `:957` | already correct — `<label>` "Select all" / mobile card |
| `LineupTab.jsx:1090`, `:1119` | already correct — `<label>` "Select all" / `{band.name}` |
| **`LineupTab.jsx:873`, `:969`** | **genuinely unnamed → fixed here** |

Re-swept after the fix: **zero remaining**. Test-file matches were excluded — they're fixtures, not UI.

## Why the ESLint rule from #777 is still not adopted

#777 asked for a JSX-aware ESLint check as a standing gate. `jsx-a11y/control-has-associated-label` is how I found these two — but it is far too noisy to enable, and #823 carries the alternative forward.

Two measurements, which disagree with each other:

- As a **config-file entry**: **90 errors** across `admin/`.
- Via the **`--rule` CLI flag**: **9 errors**. *(Worth knowing: these two forms do not agree. Trust the config number — it's what CI enforces.)*

Even in the narrower 9, **7 are false positives**:

| Flagged | Why it's fine |
|---|---|
| `RosterTab:910`, `UserManagement:335`, `VenuesTab:553` | flags a `<td>` — not a control |
| `VenuesTab:394`, `:434` | `<option>` inside a `<datalist>` — needs no label |
| `EventsTab:207` | `<button>{event.name}</button>` — has text content |
| `EventFormModal:702` | `<button role="switch" id="reveal-mode">` with a matching `<label htmlFor>` |

In the 90-error set the false positives include `components/ArtistPicker.jsx` — the file #777 itself cites as the *correctly labelled* example — and `AdminLogin.jsx`, which has a textbook `<label htmlFor>` / `<input id>` pair.

That is why the rule is not in `jsxA11y.configs.recommended`. Enabling it would turn CI red on correct markup and push contributors toward blanket `eslint-disable` — the *"burns review time and trains people to ignore the check"* outcome #777 was filed to prevent. #823 tracks the axe pass instead, which reads the rendered accessibility tree and doesn't produce these false positives.

## Verification

- [x] Tests: **1003 frontend** (89 files) pass, 0 failures
- [x] ESLint: 0 errors (2 pre-existing `react-hooks/exhaustive-deps` warnings in `AdminPanel.jsx` / `UserManagement.jsx`, unrelated)
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] Manual smoke: sibling sweep re-run post-fix returns zero unlabelled checkboxes; `make review` (CodeRabbit) **no findings**

All gate steps run with real exit codes, not through a pipe.

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added accessible labels to the desktop “Select all” checkbox and individual performance-selection checkboxes in the lineup view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->