### PR TITLE
fix(a11y): BandCard container is a labelled group; corner button is the sole toggle (#726)

### DIFF
--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -45,7 +45,13 @@ function BandCard({
         : 'bg-gradient-card text-text-primary hover:bg-bg-purple/80 hover:scale-[1.01] shadow-md border border-border'
   } relative`
 
-  const labelBase = isSelected ? `Remove ${band.name} from my route` : `Add ${band.name} to my route`
+  // ONE source of truth for the name shown and the name announced. The visible
+  // fallback used to be a literal in the markup while the labels interpolated
+  // band.name directly, so a nameless band rendered "Unnamed Artist" but
+  // announced "undefined" — WCAG 2.5.3 (Label in Name) requires the accessible
+  // name to contain the visible text. Derive both from this.
+  const displayName = band.name || 'Unnamed Artist'
+  const labelBase = isSelected ? `Remove ${displayName} from my route` : `Add ${displayName} to my route`
   const bandProfileHref = band.name ? buildBandProfileHref(band.name, eventSlug) : null
 
   // The card container is a labelled group, never a button or a click target:
@@ -54,7 +60,7 @@ function BandCard({
   // (invalid) or announce as a control while containing focusable children.
   // The corner button is the sole toggle control (#726).
   return (
-    <div className={baseClasses} role="group" aria-label={`${band.name} at ${band.venue}`}>
+    <div className={baseClasses} role="group" aria-label={band.venue ? `${displayName} at ${band.venue}` : displayName}>
       {showToggleButton && !isCancelled && (
         <button
           type="button"
@@ -110,7 +116,7 @@ function BandCard({
                 onAmber ? 'text-bg-navy' : isCancelled ? 'text-text-secondary' : 'text-text-primary'
               }`}
             >
-              {isCancelled ? <s>Unnamed Artist</s> : 'Unnamed Artist'}
+              {isCancelled ? <s>{displayName}</s> : displayName}
             </h3>
           )}
         </div>

--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -11,7 +11,6 @@ function BandCard({
   isSelected,
   onToggle,
   showVenue = true,
-  clickable = true,
   showToggleButton = true,
   eventSlug,
   onRemove,
@@ -20,23 +19,10 @@ function BandCard({
   currentTime,
   dayLabel,
 }) {
-  const handleToggle = () => {
-    if (!isInteractive) return
-    onToggle?.(band.id)
-  }
-
   const handleRemove = e => {
     e.stopPropagation()
     const handler = onRemove || onToggle
     handler?.(band.id)
-  }
-
-  const handleKeyDown = e => {
-    if (!isInteractive) return
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      handleToggle()
-    }
   }
 
   // A cancelled set is never live, never "starting soon", and never
@@ -47,7 +33,6 @@ function BandCard({
   const nowMs = +currentTime
   const startingSoon = !isCancelled && isStartingSoon(band, currentTime)
   const minutesUntil = startingSoon ? Math.ceil((band.startMs - nowMs) / 60000) : 0
-  const isInteractive = clickable && !isCancelled
 
   // Both selected and playing states use the amber gradient — dark text required throughout
   const onAmber = isSelected || isPlaying
@@ -63,17 +48,13 @@ function BandCard({
   const labelBase = isSelected ? `Remove ${band.name} from my route` : `Add ${band.name} to my route`
   const bandProfileHref = band.name ? buildBandProfileHref(band.name, eventSlug) : null
 
+  // The card container is a labelled group, never a button or a click target:
+  // it wraps a real <button> (corner add/remove toggle) and an <a> (profile
+  // link), so making it interactive would either nest interactive content
+  // (invalid) or announce as a control while containing focusable children.
+  // The corner button is the sole toggle control (#726).
   return (
-    <div
-      className={`${baseClasses} ${
-        isInteractive ? 'cursor-pointer hover:brightness-110 active:scale-95' : 'cursor-default'
-      }`}
-      onClick={isInteractive ? handleToggle : undefined}
-      onKeyDown={isInteractive ? handleKeyDown : undefined}
-      tabIndex={isInteractive ? 0 : undefined}
-      role={isInteractive ? undefined : 'group'}
-      aria-label={isInteractive ? undefined : `${band.name} at ${band.venue}`}
-    >
+    <div className={baseClasses} role="group" aria-label={`${band.name} at ${band.venue}`}>
       {showToggleButton && !isCancelled && (
         <button
           type="button"

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -629,9 +629,9 @@ function GenreDiscovery({ bands, eventSlug, eventDate }) {
               {groupBands.map(band => {
                 const isSelected = selectedIds.has(band.id)
                 // A cancelled band must never be added to a fan's schedule
-                // from this wall -- mirrors BandCard's isInteractive gate on
-                // the live schedule (#732), which freezes toggling entirely
-                // (not just hides a button) once a set is cancelled.
+                // from this wall -- mirrors BandCard on the live schedule
+                // (#732): cancelled sets render no add/remove toggle at all,
+                // so a set cannot be added once cancelled.
                 const isCancelled = Boolean(band.is_cancelled)
                 return (
                   <button

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -697,7 +697,6 @@ function MySchedule({
                       onToggle={onToggleBand}
                       onRemove={onToggleBand}
                       showVenue={true}
-                      clickable={false}
                       eventSlug={eventSlug}
                       currentTime={effectiveNow}
                       warningType={hasConflict ? 'conflict' : hasOverlap ? 'overlap' : null}

--- a/frontend/src/components/ScheduleView.jsx
+++ b/frontend/src/components/ScheduleView.jsx
@@ -485,7 +485,6 @@ function ScheduleView({
                     band={band}
                     isSelected={selectedBandsSet.has(band.id)}
                     onToggle={onToggleBand}
-                    clickable={canToggleBands}
                     showToggleButton={canToggleBands}
                     eventSlug={eventSlug}
                     showVenue={false}
@@ -519,7 +518,6 @@ function ScheduleView({
                     band={band}
                     isSelected={selectedBandsSet.has(band.id)}
                     onToggle={onToggleBand}
-                    clickable={canToggleBands}
                     showToggleButton={canToggleBands}
                     eventSlug={eventSlug}
                     showVenue={true}
@@ -561,7 +559,6 @@ function ScheduleView({
                             band={band}
                             isSelected={selectedBandsSet.has(band.id)}
                             onToggle={onToggleBand}
-                            clickable={canToggleBands}
                             showToggleButton={canToggleBands}
                             eventSlug={eventSlug}
                             showVenue={true}
@@ -607,7 +604,6 @@ function ScheduleView({
                             band={band}
                             isSelected={selectedBandsSet.has(band.id)}
                             onToggle={onToggleBand}
-                            clickable={canToggleBands}
                             showToggleButton={canToggleBands}
                             eventSlug={eventSlug}
                             showVenue={true}

--- a/frontend/src/components/__tests__/BandCard.cancelled.test.jsx
+++ b/frontend/src/components/__tests__/BandCard.cancelled.test.jsx
@@ -95,18 +95,11 @@ describe('BandCard — cancelled sets', () => {
   })
 
   it('does not fire onToggle when a cancelled card is clicked', () => {
-    // Deviation from the plan's literal test code: it clicked the band-name
-    // text, which lives inside a <Link> that already calls
-    // e.stopPropagation() on its own onClick (BandCard.jsx) for an unrelated
-    // reason (so the profile link doesn't also toggle the card). That click
-    // never reaches the wrapper div's onClick regardless of is_cancelled, so
-    // the assertion would pass identically whether or not the suppression
-    // below is implemented -- a vacuous test. Clicking the wrapper directly
-    // (`container.firstChild`) is the same target the pre-existing
-    // "click/keyboard toggle" describe block below already uses to prove
-    // toggle suppression (see the `clickable: false` case in
-    // BandCard.test.jsx), so this mirrors an established, non-vacuous
-    // pattern instead.
+    // Since #726 the card container is a labelled group, not a click target —
+    // the corner <button> is the only toggle, and cancelled cards render none
+    // (asserted above). This guards the #732 class: a cancelled set must
+    // never be togglable through ANY interaction path, even a future one that
+    // reintroduces a container handler.
     const onToggle = vi.fn()
     const { container } = renderCard({ is_cancelled: 1 }, onToggle)
     fireEvent.click(container.firstChild)

--- a/frontend/src/components/__tests__/BandCard.test.jsx
+++ b/frontend/src/components/__tests__/BandCard.test.jsx
@@ -122,3 +122,33 @@ describe('BandCard — corner button is the toggle, container is a labelled grou
     expect(onToggle).not.toHaveBeenCalled()
   })
 })
+
+// #726 follow-up — WCAG 2.5.3 (Label in Name): the accessible name must contain
+// the visible text. The visible "Unnamed Artist" fallback was a literal in the
+// markup while the labels interpolated band.name, so a nameless band rendered
+// "Unnamed Artist" and announced "undefined". Both now derive from displayName.
+describe('BandCard — band with no name', () => {
+  const nameless = { id: 9, venue: 'Stage A', startMs: 0, endMs: 0 }
+
+  it('announces the visible fallback, never "undefined"', () => {
+    const { container } = render(<BandCard band={nameless} isSelected={false} onToggle={() => {}} />)
+
+    expect(container.firstChild).toHaveAttribute('aria-label', 'Unnamed Artist at Stage A')
+    expect(container.firstChild.getAttribute('aria-label')).not.toContain('undefined')
+  })
+
+  it('uses the fallback in the toggle button name too', () => {
+    render(<BandCard band={nameless} isSelected={false} onToggle={() => {}} />)
+
+    expect(screen.getByRole('button', { name: 'Add Unnamed Artist to my route' })).toBeInTheDocument()
+  })
+
+  it('omits the venue clause when there is no venue', () => {
+    const { container } = render(
+      <BandCard band={{ id: 10, startMs: 0, endMs: 0 }} isSelected={false} onToggle={() => {}} />
+    )
+
+    expect(container.firstChild).toHaveAttribute('aria-label', 'Unnamed Artist')
+    expect(container.firstChild.getAttribute('aria-label')).not.toContain('undefined')
+  })
+})

--- a/frontend/src/components/__tests__/BandCard.test.jsx
+++ b/frontend/src/components/__tests__/BandCard.test.jsx
@@ -63,63 +63,61 @@ describe('BandCard — genre chip', () => {
   })
 })
 
-// These document the CURRENT interaction model; they do not endorse it.
-// When `clickable`, the container is a focusable div with no role and no
-// accessible name (BandCard.jsx:66-67) wrapping a real <button> (add/remove)
-// and an <a> (profile link). That nesting is why it cannot simply become a
-// <button> — and why adding role="button" would be worse, not better: it would
-// announce as a control while containing focusable children.
-// Replacing it with a distinct native toggle is tracked in #726; update these
-// tests as part of that change rather than treating them as the spec.
-describe('BandCard — click/keyboard toggle (pre-existing behaviour)', () => {
-  it('is focusable via tabIndex=0 when clickable', () => {
-    const { container } = renderCard({ clickable: true })
-    expect(container.firstChild).toHaveAttribute('tabindex', '0')
+// #726 regression tests. The card container must never be a focusable
+// interactive target: it wraps a real <button> (corner add/remove) and an <a>
+// (profile link), so it cannot itself be a <button> (nested interactive
+// content is invalid), and a role="button" would announce as a control while
+// containing focusable children. The toggle is the distinct native <button>,
+// and the container is a labelled <div role="group"> — never a click target.
+// These assert the accessible NAME (what screen readers actually announce),
+// not just a role's presence.
+describe('BandCard — corner button is the toggle, container is a labelled group (#726)', () => {
+  it('renders the toggle as a button with an accessible name', () => {
+    renderCard({})
+
+    expect(screen.getByRole('button', { name: 'Add Band Test to my route' })).toBeInTheDocument()
   })
 
-  it('calls onToggle with the band id on click', () => {
+  it('calls onToggle with the band id via the corner button', () => {
     const onToggle = vi.fn()
-    const { container } = renderCard({ onToggle, clickable: true })
+    renderCard({ onToggle })
 
-    fireEvent.click(container.firstChild)
+    fireEvent.click(screen.getByRole('button', { name: 'Add Band Test to my route' }))
 
     expect(onToggle).toHaveBeenCalledWith(baseBand.id)
   })
 
-  it('calls onToggle on Enter key press', () => {
-    const onToggle = vi.fn()
-    const { container } = renderCard({ onToggle, clickable: true })
+  it('flips the button accessible name when selected', () => {
+    renderCard({ isSelected: true })
 
-    fireEvent.keyDown(container.firstChild, { key: 'Enter' })
-
-    expect(onToggle).toHaveBeenCalledWith(baseBand.id)
+    expect(screen.getByRole('button', { name: 'Remove Band Test from my route' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Add Band Test to my route' })).toBeNull()
   })
 
-  it('calls onToggle on Space key press', () => {
-    const onToggle = vi.fn()
-    const { container } = renderCard({ onToggle, clickable: true })
+  it('hides the toggle button when showToggleButton is false', () => {
+    renderCard({ showToggleButton: false })
 
-    fireEvent.keyDown(container.firstChild, { key: ' ' })
-
-    expect(onToggle).toHaveBeenCalledWith(baseBand.id)
+    expect(screen.queryByRole('button', { name: /to my route/i })).toBeNull()
   })
 
-  it('ignores other key presses', () => {
-    const onToggle = vi.fn()
-    const { container } = renderCard({ onToggle, clickable: true })
+  it('labels the container as a group with an accessible name', () => {
+    const { container } = renderCard({})
 
-    fireEvent.keyDown(container.firstChild, { key: 'Tab' })
-
-    expect(onToggle).not.toHaveBeenCalled()
+    expect(container.firstChild).toHaveAttribute('role', 'group')
+    expect(container.firstChild).toHaveAttribute('aria-label', 'Band Test at Stage A')
   })
 
-  it('does not respond to click or keyboard when clickable is false', () => {
-    const onToggle = vi.fn()
-    const { container } = renderCard({ onToggle, clickable: false })
+  it('does not make the container focusable', () => {
+    const { container } = renderCard({})
 
     expect(container.firstChild).not.toHaveAttribute('tabindex')
+  })
+
+  it('does not toggle when the container itself is clicked', () => {
+    const onToggle = vi.fn()
+    const { container } = renderCard({ onToggle })
+
     fireEvent.click(container.firstChild)
-    fireEvent.keyDown(container.firstChild, { key: 'Enter' })
 
     expect(onToggle).not.toHaveBeenCalled()
   })

--- a/frontend/src/pages/VenuePage.jsx
+++ b/frontend/src/pages/VenuePage.jsx
@@ -29,7 +29,7 @@ function VenuePerformerCard({ perf, venueName, currentTime }) {
     {
       id: perf.band_id,
       name: perf.band_name,
-      // Feeds BandCard's non-interactive aria-label (`${name} at ${venue}`) --
+      // Feeds BandCard's aria-label (`${name} at ${venue}`) --
       // showVenue={false} below only hides the *visible* venue line, not this.
       venue: venueName,
       photo_url: perf.photo_url,
@@ -54,7 +54,6 @@ function VenuePerformerCard({ perf, venueName, currentTime }) {
     <div>
       <BandCard
         band={band}
-        clickable={false}
         showToggleButton={false}
         showVenue={false}
         eventSlug={perf.event_slug}


### PR DESCRIPTION
## Summary

Fixes the WCAG 4.1.2 (Name, Role, Value) failure on the site's most-viewed component: when interactive, `BandCard` rendered as a focusable `<div tabindex="0">` with **no role and no accessible name**, silently announcing nothing to screen readers.

The container wraps a real `<button>` (corner add/remove) and an `<a>` (profile link), so it cannot become a `<button>` itself — nested interactive content is invalid HTML — and adding `role="button"` would be *worse*: it would announce as a control while containing focusable children. Per the issue's prescribed fix, the whole-card-as-target is removed and the toggle is a **distinct native `<button>`** (the existing corner control, already correctly aria-labelled), which in every caller sits alongside the profile link rather than containing it. The container is now always `<div role="group" aria-label="<name> at <venue>">` — never a click target.

Closes #726

## What changed

| File | Change |
|------|--------|
| `frontend/src/components/BandCard.jsx` | Removed `clickable` prop, `handleToggle`, `handleKeyDown`, `isInteractive`; container loses `onClick`/`onKeyDown`/`tabIndex` and is now unconditionally `role="group"` + `aria-label`; corner `<button>` is the sole toggle |
| `frontend/src/components/__tests__/BandCard.test.jsx` | Replaced the "pre-existing behaviour" block (which documented the buggy model) with #726 regression tests asserting the toggle by role + **accessible name** and that the container is a labelled, non-focusable group |
| `frontend/src/components/__tests__/BandCard.cancelled.test.jsx` | Updated stale comment; assertion unchanged (cancelled cards render no toggle, container click is a no-op) |
| `frontend/src/components/ScheduleView.jsx` | Removed now-dead `clickable={canToggleBands}` at all 4 sites (`showToggleButton` already gates the corner button in lockstep) |
| `frontend/src/components/MySchedule.jsx` | Removed `clickable={false}` |
| `frontend/src/pages/VenuePage.jsx` | Removed `clickable={false}`; comment updated (aria-label now applies to all cards, not just non-interactive) |
| `frontend/src/components/EventTimeline.jsx` | Comment only: no longer references the removed `isInteractive` |

## Security / correctness notes

None — a11y/UX only; no auth, data, or rendering-integrity implications. No E2E behavior changed: existing E2E specs already locate the toggle by the corner button's accessible name (`cancelled-set.spec.js`, `live-experience.spec.js`, `offline-experience.spec.js`) and the container's `role="group"` name is pinned for cancelled cards.

## Verification

Fail-before proof: the new regression block was written first and run against the unchanged component — **3 tests failed** (`labels the container as a group`, `does not make the container focusable`, `does not toggle when the container itself is clicked`). After the fix all 24 BandCard tests pass.

- [x] Tests: 1141 backend + 1028 frontend pass, 0 failures (`make gate`)
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green (`make gate` includes frontend production build)
- [x] `validate:openapi`: N/A — no API changes
- [x] Manual smoke: N/A — component behavior (add/remove toggle) covered by existing E2E specs, which use the corner button's accessible name and are unchanged
- [x] CodeRabbit (`make review`): **No findings** on all 7 files

Not changed, deliberately: the two `e.stopPropagation()` calls (corner button, profile link) are retained — now defensive against any future ancestor handler rather than protecting the removed container `onClick`; removing them is unrelated cleanup. Card hover styling is unchanged beyond dropping the `cursor-pointer`/`hover:brightness-110`/`active:scale-95` interaction affordances, which no longer describe the card.

---
Built by Theo · Reviewed by Vera · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Band cards are now labelled content groups rather than clickable containers.
  - Added a dedicated, clearly named toggle button with improved keyboard and screen-reader behaviour.
  - Nameless bands now display as “Unnamed Artist” with accessible labels.
  - Cancelled bands cannot be added to or removed from schedules.

- **Bug Fixes**
  - Prevented accidental card-level toggling while preserving schedule and removal controls.

- **Tests**
  - Expanded coverage for toggle behaviour, naming, selection states, and non-interactive card containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->