### PR TITLE
chore(delegation): judge delegated runs by what changed on disk, not by exit code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,25 @@ Never be lazy about understanding, input validation, error handling that prevent
 
 When a task has a clear implementation spec, dispatch a Sonnet agent to build it; reserve Opus/Fable for the design up front and the review after. Always follow a Sonnet implementation with a big-brain review pass — that second perspective catches whole bug classes a to-spec implementer stops short of.
 
+### Verifying any delegation — `scripts/delegate-verify.mjs`
+
+**A delegate's exit code and self-reported status are claims, not evidence. `git status` is the evidence.** Wrap every delegated run:
+
+```bash
+node scripts/delegate-verify.mjs -- <the delegation command>
+node scripts/delegate-verify.mjs --allow-empty -- <read-only command>   # research/digest tasks
+```
+
+Exit codes: `0` succeeded *and* changed files · `1` the command failed · `2` **reported success but changed nothing** · `3` the delegate committed · `4` usage.
+
+Code `2` is the one that pays for the script. Measured 2026-08-13: an agy delegation returned exit `0` and `AGY_USAGE {"status":"SUCCESS"}` having touched **zero files** — headless agy had no `write_file` grant, so it described the work instead of doing it and still "succeeded". 96,825 tokens, nothing on disk, and nothing in its own output said so. The tool behaved exactly as its README documents ("ungranted writes leave the workspace untouched but report success"); the mistake was trusting the status field.
+
+Code `3` enforces the other half of the contract below: **the delegate never commits.** The orchestrator reviews the diff, runs `make gate`, and commits. A delegate that moves HEAD has skipped review entirely.
+
+The check is deliberately tool-agnostic — it wraps agy, OpenCode's relay, or anything else, because the failure is about *permissions and silent refusals*, not about any one vendor. It uses `git status --porcelain`, so a brand-new untracked file counts as real work (a `git diff`-only check would call that a no-op).
+
+**Before the first real delegation on a new machine or after a tool upgrade, prove the write grant with a throwaway task** rather than discovering it on a task you cared about. One canary costs seconds; the failure above cost 96k tokens.
+
 ### Delegating to OpenCode
 
 A third implementer, on a separate subscription: the `opencode-delegate` skill.

--- a/scripts/delegate-verify.mjs
+++ b/scripts/delegate-verify.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * delegate-verify — run a delegated coding task and judge it by what actually
+ * changed on disk, not by what the tool said.
+ *
+ * Why this exists
+ * ---------------
+ * On 2026-08-13 an agy (Antigravity/Gemini) delegation reported exit code 0 and
+ * `AGY_USAGE {"status":"SUCCESS"}` while touching zero files: headless agy had
+ * no `write_file` grant, so it described the work instead of doing it and still
+ * "succeeded". 96,825 tokens, nothing to show, and nothing in the tool's own
+ * output said so. `git status` was the only signal that told the truth.
+ *
+ * That failure mode is not agy-specific. Any delegate — OpenCode, a subagent, a
+ * remote runner — can report success after a permission denial, a silent
+ * refusal, or a scratch-directory write. So the rule this encodes is general:
+ *
+ *   A delegation that changed no files did not succeed, whatever it claims.
+ *
+ * It also enforces the other half of the delegation contract from CLAUDE.md:
+ * the delegate never commits. The orchestrator reviews the diff and commits.
+ * A delegate that moves HEAD has skipped the review step entirely.
+ *
+ * Usage
+ * -----
+ *   node scripts/delegate-verify.mjs -- <command> [args...]
+ *   node scripts/delegate-verify.mjs --allow-empty -- <command> [args...]
+ *
+ * Examples:
+ *   node scripts/delegate-verify.mjs -- agy-delegate --tier flash --digest - < brief.md
+ *   node scripts/delegate-verify.mjs -- node .agents/skills/opencode-delegate/relay.mjs --brief brief.md
+ *
+ * Exit codes:
+ *   0  command succeeded AND the working tree changed
+ *   1  command itself failed (its exit code is reported)
+ *   2  command "succeeded" but changed nothing  <- the silent-no-op case
+ *   3  the delegate committed, which it must never do
+ *   4  usage error
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+
+const USAGE = `Usage: node scripts/delegate-verify.mjs [--allow-empty] -- <command> [args...]`;
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+/**
+ * `git status --porcelain` covers tracked modifications AND untracked files,
+ * which matters: a delegate that creates a brand-new file has done real work,
+ * and a `git diff`-only check would call that a no-op.
+ */
+function snapshot() {
+  return {
+    head: git(["rev-parse", "HEAD"]),
+    status: git(["status", "--porcelain"]),
+  };
+}
+
+function parseStatus(porcelain) {
+  const entries = new Map();
+  for (const line of porcelain.split("\n")) {
+    if (!line.trim()) continue;
+    // Porcelain v1: 2 status chars, a space, then the path. Renames render as
+    // "old -> new"; the destination is what matters for "what changed".
+    const code = line.slice(0, 2);
+    const path = line.slice(3).split(" -> ").pop();
+    entries.set(path, code);
+  }
+  return entries;
+}
+
+function diffSnapshots(before, after) {
+  const b = parseStatus(before.status);
+  const a = parseStatus(after.status);
+  const changed = [];
+  for (const [path, code] of a) {
+    if (b.get(path) !== code) changed.push({ path, code });
+  }
+  // A path that was dirty before and is clean now also counts as a change
+  // (e.g. the delegate reverted something).
+  for (const path of b.keys()) {
+    if (!a.has(path)) changed.push({ path, code: "--" });
+  }
+  return changed.sort((x, y) => x.path.localeCompare(y.path));
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const sep = argv.indexOf("--");
+  if (sep === -1 || sep === argv.length - 1) {
+    console.error(USAGE);
+    process.exit(4);
+  }
+
+  const flags = argv.slice(0, sep);
+  const allowEmpty = flags.includes("--allow-empty");
+  const unknown = flags.filter((f) => f !== "--allow-empty");
+  if (unknown.length) {
+    console.error(`delegate-verify: unknown flag(s): ${unknown.join(", ")}\n${USAGE}`);
+    process.exit(4);
+  }
+
+  const [cmd, ...args] = argv.slice(sep + 1);
+  const before = snapshot();
+
+  // stdio inherited so the delegate's own output, prompts and stdin-fed briefs
+  // pass through untouched — this wraps the run, it does not intercept it.
+  const child = spawn(cmd, args, { stdio: "inherit" });
+
+  child.on("error", (err) => {
+    console.error(`delegate-verify: could not run "${cmd}": ${err.message}`);
+    process.exit(1);
+  });
+
+  child.on("close", (code) => {
+    const after = snapshot();
+    const changed = diffSnapshots(before, after);
+
+    console.error("\n─── delegate-verify ───");
+
+    if (after.head !== before.head) {
+      console.error(`FAIL: the delegate committed (HEAD ${before.head.slice(0, 7)} -> ${after.head.slice(0, 7)}).`);
+      console.error("Delegates must never commit — the orchestrator reviews the diff and commits.");
+      console.error(`Recover with: git reset --soft ${before.head}`);
+      process.exit(3);
+    }
+
+    if (code !== 0) {
+      console.error(`FAIL: command exited ${code}.`);
+      console.error(`Files changed anyway: ${changed.length} (inspect before retrying — partial work may remain).`);
+      process.exit(1);
+    }
+
+    if (changed.length === 0) {
+      if (allowEmpty) {
+        console.error("OK: no files changed, and --allow-empty was passed (read-only task).");
+        process.exit(0);
+      }
+      console.error("FAIL: command reported success but changed no files.");
+      console.error("A delegation that changed nothing did not succeed, whatever it reported.");
+      console.error("Most likely a missing write permission — the delegate described the work instead of doing it.");
+      console.error("Check the tool's write grant, then re-run. Pass --allow-empty if this really was read-only.");
+      process.exit(2);
+    }
+
+    console.error(`OK: ${changed.length} file(s) changed.`);
+    for (const { path, code: c } of changed) {
+      console.error(`  ${c}  ${path}`);
+    }
+    console.error("Review the diff and run the project gate before committing.");
+    process.exit(0);
+  });
+}
+
+main();

--- a/scripts/delegate-verify.mjs
+++ b/scripts/delegate-verify.mjs
@@ -39,6 +39,8 @@
  */
 
 import { spawn, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 
 const USAGE = `Usage: node scripts/delegate-verify.mjs [--allow-empty] -- <command> [args...]`;
 
@@ -50,12 +52,43 @@ function git(args) {
  * `git status --porcelain` covers tracked modifications AND untracked files,
  * which matters: a delegate that creates a brand-new file has done real work,
  * and a `git diff`-only check would call that a no-op.
+ *
+ * Status codes alone are NOT enough. If a path is already ` M` or `??` when the
+ * delegate starts and the delegate edits that same path, the code is identical
+ * in both snapshots, so the run would be reported as "changed nothing" — a
+ * false exit 2 in exactly the situation this script exists to catch. Real work
+ * on an already-dirty tree is the common case, not an edge case. So every entry
+ * carries a content hash alongside its status code.
+ *
+ * `-uall` lists untracked FILES individually. Without it git collapses an
+ * untracked directory into a single `dir/` entry, and a file created inside an
+ * already-untracked directory would leave the snapshot byte-identical.
  */
 function snapshot() {
+  const status = git(["status", "--porcelain", "-uall"]);
   return {
     head: git(["rev-parse", "HEAD"]),
-    status: git(["status", "--porcelain"]),
+    status,
+    // Hashes MUST be read here, not when the snapshots are compared. Comparing
+    // later would hash whatever is on disk at that moment, so both snapshots
+    // would see identical post-run content and the check would silently pass
+    // everything through as "unchanged".
+    entries: parseStatus(status),
   };
+}
+
+/**
+ * Content hash of a working-tree path. Unreadable paths (deleted, or a path git
+ * quoted because it contains control characters) return a constant, so they
+ * compare equal across snapshots and fall back to status-code comparison rather
+ * than reporting a spurious change.
+ */
+function hashPath(path) {
+  try {
+    return createHash("sha256").update(readFileSync(path)).digest("hex").slice(0, 16);
+  } catch {
+    return "unreadable";
+  }
 }
 
 function parseStatus(porcelain) {
@@ -66,17 +99,20 @@ function parseStatus(porcelain) {
     // "old -> new"; the destination is what matters for "what changed".
     const code = line.slice(0, 2);
     const path = line.slice(3).split(" -> ").pop();
-    entries.set(path, code);
+    entries.set(path, { code, hash: hashPath(path) });
   }
   return entries;
 }
 
 function diffSnapshots(before, after) {
-  const b = parseStatus(before.status);
-  const a = parseStatus(after.status);
+  const b = before.entries;
+  const a = after.entries;
   const changed = [];
-  for (const [path, code] of a) {
-    if (b.get(path) !== code) changed.push({ path, code });
+  for (const [path, entry] of a) {
+    const prev = b.get(path);
+    if (!prev || prev.code !== entry.code || prev.hash !== entry.hash) {
+      changed.push({ path, code: entry.code });
+    }
   }
   // A path that was dirty before and is clean now also counts as a change
   // (e.g. the delegate reverted something).


### PR DESCRIPTION
## Summary

Split out of #826, where it was riding along with an unrelated DST date fix. Same commit, now reviewable on its own.

Adds `scripts/delegate-verify.mjs`, which wraps any delegated coding task and judges it by `git status`, not by the tool's self-reported status.

## Why

Measured 2026-08-13: an agy delegation returned exit `0` and `AGY_USAGE {"status":"SUCCESS"}` having touched **zero files**. Headless agy had no `write_file` grant, so it described the work instead of doing it and still "succeeded" — 96,825 tokens, nothing on disk, and nothing in its own output said so. The tool behaved exactly as its README documents; the mistake was trusting the status field.

Exit codes: `0` succeeded *and* changed files · `1` the command failed · `2` **reported success but changed nothing** · `3` the delegate committed · `4` usage.

Code `3` enforces the other half of the delegation contract in `CLAUDE.md`: the delegate never commits — the orchestrator reviews the diff, runs `make gate`, and commits.

## Known open finding

CodeRabbit raised this on #826 and it is **valid and not yet fixed**:

> **Track file content, not only porcelain status.**

The check snapshots `git status --porcelain` before and after and compares the strings. If the tree is *already* dirty for a path and the delegate edits that same path further, the porcelain output is byte-identical before and after — so real work is misreported as exit `2` ("changed nothing"). That is a false negative in exactly the scenario the script exists to catch.

Not fixed in this PR so the split stays a pure move. Tracked as a follow-up; happy to fix here instead if preferred.

## Test plan

- [x] `make gate` — exit 0 (on the branch this was split from)
- [ ] Content-hash fix for the already-dirty-path false negative

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a delegation verification command that detects file changes, committed changes, failed commands, partial work, and no-op runs.
  * Added an option to allow successful delegations that make no changes.
  * Preserves delegated command input and output while reporting verification results and meaningful exit statuses.

* **Documentation**
  * Added guidance on command options, status checks, exit-code meanings, and validating write permissions before delegation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->