### PR TITLE
docs(agents): add the two rules that prevent multi-agent collisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,39 @@ Say *"the container must be reachable and announced"*, not *"make it a button"*.
 pass", and "confirm the new test FAILS against current code before calling it
 done". That last line is the one that keeps catching real defects.
 
+### Running more than one agent at once
+
+Concurrency is normal here — a delegate and the orchestrator often work the
+same repository at the same time. Two rules prevent the collisions that have
+actually happened, and they matter more than isolation does:
+
+1. **Create your own branch before your first commit, and only ever commit to a
+   branch you created.** On 2026-08-14 a delegate committed onto whatever branch
+   happened to be checked out — which belonged to another agent — and that
+   agent's next `git add -u` swept the delegate's half-finished files into an
+   unrelated docs PR. Six CI checks failed on a one-file Markdown change. Never
+   commit without first confirming `git branch --show-current` is yours.
+
+2. **Never bare `git stash` or `git stash pop`.** The stash stack is shared
+   across every worktree of a repository — a fresh worktree here immediately
+   listed seven entries belonging to other sessions. Popping takes whichever is
+   on top, which may be someone else's uncommitted work. Use
+   `git stash push -u -m "<unique-tag>"`, capture the SHA from
+   `git stash list --format='%H %gs'`, restore with `git stash apply <sha>`, and
+   drop that entry by tag afterwards.
+
+**Worktrees help but do not solve this.** They isolate the filesystem, so a
+mid-edit file cannot be swept into someone else's commit — worth using. They do
+*not* isolate refs (branches, force-pushes, deletions) or the stash, which is how
+the incident above actually happened. A worktree also starts without
+`node_modules` or `.dev.vars`, so `make gate` cannot run until you install both
+(about two minutes) and copy the env file.
+
+**The strongest protection is the brief itself:** give each concurrent task a
+disjoint set of files, and tell it to STOP if it finds itself editing a file
+assigned to another task. Four PRs ran in parallel that way with zero conflicts;
+the one collision came from a task with no file boundary.
+
 ## LSP — prefer it over grep for symbol navigation
 
 Both harnesses navigate by LSP. Two **dependencies** must be installed, and separately each

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ done". That last line is the one that keeps catching real defects.
 
 ### Running more than one agent at once
 
-Concurrency is normal here — a delegate and the orchestrator often work the
+Concurrency is normal here — a delegate and the orchestrator often work in the
 same repository at the same time. Two rules prevent the collisions that have
 actually happened, and they matter more than isolation does:
 
@@ -152,23 +152,33 @@ actually happened, and they matter more than isolation does:
    branch you created.** On 2026-08-14 a delegate committed onto whatever branch
    happened to be checked out — which belonged to another agent — and that
    agent's next `git add -u` swept the delegate's half-finished files into an
-   unrelated docs PR. Six CI checks failed on a one-file Markdown change. Never
-   commit without first confirming `git branch --show-current` is yours.
+   unrelated docs PR. Six CI checks failed on a one-file Markdown change.
+   `git branch --show-current` reports a name, not ownership, so check it
+   against the branch your brief assigned before staging anything —
+   `test "$(git branch --show-current)" = "<branch-from-brief>"` — and stop if
+   that fails instead of committing wherever you happen to be.
 
 2. **Never bare `git stash` or `git stash pop`.** The stash stack is shared
    across every worktree of a repository — a fresh worktree here immediately
    listed seven entries belonging to other sessions. Popping takes whichever is
    on top, which may be someone else's uncommitted work. Use
    `git stash push -u -m "<unique-tag>"`, capture the SHA from
-   `git stash list --format='%H %gs'`, restore with `git stash apply <sha>`, and
-   drop that entry by tag afterwards.
+   `git stash list --format='%H %gs'`, and restore with
+   `git stash apply <sha>`. To clean up, re-resolve the index from your tag —
+   `git stash list --format='%gd %gs' | grep <unique-tag>` — and drop that
+   `stash@{n}`. Verified 2026-08-14: `apply` accepts a raw SHA but `drop` does
+   **not** (`error: '<sha>' is not a stash reference`), and indices shift when
+   another agent pushes a stash, so `stash@{0}` is never safe to assume.
 
 **Worktrees help but do not solve this.** They isolate the filesystem, so a
 mid-edit file cannot be swept into someone else's commit — worth using. They do
 *not* isolate refs (branches, force-pushes, deletions) or the stash, which is how
-the incident above actually happened. A worktree also starts without
-`node_modules` or `.dev.vars`, so `make gate` cannot run until you install both
-(about two minutes) and copy the env file.
+the incident above actually happened. A worktree also starts empty of
+`node_modules`, so `make gate` cannot run until you `npm install` at the root
+and in `frontend/` — about two minutes. It also starts without `.dev.vars`;
+that file is *not* a `make gate` prerequisite (this section was written and
+gated from a worktree that never had one), but copy it across before anything
+that needs a live wrangler server, such as `make e2e`.
 
 **The strongest protection is the brief itself:** give each concurrent task a
 disjoint set of files, and tell it to STOP if it finds itself editing a file


### PR DESCRIPTION
## Summary

Concurrency is normal in this repo — a delegate and the orchestrator routinely work it at the same time — and the brief template said nothing about it. That gap cost **six red CI checks on a one-file Markdown PR** today (#855).

## What actually happened

A delegate committed onto whatever branch happened to be checked out, which belonged to another agent. That agent's next `git add -u` swept the delegate's half-finished `Modal.jsx` / `ImageLightbox.jsx` edits into an unrelated docs commit. The delegate's own branch was left empty, missing the hook file it had written.

Nothing in the tooling caught it. The PR just went red on six checks that had no relationship to its one-line change.

## The two rules added

**1. Create your own branch before your first commit, and only commit to a branch you created.** Confirm `git branch --show-current` is yours before committing. This is the exact rule that was broken.

**2. Never bare `git stash` / `git stash pop`.** The stash stack is shared across every worktree — a freshly created worktree here immediately listed **seven** entries belonging to other sessions. Popping takes whichever is on top, which may be someone else's uncommitted work. Use `git stash push -u -m "<tag>"`, capture the SHA, `apply <sha>`, drop by tag.

## Why "just use worktrees" is only half an answer

Recorded in the doc, because it's the obvious response and it's incomplete:

| worktrees isolate | worktrees do **not** isolate |
|---|---|
| the filesystem — a mid-edit file can't be swept into another commit | refs: branches, force-pushes, deletions |
| | the stash stack (verified: 7 shared entries) |

Today's collision was a **ref** problem, so a worktree would not have prevented it.

They also cost something: a new worktree starts with no `node_modules` and no `.dev.vars`, so `make gate` can't run until you install both — about two minutes, measured while writing this PR from inside one.

## The strongest protection is the brief

Disjoint file scopes per concurrent task, plus "STOP if you touch another task's file". Four PRs ran in parallel that way today (#848, #849, #850, #852) with zero conflicts. The one collision came from the single task that had no file boundary.

## Test plan

- [x] `make gate` — exit 0 (backend 1141, frontend 1042)
- [x] `markdownlint-cli2 AGENTS.md` — 0 issues
- [x] Written and gated from a worktree, which is how the setup cost was measured

## Notes

Documentation only. `AGENTS.md` is deliberately **not** in `opencode.json`'s `instructions` array, so this adds nothing to per-delegation token cost.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running multiple agents concurrently.
  * Documented branch ownership, safe stash handling, worktree limitations, dependency and environment setup, and file boundaries for parallel tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->