### PR TITLE
fix(shares): guard route import so a slug imports exactly once per session (#765)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -455,8 +455,10 @@ function App() {
 
   // Extracted from this file's inline effect so the exactly-once-per-slug claim
   // is testable (see hooks/__tests__/useSharedRouteImport.test.jsx). Same
-  // behavior: the ?import=1 refetch must not inflate share view_count (see
-  // share/[slug].js), and #765 guards it from re-firing per slug.
+  // behavior: the ?import=1 refetch must not inflate share_links.import_count
+  // (see share/[slug].js) — that is the per-fetch, undeduped counter, distinct
+  // from view_count, which is unique visitors recomputed from a ledger. #765
+  // guards it from re-firing per slug.
   useSharedRouteImport({ searchParams, setSearchParams, bands, onShareData: handleShareData })
 
   const dismissHint = () => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import { validateBandsData } from './utils/validation'
 import { prepareBands } from './utils/bandUtils'
 import { orderedFestivalDays } from './utils/festivalDays'
 import { saveSelectedBands } from './utils/scheduleStorage'
+import { useSharedRouteImport } from './hooks/useSharedRouteImport'
 
 const HINT_DISMISSED_KEY = 'scheduleHintDismissed'
 const TIME_FILTERS_STORAGE_KEY = 'timeFiltersByEvent'
@@ -446,42 +447,17 @@ function App() {
     }
   }, [bands, searchParams, setSearchParams, showScheduleToast, slug, trackScheduleBuilds])
 
-  useEffect(() => {
-    const shareSlug = searchParams.get('share')
-    if (!shareSlug || bands.length === 0) return
+  const handleShareData = useCallback(({ matchedIds, matchedNames }) => {
+    setPendingSharedBands(matchedIds)
+    setPendingSharedBandNames(matchedNames)
+    setSharedScheduleConfirmOpen(true)
+  }, [])
 
-    setSearchParams(
-      prev => {
-        const next = new URLSearchParams(prev)
-        next.delete('share')
-        return next
-      },
-      { replace: true }
-    )
-
-    // ?import=1 — this is the apply-the-route refetch after the preview already
-    // counted the view, so it must not inflate share view_count (see share/[slug].js).
-    fetch(`/api/schedule/share/${encodeURIComponent(shareSlug)}?import=1`)
-      .then(res => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
-      .then(data => {
-        const matchedBands = bands.filter(band => {
-          const parts = band.id.split('-')
-          const perfId = Number(parts[parts.length - 1])
-          return data.performance_ids.includes(perfId)
-        })
-        const matchedIds = matchedBands.map(band => band.id)
-        const matchedNames = matchedBands.map(band => band.name || '')
-
-        if (matchedIds.length === 0) return
-
-        setPendingSharedBands(matchedIds)
-        setPendingSharedBandNames(matchedNames)
-        setSharedScheduleConfirmOpen(true)
-      })
-      .catch(err => {
-        console.warn('[App] Failed to load share link', err)
-      })
-  }, [bands, searchParams, setSearchParams])
+  // Extracted from this file's inline effect so the exactly-once-per-slug claim
+  // is testable (see hooks/__tests__/useSharedRouteImport.test.jsx). Same
+  // behavior: the ?import=1 refetch must not inflate share view_count (see
+  // share/[slug].js), and #765 guards it from re-firing per slug.
+  useSharedRouteImport({ searchParams, setSearchParams, bands, onShareData: handleShareData })
 
   const dismissHint = () => {
     setShowHint(false)

--- a/frontend/src/hooks/__tests__/useSharedRouteImport.test.jsx
+++ b/frontend/src/hooks/__tests__/useSharedRouteImport.test.jsx
@@ -1,0 +1,117 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useSharedRouteImport } from '../useSharedRouteImport'
+
+function makeParams(shareSlug) {
+  const params = new URLSearchParams()
+  if (shareSlug) params.set('share', shareSlug)
+  return params
+}
+
+// band.id carries the performance id as its dash-suffixed segment, which is
+// what the hook matches against the share snapshot's performance_ids.
+const BAND_ONE = { id: 'band-profile-101', name: 'Band One' }
+const BAND_TWO = { id: 'band-profile-102', name: 'Band Two' }
+
+function makeFetchMock() {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ performance_ids: [101], band_names: ['Band One'] }),
+  })
+}
+
+describe('useSharedRouteImport', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not fetch until bands are loaded', () => {
+    const fetchMock = makeFetchMock()
+    vi.stubGlobal('fetch', fetchMock)
+    const onShareData = vi.fn()
+    const setSearchParams = vi.fn()
+
+    renderHook(props => useSharedRouteImport(props), {
+      initialProps: { searchParams: makeParams('abc123'), setSearchParams, bands: [], onShareData },
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(onShareData).not.toHaveBeenCalled()
+  })
+
+  // The exact re-fire the guard exists to stop (#765): the share-param removal
+  // is an async setSearchParams, so a second `bands` update that lands before
+  // it commits re-runs the effect with the slug STILL present. setSearchParams
+  // is deliberately a no-op here to model that window — with the param removed
+  // between renders, no second run is possible even without the guard, and the
+  // test would prove nothing.
+  it('imports the same shared slug at most once, even if bands update again before the param removal commits', async () => {
+    const fetchMock = makeFetchMock()
+    vi.stubGlobal('fetch', fetchMock)
+    const onShareData = vi.fn()
+    const setSearchParams = vi.fn()
+    const params = makeParams('abc123')
+
+    const { rerender } = renderHook(props => useSharedRouteImport(props), {
+      initialProps: { searchParams: params, setSearchParams, bands: [], onShareData },
+    })
+
+    // bands arrive — the first legitimate run
+    rerender({ searchParams: params, setSearchParams, bands: [BAND_ONE], onShareData })
+    await act(async () => {})
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('/api/schedule/share/abc123?import=1')
+    expect(onShareData).toHaveBeenCalledTimes(1)
+    expect(onShareData).toHaveBeenCalledWith({ matchedIds: ['band-profile-101'], matchedNames: ['Band One'] })
+
+    // a second bands update before the removal commits — must NOT re-fire
+    rerender({ searchParams: params, setSearchParams, bands: [BAND_ONE, BAND_TWO], onShareData })
+    await act(async () => {})
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(onShareData).toHaveBeenCalledTimes(1)
+  })
+
+  it('imports a different slug in the same session (the claim does not latch permanently)', async () => {
+    const fetchMock = makeFetchMock()
+    vi.stubGlobal('fetch', fetchMock)
+    const onShareData = vi.fn()
+    const setSearchParams = vi.fn()
+
+    const { rerender } = renderHook(props => useSharedRouteImport(props), {
+      initialProps: { searchParams: makeParams('abc123'), setSearchParams, bands: [BAND_ONE], onShareData },
+    })
+    await act(async () => {})
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // a different shared link arrives in the same session
+    rerender({ searchParams: makeParams('def456'), setSearchParams, bands: [BAND_ONE], onShareData })
+    await act(async () => {})
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/schedule/share/def456?import=1')
+    expect(onShareData).toHaveBeenCalledTimes(2)
+  })
+
+  it('removes the share param via setSearchParams after claiming the slug', async () => {
+    const fetchMock = makeFetchMock()
+    vi.stubGlobal('fetch', fetchMock)
+    const onShareData = vi.fn()
+    const setSearchParams = vi.fn(updater => updater)
+
+    renderHook(props => useSharedRouteImport(props), {
+      initialProps: {
+        searchParams: makeParams('abc123'),
+        setSearchParams,
+        bands: [BAND_ONE],
+        onShareData,
+      },
+    })
+    await act(async () => {})
+
+    expect(setSearchParams).toHaveBeenCalledTimes(1)
+    const [updater, options] = setSearchParams.mock.calls[0]
+    expect(options).toEqual({ replace: true })
+    const next = updater(new URLSearchParams('?share=abc123&keep=1'))
+    expect(next.get('share')).toBeNull()
+    expect(next.get('keep')).toBe('1')
+  })
+})

--- a/frontend/src/hooks/__tests__/useSharedRouteImport.test.jsx
+++ b/frontend/src/hooks/__tests__/useSharedRouteImport.test.jsx
@@ -115,3 +115,37 @@ describe('useSharedRouteImport', () => {
     expect(next.get('keep')).toBe('1')
   })
 })
+
+// #765 follow-up — the claim was a single ref holding only the most recent
+// slug, so A -> B -> A re-imported A once B had overwritten it. That
+// double-counts share_links.import_count for the funnel step this hook exists
+// to count once, and it is reachable: a fan can open two shared routes and
+// navigate back to the first. A Set keeps every slug claimed for the hook's
+// lifetime.
+describe('useSharedRouteImport — returning to an earlier slug', () => {
+  it('does not re-import slug A after slug B (A -> B -> A)', async () => {
+    const fetchMock = makeFetchMock()
+    vi.stubGlobal('fetch', fetchMock)
+    const onShareData = vi.fn()
+    const setSearchParams = vi.fn()
+    const bands = [BAND_ONE, BAND_TWO]
+
+    const { rerender } = renderHook(props => useSharedRouteImport(props), {
+      initialProps: { searchParams: makeParams('slug-a'), setSearchParams, bands, onShareData },
+    })
+    await act(async () => {})
+
+    await act(async () => {
+      rerender({ searchParams: makeParams('slug-b'), setSearchParams, bands, onShareData })
+    })
+
+    await act(async () => {
+      rerender({ searchParams: makeParams('slug-a'), setSearchParams, bands, onShareData })
+    })
+
+    const importedSlugs = fetchMock.mock.calls.map(([url]) => url)
+    expect(importedSlugs).toHaveLength(2)
+    expect(importedSlugs.filter(u => u.includes('slug-a'))).toHaveLength(1)
+    expect(importedSlugs.filter(u => u.includes('slug-b'))).toHaveLength(1)
+  })
+})

--- a/frontend/src/hooks/useSharedRouteImport.js
+++ b/frontend/src/hooks/useSharedRouteImport.js
@@ -10,15 +10,20 @@ import { useEffect, useRef } from 'react'
 // the same pre-update closure — the claim must happen synchronously, before any
 // async work. The claim is keyed on the slug so a DIFFERENT share link in the
 // same session still imports (#765).
+//
+// A Set, not a single ref: holding only the most recent slug means A -> B -> A
+// re-imports A, because B overwrote the claim. That double-counts the very
+// funnel step this hook exists to count once, and it is reachable — a fan can
+// open two shared routes and navigate back to the first.
 export function useSharedRouteImport({ searchParams, setSearchParams, bands, onShareData }) {
-  const importedShareSlugRef = useRef(null)
+  const importedShareSlugsRef = useRef(new Set())
 
   useEffect(() => {
     const shareSlug = searchParams.get('share')
     if (!shareSlug || bands.length === 0) return
 
-    if (importedShareSlugRef.current === shareSlug) return
-    importedShareSlugRef.current = shareSlug
+    if (importedShareSlugsRef.current.has(shareSlug)) return
+    importedShareSlugsRef.current.add(shareSlug)
 
     setSearchParams(
       prev => {

--- a/frontend/src/hooks/useSharedRouteImport.js
+++ b/frontend/src/hooks/useSharedRouteImport.js
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react'
+
+// Applies a shared route (?share=<slug>) exactly once per slug, in this order
+// of events: claim the slug synchronously, remove the param, then refetch
+// /api/schedule/share/:slug?import=1 and hand the matched bands to onShareData.
+//
+// The ?import=1 refetch counts an import server-side (share_links.import_count,
+// #703), so firing it twice for one slug inflates the funnel. The param removal
+// is an async setSearchParams, which cannot protect two effect runs that share
+// the same pre-update closure — the claim must happen synchronously, before any
+// async work. The claim is keyed on the slug so a DIFFERENT share link in the
+// same session still imports (#765).
+export function useSharedRouteImport({ searchParams, setSearchParams, bands, onShareData }) {
+  const importedShareSlugRef = useRef(null)
+
+  useEffect(() => {
+    const shareSlug = searchParams.get('share')
+    if (!shareSlug || bands.length === 0) return
+
+    if (importedShareSlugRef.current === shareSlug) return
+    importedShareSlugRef.current = shareSlug
+
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev)
+        next.delete('share')
+        return next
+      },
+      { replace: true }
+    )
+
+    fetch(`/api/schedule/share/${encodeURIComponent(shareSlug)}?import=1`)
+      .then(res => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then(data => {
+        const matchedBands = bands.filter(band => {
+          const parts = band.id.split('-')
+          const perfId = Number(parts[parts.length - 1])
+          return data.performance_ids.includes(perfId)
+        })
+        const matchedIds = matchedBands.map(band => band.id)
+        const matchedNames = matchedBands.map(band => band.name || '')
+
+        if (matchedIds.length === 0) return
+
+        onShareData({ matchedIds, matchedNames })
+      })
+      .catch(err => {
+        console.warn('[App] Failed to load share link', err)
+      })
+  }, [bands, searchParams, setSearchParams, onShareData])
+}


### PR DESCRIPTION
## Summary

Closes #765

The `?share=<slug>` import effect in `App.jsx` can fire the `?import=1`
refetch twice for the same slug. The share-param removal is an async
`setSearchParams`, so a second `bands` update that lands before that
removal commits re-runs the effect with the slug still present in the
URL — and fetches `/api/schedule/share/<slug>?import=1` again. Each
`?import=1` refetch increments `share_links.import_count` (#703), so the
re-fire inflates the share funnel.

Today the window is unlikely to matter (the effect runs once, on the
first bands load), but it is latent — a future `bands` reload (refetch,
preview, offline retry) re-runs the effect and double-imports.

Extracted the effect into `useSharedRouteImport` so the claim is
testable, and restored the synchronous per-slug claim that #763 had
reverted: the slug is recorded in a `useRef` **before** any async work,
so a second effect run in the param-removal window is a no-op. The claim
is keyed on the slug, so a *different* share link in the same session
still imports.

## What changed

| File | Change |
|------|--------|
| `frontend/src/App.jsx` | Replaced the inline `?share=` effect with `useSharedRouteImport`, passing a stable `useCallback` data handler. Behavior identical to before. |
| `frontend/src/hooks/useSharedRouteImport.js` | Extracted effect with the synchronous per-slug claim (`importedShareSlugRef`), claimed before the async `setSearchParams` + refetch. |
| `frontend/src/hooks/__tests__/useSharedRouteImport.test.jsx` | 4 tests: no fetch before bands load; exactly-once per slug across a re-render in the removal window; different slug still imports in the same session; param removal via `setSearchParams({ replace: true })`. |

## Security / correctness notes

No new surfaces. The refetch keeps the `?import=1` flag, so share
`view_count` is still not inflated (see `functions/api/schedule/share/[slug].js`).
Data integrity: `import_count` can no longer be double-counted per slug.

## Verification

- [x] Tests: 1035 pass, 0 failures (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors (`npm run lint`, both stacks)
- [x] Format check: clean (`npm run format:check`, both stacks)
- [x] Build: green (`npm run build --prefix frontend`)
- [x] `make gate` exit 0 (format → format-check → lint → test → build, both stacks)
- [x] **Fail-first proof:** disabled the guard (`if (false && …)`), the "exactly once per slug" test failed with `expected "vi.fn()" to be called 1 times, but got 2 times`; restored the guard, all 4 pass.

Regression test targets the exact window the bug describes: `setSearchParams`
is a no-op stub, so the second render keeps the `share` param (removal not
yet committed) and only the guard stops a second fetch. Without the guard
the test fails; with it, the effect stays silent while a *different* slug
still imports.

---
Built by Theo · Reviewed by Sonny + Vera · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing shared performance data from links.
  * Displays imported items in a confirmation dialog before proceeding.
  * Supports importing multiple shared links during the same session.

* **Bug Fixes**
  * Prevents duplicate imports when data loads or updates repeatedly.
  * Handles shared links reliably when bands are still loading.
  * Removes processed sharing parameters from the URL without affecting browser history.
  * Ignores empty or repeated sharing links and reports failed imports appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->