### PR TITLE
chore(opencode): grant the delegated agent unattended permissions

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -150,8 +150,7 @@
     "todowrite": "allow",
     "skill": "allow",
     "lsp": "allow",
-    "external_directory": "allow",
-    "doom_loop": "allow"
+    "external_directory": "deny"
   },
   "compaction": {
     "auto": true,

--- a/opencode.json
+++ b/opencode.json
@@ -137,8 +137,20 @@
     }
   },
   "permission": {
-    "read": "allow",
-    "edit": "allow",
+    "read": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      ".dev.vars": "deny",
+      "**/.dev.vars": "deny"
+    },
+    "edit": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      ".dev.vars": "deny",
+      "**/.dev.vars": "deny"
+    },
     "glob": "allow",
     "grep": "allow",
     "list": "allow",

--- a/opencode.json
+++ b/opencode.json
@@ -137,15 +137,21 @@
     }
   },
   "permission": {
-    "edit": "ask",
-    "bash": "ask",
-    "webfetch": "allow",
-    "websearch": "allow",
-    "read": "ask",
+    "read": "allow",
+    "edit": "allow",
     "glob": "allow",
     "grep": "allow",
-    "task": "ask",
-    "question": "allow"
+    "list": "allow",
+    "bash": "allow",
+    "task": "allow",
+    "webfetch": "allow",
+    "websearch": "allow",
+    "question": "allow",
+    "todowrite": "allow",
+    "skill": "allow",
+    "lsp": "allow",
+    "external_directory": "allow",
+    "doom_loop": "allow"
   },
   "compaction": {
     "auto": true,


### PR DESCRIPTION
## Summary

Commits an uncommitted working-tree change: OpenCode's `permission` block moves from `ask` to `allow`, so headless runs stop stalling on prompts — **with two grants deliberately withheld** after a security review.

## Why

OpenCode works issues and opens PRs unattended — #834, #835, #836, #837 and #838 all arrived that way. Any permission left on `ask` stalls a headless run at a prompt nobody is there to answer. That is the #816 failure mode: a read-only agent hanging for want of a grant.

## Two grants withheld

Automated security review flagged the blanket allow as a permission bypass. It was right about one grant specifically, and correcting it also corrected a false claim in this PR's first draft.

**`external_directory` → `deny`.** Decompiled from the opencode 1.18.18 binary, this is the prompt the *shell* tool raises when a command touches paths outside the project:

```js
ShellTool.ask = function*(o, e, r) {
  if (e.dirs.size > 0) { …
    yield* o.ask({ permission: "external_directory", patterns: i, … })
```

So `bash: allow` + `external_directory: allow` is not "unattended inside the worktree" — it is unattended across the **whole filesystem**, including `~/.ssh`, `.dev.vars`, and `~/.claude/settings.json`, which holds a live API token.

`deny` rather than `ask`, because a headless run has nobody to answer a prompt — `ask` would reproduce the #816 hang, while `deny` fails fast. It costs nothing operationally: working this repo never needs to leave it.

**`doom_loop` → dropped.** It appears only in the permission key list and its behaviour could not be determined from the binary. Granting an undefined capability is not defensible; omitting the key falls back to the default.

## What is granted, and what still contains it

`read`, `edit`, `glob`, `grep`, `list`, `bash`, `task`, `webfetch`, `websearch`, `question`, `todowrite`, `skill`, `lsp`. The `lsp` grant pairs with #831.

`bash: allow` remains the widest of these. Containment is unchanged:

| control | where |
|---|---|
| The relay never commits; the orchestrator reviews the diff and runs `make gate` before anything lands | `CLAUDE.md`, "Delegating to OpenCode" |
| `main` is ruleset-protected — no direct pushes, `strict_required_status_checks` on, unresolved threads block merge | repo ruleset |
| A delegated run is judged by what changed on disk, not its self-reported status | `scripts/delegate-verify.mjs` (#832) |
| Shell cannot reach outside the project unprompted | `external_directory: deny` (this PR) |

The agent acts freely **inside the repo** and still cannot land anything without a human-reviewed, green PR.

## Test plan

- [x] `make gate` — exit 0 (both before and after the narrowing)
- [x] `jq` validates the `permission` block
- [x] `external_directory` semantics verified against the binary, not assumed

## Notes

Config only. No runtime code, no migrations, no schema; does not affect the deployed site.

The other half of this WIP — the frontend a11y lint ratchet — is **not** included: the newly added `control-has-associated-label` reports 93 violations across 22 files and would red-gate every PR. Tracked in #842 with the full breakdown.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated permission settings to allow supported operations automatically, including reading, editing, file listing, shell commands, task execution, web access, questions, todo management, skills, and language-server operations.
  * Access to environment files and external directories remains denied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->