### PR TITLE
fix(timeFilter): label after-midnight sets with their festival day (#689)

### DIFF
--- a/frontend/src/pages/__tests__/VenuePage.performerCards.test.jsx
+++ b/frontend/src/pages/__tests__/VenuePage.performerCards.test.jsx
@@ -155,15 +155,16 @@ describe('VenuePage — performer cards (#742)', () => {
   // that evening, NOT the calendar date the clock happened to roll over to.
   it('groups an after-midnight set with the PREVIOUS evening, not the calendar date of its start time', async () => {
     // Pinned for the same reason as the multi-day test above, but here the
-    // exact date matters. Pin EARLIER than two weeks before the set and this
-    // test fails -- getTimeDescription's >2-weeks fallback branch renders the
-    // raw +1-day-offset timestamp ("Aug 8") instead of the festival day
-    // ("Aug 7"). That is the open bug #689 Finding 1, not a venue-page
-    // defect. Aug 1 keeps the set inside the window fans actually view it in,
-    // so this asserts THIS page's behaviour rather than re-failing on a known
-    // timeFilter bug.
+    // exact date matters. The clock is pinned EARLIER than two weeks before
+    // the set so getTimeDescription's date-fallback branch actually runs —
+    // inside the two-week window it renders time only and the /Aug 8/
+    // assertion below is vacuous. #689: the fallback once rendered the raw
+    // +1-day-offset timestamp ("Aug 8") instead of the festival day
+    // ("Aug 7") for exactly this set; this test is the component-level
+    // regression guard for that fix, and the negative assertion fails on a
+    // revert of timeFilter.js.
     vi.useFakeTimers({ shouldAdvanceTime: true })
-    vi.setSystemTime(new Date(2026, 7, 1, 12, 0, 0)) // Aug 1 2026
+    vi.setSystemTime(new Date(2026, 6, 20, 12, 0, 0)) // Mon Jul 20 2026 — beyond the two-week window
     fetchPublicJson.mockReset()
     fetchPublicJson.mockResolvedValue({
       venue: { id: 3, name: 'Prohibition Warehouse', location: 'Waterloo, ON', address: null, website: null },

--- a/frontend/src/utils/__tests__/timeFilter.test.js
+++ b/frontend/src/utils/__tests__/timeFilter.test.js
@@ -228,3 +228,61 @@ describe('getTimeDescription never names a weekday (#681)', () => {
     expect(getTimeDescription(nextWeekSet)).toBe(`Next week at ${expectedTime}`)
   })
 })
+
+describe('getTimeDescription date fallback renders the festival day (#689)', () => {
+  // #689 Finding 1: the >2-weeks fallback derived the date from the raw
+  // (post-prepareBands +1-day-offset) startMs, so an after-midnight set
+  // rendered the NEXT calendar day — "Aug 8" for a set whose festival day is
+  // Aug 7 — disagreeing with DayDivider for the same set. The this-week /
+  // next-week branches render time only, which is why this only ever showed
+  // for sets viewed more than two weeks out.
+  //
+  // Any test for this branch MUST pin the clock: left on the real clock the
+  // set falls inside the two-week window, the fallback never runs, and the
+  // assertion passes vacuously (#689 — the bug was concealed by the date
+  // until a pinned-clock test exposed it).
+  afterEach(() => {
+    delete globalThis.__debugScheduleTime
+  })
+
+  it('labels an after-midnight set with its festival day, not the +1-offset calendar day', () => {
+    // The real Where's Shane? set at Buddies Fest 2: performance_date
+    // 2026-08-07, start_time 00:25. prepareBands offsets startMs +1 day, so
+    // the raw Date reads Aug 8 00:25; the festival day — what DayDivider
+    // renders — is Aug 7.
+    globalThis.__debugScheduleTime = new Date(2026, 6, 13, 14, 0, 0) // Mon Jul 13, 2 PM — beyond next week
+    const offsetStart = new Date(2026, 7, 8, 0, 25, 0) // real startMs after the +1-day offset
+    const afterMidnightSet = { startMs: offsetStart.getTime() }
+
+    // Expected values derived with the same options the implementation uses,
+    // so the assertions stay locale- and timezone-independent in CI (same
+    // approach as the #681 tests above).
+    const expectedDate = new Date(2026, 7, 7, 0, 25, 0).toLocaleDateString([], {
+      month: 'short',
+      day: 'numeric',
+    })
+    const expectedTime = offsetStart.toLocaleTimeString([], {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    })
+
+    expect(getTimeDescription(afterMidnightSet)).toBe(`${expectedDate} ${expectedTime}`)
+  })
+
+  it("leaves an ordinary evening set's date unchanged in the fallback", () => {
+    // Guards against over-correcting: only sub-6AM sets belong to the
+    // previous festival day, so a normal evening set must keep its own date.
+    globalThis.__debugScheduleTime = new Date(2026, 6, 13, 14, 0, 0) // Mon Jul 13, 2 PM
+    const start = new Date(2026, 7, 7, 20, 0, 0) // Aug 7, 8 PM — no offset
+    const eveningSet = { startMs: start.getTime() }
+    const expectedDate = start.toLocaleDateString([], { month: 'short', day: 'numeric' })
+    const expectedTime = start.toLocaleTimeString([], {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    })
+
+    expect(getTimeDescription(eveningSet)).toBe(`${expectedDate} ${expectedTime}`)
+  })
+})

--- a/frontend/src/utils/timeFilter.js
+++ b/frontend/src/utils/timeFilter.js
@@ -314,9 +314,20 @@ export function getTimeDescription(performance) {
   }
 
   // Default to formatted date and time
-  const startDate = new Date(startTime)
-  return `${startDate.toLocaleDateString([], {
+  //
+  // The date comes from the FESTIVAL day, not the raw startMs (#689): an
+  // after-midnight set's startMs is already offset +1 calendar day by
+  // prepareBands() (bandUtils.js), so the raw Date's date is one day ahead of
+  // the evening the set belongs to — e.g. a set that started 00:25 on Aug 7
+  // reads "Aug 8" here while DayDivider renders "Aug 7" for the same set.
+  // festivalDayStart() resolves the correct festival day (shifting back a
+  // calendar day for sub-6AM clock times, the same resolution the this-week /
+  // next-week branches use). The clock time itself is unaffected by the
+  // +1-day offset, so it comes from the raw timestamp.
+  const rawStart = new Date(startTime)
+  const festivalDay = festivalDayStart(startTime)
+  return `${festivalDay.toLocaleDateString([], {
     month: 'short',
     day: 'numeric',
-  })} ${startDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true })}${durationStr}`
+  })} ${rawStart.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true })}${durationStr}`
 }

--- a/frontend/src/utils/timeFilter.js
+++ b/frontend/src/utils/timeFilter.js
@@ -320,10 +320,12 @@ export function getTimeDescription(performance) {
   // prepareBands() (bandUtils.js), so the raw Date's date is one day ahead of
   // the evening the set belongs to — e.g. a set that started 00:25 on Aug 7
   // reads "Aug 8" here while DayDivider renders "Aug 7" for the same set.
-  // festivalDayStart() resolves the correct festival day (shifting back a
-  // calendar day for sub-6AM clock times, the same resolution the this-week /
-  // next-week branches use). The clock time itself is unaffected by the
-  // +1-day offset, so it comes from the raw timestamp.
+  // festivalDayStart() resolves the correct festival day, shifting back a
+  // calendar day for sub-6AM clock times. Note the this-week / next-week
+  // branches do NOT share this resolution: they compare raw startMs against
+  // week boundaries and render no date at all, so there is nothing for the
+  // +1-day offset to skew there. The clock time itself is likewise unaffected
+  // by the offset, so it comes from the raw timestamp.
   const rawStart = new Date(startTime)
   const festivalDay = festivalDayStart(startTime)
   return `${festivalDay.toLocaleDateString([], {


### PR DESCRIPTION
## Summary

Fixes #689 Finding 1: `getTimeDescription`'s >2-weeks date fallback derived the date from the raw `startMs`, which `prepareBands()` offsets +1 calendar day for sub-6AM sets — so an after-midnight set that started 00:25 on Aug 7 rendered "Aug 8" while `DayDivider` rendered "Aug 7" for the same set. The fallback now takes the date from `festivalDayStart()` (the festival day, the same resolution the this-week/next-week branches already use) and the clock time from the raw timestamp.

Closes #689

## What changed

| File | Change |
|------|--------|
| `frontend/src/utils/timeFilter.js` | Fallback date derived from `festivalDayStart(startTime)`; clock time from the raw timestamp |
| `frontend/src/utils/__tests__/timeFilter.test.js` | Pinned-clock regression tests: real Buddies Fest 2 Where's Shane? fixture (Aug 7 00:25 → "Aug 7", not "Aug 8") + over-correction guard for ordinary evening sets |
| `frontend/src/pages/__tests__/VenuePage.performerCards.test.jsx` | Clock re-pinned Aug 1 → Jul 20 so the fallback branch actually runs; its `/Aug 8/` negative assertion was vacuous before (it was pinned inside the 2-week window purely to dodge this bug); stale "open bug" comment updated |

## Security / correctness notes

None — display-only change; no auth, CSRF, or data-integrity surface.

## Verification

- [x] Tests: 1024 frontend + 1128 backend pass, 0 failures
- [x] ESLint: 0 errors on changed files (repo-wide lint is currently red only on pre-existing, *uncommitted* a11y-rule changes to `frontend/eslint.config.js` in a local working tree — not part of this PR or its CI run)
- [x] Format check: clean
- [x] Build: green
- [ ] `validate:openapi`: N/A (no `docs/api-spec.yaml` change)
- [x] Manual smoke: pinned-clock unit tests cover the >2-weeks scenario end to end; non-vacuity proven by reverting the fix (test fails with "Aug 8" vs "Aug 7")

---
Built by Theo · Reviewed by Claude (pending) · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected displayed dates for after-midnight performances so they remain associated with the appropriate festival day.
  * Preserved accurate clock times while preventing performances from appearing on the following calendar date.
  * Evening performances continue to display their actual calendar date.

* **Tests**
  * Added regression coverage for after-midnight and evening performance date formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->