### PR TITLE
refactor(ui): refcount the body-scroll lock across stacked overlays (#657)

### DIFF
--- a/frontend/src/components/ui/ImageLightbox.jsx
+++ b/frontend/src/components/ui/ImageLightbox.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { X } from 'lucide-react'
 import PosterImage from '../PosterImage'
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock'
 
 /**
  * ImageLightbox — full-viewport click-to-enlarge image viewer (#655).
@@ -15,10 +16,13 @@ import PosterImage from '../PosterImage'
  * row (it's `position: fixed` but rendered *inside* the `role="dialog"` div
  * below, so it stays reachable by the focus trap and by assistive tech,
  * which treats everything outside that element as inert under
- * aria-modal="true"). The focus-trap / ESC / scroll-lock behavior below
- * mirrors the pattern already duplicated in Modal.jsx and ConfirmDialog.jsx
- * — there is no shared hook in this codebase to extend, so this follows the
- * same proven approach rather than introducing a third, different one.
+ * aria-modal="true"). The focus-trap / ESC behavior below
+ * mirrors the pattern duplicated in Modal.jsx and ConfirmDialog.jsx — there is
+ * no shared focus-trap hook in this codebase to extend, so this follows the
+ * same proven approach rather than introducing a third, different one. The
+ * scroll lock is NOT part of that duplication: it goes through the shared
+ * useBodyScrollLock() hook (#657) like Modal, so stacked overlays share one
+ * refcount and the lock survives until the last overlay closes.
  *
  * The close button uses `text-white` deliberately — it sits over a fixed
  * dark scrim (bg-black/90), one of the documented theme-token exceptions
@@ -96,18 +100,11 @@ export default function ImageLightbox({ src, alt, isOpen, onClose, width = 1600 
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [isOpen, handleKeyDown])
 
-  // Lock body scroll while open. The cleanup always restores it, even if the
-  // component unmounts while still open, so an unmount-while-open can never
-  // leave the page stuck unscrollable.
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden'
-    }
-
-    return () => {
-      document.body.style.overflow = ''
-    }
-  }, [isOpen])
+  // Lock body scroll while open. The shared hook refcounts across stacked
+  // overlays (#657): the cleanup must not release the lock while a modal below
+  // is still open, and unmounting while open must never leave the page stuck
+  // unscrollable — both are properties of the refcount, not this component.
+  useBodyScrollLock(isOpen)
 
   const handleBackdropClick = e => {
     if (e.target === e.currentTarget) {

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { X } from 'lucide-react'
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock'
 
 /**
  * Modal Component - Design System v2.0
@@ -139,18 +140,10 @@ export default function Modal({
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [isOpen, handleKeyDown])
 
-  // Lock body scroll when modal is open
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = ''
-    }
-
-    return () => {
-      document.body.style.overflow = ''
-    }
-  }, [isOpen])
+  // Lock body scroll while open. The shared hook refcounts across stacked
+  // overlays (#657): closing THIS modal must not unlock the page while a
+  // lightbox or another overlay is still open above it.
+  useBodyScrollLock(isOpen)
 
   // Handle backdrop click
   const handleBackdropClick = e => {

--- a/frontend/src/hooks/__tests__/useBodyScrollLock.test.jsx
+++ b/frontend/src/hooks/__tests__/useBodyScrollLock.test.jsx
@@ -1,0 +1,93 @@
+import { act, render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useBodyScrollLock } from '../useBodyScrollLock'
+
+// Regression suite for #657. The defect class: Modal.jsx and ImageLightbox.jsx
+// each wrote document.body.style.overflow directly, and each cleanup reset it
+// unconditionally — so with two overlays stacked, closing the TOP one released
+// the lock while the one below was still open. A shared refcount can only be
+// proven by nesting, which is why every test here drives TWO consumers (as the
+// real components do when a lightbox opens over a modal).
+function Harness({ locked }) {
+  useBodyScrollLock(locked)
+  return null
+}
+
+function mountLocked() {
+  return render(<Harness locked={true} />)
+}
+
+describe('useBodyScrollLock', () => {
+  it('locks body scroll while locked and restores it when unlocked', () => {
+    const first = mountLocked()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    act(() => first.rerender(<Harness locked={false} />))
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('does not touch body scroll when never locked', () => {
+    render(<Harness locked={false} />)
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('keeps the lock until the LAST overlay closes, regardless of close order', () => {
+    // The modal opens first, the lightbox opens on top of it.
+    const modal = mountLocked()
+    const lightbox = mountLocked()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    // Topmost overlay closes — the modal below is STILL open, so the page must
+    // stay locked. This is the exact #657 failure: the lightbox's old cleanup
+    // reset overflow to '' here while the modal was still open.
+    act(() => lightbox.rerender(<Harness locked={false} />))
+    expect(document.body.style.overflow).toBe('hidden')
+
+    // The last overlay closes — only now does the lock release.
+    act(() => modal.rerender(<Harness locked={false} />))
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('keeps the lock when the CLOSER releases, regardless of which overlay closes first', () => {
+    const modal = mountLocked()
+    const lightbox = mountLocked()
+
+    act(() => modal.rerender(<Harness locked={false} />))
+    expect(document.body.style.overflow).toBe('hidden')
+
+    act(() => lightbox.rerender(<Harness locked={false} />))
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('keeps the lock if the top overlay unmounts while open, until the other closes', () => {
+    const modal = mountLocked()
+    const lightbox = mountLocked()
+
+    act(() => lightbox.unmount())
+    expect(document.body.style.overflow).toBe('hidden')
+
+    act(() => modal.unmount())
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('preserves a pre-existing overflow value rather than assuming empty', () => {
+    // A future global style could set something else; the hook must restore
+    // the exact prior value (issue note).
+    document.body.style.overflow = 'scroll'
+    const overlay = mountLocked()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    act(() => overlay.unmount())
+    expect(document.body.style.overflow).toBe('scroll')
+    document.body.style.overflow = ''
+  })
+
+  it('re-locks cleanly after a full lock/unlock cycle', () => {
+    const overlay = mountLocked()
+    act(() => overlay.rerender(<Harness locked={false} />))
+    expect(document.body.style.overflow).toBe('')
+
+    act(() => overlay.rerender(<Harness locked={true} />))
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+})

--- a/frontend/src/hooks/useBodyScrollLock.js
+++ b/frontend/src/hooks/useBodyScrollLock.js
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+
+// Module-level refcount shared by EVERY overlay in the app (Modal,
+// ImageLightbox, …). Overlays stack: a lightbox can open over a modal, and a
+// later drawer over both. Before #657 each component wrote
+// document.body.style.overflow directly and each cleanup restored it
+// unconditionally — closing the TOP overlay released the lock while the one
+// below was still open, and the page scrolled again behind a live modal.
+//
+// The count lives at module scope rather than in component state so that
+// independent consumers share it; the FIRST lock captures the pre-existing
+// overflow value and the LAST unlock restores exactly that value — not an
+// assumed '' — so a future global style survives an overlay cycle.
+let lockCount = 0
+let previousOverflow = null
+
+export function useBodyScrollLock(isLocked) {
+  useEffect(() => {
+    if (!isLocked) return
+
+    if (lockCount === 0) {
+      previousOverflow = document.body.style.overflow
+      document.body.style.overflow = 'hidden'
+    }
+    lockCount += 1
+
+    return () => {
+      lockCount -= 1
+      if (lockCount === 0) {
+        document.body.style.overflow = previousOverflow
+        previousOverflow = null
+      }
+    }
+  }, [isLocked])
+}


### PR DESCRIPTION
Closes #657

## Summary

Fixes the early body-scroll release when overlays stack: opening a second
overlay on top of an open one (e.g. an ImageLightbox over a Modal) used to
release the page lock when the top overlay closed or the underlying one
re-locked, leaving the page scrollable behind a still-open overlay.

Extracts the scroll lock into a shared `useBodyScrollLock` hook that
refcounts at module level and restores the *original* overflow value on the
final unlock, then wires Modal and ImageLightbox to it.

## Why this approach

- `useBodyScrollLock(isOpen)` — module-level refcount: the first lock
  captures the prior overflow, the last unlock restores exactly that value
  (not an assumed `''`).
- Nested-close ordering (child closes before parent) and unmount-while-open
  are both properties of the refcount, so a naive "always restore in
  cleanup" implementation fails them — proven by a mutation-tested suite.

## Changes

- `frontend/src/hooks/useBodyScrollLock.js` — new shared hook
- `frontend/src/components/ui/Modal.jsx` — use the hook instead of a local
  `useEffect`
- `frontend/src/components/ui/ImageLightbox.jsx` — same, comment updated
- `frontend/src/hooks/__tests__/useBodyScrollLock.test.jsx` — new tests

## Not changed (deliberately)

- `ConfirmDialog.jsx` — it has no scroll lock today (focus trap + ESC
  only), so it cannot participate in the early-release bug; wiring it would
  be a behavior change, not a refactor.
- Focus-trap/ESC triplication across Modal/ConfirmDialog/ImageLightbox is
  left alone — the issue marks it "worth doing" but it is not required, and
  unifying three subtly different implementations is a11y-risk.
- `eslint.config.js` — untouched (hook-protected).

## Verification

- `make gate` exit 0 (format, lint, 1141 backend tests, 1049 frontend
  tests, production build).
- Regression suite: `useBodyScrollLock.test.jsx` — 7 tests driving two
  harness consumers. Mutation check: with a per-instance unconditional
  restore (the old Modal.jsx logic), exactly the 4 defect-encoding tests
  fail (nested-close ordering ×3 + preserve-value) while the 3
  single-overlay tests pass; with the real hook, 7/7 pass.
- Existing `ImageLightbox.test.jsx` scroll-lock tests pass unchanged.

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scrolling behaviour when multiple overlays, modals, or image lightboxes are open.
  - Prevented one overlay from re-enabling page scrolling while another remains open.
  - Restored the page’s original scrolling state after all overlays close.

- **Tests**
  - Added coverage for nested overlays, cleanup, inactive locks, and repeated open-and-close cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->