### PR TITLE
fix(a11y): one labelled navigation link per event card

### DIFF
--- a/e2e/accessibility/theme-contrast.spec.js
+++ b/e2e/accessibility/theme-contrast.spec.js
@@ -86,12 +86,15 @@ async function waitForPrivacyBannerSettled(page) {
 }
 
 /** Resolves the seeded upcoming event's slug from the homepage event card —
- * the same [data-testid="event-card"] locator public-timeline.spec.js uses. */
+ * the same [data-testid="event-card"] locator public-timeline.spec.js uses.
+ * Since #700 the card's single navigation link wraps the title heading
+ * (`<a><h3>…</h3></a>`), so target the link by its href instead of assuming
+ * the anchor sits inside the heading (`h3 a` matches nothing now). */
 async function resolveEventSlug(page) {
   await page.goto("/");
   const card = page.locator('[data-testid="event-card"]').first();
   await expect(card).toBeVisible();
-  const href = await card.locator("h3 a").first().getAttribute("href");
+  const href = await card.locator('a[href^="/event/"]:has(h3)').first().getAttribute("href");
   return href ? href.replace(/^\/event\//, "") : null;
 }
 

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -26,34 +26,6 @@ import { Alert, Badge, Button, Card, Loading } from './ui'
 import EventsPageSkeleton from './EventsPageSkeleton'
 
 const POSTER_BOX_CLASS = 'w-28 sm:w-36 shrink-0 self-start overflow-hidden rounded-lg border border-border'
-
-/**
- * Wraps a listing poster so it links to the event, like the title does (#697).
- *
- * The link carries its own accessible name rather than being `aria-hidden`: an
- * interactive element removed from the accessibility tree is an invalid contract,
- * even when it is unfocusable. The image itself stays `alt=""` (decorative — the
- * name lives on the link).
- *
- * `tabIndex={-1}` keeps it out of the tab order, so keyboard users get one stop
- * per card via the title rather than two to the same destination.
- *
- * Renders a plain div when there is no slug, mirroring the title's own
- * `event.slug` guard; otherwise this would link to `/event/undefined`.
- */
-function PosterBox({ slug, name, children }) {
-  if (!slug) return <div className={POSTER_BOX_CLASS}>{children}</div>
-  return (
-    <Link
-      to={`/event/${slug}`}
-      aria-label={name}
-      tabIndex={-1}
-      className={`${POSTER_BOX_CLASS} block transition-opacity hover:opacity-90`}
-    >
-      {children}
-    </Link>
-  )
-}
 import PosterImage from './PosterImage'
 
 /**
@@ -772,104 +744,129 @@ function EventCard({
       {/* Event Header */}
       <div className="p-6">
         <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4 mb-4">
-          <div className="flex flex-1 gap-4 min-w-0">
-            {/* Decorative: alt="" because the card's link text already names
-                the event. Do not make this open a lightbox — that would nest
-                a <button> inside the card's <a>, which is invalid and breaks
-                keyboard nav; the full-size view lives on the event page.
-                `self-start` stops the flex row's default align-items:stretch
-                from stretching this box to the height of the text column
-                beside it — without it, the box was taller than the poster's
-                real aspect ratio and the image (object-contain) letterboxed
-                inside the extra space, reading as "artificially and doubly
-                constrained" (#659 follow-up). No fixed aspect ratio either:
-                production posters range ~0.75-0.80 (3:4 to 4:5), so any
-                single ratio letterboxes most of them — `h-auto` lets the
-                image set its own height and letterboxes none. Trade-off:
-                this gives up the reserved layout space that guarded against
-                CLS; accepted because the image is loading="lazy" and the
-                past-section cards are additionally gated behind a collapsed
-                "Show History" toggle, so neither mounts until near-viewport
-                or explicitly expanded. */}
-            {event.poster_url && (
-              <PosterBox slug={event.slug} name={event.name}>
-                <PosterImage
-                  src={event.poster_url}
-                  width={200}
-                  alt=""
-                  loading="lazy"
-                  decoding="async"
-                  /* aspect-[auto_3/4] is the TWO-VALUE aspect-ratio syntax:
-                     reserve a 3:4 box while the lazy image has no intrinsic
-                     dimensions, then let the real ratio take over once it
-                     loads. This is NOT the fixed-ratio box that caused
-                     letterboxing — that was a stretched container plus
-                     object-contain, which pinned the wrong ratio permanently.
-                     Nothing letterboxes after load here, and the reserved box
-                     stops expanding History from cascading layout shifts. */
-                  className="aspect-[auto_3/4] h-auto w-full"
-                />
-              </PosterBox>
-            )}
-            <div className="flex-1 min-w-0">
-              <div className="flex flex-wrap items-start gap-2 mb-2">
-                {event.slug ? (
-                  <h3 className="text-2xl font-bold text-accent-500 flex-1">
-                    <Link
-                      to={`/event/${event.slug}`}
-                      className="hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500/70 rounded-xs"
-                    >
-                      {event.name}
-                    </Link>
-                  </h3>
-                ) : (
-                  <h3 className="text-2xl font-bold text-accent-500 flex-1">{event.name}</h3>
-                )}
-                {isLive && (
-                  <Badge variant="error" size="md">
-                    LIVE NOW
-                  </Badge>
-                )}
-                {event.status === 'archived' && (
-                  <Badge variant="default" size="md">
-                    <Archive size={12} className="mr-1" aria-hidden="true" />
-                    Archived
-                  </Badge>
-                )}
-              </div>
+          {/* Poster + title are ONE link (#700): the listing card exposes a
+              single labelled navigation link to the event. Previously the
+              poster was its own aria-labelled link with tabIndex={-1} beside
+              the title link (#697), so a screen reader in browse mode
+              announced the event name twice per card. Wrapping both in one
+              <a> fixes the duplication: the poster image stays alt=""
+              (decorative — the name lives on the title text inside the link).
+              The badges/date/stats are SIBLINGS of the link, never children —
+              anything inside it joins its accessible name, so a "LIVE NOW"
+              badge must not extend the name to "Vol. 18 LIVE NOW". A
+              card-spanning stretched link was rejected (#699): the card nests
+              band-profile links and the ticket button, and an anchor cannot
+              wrap anchors. */}
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-wrap items-start gap-2 mb-2">
+              {event.slug ? (
+                <Link
+                  to={`/event/${event.slug}`}
+                  className="flex items-start gap-4 min-w-0 flex-1 rounded-xs hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500/70"
+                >
+                  {event.poster_url && (
+                    /* Decorative: alt="" because the link's title text already
+                        names the event. Do not make this open a lightbox — that
+                        would nest a <button> inside the card's <a>, which is
+                        invalid and breaks keyboard nav; the full-size view
+                        lives on the event page. `self-start` (via
+                        POSTER_BOX_CLASS) stops the flex row's default
+                        align-items:stretch from stretching this box to the
+                        height of the title beside it — without it, the box was
+                        taller than the poster's real aspect ratio and the image
+                        (object-contain) letterboxed inside the extra space,
+                        reading as "artificially and doubly constrained" (#659
+                        follow-up). No fixed aspect ratio either: production
+                        posters range ~0.75-0.80 (3:4 to 4:5), so any single
+                        ratio letterboxes most of them — `h-auto` lets the image
+                        set its own height and letterboxes none. Trade-off: this
+                        gives up the reserved layout space that guarded against
+                        CLS; accepted because the image is loading="lazy" and
+                        the past-section cards are additionally gated behind a
+                        collapsed "Show History" toggle, so neither mounts until
+                        near-viewport or explicitly expanded. */
+                    <div className={POSTER_BOX_CLASS}>
+                      <PosterImage
+                        src={event.poster_url}
+                        width={200}
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        /* aspect-[auto_3/4] is the TWO-VALUE aspect-ratio syntax:
+                           reserve a 3:4 box while the lazy image has no intrinsic
+                           dimensions, then let the real ratio take over once it
+                           loads. This is NOT the fixed-ratio box that caused
+                           letterboxing — that was a stretched container plus
+                           object-contain, which pinned the wrong ratio permanently.
+                           Nothing letterboxes after load here, and the reserved box
+                           stops expanding History from cascading layout shifts. */
+                        className="aspect-[auto_3/4] h-auto w-full"
+                      />
+                    </div>
+                  )}
+                  <h3 className="text-2xl font-bold text-accent-500 flex-1 min-w-0">{event.name}</h3>
+                </Link>
+              ) : (
+                <div className="flex items-start gap-4 min-w-0 flex-1">
+                  {event.poster_url && (
+                    <div className={POSTER_BOX_CLASS}>
+                      <PosterImage
+                        src={event.poster_url}
+                        width={200}
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        className="aspect-[auto_3/4] h-auto w-full"
+                      />
+                    </div>
+                  )}
+                  <h3 className="text-2xl font-bold text-accent-500 flex-1 min-w-0">{event.name}</h3>
+                </div>
+              )}
+              {isLive && (
+                <Badge variant="error" size="md">
+                  LIVE NOW
+                </Badge>
+              )}
+              {event.status === 'archived' && (
+                <Badge variant="default" size="md">
+                  <Archive size={12} className="mr-1" aria-hidden="true" />
+                  Archived
+                </Badge>
+              )}
+            </div>
 
-              <p className="text-text-secondary text-sm mb-4 flex items-center gap-2">
-                <CalendarDays size={12} />
-                {formatDate(event.date)}
-              </p>
+            <p className="text-text-secondary text-sm mb-4 flex items-center gap-2">
+              <CalendarDays size={12} />
+              {formatDate(event.date)}
+            </p>
 
-              {/* Event Stats */}
-              <div className="flex flex-wrap gap-6 text-sm">
-                {allBandCount > 0 ? (
-                  <div className="flex items-center gap-2">
-                    <span className="font-bold text-text-primary">{allBandCount}</span>
-                    <span className="text-text-tertiary">{allBandCount === 1 ? 'Band' : 'Bands'}</span>
-                  </div>
-                ) : (
-                  // A future event with an empty lineup isn't missing data —
-                  // it just hasn't been booked yet, so say so instead of
-                  // showing "0 Bands" (which reads as broken). A CONCLUDED
-                  // event with zero bands is a different situation: there's
-                  // no lineup still coming, just a historical gap (same as
-                  // the "0 Venues" case below), so "Lineup TBA" would be
-                  // nonsense there — omit the stat entirely instead.
-                  !isPast && <span className="text-text-tertiary">Lineup TBA</span>
-                )}
-                {/* Historical volumes have roster-only lineups with no venue
+            {/* Event Stats */}
+            <div className="flex flex-wrap gap-6 text-sm">
+              {allBandCount > 0 ? (
+                <div className="flex items-center gap-2">
+                  <span className="font-bold text-text-primary">{allBandCount}</span>
+                  <span className="text-text-tertiary">{allBandCount === 1 ? 'Band' : 'Bands'}</span>
+                </div>
+              ) : (
+                // A future event with an empty lineup isn't missing data —
+                // it just hasn't been booked yet, so say so instead of
+                // showing "0 Bands" (which reads as broken). A CONCLUDED
+                // event with zero bands is a different situation: there's
+                // no lineup still coming, just a historical gap (same as
+                // the "0 Venues" case below), so "Lineup TBA" would be
+                // nonsense there — omit the stat entirely instead.
+                !isPast && <span className="text-text-tertiary">Lineup TBA</span>
+              )}
+              {/* Historical volumes have roster-only lineups with no venue
                   assignments — "0 Venues" reads as missing data, so omit the
                   stat entirely rather than showing a zero. */}
-                {allVenueCount > 0 && (
-                  <div className="flex items-center gap-2">
-                    <span className="font-bold text-text-primary">{allVenueCount}</span>
-                    <span className="text-text-tertiary">{allVenueCount === 1 ? 'Venue' : 'Venues'}</span>
-                  </div>
-                )}
-              </div>
+              {allVenueCount > 0 && (
+                <div className="flex items-center gap-2">
+                  <span className="font-bold text-text-primary">{allVenueCount}</span>
+                  <span className="text-text-tertiary">{allVenueCount === 1 ? 'Venue' : 'Venues'}</span>
+                </div>
+              )}
             </div>
           </div>
 

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -730,24 +730,46 @@ describe('EventTimeline past-section poster lazy mounting (#658)', () => {
       expect(img).toHaveAttribute('alt', '')
     })
 
-    // #697: each poster links to its event, like the title does. The link must
-    // carry its own accessible name — never be aria-hidden, which would be an
-    // interactive element removed from the accessibility tree — and must stay
-    // out of the tab order so keyboard users get one stop per card, not two.
-    const names = ['Past Fest One', 'Past Fest Two', 'Past Fest Three']
+    // #700: poster and title are ONE labelled navigation link per card.
+    // Previously the poster was a second, aria-labelled link with
+    // tabindex="-1" beside the title link (#697), so a screen reader in
+    // browse mode announced the event name twice per card. The poster img
+    // must sit inside that single link; the link must carry no separate
+    // aria-label (the accessible name comes from the title text inside it)
+    // and no tabindex hack (it is the card's real, focusable link — one tab
+    // stop). aria-hidden on the link stays forbidden: that would remove an
+    // interactive element from the accessibility tree.
     posterImgs.forEach((img, i) => {
       const link = img.closest('a')
       expect(link).not.toBeNull()
       expect(link).toHaveAttribute('href', `/event/past-fest-${['one', 'two', 'three'][i]}`)
       expect(link).not.toHaveAttribute('aria-hidden')
-      expect(link).toHaveAttribute('aria-label', names[i])
-      expect(link).toHaveAttribute('tabindex', '-1')
+      expect(link).not.toHaveAttribute('aria-label')
+      expect(link).not.toHaveAttribute('tabindex')
     })
+
+    // Exactly one link TO the event named by the event itself per card — the
+    // poster+title link. The card also carries a "View Lineup"/"Build Your
+    // Schedule" primary CTA that navigates to the same page, but that button
+    // is labelled by its action, not by the event name, so it must not be
+    // counted here; the event name is announced as a link exactly once.
+    ;[
+      ['Past Fest One', 'past-fest-one'],
+      ['Past Fest Two', 'past-fest-two'],
+      ['Past Fest Three', 'past-fest-three'],
+    ].forEach(([name, slug]) => {
+      const nameLinks = [...container.querySelectorAll(`a[href="/event/${slug}"]`)].filter(a =>
+        a.textContent.includes(name)
+      )
+      expect(nameLinks).toHaveLength(1)
+    })
+    expect(screen.getAllByRole('link', { name: 'Past Fest One' })).toHaveLength(1)
   })
 
-  it('raises no axe violation for the labelled poster link', async () => {
-    // Guards the accessibility contract: a labelled, unfocusable link. Catches
-    // both a regression to aria-hidden-on-interactive and an unlabelled link.
+  it('raises no axe violation for the single event link', async () => {
+    // Guards the accessibility contract (#700): one labelled navigation link
+    // per card whose accessible name comes from visible text. Catches both a
+    // regression to aria-hidden-on-interactive and an unlabelled link.
     const { axe, toHaveNoViolations } = await import('jest-axe')
     expect.extend(toHaveNoViolations)
 


### PR DESCRIPTION
## Summary

Each event listing card exposed **two** links to the event — the title link and a second poster link carrying its own `aria-label` with `tabIndex={-1}` (#697) — so a screen reader in browse mode announced the event name **twice per card**. This PR folds the poster into the title link: one labelled navigation link per card whose accessible name comes from the title text (poster stays `alt=""`), with one keyboard tab stop.

Closes #700

## What changed

| File | Change |
|------|--------|
| `frontend/src/components/EventTimeline.jsx` | Remove the `PosterBox` link wrapper; wrap poster + title in a single `<Link>` (poster is a sibling of the title text *inside* the link — both clickable). Badges/date/stats stay siblings of the link so `LIVE NOW` cannot extend the accessible name to "Vol. 18 LIVE NOW". No-slug events keep a plain non-link layout. Also fixed a latent parse break: the poster-conditional's long comment ended `*/}` — the `}` closed the JSX expression early and left the `(` dangling. |
| `frontend/src/components/__tests__/EventTimeline.test.jsx` | Rewrite the #697 poster-link assertions to the #700 one-link contract; assert the event name is announced as a link exactly once. |

## Security / correctness notes

None — presentation-only a11y change, no data or auth surface. The "View Lineup"/"Build Your Schedule" CTA remains a separate link to the same page, but it is labelled by its action, not by the event name, so it does not duplicate the name announcement.

## Verification

- [x] Tests: 1031 pass, 0 failures (`cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`cd frontend && npm run format:check`)
- [x] Build: green (`npm run build --prefix frontend`)
- [x] `make gate`: exit 0
- [x] Manual smoke: N/A (covered by the axe test — `jest-axe` raises no violation for the single event link)

Fail-first proof: the updated test was run against the pre-fix component and failed (poster link still carried `aria-label`/`tabindex`), before the component change landed.

---
Built by Theo · Reviewed by Sonny + Vera · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Combined event posters and titles into a single, clearly labelled link for easier keyboard navigation.
  * Improved screen-reader support while keeping poster images decorative and lazy-loaded.
  * Added accessibility validation for event cards.

* **Bug Fixes**
  * Improved event statistics display, including lineup, past-event, and venue-count handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->