### PR TITLE
fix(delegation): the contract is "never move main", not "never commit"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,11 +75,11 @@ node scripts/delegate-verify.mjs -- <the delegation command>
 node scripts/delegate-verify.mjs --allow-empty -- <read-only command>   # research/digest tasks
 ```
 
-Exit codes: `0` succeeded *and* changed files · `1` the command failed · `2` **reported success but changed nothing** · `3` the delegate committed · `4` usage.
+Exit codes: `0` succeeded *and* changed files · `1` the command failed · `2` **reported success but changed nothing** · `3` the delegate committed on a protected branch · `4` usage.
 
 Code `2` is the one that pays for the script. Measured 2026-08-13: an agy delegation returned exit `0` and `AGY_USAGE {"status":"SUCCESS"}` having touched **zero files** — headless agy had no `write_file` grant, so it described the work instead of doing it and still "succeeded". 96,825 tokens, nothing on disk, and nothing in its own output said so. The tool behaved exactly as its README documents ("ungranted writes leave the workspace untouched but report success"); the mistake was trusting the status field.
 
-Code `3` enforces the other half of the contract below: **the delegate never commits.** The orchestrator reviews the diff, runs `make gate`, and commits. A delegate that moves HEAD has skipped review entirely.
+Code `3` enforces the other half of the contract below: **a delegate never moves `main`.** It may branch, commit and open a PR — that is the normal workflow now, and it routes the change through the ruleset (protected main, strict checks, threads resolved) rather than through someone remembering to look. What it must never do is commit on the default branch, which bypasses review entirely. A commit on a feature branch is reported, not failed.
 
 The check is deliberately tool-agnostic — it wraps agy, OpenCode's relay, or anything else, because the failure is about *permissions and silent refusals*, not about any one vendor. It uses `git status --porcelain`, so a brand-new untracked file counts as real work (a `git diff`-only check would call that a no-op).
 
@@ -98,7 +98,7 @@ npx skills add amElnagdy/delegate-skills --skill opencode-delegate
 
 It also needs the `opencode` CLI on PATH and an authenticated provider (`opencode auth list`).
 
-Use it for well-specified work that would otherwise consume this session's context. **The relay never commits — the orchestrator reviews the diff, re-runs `make gate`, and commits.** Same contract as a Sonnet agent, different process.
+Use it for well-specified work that would otherwise consume this session's context. **OpenCode works issues end to end: it branches, commits, and opens a PR.** The orchestrator reviews that PR, re-runs `make gate`, and merges. Review moved from "read the diff before committing" to "read the PR before merging" — a stronger gate, because the ruleset enforces it rather than habit. The invariant that survived unchanged: **nothing lands on `main` unreviewed.**
 
 Four rules, each learned by something breaking:
 

--- a/scripts/delegate-verify.mjs
+++ b/scripts/delegate-verify.mjs
@@ -188,29 +188,46 @@ function main() {
     // Compare REFS, not the closing checkout: committing on main and then
     // `git switch -c feature` leaves after.branch innocent while main has
     // already moved.
-    const movedRefs = [...after.refs].filter(([name, sha]) => before.refs.get(name) !== sha);
-    const movedProtected = movedRefs.filter(([name]) => PROTECTED_BRANCHES.has(name));
+    // Walk the UNION of before and after. Iterating only `after` misses a
+    // deleted ref, and deleting main is at least as bad as moving it.
+    const refNames = new Set([...before.refs.keys(), ...after.refs.keys()]);
+    const refDelta = [];
+    for (const name of refNames) {
+      const from = before.refs.get(name);
+      const to = after.refs.get(name);
+      if (from === to) continue;
+      refDelta.push({ name, from, to, kind: !from ? "added" : !to ? "deleted" : "updated" });
+    }
 
-    if (movedProtected.length > 0) {
-      console.error("FAIL: the delegate moved a protected branch.");
-      for (const [name, sha] of movedProtected) {
-        const from = before.refs.get(name);
-        console.error(`  ${name}: ${from ? from.slice(0, 7) : "(new)"} -> ${sha.slice(0, 7)}`);
-        if (from) console.error(`  Recover with: git branch -f ${name} ${from}`);
+    const protectedDelta = refDelta.filter((d) => PROTECTED_BRANCHES.has(d.name));
+    if (protectedDelta.length > 0) {
+      console.error("FAIL: the delegate altered a protected branch.");
+      for (const { name, from, to, kind } of protectedDelta) {
+        console.error(
+          `  ${name} ${kind}: ${from ? from.slice(0, 7) : "(absent)"} -> ${to ? to.slice(0, 7) : "(deleted)"}`,
+        );
+        if (kind === "deleted") console.error(`  Recover with: git branch ${name} ${from}`);
+        else if (kind === "updated") console.error(`  Recover with: git branch -f ${name} ${from}`);
+        else console.error(`  Recover with: git branch -D ${name}`);
       }
-      console.error("Commits on a protected branch bypass PR review entirely.");
+      console.error("Protected branches must only change through a reviewed PR.");
       process.exit(3);
     }
 
     // A commit on a feature branch IS delegated work even when the tree ends up
     // clean — committing everything leaves git status empty, and without this
     // the no-change check below would report a successful delegation as exit 2.
-    const movedFeature = movedRefs.filter(([name]) => !PROTECTED_BRANCHES.has(name));
+    //
+    // But only a NEW COMMIT counts. `git switch -c feature` creates a ref at an
+    // existing commit; treating that as work would let a delegate that merely
+    // branched pass as a success, which is the silent no-op this script exists
+    // to catch. So compare against every commit the refs already pointed at.
+    const knownBefore = new Set([...before.refs.values(), before.head]);
+    const movedFeature = refDelta.filter((d) => !PROTECTED_BRANCHES.has(d.name) && d.to && !knownBefore.has(d.to));
 
-    for (const [name, sha] of movedFeature) {
-      const from = before.refs.get(name);
+    for (const { name, from, to } of movedFeature) {
       console.error(
-        `NOTE: the delegate committed on ${name} (${from ? from.slice(0, 7) : "(new branch)"} -> ${sha.slice(0, 7)}).`,
+        `NOTE: the delegate committed on ${name} (${from ? from.slice(0, 7) : "(new branch)"} -> ${to.slice(0, 7)}).`,
       );
     }
     if (movedFeature.length > 0) {

--- a/scripts/delegate-verify.mjs
+++ b/scripts/delegate-verify.mjs
@@ -67,11 +67,29 @@ function git(args) {
 /** Branches a delegate must never move. A commit anywhere else is reviewable. */
 const PROTECTED_BRANCHES = new Set(["main", "master"]);
 
+/**
+ * Every local branch tip, not just the checked-out one. Reading only the final
+ * checkout is unsound: a delegate can commit on main and then `git switch -c
+ * feature`, leaving the protected branch moved while the closing branch name
+ * looks innocent. Comparing refs catches that wherever it ends up.
+ */
+function branchRefs() {
+  const out = git(["for-each-ref", "--format=%(refname:short) %(objectname)", "refs/heads"]);
+  const refs = new Map();
+  for (const line of out.split("\n")) {
+    if (!line.trim()) continue;
+    const cut = line.lastIndexOf(" ");
+    refs.set(line.slice(0, cut), line.slice(cut + 1));
+  }
+  return refs;
+}
+
 function snapshot() {
   const status = git(["status", "--porcelain", "-uall"]);
   return {
     head: git(["rev-parse", "HEAD"]),
     branch: git(["rev-parse", "--abbrev-ref", "HEAD"]),
+    refs: branchRefs(),
     status,
     // Hashes MUST be read here, not when the snapshots are compared. Comparing
     // later would hash whatever is on disk at that moment, so both snapshots
@@ -160,25 +178,41 @@ function main() {
 
     console.error("\n─── delegate-verify ───");
 
-    // What must never happen is an UNREVIEWED change landing on the default
+    // What must never happen is an UNREVIEWED change landing on a protected
     // branch — not a commit as such. A delegate that branches, commits and
-    // opens a PR has not skipped review; it has routed the change through the
+    // opens a PR has not skipped review; it routed the change through the
     // ruleset (protected main, strict checks, threads resolved), which is a
-    // stronger gate than a human remembering to look. Only a commit that moves
-    // a protected branch bypasses that.
-    if (after.head !== before.head && PROTECTED_BRANCHES.has(after.branch)) {
-      console.error(
-        `FAIL: the delegate committed on ${after.branch} (HEAD ${before.head.slice(0, 7)} -> ${after.head.slice(0, 7)}).`,
-      );
+    // stronger gate than a human remembering to look.
+    //
+    // Compare REFS, not the closing checkout: committing on main and then
+    // `git switch -c feature` leaves after.branch innocent while main has
+    // already moved.
+    const movedRefs = [...after.refs].filter(([name, sha]) => before.refs.get(name) !== sha);
+    const movedProtected = movedRefs.filter(([name]) => PROTECTED_BRANCHES.has(name));
+
+    if (movedProtected.length > 0) {
+      console.error("FAIL: the delegate moved a protected branch.");
+      for (const [name, sha] of movedProtected) {
+        const from = before.refs.get(name);
+        console.error(`  ${name}: ${from ? from.slice(0, 7) : "(new)"} -> ${sha.slice(0, 7)}`);
+        if (from) console.error(`  Recover with: git branch -f ${name} ${from}`);
+      }
       console.error("Commits on a protected branch bypass PR review entirely.");
-      console.error(`Recover with: git reset --soft ${before.head}`);
       process.exit(3);
     }
 
-    if (after.head !== before.head) {
+    // A commit on a feature branch IS delegated work even when the tree ends up
+    // clean — committing everything leaves git status empty, and without this
+    // the no-change check below would report a successful delegation as exit 2.
+    const movedFeature = movedRefs.filter(([name]) => !PROTECTED_BRANCHES.has(name));
+
+    for (const [name, sha] of movedFeature) {
+      const from = before.refs.get(name);
       console.error(
-        `NOTE: the delegate committed on ${after.branch} (HEAD ${before.head.slice(0, 7)} -> ${after.head.slice(0, 7)}).`,
+        `NOTE: the delegate committed on ${name} (${from ? from.slice(0, 7) : "(new branch)"} -> ${sha.slice(0, 7)}).`,
       );
+    }
+    if (movedFeature.length > 0) {
       console.error("Allowed on a feature branch — review happens on the PR. Verify it before merging.");
     }
 
@@ -188,7 +222,7 @@ function main() {
       process.exit(1);
     }
 
-    if (changed.length === 0) {
+    if (changed.length === 0 && movedFeature.length === 0) {
       if (allowEmpty) {
         console.error("OK: no files changed, and --allow-empty was passed (read-only task).");
         process.exit(0);
@@ -200,11 +234,18 @@ function main() {
       process.exit(2);
     }
 
-    console.error(`OK: ${changed.length} file(s) changed.`);
-    for (const { path, code: c } of changed) {
-      console.error(`  ${c}  ${path}`);
+    // Report both shapes of work. A delegate that commits everything leaves an
+    // empty working tree, so "0 files changed" alongside a NOTE above would
+    // read like a failed run rather than a clean one.
+    if (changed.length > 0) {
+      console.error(`OK: ${changed.length} file(s) changed in the working tree.`);
+      for (const { path, code: c } of changed) {
+        console.error(`  ${c}  ${path}`);
+      }
+    } else {
+      console.error(`OK: no working-tree changes; work landed as ${movedFeature.length} branch commit(s) above.`);
     }
-    console.error("Review the diff and run the project gate before committing.");
+    console.error("Review the diff (or the PR) and run the project gate before merging.");
     process.exit(0);
   });
 }

--- a/scripts/delegate-verify.mjs
+++ b/scripts/delegate-verify.mjs
@@ -18,8 +18,9 @@
  *   A delegation that changed no files did not succeed, whatever it claims.
  *
  * It also enforces the other half of the delegation contract from CLAUDE.md:
- * the delegate never commits. The orchestrator reviews the diff and commits.
- * A delegate that moves HEAD has skipped the review step entirely.
+ * a delegate never moves a PROTECTED branch. Branching, committing and opening
+ * a PR is the normal workflow — review happens on the PR, enforced by the
+ * ruleset. Moving main directly is what bypasses review entirely.
  *
  * Usage
  * -----
@@ -31,10 +32,10 @@
  *   node scripts/delegate-verify.mjs -- node .agents/skills/opencode-delegate/relay.mjs --brief brief.md
  *
  * Exit codes:
- *   0  command succeeded AND the working tree changed
+ *   0  command succeeded AND changed the working tree or committed to a branch
  *   1  command itself failed (its exit code is reported)
  *   2  command "succeeded" but changed nothing  <- the silent-no-op case
- *   3  the delegate committed, which it must never do
+ *   3  the delegate moved a protected branch (main/master) — bypasses review
  *   4  usage error
  */
 

--- a/scripts/delegate-verify.mjs
+++ b/scripts/delegate-verify.mjs
@@ -64,10 +64,14 @@ function git(args) {
  * untracked directory into a single `dir/` entry, and a file created inside an
  * already-untracked directory would leave the snapshot byte-identical.
  */
+/** Branches a delegate must never move. A commit anywhere else is reviewable. */
+const PROTECTED_BRANCHES = new Set(["main", "master"]);
+
 function snapshot() {
   const status = git(["status", "--porcelain", "-uall"]);
   return {
     head: git(["rev-parse", "HEAD"]),
+    branch: git(["rev-parse", "--abbrev-ref", "HEAD"]),
     status,
     // Hashes MUST be read here, not when the snapshots are compared. Comparing
     // later would hash whatever is on disk at that moment, so both snapshots
@@ -156,11 +160,26 @@ function main() {
 
     console.error("\n─── delegate-verify ───");
 
-    if (after.head !== before.head) {
-      console.error(`FAIL: the delegate committed (HEAD ${before.head.slice(0, 7)} -> ${after.head.slice(0, 7)}).`);
-      console.error("Delegates must never commit — the orchestrator reviews the diff and commits.");
+    // What must never happen is an UNREVIEWED change landing on the default
+    // branch — not a commit as such. A delegate that branches, commits and
+    // opens a PR has not skipped review; it has routed the change through the
+    // ruleset (protected main, strict checks, threads resolved), which is a
+    // stronger gate than a human remembering to look. Only a commit that moves
+    // a protected branch bypasses that.
+    if (after.head !== before.head && PROTECTED_BRANCHES.has(after.branch)) {
+      console.error(
+        `FAIL: the delegate committed on ${after.branch} (HEAD ${before.head.slice(0, 7)} -> ${after.head.slice(0, 7)}).`,
+      );
+      console.error("Commits on a protected branch bypass PR review entirely.");
       console.error(`Recover with: git reset --soft ${before.head}`);
       process.exit(3);
+    }
+
+    if (after.head !== before.head) {
+      console.error(
+        `NOTE: the delegate committed on ${after.branch} (HEAD ${before.head.slice(0, 7)} -> ${after.head.slice(0, 7)}).`,
+      );
+      console.error("Allowed on a feature branch — review happens on the PR. Verify it before merging.");
     }
 
     if (code !== 0) {


### PR DESCRIPTION
## Summary

`delegate-verify` exited `3` on **any** commit, and `CLAUDE.md` stated in three places that the delegate never commits and the orchestrator commits on its behalf.

Both describe a workflow that is no longer the one being run. OpenCode now works issues end to end — branches, commits, opens a PR. That is how #834, #835, #836, #837, #838, #844 and #845 arrived.

So the tool shipped in #832 **would have failed every legitimate delegated run**, and the docs would have told the next reader that the working process was forbidden.

## The invariant did not change — the mechanism did

It was never "do not commit". It is **"nothing lands on `main` unreviewed."**

A delegate that branches, commits and opens a PR satisfies that *more* strongly than the old contract, because review is enforced by the ruleset — protected `main`, `strict_required_status_checks`, unresolved threads blocking merge — rather than by someone remembering to read a diff before committing.

| | old contract | now |
|---|---|---|
| Delegate may commit | never | on a feature branch |
| Review happens | reading the diff, by habit | on the PR, by ruleset |
| `main` protected from unreviewed change | by convention | by convention **and** by ruleset |

## What changed

`snapshot()` now records the branch. Exit `3` fires only when HEAD moves **while on a protected branch** (`main`/`master`). A commit on a feature branch prints a `NOTE` and passes — the signal stays visible without being a failure.

## Verification

| case | result |
|---|---|
| Delegate commits on a feature branch | **exit 0** with NOTE (was exit 3) |
| Delegate changes nothing | exit 2, unchanged |
| Delegate commits on `main`/`master` | exit 3 — **predicate-verified, not end-to-end** |

The protected-branch path is verified by inspecting the guard plus a truth-table check of the predicate, rather than end-to-end: exercising it for real means committing to a protected branch, which is the thing the guard exists to prevent. Flagging that explicitly rather than implying full coverage.

- [x] `make gate` — exit 0

## Notes

No runtime code, no migrations, no schema. Affects the delegation tooling and its documentation only.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved verification to prevent automated commits directly on protected default branches.
  - Detects protected-branch changes even if branch switching occurs afterward.
  - Clearer status reporting distinguishes protected-branch commits from permitted feature-branch commits.
  - Added recovery guidance when a protected-branch commit is detected.
  - Feature-branch commits can now satisfy verification for completed changes.

- **Documentation**
  - Clarified the OpenCode workflow, including branch creation, pull request opening, review, and merging responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->