### PR TITLE
fix(ui): give the unselected BandCard name pill a visible surface (#729)

### DIFF
--- a/frontend/src/__tests__/themeTokens.test.js
+++ b/frontend/src/__tests__/themeTokens.test.js
@@ -276,6 +276,41 @@ describe('theme token contrast (WCAG AA, 4.5:1)', () => {
       ).toBeGreaterThanOrEqual(MIN_CONTRAST)
     })
 
+    // BandCard's artist-name pill (#729). It carries `bg-surface`, which is
+    // rgba with 4-5% alpha in every theme — so it barely tints the card and
+    // the text effectively reads against gradient-card itself. #729 asked for
+    // this check explicitly because BandCard has already shipped one WCAG
+    // failure (#720, the selected-card gradient at 2.3:1), and nothing else
+    // covers the pairing: BandCard.test.jsx asserts the CLASSES are
+    // `bg-surface border-border`, which says nothing about whether the result
+    // is readable. Both gradient-card stops are checked and the worse ratio
+    // asserted, since the pill sits anywhere along the card.
+    it('BandCard name-pill text clears 4.5:1 against bg-surface composited over gradient-card', () => {
+      const surfaceRaw = resolveHex('--color-surface', theme)
+      const surfaceMatch = /rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\s*\)/.exec(surfaceRaw)
+      expect(surfaceMatch, `[${theme}] could not parse --color-surface: ${surfaceRaw}`).toBeTruthy()
+      const surfaceHex = rgbToHex([Number(surfaceMatch[1]), Number(surfaceMatch[2]), Number(surfaceMatch[3])])
+      const surfaceAlphaPercent = (surfaceMatch[4] === undefined ? 1 : Number(surfaceMatch[4])) * 100
+
+      const textColor = resolveHex('--color-text-primary', theme)
+      const cardStops = resolveGradientCardStops(theme)
+
+      const results = [cardStops.start, cardStops.end].map(stop => {
+        const cardBg = compositeCardStopOverPage(stop, bgNavy)
+        const pillBg = blend(surfaceHex, cardBg, surfaceAlphaPercent)
+        return { cardBg, pillBg, ratio: contrastRatio(textColor, pillBg) }
+      })
+      const worst = results[0].ratio <= results[1].ratio ? results[0] : results[1]
+
+      expect(
+        worst.ratio,
+        `[${theme}] BandCard name-pill text (--color-text-primary=${textColor}) against its composited pill ` +
+          `background (--color-surface=${surfaceRaw} over the gradient-card stop composited over ` +
+          `--color-bg-navy=${bgNavy} => ${worst.cardBg} => ${worst.pillBg}) computes to ` +
+          `${worst.ratio.toFixed(2)}:1, below the ${MIN_CONTRAST}:1 WCAG AA floor`
+      ).toBeGreaterThanOrEqual(MIN_CONTRAST)
+    })
+
     // Bonus guard: accent-500 is the token gradient-accent's stops are meant
     // to match (VenueStrip and BandCard both use it directly against
     // bg-navy/bg-purple) — same bug class, cheap to also pin down here.

--- a/frontend/src/components/BandCard.jsx
+++ b/frontend/src/components/BandCard.jsx
@@ -94,7 +94,12 @@ function BandCard({
             Starts in {minutesUntil}m · {formatTime(band.startTime)}
           </span>
         )}
-        <div className={`inline-block px-3 py-1.5 rounded-lg mb-1 ${onAmber ? 'bg-bg-navy/15' : 'bg-bg-navy/60'}`}>
+        {/* Visible pill on the unselected card (#729): bg-bg-navy/60 blended
+            into the card's own gradient, so the name-to-genre gap read as
+            unexplained whitespace. Same pairing as the genre chip's. */}
+        <div
+          className={`inline-block px-3 py-1.5 rounded-lg mb-1 ${onAmber ? 'bg-bg-navy/15' : 'bg-surface border border-border'}`}
+        >
           {band.name ? (
             <Link
               to={bandProfileHref}

--- a/frontend/src/components/__tests__/BandCard.test.jsx
+++ b/frontend/src/components/__tests__/BandCard.test.jsx
@@ -63,6 +63,32 @@ describe('BandCard — genre chip', () => {
   })
 })
 
+// Root-cause regression guard for #729: the pill behind the artist name uses a
+// navy tint that blends into the card's own dark gradient when the card is
+// unselected (`bg-bg-navy/60` on `bg-gradient-card`), so the name-to-genre gap
+// reads as unexplained whitespace there while the identical geometry on a
+// selected (amber) card reads as deliberate padding around a visible pill.
+// The unselected pill now carries the same visible surface the genre chip
+// already uses (Option 1 in #729); the amber state keeps its faint navy tint.
+describe('BandCard — name pill (#729)', () => {
+  it('gives the unselected name pill a visible surface', () => {
+    const { container } = renderCard({})
+
+    const pill = container.querySelector('div.inline-block')
+    expect(pill.className).toMatch(/bg-surface/)
+    expect(pill.className).toMatch(/border-border/)
+    expect(pill.className).not.toMatch(/bg-bg-navy\/60/)
+  })
+
+  it('keeps the navy-tinted pill on the amber card', () => {
+    const { container } = renderCard({ isSelected: true })
+
+    const pill = container.querySelector('div.inline-block')
+    expect(pill.className).toMatch(/bg-bg-navy\/15/)
+    expect(pill.className).not.toMatch(/bg-surface/)
+  })
+})
+
 // #726 regression tests. The card container must never be a focusable
 // interactive target: it wraps a real <button> (corner add/remove) and an <a>
 // (profile link), so it cannot itself be a <button> (nested interactive


### PR DESCRIPTION
## Summary

Fixes #729 (Option 1, the issue's recommended answer): the pill behind the artist name on an **unselected** BandCard used `bg-bg-navy/60` — a navy tint that blends into the card's own `bg-gradient-card`, so the name-to-genre gap read as unexplained whitespace while the identical geometry on a selected (amber) card read as deliberate padding around a visible pill. The unselected pill now uses `bg-surface border border-border` — the same pairing the genre chip already uses in its non-amber state — so both states read consistently. The amber state is untouched.

Closes #729

## What changed

| File | Change |
|------|--------|
| `frontend/src/components/BandCard.jsx` | Unselected name pill: `bg-bg-navy/60` → `bg-surface border border-border` (amber state unchanged) |
| `frontend/src/components/__tests__/BandCard.test.jsx` | New "name pill (#729)" describe: unselected pill has a visible surface; amber pill keeps its navy tint |

## Security / correctness notes

None. Class-only change; no markup, roles, aria-labels, or behaviour touched (the #726/#845 a11y structure is untouched). Classes remain complete literals, so the theme-token source scans are unaffected.

## Verification

- [x] Tests: 1141 backend + 1038 frontend pass, 0 failures (`make gate`)
- [x] ESLint: 0 errors (2 pre-existing warnings, unchanged from main)
- [x] Format check: clean (both stacks)
- [x] Build: green (`make gate` exit 0)
- [x] `validate:openapi`: no drift (no API change)
- [x] Manual smoke: `npm run pages:dev` + real browser on the Future Fest E2E lineup. Confirmed per-theme computed styles of the unselected pill (midnight-ember, daybreak, silver-lining; arctic-night shares identical surface/border token values with midnight-ember): `bg-surface`/`border-border` resolve to each theme's declared surface/border values — no hardcoded colours; selected card keeps `bg-bg-navy/15`. Contrast of `text-text-primary` against the composited pill background (surface over gradient-card over page bg, same math as `themeTokens.test.js`) verified for all four themes: worst case **13.85:1** on daybreak, far above the 4.5:1 AA floor (issue's contrast note).
- [x] New test proven to FAIL before the fix: `AssertionError: expected 'inline-block px-3 py-1.5 rounded-lg mb-1 bg-bg-navy/60' to match /bg-surface/` — fails against main, passes with the fix.

---
Built by OpenCode · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated unselected band cards with a lighter surface background and visible border for improved readability.
  * Preserved the existing navy-tinted styling for selected or playing cards.

* **Tests**
  * Added regression coverage to verify card appearance, selected-card styling, and accessible text contrast across themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->