### PR TITLE
fix(directions): scope fallback search to venue city, not hardcoded Waterloo (#767)

### DIFF
--- a/frontend/src/utils/__tests__/directions.test.js
+++ b/frontend/src/utils/__tests__/directions.test.js
@@ -69,10 +69,15 @@ describe('buildDirectionsHrefForBand (#754)', () => {
     expect(href).toBe('https://www.google.com/maps/dir/?api=1&destination=43.46,-80.52')
   })
 
+  // Deliberately a NON-Waterloo city, asserted as a whole URL. With
+  // venue_city: 'Waterloo' and a toContain() assertion this test passed against
+  // the old hardcoded "<venue> Waterloo ON" implementation too — "The Roost
+  // Waterloo ON" contains "The Roost Waterloo" — so it proved nothing about
+  // #767. Buddies Fest 2 is in Tillsonburg, which is the case that was broken.
   it('falls back to a name search scoped to the venue city when coords are missing', () => {
-    const href = buildDirectionsHrefForBand({ venue: 'The Roost', venue_city: 'Waterloo' })
-    expect(href).toContain('/maps/search/')
-    expect(href).toContain(encodeURIComponent('The Roost Waterloo'))
+    const href = buildDirectionsHrefForBand({ venue: 'The Roost', venue_city: 'Tillsonburg' })
+    expect(href).toBe(`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent('The Roost Tillsonburg')}`)
+    expect(href).not.toContain('Waterloo')
   })
 
   it('falls back to a bare venue-name search when coords AND city are missing', () => {

--- a/frontend/src/utils/__tests__/directions.test.js
+++ b/frontend/src/utils/__tests__/directions.test.js
@@ -69,10 +69,17 @@ describe('buildDirectionsHrefForBand (#754)', () => {
     expect(href).toBe('https://www.google.com/maps/dir/?api=1&destination=43.46,-80.52')
   })
 
-  it('falls back to a name search when coords are missing', () => {
+  it('falls back to a name search scoped to the venue city when coords are missing', () => {
+    const href = buildDirectionsHrefForBand({ venue: 'The Roost', venue_city: 'Waterloo' })
+    expect(href).toContain('/maps/search/')
+    expect(href).toContain(encodeURIComponent('The Roost Waterloo'))
+  })
+
+  it('falls back to a bare venue-name search when coords AND city are missing', () => {
     const href = buildDirectionsHrefForBand({ venue: 'The Roost' })
     expect(href).toContain('/maps/search/')
-    expect(href).toContain(encodeURIComponent('The Roost Waterloo ON'))
+    expect(href).toContain(encodeURIComponent('The Roost'))
+    expect(href).not.toContain('Waterloo')
   })
 
   // Bad coordinates must degrade to the venue-name search, not build a pin
@@ -86,8 +93,18 @@ describe('buildDirectionsHrefForBand (#754)', () => {
     ['out-of-range longitude', 43.46, 181],
     ['string coords', '43.46', '-80.52'],
   ])('falls back to the name search for %s coords', (_label, lat, lng) => {
-    const href = buildDirectionsHrefForBand({ venue: 'Roost', venue_lat: lat, venue_lng: lng })
-    expect(href).toBe('https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent('Roost Waterloo ON'))
+    const href = buildDirectionsHrefForBand({ venue: 'Roost', venue_city: 'Waterloo', venue_lat: lat, venue_lng: lng })
+    expect(href).toBe('https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent('Roost Waterloo'))
+  })
+
+  it('trims surrounding whitespace from the city qualifier', () => {
+    const href = buildDirectionsHrefForBand({ venue: 'The Roost', venue_city: '  Waterloo, ON  ' })
+    expect(href).toBe('https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent('The Roost Waterloo, ON'))
+  })
+
+  it('ignores a non-string city and searches by venue name alone', () => {
+    const href = buildDirectionsHrefForBand({ venue: 'The Roost', venue_city: 42 })
+    expect(href).toBe('https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent('The Roost'))
   })
 
   it('returns null when coords are unusable and there is no venue name', () => {

--- a/frontend/src/utils/directions.js
+++ b/frontend/src/utils/directions.js
@@ -37,7 +37,7 @@ export function buildDirectionsHref(name, address) {
 // go through; do not reintroduce a third copy in a component file.
 export function buildDirectionsHrefForBand(band) {
   if (!band) return null
-  const { venue_lat: lat, venue_lng: lng, venue } = band
+  const { venue_lat: lat, venue_lng: lng, venue, venue_city: city } = band
   // Number.isFinite (not !Number.isNaN) — the latter accepts Infinity, which
   // would build a literal "destination=Infinity,Infinity" URL. Range-check to
   // WGS84 bounds too: an out-of-range pair is bad data, and a broken pin is
@@ -46,16 +46,15 @@ export function buildDirectionsHrefForBand(band) {
   if (hasUsableCoords) {
     return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`
   }
-  // KNOWN LIMITATION: this fallback hardcodes "Waterloo ON", which is wrong
-  // for events outside Waterloo Region (Buddies Fest 2 is in Tillsonburg).
-  // It is currently unreachable in production -- every venue row has
-  // latitude/longitude (migrations 0043/0044) and schedule.js projects them
-  // as venue_lat/venue_lng, so the coordinate branch above always wins.
-  // Threading the event's own city through here is tracked in #767; until
-  // then, do NOT rely on this branch for a non-Waterloo event.
+  // Fallback for a venue without usable coordinates: search by name. Scope the
+  // search to the venue's own city when known (#767) — never a hardcoded city,
+  // which is confidently wrong for events outside Waterloo Region. When city is
+  // unknown, a bare venue-name search is vaguer but never wrong.
   const trimmedVenue = typeof venue === 'string' ? venue.trim() : ''
   if (trimmedVenue) {
-    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${trimmedVenue} Waterloo ON`)}`
+    const trimmedCity = typeof city === 'string' ? city.trim() : ''
+    const query = trimmedCity ? `${trimmedVenue} ${trimmedCity}` : trimmedVenue
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
   }
   return null
 }

--- a/frontend/src/utils/directions.js
+++ b/frontend/src/utils/directions.js
@@ -27,7 +27,9 @@ export function buildDirectionsHref(name, address) {
 // payload (venue NAME + optional venue_lat/venue_lng — schedule.js never
 // joins the venue's address). Prefers exact coordinates, which opens the
 // device's native maps app rather than a Google web search; falls back to a
-// "<venue> Waterloo ON" name search when coordinates aren't available.
+// "<venue> <venue_city>" name search when coordinates aren't available, or a
+// bare venue-name search when the city is unknown (#767 — never a hardcoded
+// city, which is confidently wrong outside Waterloo Region).
 //
 // Consolidated from utils/nextMove.js's own copy of this exact function
 // (#754) — issue #754's correction confirmed there were two directions-URL

--- a/functions/api/__tests__/schedule-venue-city.test.js
+++ b/functions/api/__tests__/schedule-venue-city.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../test-utils";
+import * as scheduleHandler from "../schedule.js";
+
+// #767: buildDirectionsHrefForBand's fallback hardcoded "Waterloo ON", which is
+// wrong for events outside Waterloo Region (Buddies Fest 2 was in Tillsonburg).
+// schedule.js now projects each venue's own city as venue_city so the frontend
+// can scope its fallback search to the venue's real city. Regression coverage
+// for the read path: venue_city must flow through /api/schedule.
+describe("GET /api/schedule - venue_city (#767)", () => {
+  it("returns the venue's city when it has one", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const ev = insertEvent(rawDb, { name: "BF2", slug: "bf2-venue-city" });
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
+    const venue = insertVenue(rawDb, { name: "The Mill", city: "Tillsonburg" });
+    insertBand(rawDb, { name: "City Band", event_id: ev.id, venue_id: venue.id });
+
+    const req = new Request("https://example.test/api/schedule?event=bf2-venue-city");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.bands.length).toBe(1);
+    expect(data.bands[0].venue_city).toBe("Tillsonburg");
+  });
+
+  it("returns null venue_city when the venue has none", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const ev = insertEvent(rawDb, { name: "Vol18", slug: "vol18-no-city" });
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(ev.id);
+    const venue = insertVenue(rawDb, { name: "Roost", city: null });
+    insertBand(rawDb, { name: "No City Band", event_id: ev.id, venue_id: venue.id });
+
+    const req = new Request("https://example.test/api/schedule?event=vol18-no-city");
+    const res = await scheduleHandler.onRequestGet({ request: req, env });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.bands.length).toBe(1);
+    expect(data.bands[0].venue_city).toBeNull();
+  });
+});

--- a/functions/api/schedule.js
+++ b/functions/api/schedule.js
@@ -87,7 +87,8 @@ export async function onRequestGet(context) {
         b.genre,
         v.name as venue,
         v.latitude as venue_lat,
-        v.longitude as venue_lng
+        v.longitude as venue_lng,
+        v.city as venue_city
       FROM performances p
       INNER JOIN band_profiles b ON p.band_profile_id = b.id
       LEFT JOIN venues v ON p.venue_id = v.id
@@ -147,6 +148,7 @@ export async function onRequestGet(context) {
         venue: band.venue ?? null,
         venue_lat: typeof band.venue_lat === "number" ? band.venue_lat : null,
         venue_lng: typeof band.venue_lng === "number" ? band.venue_lng : null,
+        venue_city: band.venue_city ?? null,
         // Per-set festival day: a performance carries its own performance_date
         // when the event spans multiple days (epic #543); NULL inherits the
         // event's single date, keeping single-day events byte-identical.


### PR DESCRIPTION
## Summary

Fixes the directions fallback that hardcoded `"Waterloo ON"` when a venue lacks usable coordinates. `buildDirectionsHrefForBand()` now scopes its venue-name search to the **venue's own city**, threaded through from `schedule.js` as `venue_city`. When the city is unknown, it degrades to a bare venue-name search — vaguer, but never confidently wrong (the failure mode that sent BF2 fans ~90km to the wrong city).

Closes #767

## What changed

| File | Change |
|------|--------|
| `functions/api/schedule.js` | Select and project `v.city as venue_city` onto each band |
| `frontend/src/utils/directions.js` | Fallback uses `venue_city`; bare venue search when absent; drops the `KNOWN LIMITATION` comment |
| `frontend/src/utils/__tests__/directions.test.js` | Fallback assertions updated to the new semantics + whitespace/non-string city cases |
| `functions/api/__tests__/schedule-venue-city.test.js` | New — regression that `venue_city` flows through `/api/schedule` (present and null) |

## Security / correctness notes

- The coordinate branch is unchanged and still wins whenever `latitude`/`longitude` are usable — this only affects the name-search fallback.
- The fallback can no longer assert a wrong city. City presence is the scope, never a hardcoded default; a missing city yields a bare venue-name search.
- `venue_city` is a per-venue value (all 12 venues have one in production), which is more precise than threading the event's city — a multi-city event gets each venue scoped correctly. I chose venue city over the issue's suggested event city for this reason.
- Latent, not live: no production venue currently lacks coordinates (0043/0044), so the fallback is still unreachable today — but the next venue without coords will now resolve to its real city.

## Verification

- [x] Tests: backend 1130 pass + frontend 1025 pass, 0 failures (includes 2 new backend + 3 new frontend cases)
- [x] ESLint: 0 errors on all changed files
- [x] Format check: clean
- [x] Build: green (`npm run build --prefix frontend`)
- [ ] `validate:openapi`: n/a (no `docs/api-spec.yaml` change)
- [ ] Manual smoke: not run — no production venue triggers the fallback today; covered by unit tests on both sides

---

Built by Theo · Reviewed by Claude (pending) · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directions searches now include the venue’s city when available.
  * Searches fall back to the venue name alone when city information is unavailable.
  * Improved handling for invalid coordinates, trimmed city names, and missing location data.
  * Schedule information now correctly includes venue city details, including when no city is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->