### PR TITLE
fix(admin): make Most-Viewed Shared Routes panel actionable (#702)

### DIFF
--- a/frontend/src/admin/MetricsDashboard.jsx
+++ b/frontend/src/admin/MetricsDashboard.jsx
@@ -95,13 +95,27 @@ export default function MetricsDashboard({ eventId }) {
                 <span className="text-white">
                   {idx + 1}. /s/{route.slug}
                 </span>
-                <span className="text-gray-400">{route.view_count} views</span>
+                <span className="text-gray-400">
+                  {route.band_count} {route.band_count === 1 ? 'band' : 'bands'}
+                  {route.created_at ? (
+                    <>
+                      {' · '}
+                      {route.created_at.slice(0, 10)}
+                    </>
+                  ) : null}
+                  {' · '}
+                  {route.view_count} {route.view_count === 1 ? 'view' : 'views'}
+                </span>
               </div>
             ))
           ) : (
-            <p className="text-gray-400 text-sm">No shared routes yet</p>
+            <p className="text-gray-400 text-sm">No shared routes with views yet</p>
           )}
         </div>
+        <p className="text-gray-400 text-xs mt-3">
+          Views count unique visitors per link — reloads and crawlers don&apos;t inflate them. Imports count per-fetch
+          adoptions.
+        </p>
       </div>
     </div>
   )

--- a/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
+++ b/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
@@ -46,6 +46,14 @@ describe('MetricsDashboard', () => {
     expect(screen.getByText(/1 band/)).toBeInTheDocument()
     // Plural "views" still renders within the compound row
     expect(screen.getByText(/30 views/)).toBeInTheDocument()
+    // view_count and import_count are different units and get conflated
+    // (CLAUDE.md "Metrics & Analytics"): views are unique visitors recomputed
+    // from a ledger, imports are per-fetch and undeduped, so imports CAN exceed
+    // views. This caption is the only place a reader learns that — assert it
+    // survives, because silently dropping it makes the panel misleading rather
+    // than merely sparser.
+    expect(screen.getByText(/Views count unique visitors per link/)).toBeInTheDocument()
+    expect(screen.getByText(/Imports count per-fetch/)).toBeInTheDocument()
   })
 
   it('renders 0 for share imports when the field is absent (older data)', async () => {
@@ -66,5 +74,9 @@ describe('MetricsDashboard', () => {
     expect(await screen.findByText('Shares Imported')).toBeInTheDocument()
     const shareImportsLabel = screen.getByText('Shares Imported')
     expect(shareImportsLabel.parentElement.textContent).toContain('0')
+    // An empty topSharedRoutes must show the empty state, not a bare heading.
+    // The endpoint filters to view_count > 0, so "no rows" is the normal
+    // between-seasons case rather than an error — it needs to read that way.
+    expect(screen.getByText('No shared routes with views yet')).toBeInTheDocument()
   })
 })

--- a/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
+++ b/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
@@ -22,8 +22,8 @@ describe('MetricsDashboard', () => {
         totalShareViews: 42,
         totalShareImports: 5,
         topSharedRoutes: [
-          { slug: 'abc123', view_count: 30 },
-          { slug: 'def456', view_count: 12 },
+          { slug: 'abc123', view_count: 30, band_count: 4, created_at: '2026-07-16 07:02:00' },
+          { slug: 'def456', view_count: 1, band_count: 1, created_at: '2026-07-29 21:59:00' },
         ],
       },
     })
@@ -38,7 +38,14 @@ describe('MetricsDashboard', () => {
     expect(screen.getByText('5')).toBeInTheDocument()
     expect(screen.getByText('Most-Viewed Shared Routes')).toBeInTheDocument()
     expect(screen.getByText(/abc123/)).toBeInTheDocument()
-    expect(screen.getByText('30 views')).toBeInTheDocument()
+    // Band count + creation date surfaced so the slug is actionable (#702)
+    expect(screen.getByText(/4 bands/)).toBeInTheDocument()
+    expect(screen.getByText(/2026-07-16/)).toBeInTheDocument()
+    // Singular "view" pluralises correctly
+    expect(screen.getByText(/1 view/)).toBeInTheDocument()
+    expect(screen.getByText(/1 band/)).toBeInTheDocument()
+    // Plural "views" still renders within the compound row
+    expect(screen.getByText(/30 views/)).toBeInTheDocument()
   })
 
   it('renders 0 for share imports when the field is absent (older data)', async () => {

--- a/functions/api/admin/events/[id]/metrics.js
+++ b/functions/api/admin/events/[id]/metrics.js
@@ -46,8 +46,8 @@ export async function onRequestGet(context) {
          FROM share_links WHERE event_id = ?`,
         ).bind(eventId),
         DB.prepare(
-          `SELECT slug, view_count FROM share_links
-         WHERE event_id = ?
+          `SELECT slug, view_count, band_names, created_at FROM share_links
+         WHERE event_id = ? AND view_count > 0
          ORDER BY view_count DESC, created_at DESC
          LIMIT 10`,
         ).bind(eventId),
@@ -91,7 +91,23 @@ export async function onRequestGet(context) {
     const metrics = metricsRes.results?.[0];
     const popularBands = popularBandsRes.results || [];
     const shareStats = shareStatsRes.results?.[0];
-    const topSharedRoutes = topRoutesRes.results || [];
+    const topSharedRoutes = (topRoutesRes.results || []).map((row) => {
+      // band_names is the JSON snapshot stored at share time; a band playing
+      // twice appears twice, so count DISTINCT names — the route size an admin
+      // actually cares about. Malformed JSON degrades to 0 bands, not a 500.
+      let bandCount;
+      try {
+        bandCount = new Set(JSON.parse(row.band_names)).size;
+      } catch {
+        bandCount = 0;
+      }
+      return {
+        slug: row.slug,
+        view_count: row.view_count,
+        created_at: row.created_at,
+        band_count: bandCount,
+      };
+    });
     const announcementPlanning = announcementPlanningRes.results || [];
     const telemetryStats = telemetryStatsRes.results?.[0];
     // bp.name is only the final tiebreaker here (after is_announced, then

--- a/functions/api/admin/events/__tests__/metrics.test.js
+++ b/functions/api/admin/events/__tests__/metrics.test.js
@@ -111,6 +111,44 @@ describe("GET /api/admin/events/[id]/metrics", () => {
     expect(routes[0].created_at).toBe("2026-07-16 07:02:00");
   });
 
+  // band_names is a JSON snapshot written at share time, so a malformed value
+  // is a data-integrity question rather than a caller-input one — no validation
+  // on the read path can prevent it. The handler degrades that row to
+  // band_count 0 instead of throwing, because one bad snapshot must not take
+  // the whole metrics panel down for the event.
+  test("a malformed band_names snapshot degrades to 0 bands, not a 500", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "RouteFest", slug: "route-fest" });
+    insertShareLink(rawDb, {
+      slug: "routegood",
+      event_id: event.id,
+      event_slug: "route-fest",
+      band_names: ["A", "B"],
+      expires_at: "2026-08-20 00:00:00",
+    });
+    insertShareLink(rawDb, {
+      slug: "routebad",
+      event_id: event.id,
+      event_slug: "route-fest",
+      band_names: ["placeholder"],
+      expires_at: "2026-08-20 00:00:00",
+    });
+    rawDb.prepare("UPDATE share_links SET view_count = ? WHERE slug = ?").run(5, "routegood");
+    rawDb
+      .prepare("UPDATE share_links SET view_count = ?, band_names = ? WHERE slug = ?")
+      .run(3, "{invalid-json", "routebad");
+
+    const res = await call(env, event.id);
+
+    expect(res.status).toBe(200);
+    const routes = (await res.json()).metrics.topSharedRoutes;
+    // The bad row still appears, ranked by its real view_count — dropping it
+    // would hide a route the admin can see traffic for.
+    expect(routes.map((r) => r.slug)).toEqual(["routegood", "routebad"]);
+    expect(routes[0].band_count).toBe(2);
+    expect(routes[1].band_count).toBe(0);
+  });
+
   test("includes share import totals -- the conversion signal beside shares/views (#703)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "Fest", slug: "fest" });

--- a/functions/api/admin/events/__tests__/metrics.test.js
+++ b/functions/api/admin/events/__tests__/metrics.test.js
@@ -64,6 +64,53 @@ describe("GET /api/admin/events/[id]/metrics", () => {
     expect(body.metrics.topSharedRoutes[0].view_count).toBe(5);
   });
 
+  test("top routes carry band_count and created_at, and zero-view shares are excluded (#702)", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Route Fest", slug: "route-fest" });
+    // Two distinct bands
+    insertShareLink(rawDb, {
+      slug: "routeaa2",
+      event_id: event.id,
+      event_slug: "route-fest",
+      performance_ids: [1, 2],
+      band_names: ["A", "B"],
+      expires_at: "2026-08-20 00:00:00",
+    });
+    // One band played twice → distinct count is 1, not 2
+    insertShareLink(rawDb, {
+      slug: "routebb2",
+      event_id: event.id,
+      event_slug: "route-fest",
+      performance_ids: [3, 4],
+      band_names: ["C", "C"],
+      expires_at: "2026-08-20 00:00:00",
+    });
+    // Zero-view share must not appear in a "most-viewed" list
+    insertShareLink(rawDb, {
+      slug: "routezero",
+      event_id: event.id,
+      event_slug: "route-fest",
+      performance_ids: [5],
+      band_names: ["D"],
+      expires_at: "2026-08-20 00:00:00",
+    });
+    rawDb.prepare("UPDATE share_links SET view_count = ? WHERE slug = ?").run(5, "routeaa2");
+    rawDb.prepare("UPDATE share_links SET view_count = ? WHERE slug = ?").run(2, "routebb2");
+    rawDb.prepare("UPDATE share_links SET created_at = ? WHERE slug = ?").run("2026-07-16 07:02:00", "routeaa2");
+
+    const res = await call(env, event.id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const routes = body.metrics.topSharedRoutes;
+    // Zero-view share filtered out
+    expect(routes.map((r) => r.slug)).toEqual(["routeaa2", "routebb2"]);
+    // Distinct band count, not performance count
+    expect(routes[0].band_count).toBe(2);
+    expect(routes[1].band_count).toBe(1);
+    // Creation date surfaced so age is visible
+    expect(routes[0].created_at).toBe("2026-07-16 07:02:00");
+  });
+
   test("includes share import totals -- the conversion signal beside shares/views (#703)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "Fest", slug: "fest" });


### PR DESCRIPTION
## Summary

Closes #702

The Most-Viewed Shared Routes panel was a dead-end: opaque slugs, zero-view rows ranked alongside real ones, "1 views" grammar, and no way to tell a route's age or size. Each row now shows distinct band count and creation date, zero-view shares are excluded from the ranking, view counts pluralise, and the panel states what its numbers actually mean.

One premise in the issue is outdated and deliberately **not** implemented: it claimed view counts "have no dedup and count fetches." Since #705, `view_count` is unique visitors per link (deduped via the `share_link_views` ledger) — the UI note now states the current semantics. `import_count` remains per-fetch and undeduped, which the note also says.

## What changed

| File | Change |
|------|--------|
| `functions/api/admin/events/[id]/metrics.js` | Top-routes query selects `band_names` + `created_at`, filters `view_count > 0`, maps rows to `band_count` (distinct names; malformed JSON degrades to 0, never a 500) |
| `frontend/src/admin/MetricsDashboard.jsx` | Rows show `/s/{slug}` + band count + creation date + pluralised view count; footnote clarifies view/import units; empty state updated |
| `functions/api/admin/events/__tests__/metrics.test.js` | New test: zero-view share excluded, distinct band count (band played twice counts once), `created_at` surfaced |
| `frontend/src/admin/__tests__/MetricsDashboard.test.jsx` | New assertions: band count, creation date, "1 view"/"1 band" singulars, plural still renders |

## Security / correctness notes

None. Read-only metrics endpoint and admin panel; band count is computed from the existing JSON snapshot. New test verified to FAIL against current code before the fix (zero-view row present, no `band_count`).

## Verification

- [x] Tests: 1142 backend + 1042 frontend pass, 0 failures (`npm test` / `cd frontend && npm test -- --run`)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Format check: clean (`npm run format:check` / `cd frontend && npm run format:check`)
- [x] Build: green (`npm run build --prefix frontend`)
- [ ] `validate:openapi`: n/a — `topSharedRoutes` not documented in `docs/api-spec.yaml`; no spec change
- [ ] Manual smoke: not run — endpoint unit-tested; panel rendering covered by component tests

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Shared-route metrics now show creation dates and the number of distinct bands.
  - View and band labels use correct singular or plural wording.
  - Metrics clarify how views and imports are counted.

- **Bug Fixes**
  - Routes with no views are excluded from top shared-route results.
  - Empty states now explain that routes must have views to appear.
  - Invalid band data is handled gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->