### PR TITLE
chore(markdown): remove the rel hook by identity, not by type (#793)

### DIFF
--- a/frontend/src/utils/__tests__/markdown.test.js
+++ b/frontend/src/utils/__tests__/markdown.test.js
@@ -5,7 +5,7 @@
  * XSS tests are mandatory and must pass before any deploy.
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import DOMPurify from 'dompurify'
 import { renderMarkdownToSafeHtml, stripMarkdownToText } from '../markdown'
 
@@ -186,6 +186,40 @@ describe('renderMarkdownToSafeHtml — XSS protection', () => {
 
   it('cleans up DOMPurify hooks after sanitization without leaking (#793)', () => {
     renderMarkdownToSafeHtml('[x](https://settimes.ca)')
+    const directSanitized = DOMPurify.sanitize('<a href="https://example.com">direct</a>', {
+      ALLOWED_TAGS: ['a'],
+      ALLOWED_ATTR: ['href', 'rel'],
+    })
+    expect(directSanitized).not.toContain('rel="noopener noreferrer"')
+  })
+
+  it('does not remove hooks registered by other consumers (#793)', () => {
+    const markSentinel = node => {
+      if (node.tagName === 'A') node.setAttribute('data-hook', 'sentinel')
+    }
+    DOMPurify.addHook('afterSanitizeAttributes', markSentinel)
+    try {
+      renderMarkdownToSafeHtml('[x](https://settimes.ca)')
+      const directSanitized = DOMPurify.sanitize('<a href="https://example.com">direct</a>', {
+        ALLOWED_TAGS: ['a'],
+        ALLOWED_ATTR: ['href', 'rel', 'data-hook'],
+      })
+      expect(directSanitized).toContain('data-hook="sentinel"')
+      expect(directSanitized).not.toContain('rel="noopener noreferrer"')
+    } finally {
+      DOMPurify.removeHook('afterSanitizeAttributes', markSentinel)
+    }
+  })
+
+  it('cleans up hooks even when sanitize throws (#793)', () => {
+    const sanitizeSpy = vi.spyOn(DOMPurify, 'sanitize').mockImplementation(() => {
+      throw new Error('sanitize failed')
+    })
+    try {
+      expect(() => renderMarkdownToSafeHtml('[x](https://settimes.ca)')).toThrow('sanitize failed')
+    } finally {
+      sanitizeSpy.mockRestore()
+    }
     const directSanitized = DOMPurify.sanitize('<a href="https://example.com">direct</a>', {
       ALLOWED_TAGS: ['a'],
       ALLOWED_ATTR: ['href', 'rel'],

--- a/frontend/src/utils/__tests__/markdown.test.js
+++ b/frontend/src/utils/__tests__/markdown.test.js
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import DOMPurify from 'dompurify'
 import { renderMarkdownToSafeHtml, stripMarkdownToText } from '../markdown'
 
 // ---------------------------------------------------------------------------
@@ -181,6 +182,15 @@ describe('renderMarkdownToSafeHtml — XSS protection', () => {
 
   it('forces rel on markdown-syntax links too', () => {
     expect(renderMarkdownToSafeHtml('[x](https://settimes.ca)')).toContain('rel="noopener noreferrer"')
+  })
+
+  it('cleans up DOMPurify hooks after sanitization without leaking (#793)', () => {
+    renderMarkdownToSafeHtml('[x](https://settimes.ca)')
+    const directSanitized = DOMPurify.sanitize('<a href="https://example.com">direct</a>', {
+      ALLOWED_TAGS: ['a'],
+      ALLOWED_ATTR: ['href', 'rel'],
+    })
+    expect(directSanitized).not.toContain('rel="noopener noreferrer"')
   })
 })
 

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -44,12 +44,14 @@ export function renderMarkdownToSafeHtml(md) {
 
   const html = marked.parse(md, { async: false })
   // Scope the rel-forcing hook to this call (add before, remove after) so there
-  // are no global DOMPurify side effects (#793).
+  // are no global DOMPurify side effects (#793). removeHook(type, fn) removes
+  // by identity — the plain removeHook(type) form would pop whatever hook is
+  // last, clobbering hooks other consumers may have registered.
   DOMPurify.addHook('afterSanitizeAttributes', forceLinkRel)
   try {
     return DOMPurify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR })
   } finally {
-    DOMPurify.removeAllHooks()
+    DOMPurify.removeHook('afterSanitizeAttributes', forceLinkRel)
   }
 }
 

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -44,12 +44,12 @@ export function renderMarkdownToSafeHtml(md) {
 
   const html = marked.parse(md, { async: false })
   // Scope the rel-forcing hook to this call (add before, remove after) so there
-  // are no global DOMPurify side effects.
+  // are no global DOMPurify side effects (#793).
   DOMPurify.addHook('afterSanitizeAttributes', forceLinkRel)
   try {
     return DOMPurify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR })
   } finally {
-    DOMPurify.removeHook('afterSanitizeAttributes')
+    DOMPurify.removeAllHooks()
   }
 }
 


### PR DESCRIPTION
## Summary

`frontend/src/utils/markdown.js` scopes the `forceLinkRel` DOMPurify hook to a single sanitize call by removing it in a `finally`. The original code called `removeHook(type)`, which pops the **last** hook registered for that type — so if any other code ever registered an `afterSanitizeAttributes` hook, this cleanup would remove the wrong one and `forceLinkRel` would leak into every later sanitize call.

DOMPurify 3.4.x's `removeHook(entryPoint, hookFunction)` removes by **identity**, so this change passes `forceLinkRel` itself — only our hook is removed, and hooks other consumers register stay intact. This is strictly safer than the earlier `removeAllHooks()` revision, which guaranteed no leak but also cleared every other consumer's hook.

Closes #793

## What changed

| File | Change |
|------|--------|
| `frontend/src/utils/markdown.js` | `DOMPurify.removeHook('afterSanitizeAttributes', forceLinkRel)` — identity-based removal in the `finally` |
| `frontend/src/utils/__tests__/markdown.test.js` | Leak regression test, plus: a sentinel-hook test proving hooks other consumers register survive, and an error-path test proving cleanup runs even when `sanitize` throws |

## Security / correctness notes

The rel-forcing behavior is unchanged for callers — every link still gets `rel="noopener noreferrer"`. The difference is purely in cleanup: targeted removal preserves DOMPurify's module-global hook state for anyone else, eliminating the cross-consumer clobbering that motivated #793.

## Verification

- [x] `make gate`: format → lint → tests → build, all green (frontend tests now 1013, backend 1127)
- [x] ESLint: 0 errors
- [x] Build: green (`npm run build --prefix frontend`)
- [x] Regression test proves no hook leak after sanitization
- [x] Sentinel test proves other consumers' hooks are preserved
- [x] Error-path test proves cleanup runs on throw

---
Built by Gemini + Claude (orchestrator) · Reviewed by CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where markdown sanitization cleanup could inadvertently affect other HTML sanitization operations.
  * Ensured markdown rendering removes only its own temporary sanitization behavior, including when rendering fails.

* **Tests**
  * Added regression coverage confirming sanitization cleanup occurs after successful and failed rendering.
  * Verified sanitization behavior registered by other consumers remains unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
