### PR TITLE
docs(agents): add a delegation-brief template, from two real failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,11 @@ masks failures (this shipped a red lint to CI once). `make` propagates failures 
 
 ## Writing a delegation brief
 
-A delegated run sees only the brief plus the working tree. Two failures have
-already happened here, both the brief's fault rather than the delegate's.
+A delegated run has no memory of the conversation that produced it. It gets
+three things: the brief, the instructions `opencode.json` loads globally, and
+the working tree. Anything you worked out in chat and did not write down is
+invisible to it. Two failures have already happened here, both the brief's
+fault rather than the delegate's.
 
 **1. Name the domain instruction file — the loaded set is deliberately small.**
 `opencode.json`'s `instructions` array carries only what governs *every* diff.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ fault rather than the delegate's.
 
 **1. Name the domain instruction file — the loaded set is deliberately small.**
 `opencode.json`'s `instructions` array carries only what governs *every* diff.
-Per-domain guidance is not loaded, because `a11y.instructions.md` alone is
+Per-domain guidance is not loaded because `a11y.instructions.md` alone is
 ~5.7k tokens on every delegation. So the brief must name what the task needs:
 
 | task touches | brief must name |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,41 @@ masks failures (this shipped a red lint to CI once). `make` propagates failures 
 - E2E spec files are under the same prettier/eslint scope as `functions/`/`scripts/` (#622) —
   double quotes/semis, `eslint.config.js`'s `e2e/**` block covers Playwright + browser globals.
 
+## Writing a delegation brief
+
+A delegated run sees only the brief plus the working tree. Two failures have
+already happened here, both the brief's fault rather than the delegate's.
+
+**1. Name the domain instruction file — the loaded set is deliberately small.**
+`opencode.json`'s `instructions` array carries only what governs *every* diff.
+Per-domain guidance is not loaded, because `a11y.instructions.md` alone is
+~5.7k tokens on every delegation. So the brief must name what the task needs:
+
+| task touches | brief must name |
+|---|---|
+| `frontend/src/**` (UI) | `docs/design-system/DESIGN_SYSTEM.md`, `docs/design-system/COMPONENT_USAGE.md`, `.github/instructions/a11y.instructions.md` |
+| `e2e/**` | `.github/instructions/playwright-typescript.instructions.md` |
+| styling / Tailwind | `.github/instructions/tailwind-v4-vite.instructions.md` |
+| `migrations/**` | `make schema-check`, and the migration invariants in `CLAUDE.md` |
+
+A UI brief that names none of these gets a competent fix that never reaches for
+an existing `components/ui/` primitive. That has happened.
+
+**2. State the goal and the constraints, not the implementation.** The brief
+for #726 instructed "prefer a native `<button>`". That was wrong: `BandCard`
+contains both a `<button>` and an `<a>`, so a button container nests
+interactive content. The delegate reasoned past the instruction and used
+`role="group"` with an accessible name, which is correct. Had it complied
+literally, the brief would have produced invalid markup.
+
+The implementer can see the code; the brief writer is working from memory.
+Say *"the container must be reachable and announced"*, not *"make it a button"*.
+
+**Always include:** branch name, one PR per issue, `make gate` must exit 0,
+"STOP and report rather than weaken a test, lint rule or config to make a gate
+pass", and "confirm the new test FAILS against current code before calling it
+done". That last line is the one that keeps catching real defects.
+
 ## LSP — prefer it over grep for symbol navigation
 
 Both harnesses navigate by LSP. Two **dependencies** must be installed, and separately each


### PR DESCRIPTION
## Summary

Adds a "Writing a delegation brief" section to `AGENTS.md`, derived from two failures this week. Both were the **brief's** fault, not the delegate's.

## Failure 1 — the brief named no domain instruction file

`opencode.json`'s `instructions` array deliberately carries only what governs *every* diff, because `a11y.instructions.md` alone is ~5.7k tokens on every delegation. `CLAUDE.md` already documents that per-domain files must be named in the brief.

Then the first frontend brief written under that rule named none of them — so a UI change to the most-viewed component on the site ran with `CLAUDE.md`'s theming paragraph and nothing else: not the 526-line design system, not the 460-line component usage guide, not the 731-line a11y doc.

Fixed with a path → required-reading table, so the rule is mechanical rather than remembered.

## Failure 2 — the brief prescribed an implementation, and was wrong

The #726 brief said *"prefer a native `<button>`"*. That is the standard a11y advice and it was **wrong here**: `BandCard` contains both a `<button>` and an `<a>`, so a button container nests interactive content.

The delegate reasoned past the instruction and used `role="group"` with an accessible name — the correct answer. But a *compliant* delegate would have shipped invalid markup on the brief's authority.

The lesson is directional: the implementer can read the code, the brief writer is working from memory. State the goal and the constraints, not the implementation.

## Also recorded

The four lines every brief needs — branch name, one PR per issue, `make gate` exit 0, "STOP rather than weaken a gate", and **"confirm the new test FAILS against current code before calling it done"**. That last one has caught the most real defects: #767's original test passed against the unfixed code, and so did #826's DST test.

## Why `AGENTS.md` and not `CLAUDE.md`

`AGENTS.md` is **not** in the `instructions` array, so this costs nothing per delegation — consistent with the membership rule the array itself follows.

## Test plan

- [x] `make gate` — exit 0
- [x] `markdownlint-cli2 AGENTS.md` — 0 issues

## Notes

Documentation only. No code, no config, no runtime impact.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for writing delegation briefs.
  * Documented required instructions, goals, constraints, branch naming, validation gates, test preservation, and pre-implementation test checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->