### PR TITLE
fix(seo): thread venue/event city through SSR identity meta, never hardcode Waterloo (#840)

### DIFF
--- a/functions/event/[slug].js
+++ b/functions/event/[slug].js
@@ -2,14 +2,7 @@
 // JSON-LD for crawlers. See functions/utils/ssrMeta.js for rationale + fallback.
 
 import { isPublicDataEnabled } from "../utils/publicGate.js";
-import {
-  escapeAttr,
-  toPlainText,
-  serveWithInjectedMeta,
-  WATERLOO_ADDRESS,
-  CANONICAL_HOST,
-  DEFAULT_OG_IMAGE,
-} from "../utils/ssrMeta.js";
+import { escapeAttr, toPlainText, serveWithInjectedMeta, CANONICAL_HOST, DEFAULT_OG_IMAGE } from "../utils/ssrMeta.js";
 import { normalizeHttpUrl } from "../utils/validation.js";
 import { sortableName } from "../utils/sortableName.js";
 import { torontoUtcOffset, AFTER_MIDNIGHT_THRESHOLD_HOUR } from "../utils/eventDay.js";
@@ -198,7 +191,7 @@ export async function onRequest(context) {
           address: {
             "@type": "PostalAddress",
             ...(v.address_line1 || v.address ? { streetAddress: v.address_line1 || v.address } : {}),
-            addressLocality: v.city || "Waterloo",
+            ...(v.city ? { addressLocality: v.city } : {}),
             addressRegion: v.region || "ON",
             ...(v.postal_code ? { postalCode: v.postal_code } : {}),
             addressCountry: "CA",
@@ -207,7 +200,12 @@ export async function onRequest(context) {
       : {
           "@type": "Place",
           name: event.city || "Waterloo Region, ON",
-          address: WATERLOO_ADDRESS,
+          address: {
+            "@type": "PostalAddress",
+            ...(event.city ? { addressLocality: event.city } : {}),
+            addressRegion: "ON",
+            addressCountry: "CA",
+          },
         };
 
   // Per-day subEvent (#542 PR-4): MULTI-DAY events only (end_date > date).
@@ -368,7 +366,7 @@ export async function onRequest(context) {
     ],
   };
 
-  const title = `${event.name} — Set Times & Lineup in Waterloo | SetTimes`;
+  const title = `${event.name} — Set Times & Lineup${event.city ? ` in ${event.city}` : ""} | SetTimes`;
 
   return serveWithInjectedMeta(context, { title, metaTags, jsonLd: [musicEvent, breadcrumb] });
 }

--- a/functions/event/__tests__/slug.locality.test.js
+++ b/functions/event/__tests__/slug.locality.test.js
@@ -1,0 +1,127 @@
+/**
+ * SSR /event/[slug] Tests — venue city threading (#840)
+ *
+ * The MusicEvent JSON-LD `location` (per-venue MusicVenue addresses) fell back
+ * to a hardcoded "Waterloo" addressLocality when a venue had no city, and the
+ * route's <title> asserted "in Waterloo" unconditionally. Buddies Fest 2
+ * (event 36, archived, Tillsonburg) proved the class: its venues emitted
+ * structured data placing them in Waterloo. The fix threads each venue's own
+ * city through and OMITS the locality (never a default) when it is absent.
+ */
+import { describe, expect, test } from "vitest";
+import { onRequest } from "../[slug].js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../api/test-utils.js";
+
+const STUB_HTML = `<!doctype html><html><head>
+    <meta name="description" content="Homepage description" />
+    <title>SetTimes</title>
+  </head><body><div id="root"></div></body></html>`;
+
+function makeContext({ env, slug }) {
+  env.ASSETS = {
+    fetch: async () => new Response(STUB_HTML, { status: 200, headers: { "content-type": "text/html" } }),
+  };
+  return {
+    request: new Request(`https://settimes.ca/event/${slug}`),
+    env,
+    params: { slug },
+  };
+}
+
+function extractJsonLd(html) {
+  const matches = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+  return matches.map((m) => JSON.parse(m[1]));
+}
+
+describe("SSR /event/[slug] — venue city threading (#840)", () => {
+  test("location JSON-LD uses each venue's OWN city (Tillsonburg), never a hardcoded Waterloo", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Buddies Fest 2",
+      slug: "slug-840-tillsonburg",
+      date: "2026-08-07",
+    });
+    rawDb.prepare("UPDATE events SET status = 'published', city=? WHERE id=?").run("Tillsonburg, ON", event.id);
+
+    const venue = insertVenue(rawDb, {
+      name: "The Copper Mug",
+      city: "Tillsonburg",
+      region: "ON",
+      address_line1: "79 Broadway Street",
+    });
+    insertBand(rawDb, { name: "Copper Mug Headliner", event_id: event.id, venue_id: venue.id });
+
+    const response = await onRequest(makeContext({ env, slug: "slug-840-tillsonburg" }));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    const [musicEvent] = extractJsonLd(html);
+    expect(musicEvent.location).toHaveLength(1);
+    expect(musicEvent.location[0].address.addressLocality).toBe("Tillsonburg");
+
+    // The <title> threads the event's own city too — never a bare "in Waterloo".
+    expect(html).toContain("Buddies Fest 2 — Set Times &amp; Lineup in Tillsonburg, ON | SetTimes");
+    expect(html).not.toContain('"addressLocality":"Waterloo"');
+    expect(html).not.toContain("in Waterloo |");
+  });
+
+  test("venue with no city: addressLocality is omitted, not defaulted to Waterloo", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Cityless Venue Fest",
+      slug: "slug-840-cityless-venue",
+      date: "2026-08-07",
+    });
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(event.id);
+
+    const venue = insertVenue(rawDb, { name: "No City Stage", city: null });
+    insertBand(rawDb, { name: "Cityless Headliner", event_id: event.id, venue_id: venue.id });
+
+    const response = await onRequest(makeContext({ env, slug: "slug-840-cityless-venue" }));
+    const html = await response.text();
+    const [musicEvent] = extractJsonLd(html);
+
+    expect(musicEvent.location).toHaveLength(1);
+    expect(musicEvent.location[0].address).not.toHaveProperty("addressLocality");
+    expect(html).toContain("Cityless Venue Fest — Set Times &amp; Lineup | SetTimes");
+    expect(html).not.toContain('"addressLocality":"Waterloo"');
+    expect(html).not.toContain("in Waterloo |");
+  });
+
+  test("event with no venues: fallback Place threads event.city, omits locality when the event has none", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const event = insertEvent(rawDb, {
+      name: "Lineup TBA",
+      slug: "slug-840-novenue",
+      date: "2026-10-11",
+    });
+    rawDb.prepare("UPDATE events SET status = 'published', city=? WHERE id=?").run("Tillsonburg, ON", event.id);
+
+    const response = await onRequest(makeContext({ env, slug: "slug-840-novenue" }));
+    const html = await response.text();
+    const [musicEvent] = extractJsonLd(html);
+
+    expect(musicEvent.location["@type"]).toBe("Place");
+    expect(musicEvent.location.address.addressLocality).toBe("Tillsonburg, ON");
+    expect(html).toContain("Lineup TBA — Set Times &amp; Lineup in Tillsonburg, ON | SetTimes");
+    expect(html).not.toContain('"addressLocality":"Waterloo"');
+
+    const cityless = insertEvent(rawDb, {
+      name: "Cityless Event",
+      slug: "slug-840-cityless-event",
+      date: "2026-10-11",
+    });
+    rawDb.prepare("UPDATE events SET status = 'published' WHERE id=?").run(cityless.id);
+
+    const citylessRes = await onRequest(makeContext({ env, slug: "slug-840-cityless-event" }));
+    const citylessHtml = await citylessRes.text();
+    const [citylessMusicEvent] = extractJsonLd(citylessHtml);
+    expect(citylessMusicEvent.location["@type"]).toBe("Place");
+    expect(citylessMusicEvent.location.address).not.toHaveProperty("addressLocality");
+    expect(citylessHtml).toContain("Cityless Event — Set Times &amp; Lineup | SetTimes");
+    expect(citylessHtml).not.toContain('"addressLocality":"Waterloo"');
+  });
+});

--- a/functions/utils/__tests__/hardcodedCityGuard.test.js
+++ b/functions/utils/__tests__/hardcodedCityGuard.test.js
@@ -1,0 +1,110 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// --- Durable guard: no hardcoded city literal in SSR venue/event surfaces
+// ------------------------------------------------------------------------
+//
+// #840: #767 removed the hardcoded "Waterloo" from frontend directions, but the
+// class stayed live on four SSR surfaces — the venue page <title> and its
+// MusicVenue JSON-LD, the event page MusicVenue addressLocality, and
+// ssrMeta.js's WATERLOO_ADDRESS constant — each asserting "Waterloo" for venues
+// whose own city (e.g. Buddies Fest 2's Tillsonburg venues) said otherwise.
+// That is false structured data on a repo where SEO is a priority.
+//
+// The fix threads each venue's own city through and omits the locality when it
+// is absent (vague but never wrong). This source scan (same technique as
+// functions/utils/__tests__/afterMidnightThreshold.test.js and
+// eventVisibility.test.js) keeps a hardcoded city literal from creeping back
+// into the files that build SSR identity meta / JSON-LD.
+//
+// Deliberate scope: "Waterloo Region" (a REGION) stays allowed — the platform's
+// stated focus, used as product-language fallback copy — while the bare city
+// literal "Waterloo" (and any other hardcoded city) is the defect. The lookahead
+// below is that line: `Waterloo(?!\s+Region)` matches the city claim and not the
+// region fallback. Line-level heuristic, not a JS parser — same caveat as the
+// "06:00" guard: it misses a literal assembled across string concatenations and
+// flags a non-comment line that merely mentions the city; there is no such
+// legitimate string in these files today, and one appearing would be worth a
+// human's attention regardless.
+
+const SCANNED_EXTENSIONS = [".js", ".ts"];
+
+// The three surface families #840 covered: venue SSR, event SSR, and the shared
+// ssrMeta helper they both import from.
+const TARGETS = [
+  path.join("functions", "venue"),
+  path.join("functions", "event"),
+  path.join("functions", "utils", "ssrMeta.js"),
+];
+
+const currentFile = fileURLToPath(import.meta.url);
+const repoRoot = path.join(path.dirname(currentFile), "../../../");
+
+function isCommentLine(trimmed) {
+  return trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*");
+}
+
+function isExempt(relPath) {
+  // Test files necessarily name the literal; the snapshots and spec fixtures
+  // describe Waterloo venues. Only the production surfaces are in scope.
+  return relPath.split(path.sep).join("/").split("/").includes("__tests__");
+}
+
+function scanFile(absPath, relPath, offenders) {
+  if (isExempt(relPath)) return;
+  const source = readFileSync(absPath, "utf8");
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (isCommentLine(trimmed)) continue;
+    // A bare "Waterloo" NOT part of "Waterloo Region". The lookahead is the
+    // whole precision of this guard: the platform's focus copy ("Waterloo
+    // Region" as a REGION) stays legal; the CITY claim (addressLocality,
+    // titles, `|| "Waterloo"` fallbacks) is the defect. Line-level and
+    // name-based — it catches the exact copy-paste that shipped in #840 and
+    // misses a literal built across concatenations, same caveat as the
+    // AFTER_MIDNIGHT threshold guard.
+    if (/\bWaterloo\b(?!\s+Region)/.test(trimmed)) {
+      offenders.push(`${relPath}:${i + 1}`);
+    }
+  }
+}
+
+describe("no hardcoded city literal in SSR venue/event surfaces (#840)", () => {
+  it("has no hardcoded city string in functions/venue/, functions/event/, or ssrMeta.js", () => {
+    const offenders = [];
+
+    for (const target of TARGETS) {
+      const absTarget = path.join(repoRoot, target);
+      if (target.endsWith(".js")) {
+        scanFile(absTarget, target, offenders);
+        continue;
+      }
+      if (!readdirSync(absTarget, { withFileTypes: true })) continue;
+      const stack = [absTarget];
+      while (stack.length > 0) {
+        const dir = stack.pop();
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          const rel = path.relative(repoRoot, full);
+          if (entry.isDirectory()) {
+            stack.push(full);
+          } else if (entry.isFile() && SCANNED_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+            scanFile(full, rel, offenders);
+          }
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      offenders.length > 0
+        ? `These lines hardcode a city literal instead of threading the venue's own city through ` +
+            `(or naming a Region): ${offenders.join(", ")}. Thread venue.city / event.city and omit the ` +
+            `locality when it is absent — see #840 and functions/utils/__tests__/hardcodedCityGuard.test.js.`
+        : undefined,
+    ).toEqual([]);
+  });
+});

--- a/functions/utils/ssrMeta.js
+++ b/functions/utils/ssrMeta.js
@@ -174,11 +174,3 @@ export async function serveWithInjectedMeta(context, { title = null, metaTags = 
     return env.ASSETS.fetch(request);
   }
 }
-
-// Waterloo Region location block reused across event/venue structured data.
-export const WATERLOO_ADDRESS = {
-  "@type": "PostalAddress",
-  addressLocality: "Waterloo",
-  addressRegion: "ON",
-  addressCountry: "CA",
-};

--- a/functions/venue/[id].js
+++ b/functions/venue/[id].js
@@ -29,10 +29,10 @@ export async function onRequest(context) {
 
   // Pin to the production host — preview deploys must not self-canonicalise.
   const url = `${CANONICAL_HOST}/venue/${id}`;
-  const locality = venue.city || "Waterloo";
+  const locality = venue.city;
   const description =
     [venue.name, venue.address].filter(Boolean).join(" — ") ||
-    `${venue.name} — a live music venue in ${locality}, ON on SetTimes.`;
+    `${venue.name} — a live music venue${locality ? ` in ${locality}, ON` : ""} on SetTimes.`;
 
   const metaTags = [
     `<meta name="description" content="${escapeAttr(description)}" />`,
@@ -68,7 +68,7 @@ export async function onRequest(context) {
     address: {
       "@type": "PostalAddress",
       ...(venue.address_line1 || venue.address ? { streetAddress: venue.address_line1 || venue.address } : {}),
-      addressLocality: locality,
+      ...(locality ? { addressLocality: locality } : {}),
       addressRegion: venue.region || "ON",
       ...(venue.postal_code ? { postalCode: venue.postal_code } : {}),
       addressCountry: "CA",
@@ -97,7 +97,7 @@ export async function onRequest(context) {
     ],
   };
 
-  const title = `${venue.name} — Live Music Venue in Waterloo, ON | SetTimes`;
+  const title = `${venue.name} — Live Music Venue${locality ? ` in ${locality}, ON` : ""} | SetTimes`;
 
   return serveWithInjectedMeta(context, { title, metaTags, jsonLd: [musicVenue, breadcrumb] });
 }

--- a/functions/venue/__tests__/id.locality.test.js
+++ b/functions/venue/__tests__/id.locality.test.js
@@ -1,0 +1,74 @@
+/**
+ * SSR /venue/[id] Tests — venue city threading (#840)
+ *
+ * Until #767's fix reached the SSR surfaces, every venue page title claimed
+ * "Waterloo, ON" and the MusicVenue JSON-LD hardcoded addressLocality
+ * "Waterloo" regardless of the venue's own city (with a `|| "Waterloo"`
+ * fallback where a venue.city read existed at all). Buddies Fest 2's Tillsonburg
+ * venues rendered structured data asserting they were in Waterloo — false data
+ * Google consumes. The class is fixed by threading the venue's own city through
+ * and OMITTING the locality (never defaulting it) when the venue has no city.
+ */
+import { describe, expect, test } from "vitest";
+import { onRequest } from "../[id].js";
+import { createTestEnv, insertVenue } from "../../api/test-utils.js";
+
+const STUB_HTML = `<!doctype html><html><head>
+    <meta name="description" content="Homepage description" />
+    <title>SetTimes</title>
+  </head><body><div id="root"></div></body></html>`;
+
+function makeContext({ env, id }) {
+  env.ASSETS = {
+    fetch: async () => new Response(STUB_HTML, { status: 200, headers: { "content-type": "text/html" } }),
+  };
+  return {
+    request: new Request(`https://settimes.ca/venue/${id}`),
+    env,
+    params: { id: String(id) },
+  };
+}
+
+function extractJsonLd(html) {
+  const matches = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+  return matches.map((m) => JSON.parse(m[1]));
+}
+
+describe("SSR /venue/[id] — venue city threading (#840)", () => {
+  test("title + JSON-LD use the venue's OWN city (Tillsonburg), never a hardcoded Waterloo", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const venue = insertVenue(rawDb, {
+      name: "The Copper Mug",
+      city: "Tillsonburg",
+      region: "ON",
+      address_line1: "79 Broadway Street",
+    });
+
+    const response = await onRequest(makeContext({ env, id: venue.id }));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    expect(html).toContain("Live Music Venue in Tillsonburg, ON");
+    expect(html).not.toContain("Waterloo");
+
+    const [musicVenue] = extractJsonLd(html);
+    expect(musicVenue["@type"]).toBe("MusicVenue");
+    expect(musicVenue.address.addressLocality).toBe("Tillsonburg");
+  });
+
+  test("venue with no city: locality is OMITTED from JSON-LD and the title, never defaulted", async () => {
+    const { env, rawDb } = createTestEnv();
+    env.PUBLIC_DATA_PUBLISH_ENABLED = "true";
+    const venue = insertVenue(rawDb, { name: "No City Venue", city: null });
+
+    const response = await onRequest(makeContext({ env, id: venue.id }));
+    const html = await response.text();
+
+    expect(html).not.toContain("Waterloo");
+    expect(html).toContain("No City Venue — Live Music Venue | SetTimes");
+
+    const [musicVenue] = extractJsonLd(html);
+    expect(musicVenue.address).not.toHaveProperty("addressLocality");
+  });
+});


### PR DESCRIPTION
## Summary

Threads each venue's (and event's) own city through the SSR identity meta and JSON-LD on `/venue/[id]` and `/event/[slug]`, and **omits the locality** — never defaults it — when no city exists. A missing locality is vague; a hardcoded "Waterloo" on a Tillsonburg venue is false structured data Google consumes.

Closes #840

## What changed

| File | Change |
|------|--------|
| `functions/venue/[id].js` | `locality = venue.city` (was `|| "Waterloo"`); title + description + JSON-LD `addressLocality` all omit when absent |
| `functions/event/[slug].js` | Per-venue `addressLocality: v.city` (was `|| "Waterloo"`); event-city-less `Place` fallback omits locality; `<title>` threads `event.city` instead of hardcoding "in Waterloo" |
| `functions/utils/ssrMeta.js` | Remove the now-unused `WATERLOO_ADDRESS` constant (last import was `event/[slug].js`) |
| `functions/venue/__tests__/id.locality.test.js` | **New** — venue city threaded through (Tillsonburg) + no-city omission |
| `functions/event/__tests__/slug.locality.test.js` | **New** — per-venue city, no-city venue, no-venue event fallback |
| `functions/utils/__tests__/hardcodedCityGuard.test.js` | **New** — source-scanning guard: no bare `Waterloo` city literal in the three SSR surface files (allows "Waterloo Region" as region-copy) |

## Why this shape

- **Venue city, not event city**, for the per-venue `location` entries — a multi-city event gets each venue scoped correctly (same reasoning as #767).
- **Omission over fallback**: when `venue.city` is NULL, `addressLocality` is dropped entirely rather than substituted. Verified against production data: all 12 venues have a city, so the omission branch is currently a safety net, not a regression.
- **Guard test**: same family as `afterMidnightThreshold.test.js` / `eventVisibility.test.js` — a bare `Waterloo` literal (not part of "Waterloo Region") in `functions/venue/`, `functions/event/`, or `ssrMeta.js` fails CI, so the class can't silently return.
- **No client-side duplicates**: SSR owns identity meta + JSON-LD on these routes; nothing added to `<Helmet>`.

## Verification

- [x] **New tests fail before the fix**: stashed the 3 source files, ran the new tests → all 6 failed (guard flagged `[id].js:32, [id].js:100, [slug].js:201, [slug].js:371, ssrMeta.js:181`; assertion tests caught Waterloo in titles/JSON-LD). Restored, all 6 pass.
- [x] `make gate` exit 0: backend **1141 passed** (115 files), frontend **1027 passed** (91 files), lint 0 errors, format clean, build green.
- [x] Lint warnings (3) are pre-existing in files untouched by this PR (ical-cancelled test, AdminPanel, UserManagement).
- [ ] Manual smoke: not run — SSR routes verified via unit tests (mocked ASSETS), matching the existing test pattern for these routes.

---

Built by Theo · Reviewed by Claude (pending) · 🤖 [Claude Code](https://claude.ai/claude-code)
