### PR TITLE
chore(tooling): wire LSP for Claude Code and OpenCode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,32 +106,38 @@ masks failures (this shipped a red lint to CI once). `make` propagates failures 
 
 ## LSP — prefer it over grep for symbol navigation
 
-Both harnesses are wired for LSP-backed navigation. **Neither bundles the server**; one global
-install serves both, and it is a per-machine prerequisite a fresh clone will not have:
+Both harnesses navigate by LSP. The setup has exactly **two** pieces, and both are required:
 
 ```bash
-npm install -g typescript-language-server typescript@5
+npm install -g typescript-language-server   # 1. the server binary — per machine, not in this repo
+make install                                # 2. typescript@^5 — a devDependency, already declared
 ```
 
-**The `@5` pin is load-bearing.** Bare `typescript` now resolves to 7.x, the native Go port,
-whose `lib/` ships only `getExePath.js` and `tsc.js` — there is no `tsserver.js`.
-`typescript-language-server` works by spawning exactly that file, so TS 7 fails every LSP call
-with `Could not find a valid TypeScript installation` while `tsc --version` reports a perfectly
-healthy 7.x. Verified 2026-08-13: TS 7.0.2 broke it, TS 5.9.3 is the working target.
+**`typescript` is a local devDependency on purpose, not an oversight in a repo with no `.ts`
+files.** OpenCode's built-in typescript server resolves `typescript/lib/tsserver.js` *from the
+project directory*, and node resolution never consults global `node_modules` — so with only a
+global install it hits `if (!Z) return` and the LSP is **silently off**, no error anywhere. The
+local copy also serves Claude Code, so the global `typescript` is unnecessary; only the server
+binary has to be global. Node resolution walks up, so the single root install covers
+`frontend/` too.
+
+**Never move that dependency to `typescript@7`.** TS 7 is the native Go port: its `lib/` ships
+only `getExePath.js` and `tsc.js` — no `tsserver.js`, which is exactly the file the language
+server spawns. It fails every LSP call with `Could not find a valid TypeScript installation`
+while `tsc --version` reports a perfectly healthy 7.x. Verified 2026-08-13: 7.0.2 breaks it,
+5.9.3 works. The `^5` caret is what keeps a routine bump from silently disabling navigation.
 
 - The server handles `.js .jsx .mjs .cjs .ts .tsx .mts .cts`. `jsconfig.json`'s `include`
   globs cover every tracked `.js`/`.jsx`/`.mjs` under `functions/`, `frontend/`, `scripts/`
   and `e2e/`, plus the root config files — the only exclusion is `.github/` skill assets.
 - Claude Code: the `typescript-lsp` plugin plus `ENABLE_LSP_TOOL=1`, both in
-  `~/.claude/settings.json` (machine-local, not in this repo). **Verified working.**
-- OpenCode: `"lsp": true` in `opencode.json` activates the built-in server definitions, and
-  its typescript entry is **not** on OpenCode's auto-download list. Whether it resolves the
-  global binary or insists on a local `node_modules/typescript` is **unverified** — this repo
-  declares no local `typescript`, so confirm on the first delegated run before relying on it
-  (#830). Claude Code's path does not depend on the answer.
-- **Verify by making an LSP call, never by reading config.** A missing binary fails at call
-  time with `ENOENT: typescript-language-server`, not at startup, so a green-looking config
-  proves nothing.
+  `~/.claude/settings.json` (machine-local, not in this repo).
+- OpenCode: `"lsp": true` in `opencode.json` activates the built-in definitions. Its typescript
+  entry is **not** on OpenCode's auto-download list, which is why both pieces above are on you.
+- **Verify by making an LSP call, never by reading config.** Every failure mode here is silent
+  or misleading at rest: a missing binary throws `ENOENT` only at call time, a missing local
+  `typescript` makes OpenCode skip the server without a word, and a wrong TS major still
+  reports a healthy `tsc --version`.
 
 **Use LSP for symbol questions, grep for textual ones.** `goToDefinition`, `findReferences`
 and `workspaceSymbol` resolve the symbol graph and answer "who calls this?" without the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,13 +119,16 @@ whose `lib/` ships only `getExePath.js` and `tsc.js` — there is no `tsserver.j
 with `Could not find a valid TypeScript installation` while `tsc --version` reports a perfectly
 healthy 7.x. Verified 2026-08-13: TS 7.0.2 broke it, TS 5.9.3 is the working target.
 
-- Covers `.js .jsx .mjs .cjs .ts .tsx .mts .cts` — i.e. the whole repo (347 `.js` + 162 `.jsx`,
-  no TypeScript).
+- The server handles `.js .jsx .mjs .cjs .ts .tsx .mts .cts`. `jsconfig.json`'s `include`
+  globs cover every tracked `.js`/`.jsx`/`.mjs` under `functions/`, `frontend/`, `scripts/`
+  and `e2e/`, plus the root config files — the only exclusion is `.github/` skill assets.
 - Claude Code: the `typescript-lsp` plugin plus `ENABLE_LSP_TOOL=1`, both in
-  `~/.claude/settings.json` (machine-local, not in this repo).
-- OpenCode: `"lsp": true` in `opencode.json` activates the built-in server definitions. Its
-  typescript entry is **not** on OpenCode's auto-download list, so it resolves the same global
-  binary — one install unblocks both.
+  `~/.claude/settings.json` (machine-local, not in this repo). **Verified working.**
+- OpenCode: `"lsp": true` in `opencode.json` activates the built-in server definitions, and
+  its typescript entry is **not** on OpenCode's auto-download list. Whether it resolves the
+  global binary or insists on a local `node_modules/typescript` is **unverified** — this repo
+  declares no local `typescript`, so confirm on the first delegated run before relying on it
+  (#830). Claude Code's path does not depend on the answer.
 - **Verify by making an LSP call, never by reading config.** A missing binary fails at call
   time with `ENOENT: typescript-language-server`, not at startup, so a green-looking config
   proves nothing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,51 @@ masks failures (this shipped a red lint to CI once). `make` propagates failures 
   are required for ANY Playwright invocation, including `--list`). `make e2e` handles this.
 - E2E spec files are under the same prettier/eslint scope as `functions/`/`scripts/` (#622) —
   double quotes/semis, `eslint.config.js`'s `e2e/**` block covers Playwright + browser globals.
+
+## LSP — prefer it over grep for symbol navigation
+
+Both harnesses are wired for LSP-backed navigation. **Neither bundles the server**; one global
+install serves both, and it is a per-machine prerequisite a fresh clone will not have:
+
+```bash
+npm install -g typescript-language-server typescript@5
+```
+
+**The `@5` pin is load-bearing.** Bare `typescript` now resolves to 7.x, the native Go port,
+whose `lib/` ships only `getExePath.js` and `tsc.js` — there is no `tsserver.js`.
+`typescript-language-server` works by spawning exactly that file, so TS 7 fails every LSP call
+with `Could not find a valid TypeScript installation` while `tsc --version` reports a perfectly
+healthy 7.x. Verified 2026-08-13: TS 7.0.2 broke it, TS 5.9.3 is the working target.
+
+- Covers `.js .jsx .mjs .cjs .ts .tsx .mts .cts` — i.e. the whole repo (347 `.js` + 162 `.jsx`,
+  no TypeScript).
+- Claude Code: the `typescript-lsp` plugin plus `ENABLE_LSP_TOOL=1`, both in
+  `~/.claude/settings.json` (machine-local, not in this repo).
+- OpenCode: `"lsp": true` in `opencode.json` activates the built-in server definitions. Its
+  typescript entry is **not** on OpenCode's auto-download list, so it resolves the same global
+  binary — one install unblocks both.
+- **Verify by making an LSP call, never by reading config.** A missing binary fails at call
+  time with `ENOENT: typescript-language-server`, not at startup, so a green-looking config
+  proves nothing.
+
+**Use LSP for symbol questions, grep for textual ones.** `goToDefinition`, `findReferences`
+and `workspaceSymbol` resolve the symbol graph and answer "who calls this?" without the
+false positives a name-based grep returns. But this repo's source-scanning guards are
+deliberately textual — the Tailwind class literals in `bandFields.test.js`, the `is_published`
+scans, the after-midnight threshold check — and LSP cannot see a class name inside a string or
+a literal in a comment. Do not convert those to LSP; they are text scans on purpose.
+
+The split is measurable. `git grep AFTER_MIDNIGHT_THRESHOLD_HOUR` returns ~30 hits, mostly
+comments and strings inside the guard test; `findReferences` returns the 8 real bindings and
+correctly drops `functions/api/events/timeline.js`, which mentions the constant only in prose
+and actually imports the sibling `AFTER_MIDNIGHT_THRESHOLD_TIME`. Each tool is right about a
+different question.
+
+**`jsconfig.json` at the repo root is load-bearing — do not delete it.** It exists solely to
+give tsserver a project: nothing imports it and it emits nothing (`noEmit: true`). Without it,
+tsserver falls back to inferred-project mode, which indexes only files already opened — and
+then `findReferences` on `AFTER_MIDNIGHT_THRESHOLD_HOUR` reports "3 references across 1 files",
+silently omitting `functions/event/[slug].js` and the test that imports it. That is the sibling
+sweep's worst failure shape: not an error, but a confident and incomplete answer. With the
+project file the same query returns 8 across 3. Adding it was verified 2026-08-13 to leave
+`npm run build --prefix frontend` (exit 0) and the 1127-test backend suite green.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,9 @@ masks failures (this shipped a red lint to CI once). `make` propagates failures 
 
 ## LSP — prefer it over grep for symbol navigation
 
-Both harnesses navigate by LSP. The setup has exactly **two** pieces, and both are required:
+Both harnesses navigate by LSP. Two **dependencies** must be installed, and separately each
+harness must be **configured** (both listed below) — all of it is required, and a missing
+piece fails silently rather than loudly.
 
 ```bash
 npm install -g typescript-language-server   # 1. the server binary — per machine, not in this repo

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "jsx": "react-jsx",
+    "resolveJsonModule": true
+  },
+  "include": [
+    "functions/**/*.js",
+    "frontend/src/**/*.js",
+    "frontend/src/**/*.jsx",
+    "scripts/**/*.mjs",
+    "e2e/**/*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "frontend/node_modules",
+    "frontend/dist",
+    ".wrangler",
+    "coverage",
+    "playwright-report",
+    "test-results"
+  ]
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -10,9 +10,14 @@
     "resolveJsonModule": true
   },
   "include": [
+    "*.js",
     "functions/**/*.js",
+    "frontend/*.js",
     "frontend/src/**/*.js",
     "frontend/src/**/*.jsx",
+    "frontend/public/sw.js",
+    "frontend/scripts/**/*.mjs",
+    "scripts/**/*.js",
     "scripts/**/*.mjs",
     "e2e/**/*.js"
   ],

--- a/opencode.json
+++ b/opencode.json
@@ -40,6 +40,7 @@
     }
   },
   "small_model": "opencode-go/deepseek-v4-flash",
+  "lsp": true,
   "instructions": [
     "CLAUDE.md",
     "CONTRIBUTING.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.9.0",
         "prettier": "^3.9.6",
+        "typescript": "^5.9.3",
         "vite": "^8.2.1",
         "vitest": "^4.1.10"
       }
@@ -2494,6 +2495,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-config-prettier": "^10.1.5",
     "globals": "^17.9.0",
     "prettier": "^3.9.6",
+    "typescript": "^5.9.3",
     "vite": "^8.2.1",
     "vitest": "^4.1.10"
   },


### PR DESCRIPTION
## Summary

Wires LSP-backed code navigation for both harnesses, documents the traps found along the way, and adds the project file that makes `findReferences` actually correct.

Closes #830

## The setup has exactly two pieces, and both are required

```bash
npm install -g typescript-language-server   # 1. the server binary — per machine
make install                                # 2. typescript@^5 — a devDependency, declared here
```

**Why `typescript` is a devDependency in a repo with zero `.ts` files.** OpenCode's built-in typescript server resolves `typescript/lib/tsserver.js` **from the project directory**, and node resolution never consults global `node_modules`. Decompiled from the 1.18.18 binary:

```js
async spawn($, Y) {
  let Z = resolve("typescript/lib/tsserver.js", Y.directory);
  if (!Z) return;                                   // ← no LOCAL typescript, bail
  let X = await which("typescript-language-server");
  if (!X) return;
  return { process: q(X, ["--stdio"], …), initialization: { tsserver: { path: Z } } };
}
```

With only a global install, that first guard fires and OpenCode's LSP is **silently off** — no error, no log. The local copy also serves Claude Code, so the global `typescript` is now unnecessary; only the server binary must be global. Node resolution walks up, so one root install covers `frontend/` too.

## Three silent failure modes, now documented

| symptom | cause |
|---|---|
| `ENOENT: typescript-language-server` at call time | server binary missing from PATH |
| nothing happens, no error at all | no local `typescript` — OpenCode skips the server |
| `Could not find a valid TypeScript installation` | wrong TS major (7.x ships no `tsserver.js`) |

The third is the nastiest: `npm i -g typescript` now installs **7.x**, the native Go port, whose `lib/` has only `getExePath.js` and `tsc.js`. `tsc --version` reports a healthy `7.0.2` the whole time. The `^5` caret on the devDependency is what stops a routine bump from silently disabling navigation.

## Why `jsconfig.json` is not cosmetic

Without a project file, tsserver runs in inferred-project mode and indexes only already-opened files:

| query | without `jsconfig.json` | with it |
|---|---|---|
| `findReferences` on `AFTER_MIDNIGHT_THRESHOLD_HOUR` | **3 refs / 1 file** | 8 refs / 3 files |

The 3-reference answer silently omitted `functions/event/[slug].js` and its test. Not an error — a **confident, incomplete answer**, the worst failure mode for the sibling-sweep discipline in `CLAUDE.md`. `AGENTS.md` marks the file load-bearing so nobody deletes it as clutter. It emits nothing (`noEmit: true`).

## LSP vs grep

Documented explicitly, because this repo needs both. `git grep AFTER_MIDNIGHT_THRESHOLD_HOUR` returns ~30 hits (mostly comments and strings inside the guard test); `findReferences` returns the 8 real bindings. So `AGENTS.md` tells future agents **not** to convert the source-scanning guards (Tailwind class literals, `is_published`, threshold scans) to LSP — those are text scans on purpose.

## Review findings addressed

CodeRabbit ran before this PR opened, per the standing gate:

- **Coverage claim overstated** (`f005c50`) — globs reached 334/347 `.js`, 162/162 `.jsx`, 8/9 `.mjs`, not "the whole repo". Widened; only `.github/` skill assets excluded now.
- **"Add a local TypeScript dependency for OpenCode"** (`4e1e385`) — **correct, and confirmed by decompiling the binary.** Initially deferred to #830 rather than guessed at; now settled and fixed.

## Test plan

- [x] `make gate` — exit 0
- [x] Backend 1127 passed · frontend 1013 passed
- [x] `markdownlint-cli2 AGENTS.md` — 0 issues
- [x] LSP verified live: `documentSymbol`, `findReferences`, `workspaceSymbol`, `hover`
- [x] `findReferences` re-verified after widening globs and after the local-typescript change — still 8 across 3
- [x] `tsserver.js` resolution verified from both repo root and `frontend/`
- [x] Frontend `.jsx` verified: 12 refs across 5 files for `saveSelectedBands`

## Notes

No migrations, no schema change, no runtime code touched. `jsconfig.json` is tooling-only; `typescript` is a devDependency and ships nothing to the browser.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for setting up and using the TypeScript Language Server, including configuration, verification, supported files, and search recommendations.

* **Developer Experience**
  * Added project-wide JavaScript type-checking support with React, JSON, and modern module compatibility.
  * Enabled Language Server Protocol support for improved navigation and diagnostics.
  * Added the required TypeScript tooling for local type checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->