### PR TITLE
fix(lifecycle): count calendar days in getDaysSinceEvent, not elapsed ms (#770)

### DIFF
--- a/frontend/src/utils/__tests__/eventLifecycle.test.js
+++ b/frontend/src/utils/__tests__/eventLifecycle.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { getDaysSinceEvent } from '../eventLifecycle'
+
+describe('getDaysSinceEvent', () => {
+  it('returns -1 for empty or missing event date', () => {
+    expect(getDaysSinceEvent(null)).toBe(-1)
+    expect(getDaysSinceEvent('')).toBe(-1)
+  })
+
+  it('calculates days elapsed for standard non-transition dates', () => {
+    // Event ended on 2026-08-10 at 23:59:59
+    // Reference time: 2026-08-13 at 23:59:59 (3 days later)
+    expect(getDaysSinceEvent('2026-08-10', new Date('2026-08-13T23:59:59'))).toBe(3)
+  })
+
+  it('correctly calculates days elapsed across fall-back DST transition (2026-11-01, 25h day)', () => {
+    // Event ended on 2026-10-31 at 23:59:59
+    // Reference time: 2026-11-01 at 23:59:59 (1 day later, 25 wall-clock hours)
+    expect(getDaysSinceEvent('2026-10-31', new Date('2026-11-01T23:59:59'))).toBe(1)
+  })
+
+  it('correctly calculates days elapsed across spring-forward DST transition (2027-03-14, 23h day)', () => {
+    // Event ended on 2027-03-13 at 23:59:59
+    // Reference time: 2027-03-14 at 23:59:59 (1 day later, 23 wall-clock hours)
+    // #770: Math.floor previously returned 0 due to 23h / 24h < 1
+    expect(getDaysSinceEvent('2027-03-13', new Date('2027-03-14T23:59:59'))).toBe(1)
+  })
+})

--- a/frontend/src/utils/__tests__/eventLifecycle.test.js
+++ b/frontend/src/utils/__tests__/eventLifecycle.test.js
@@ -13,7 +13,12 @@ describe('getDaysSinceEvent', () => {
     expect(jan).not.toBe(jul)
   })
 
-  it('returns -1 for empty or missing event date', () => {
+  // `undefined` is the repo's convention for an absent optional value
+  // (instructions/nodejs-javascript-vitest.instructions.md), but `null` is
+  // what actually arrives at runtime: `event.date` is deserialized from D1,
+  // where a NULL column becomes JSON null. Both are asserted deliberately.
+  it('returns -1 for a missing or empty event date', () => {
+    expect(getDaysSinceEvent(undefined)).toBe(-1)
     expect(getDaysSinceEvent(null)).toBe(-1)
     expect(getDaysSinceEvent('')).toBe(-1)
   })

--- a/frontend/src/utils/__tests__/eventLifecycle.test.js
+++ b/frontend/src/utils/__tests__/eventLifecycle.test.js
@@ -1,28 +1,65 @@
 import { describe, expect, it } from 'vitest'
 import { getDaysSinceEvent } from '../eventLifecycle'
 
+// These fixtures only mean anything in a DST-observing zone: in UTC there is
+// no transition, so every case below passes against the pre-#770 code too.
+// frontend/vitest.config.js pins TZ=America/Toronto for exactly this reason.
 describe('getDaysSinceEvent', () => {
+  it('is pinned to a DST-observing timezone', () => {
+    // Guards the guard: if the TZ pin is ever dropped, the DST cases below
+    // silently stop testing anything rather than failing.
+    const jan = new Date('2026-01-15T12:00:00').getTimezoneOffset()
+    const jul = new Date('2026-07-15T12:00:00').getTimezoneOffset()
+    expect(jan).not.toBe(jul)
+  })
+
   it('returns -1 for empty or missing event date', () => {
     expect(getDaysSinceEvent(null)).toBe(-1)
     expect(getDaysSinceEvent('')).toBe(-1)
   })
 
-  it('calculates days elapsed for standard non-transition dates', () => {
-    // Event ended on 2026-08-10 at 23:59:59
-    // Reference time: 2026-08-13 at 23:59:59 (3 days later)
+  it('counts whole calendar days for standard dates', () => {
     expect(getDaysSinceEvent('2026-08-10', new Date('2026-08-13T23:59:59'))).toBe(3)
   })
 
-  it('correctly calculates days elapsed across fall-back DST transition (2026-11-01, 25h day)', () => {
-    // Event ended on 2026-10-31 at 23:59:59
-    // Reference time: 2026-11-01 at 23:59:59 (1 day later, 25 wall-clock hours)
-    expect(getDaysSinceEvent('2026-10-31', new Date('2026-11-01T23:59:59'))).toBe(1)
+  it('returns 0 on the event date itself, at any hour', () => {
+    expect(getDaysSinceEvent('2026-08-10', new Date('2026-08-10T00:00:01'))).toBe(0)
+    expect(getDaysSinceEvent('2026-08-10', new Date('2026-08-10T12:00:00'))).toBe(0)
+    expect(getDaysSinceEvent('2026-08-10', new Date('2026-08-10T23:59:59'))).toBe(0)
   })
 
-  it('correctly calculates days elapsed across spring-forward DST transition (2027-03-14, 23h day)', () => {
-    // Event ended on 2027-03-13 at 23:59:59
-    // Reference time: 2027-03-14 at 23:59:59 (1 day later, 23 wall-clock hours)
-    // #770: Math.floor previously returned 0 due to 23h / 24h < 1
+  // #770 regression: Math.round on elapsed milliseconds rounded a half-day up,
+  // so the day after an event drifted from 0 to 1 partway through the morning.
+  // Calendar differencing pins the whole date to a single value.
+  it('reports a stable 1 for every hour of the day after the event', () => {
+    for (const hour of ['00:00:01', '06:00:00', '12:00:00', '18:00:00', '23:59:59']) {
+      expect(getDaysSinceEvent('2026-08-10', new Date(`2026-08-11T${hour}`))).toBe(1)
+    }
+  })
+
+  it('crosses the fall-back DST transition (2026-11-01, a 25-hour day)', () => {
+    expect(getDaysSinceEvent('2026-10-31', new Date('2026-11-01T23:59:59'))).toBe(1)
+    expect(getDaysSinceEvent('2026-10-31', new Date('2026-11-01T00:30:00'))).toBe(1)
+  })
+
+  // #770 original report: a 23-hour day made Math.floor(23/24) return 0 for a
+  // full calendar day.
+  it('crosses the spring-forward DST transition (2027-03-14, a 23-hour day)', () => {
     expect(getDaysSinceEvent('2027-03-13', new Date('2027-03-14T23:59:59'))).toBe(1)
+    expect(getDaysSinceEvent('2027-03-13', new Date('2027-03-14T04:00:00'))).toBe(1)
+  })
+
+  // #770 regression: Math.round produced -0 for a near-future event, which
+  // renders as "0" and reads as "ended today".
+  it('returns a strictly negative count for future events', () => {
+    const tomorrow = getDaysSinceEvent('2026-08-14', new Date('2026-08-13T23:00:00'))
+    expect(tomorrow).toBe(-1)
+    expect(Object.is(tomorrow, -0)).toBe(false)
+    expect(getDaysSinceEvent('2026-08-16', new Date('2026-08-13T12:00:00'))).toBe(-3)
+  })
+
+  it('accepts a string or numeric referenceTime', () => {
+    expect(getDaysSinceEvent('2026-08-10', '2026-08-12T09:00:00')).toBe(2)
+    expect(getDaysSinceEvent('2026-08-10', new Date('2026-08-12T09:00:00').getTime())).toBe(2)
   })
 })

--- a/frontend/src/utils/eventLifecycle.js
+++ b/frontend/src/utils/eventLifecycle.js
@@ -73,15 +73,16 @@ export function isEventUpcoming(eventDate) {
  * Calculate days since event ended
  *
  * @param {string} eventDate - Event date in YYYY-MM-DD format
+ * @param {Date|string|number} referenceTime - Optional time to evaluate against
  * @returns {number} Days since event ended (0 if upcoming, negative if in future)
  */
-export function getDaysSinceEvent(eventDate) {
+export function getDaysSinceEvent(eventDate, referenceTime = new Date()) {
   if (!eventDate) return -1
 
-  const now = new Date()
+  const now = referenceTime instanceof Date ? referenceTime : new Date(referenceTime)
   const eventEnd = new Date(eventDate + 'T23:59:59')
   const diffMs = now.getTime() - eventEnd.getTime()
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24))
 
   return diffDays
 }

--- a/frontend/src/utils/eventLifecycle.js
+++ b/frontend/src/utils/eventLifecycle.js
@@ -70,21 +70,32 @@ export function isEventUpcoming(eventDate) {
 }
 
 /**
- * Calculate days since event ended
+ * Calculate whole calendar days since the event date
+ *
+ * Counts CALENDAR days in the local zone, not elapsed time: the event's own
+ * date is 0, the next date is 1, a future date is negative.
  *
  * @param {string} eventDate - Event date in YYYY-MM-DD format
  * @param {Date|string|number} referenceTime - Optional time to evaluate against
- * @returns {number} Days since event ended (0 if upcoming, negative if in future)
+ * @returns {number} Calendar days since the event date (negative if future, -1 if no date)
  */
 export function getDaysSinceEvent(eventDate, referenceTime = new Date()) {
   if (!eventDate) return -1
 
   const now = referenceTime instanceof Date ? referenceTime : new Date(referenceTime)
-  const eventEnd = new Date(eventDate + 'T23:59:59')
-  const diffMs = now.getTime() - eventEnd.getTime()
-  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24))
+  const [year, month, day] = eventDate.split('-').map(Number)
 
-  return diffDays
+  // Both endpoints are projected onto UTC midnight, so their difference is
+  // always an exact multiple of 24h no matter what the local zone does in
+  // between. Dividing REAL elapsed milliseconds by 86400000 cannot work here
+  // (#770): a spring-forward day is only 23 wall-clock hours, so Math.floor
+  // reported 0 for a full calendar day. Math.round appears to fix that case
+  // but is worse — it rounds 12h up, so an event reads "1 day ago" at noon
+  // the morning after, and a future event yields -0 instead of a negative.
+  const eventDayUtc = Date.UTC(year, month - 1, day)
+  const todayUtc = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())
+
+  return Math.round((todayUtc - eventDayUtc) / (1000 * 60 * 60 * 24))
 }
 
 /**

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,6 +1,12 @@
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
+// Pin the test timezone. Several suites assert DST behaviour (#770), and DST
+// does not exist in UTC — under a UTC runner those fixtures pass against the
+// broken implementation as readily as the fixed one, which is worse than no
+// test at all. America/Toronto is the zone the product actually runs in.
+process.env.TZ = 'America/Toronto'
+
 export default defineConfig({
   plugins: [react()],
   test: {


### PR DESCRIPTION
Closes #770

## Summary

The original approach (`Math.floor` → `Math.round`) fixed the reported DST case but broke three others, and the test that justified it **could not fail**. This replaces the rounding-mode change with calendar-day differencing and makes the DST fixtures actually bite.

## Why `Math.round` was not the fix

Measured in `America/Toronto`:

| case | expected | `floor` | `round` |
|---|---|---|---|
| spring-forward 2027-03-14 (23h day) | 1 | **0** ✗ | 1 ✓ |
| +12h / +13h / +20h after event end | 0 | 0 ✓ | **1** ✗ |
| event 10h in the future | negative | −1 ✓ | **−0** ✗ |
| event 3d in the future | −3 | −4 ✗ | −3 ✓ |

`round` traded one wrong answer for three. The `-0` is the worst: it renders as `"0"`, so a **future** event displayed "Ended 0 days ago".

**The rounding mode was never the axis.** This is calendar-day arithmetic performed by dividing real elapsed milliseconds. A spring-forward day is 23 wall-clock hours and a fall-back day is 25, so *no* rounding mode can be correct. Both endpoints are now projected onto UTC midnight, which makes the difference an exact multiple of 24h regardless of what the local zone does in between. Same family as the UTC event-day bug class documented in `CLAUDE.md`.

## The test could not fail

No `TZ` pin exists anywhere in this repo, and **DST does not exist in UTC**. Under CI's UTC runner the spring-forward fixture returned `1` under *both* `floor` and `round` — it passed against the unfixed code. Green CI proved nothing.

Fixed by pinning `TZ=America/Toronto` in `frontend/vitest.config.js`, plus a test asserting the January and July UTC offsets differ — so if the pin is ever dropped, the suite fails loudly instead of silently disarming every DST case.

## Verified by mutation, not assertion

| implementation | result |
|---|---|
| `Math.round` (previous) | **5 of 9 fail** |
| `Math.floor` (original) | **6 of 9 fail** |
| calendar differencing (this PR) | 9 pass |

## Behaviour note

`getDaysSinceEvent` is **display-only**. `getEventState` does its own millisecond comparison and never calls it, so grace-period and archive gating are untouched. The visible change: the day after an event now reads a stable "1 day ago" all day, instead of drifting 0 → 1 → 2 as the hours pass.

## Scope

The unrelated `delegate-verify` tooling that shared this branch has been split to its own branch and PR — this branch is now only the #770 fix.

## Test plan

- [x] `make gate` — exit 0
- [x] Backend suite — 1127 passed
- [x] Frontend suite — 1022 passed (TZ pin affects all frontend tests; none broke)
- [x] Mutation-tested against both prior implementations
- [x] DST fixtures verified meaningful under the pinned zone

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event day calculations using local calendar dates for consistent results across daylight saving time changes.
  * Future event dates now correctly return negative day differences without displaying negative zero.
  * Added reliable calculations using specified reference times.
  * Events without a date continue to return the expected unavailable result.

* **Tests**
  * Expanded coverage for same-day, future, timezone, and daylight saving time scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->