### PR TITLE
docs(agents): add Gemini role and branch convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,3 +162,11 @@ silently omitting `functions/event/[slug].js` and the test that imports it. That
 sweep's worst failure shape: not an error, but a confident and incomplete answer. With the
 project file the same query returns 8 across 3. Adding it was verified 2026-08-13 to leave
 `npm run build --prefix frontend` (exit 0) and the 1127-test backend suite green.
+
+<!-- Global instructions for all agents go above this line -->
+
+## Gemini Specific Instructions
+- When running as Gemini, your role is a "Draftsman".
+- Focus on drafting initial patches, fixing small bugs, and writing unit tests.
+- Always push your work to a new feature branch named `gemini/issue-[number]`.
+- Do not attempt to merge code directly into the `main` or `master` branches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,7 @@ project file the same query returns 8 across 3. Adding it was verified 2026-08-1
 
 <!-- Global instructions for all agents go above this line -->
 
-## Gemini Specific Instructions
+## Gemini-Specific Instructions
 - When running as Gemini, your role is a "Draftsman".
 - Focus on drafting initial patches, fixing small bugs, and writing unit tests.
 - Always push your work to a new feature branch named `gemini/issue-[number]`.


### PR DESCRIPTION
## Summary

Commits the Gemini instruction block that had been sitting uncommitted in the working tree, and adds a marker separating harness-agnostic instructions from per-harness ones.

## Why it is accurate rather than aspirational

The branch convention it documents (`gemini/issue-[number]`) is already what happens: #826 arrived on `gemini/issue-770` and #827 on `gemini/issue-756`. This records observed practice.

The marker comment (`<!-- Global instructions for all agents go above this line -->`) gives future per-harness sections an obvious home, instead of being appended wherever there happens to be room — which is how `AGENTS.md` sections have drifted before.

## Test plan

- [x] `make gate` — exit 0
- [x] `markdownlint-cli2 AGENTS.md` — 0 issues

## Notes

Documentation only. No code, no config, no runtime impact.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for Gemini’s role, preferred work scope, feature-branch naming, and merge restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->