### PR TITLE
fix(opencode): grant the plan agent read access so read-only runs stop hanging (#816)

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -94,6 +94,17 @@
         "edit": "deny",
         "bash": "ask"
       }
+    },
+    "plan": {
+      "description": "Read-only review and diagnosis; never edits",
+      "mode": "primary",
+      "permission": {
+        "read": "allow",
+        "glob": "allow",
+        "grep": "allow",
+        "edit": "deny",
+        "bash": "deny"
+      }
     }
   },
   "command": {


### PR DESCRIPTION
## Summary

The relay dispatches read-only delegations with `--agent plan` and deliberately withholds `--auto` there, so autonomy is denied at the write tools. But the built-in `plan` agent inherited the root permission block's `read: ask`, so the very first file read triggered a permission prompt nothing can answer in headless mode — the relay hangs until its watchdog kills the child.

This overrides the built-in `plan` agent in `opencode.json` with `read`/`glob`/`grep: allow` and `edit`/`bash: deny`, matching the existing read-only subagents (`code-reviewer`, `code-explorer`, `db-architect`).

## Why

Read-only delegation is the cheapest review lane (plan runs never get `--auto`, so they can't be auto-approved into edits), and it was unusable: every plan run hung on the first read.

## Verification

- `opencode.json` parses and validates against the OpenCode config schema (`agent.plan` is a named key; `mode: "primary"`; all permission keys legal).
- Reproduced empirically through the relay: `relay.mjs --agent plan --model opencode-go/glm-5.2 --timeout 150s` with a tiny read brief. **Completed, exit 0, no writes** — read `opencode.json` and reported all five agents, including the new `plan`. Previously this hung on the first read prompt.
- `make gate` passes (backend 1127 tests, frontend 1013 tests, lint 0 errors, build green).

Closes #816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only planning agent for reviewing project files and diagnosing issues.
  * The agent can search and inspect content but cannot modify files or run shell commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->