### PR TITLE
refactor(admin): dedupe checkConflicts into shared timeConflicts util (part of #679)

### DIFF
--- a/functions/api/admin/bands.js
+++ b/functions/api/admin/bands.js
@@ -14,7 +14,7 @@ import {
   sanitizeString,
   validatePerformanceDate,
 } from "../../utils/validation.js";
-import { buildIntervals, intervalsOverlap } from "../../utils/timeConflicts.js";
+import { checkConflicts } from "../../utils/timeConflicts.js";
 import { parseOrigin } from "../../utils/parseOrigin.js";
 import { normalizeBandName } from "../../utils/bandName.js";
 import { sortableName } from "../../utils/sortableName.js";
@@ -66,61 +66,6 @@ function unpackSocialLinks(band) {
     apple_music: social.apple_music || "",
     linktree: social.linktree || "",
   };
-}
-
-async function checkConflicts(
-  DB,
-  eventId,
-  venueId,
-  startTime,
-  endTime,
-  excludePerformanceId = null,
-  performanceDate = null,
-  eventDate = null,
-) {
-  let query = `
-    SELECT p.id, p.start_time, p.end_time, p.performance_date, bp.name
-    FROM performances p
-    JOIN band_profiles bp ON p.band_profile_id = bp.id
-    WHERE p.event_id = ? AND p.venue_id = ?
-  `;
-  const bindings = [eventId, venueId];
-  if (excludePerformanceId) {
-    query += ` AND p.id != ?`;
-    bindings.push(excludePerformanceId);
-  }
-
-  const { results: existingPerformances } = await DB.prepare(query)
-    .bind(...bindings)
-    .all();
-  const newIntervals = buildIntervals(startTime, endTime);
-  // Festival-day scoping (#540): two sets on different festival days never
-  // conflict, even at the same venue and clock time (a Day-1 8 PM and a Day-2
-  // 8 PM set at the same venue are distinct slots). Falls back to eventDate for
-  // NULL performance_date, so single-day events (both sides NULL → same day)
-  // keep conflicting exactly as before. Mirrors detectConflicts in
-  // frontend/src/admin/utils/timeUtils.js (#538).
-  const candidateDay = performanceDate || eventDate;
-  const conflicts = [];
-
-  for (const perf of existingPerformances) {
-    if (!perf.start_time || !perf.end_time) continue;
-    const otherDay = perf.performance_date || eventDate;
-    if (candidateDay && otherDay && candidateDay !== otherDay) continue;
-    const perfIntervals = buildIntervals(perf.start_time, perf.end_time);
-    const hasOverlap = perfIntervals.some((b) => newIntervals.some((a) => intervalsOverlap(a, b)));
-    if (hasOverlap) {
-      conflicts.push({
-        id: perf.id,
-        name: perf.name,
-        startTime: perf.start_time,
-        endTime: perf.end_time,
-        type: perf.start_time === startTime && perf.end_time === endTime ? "conflict" : "overlap",
-      });
-    }
-  }
-
-  return conflicts;
 }
 
 // GET - List bands for an event
@@ -520,16 +465,14 @@ export async function onRequestPost(context) {
 
     // Check for conflicts (only if times are provided)
     if (!isGlobalAdd && resolvedVenueId && startTime && endTime) {
-      const conflicts = await checkConflicts(
-        DB,
+      const conflicts = await checkConflicts(DB, {
         eventId,
-        resolvedVenueId,
+        venueId: resolvedVenueId,
         startTime,
         endTime,
-        null,
-        resolvedPerformanceDate,
-        event.date,
-      );
+        performanceDate: resolvedPerformanceDate,
+        eventDate: event.date,
+      });
       if (conflicts.length > 0) {
         return new Response(
           JSON.stringify({

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -14,7 +14,7 @@ import {
   validatePerformanceDate,
 } from "../../../utils/validation.js";
 import { getClientIP, getUrlId } from "../../../utils/request.js";
-import { buildIntervals, intervalsOverlap } from "../../../utils/timeConflicts.js";
+import { checkConflicts } from "../../../utils/timeConflicts.js";
 import { parseOrigin } from "../../../utils/parseOrigin.js";
 import { normalizeBandName } from "../../../utils/bandName.js";
 
@@ -31,60 +31,6 @@ async function getEventForPerformance(DB, performanceId) {
   )
     .bind(performanceId)
     .first();
-}
-
-async function checkConflicts(
-  DB,
-  eventId,
-  venueId,
-  startTime,
-  endTime,
-  excludePerformanceId = null,
-  performanceDate = null,
-  eventDate = null,
-) {
-  const query = excludePerformanceId
-    ? `SELECT p.id, p.start_time, p.end_time, p.performance_date, bp.name
-       FROM performances p
-       JOIN band_profiles bp ON p.band_profile_id = bp.id
-       WHERE p.event_id = ? AND p.venue_id = ? AND p.id != ?`
-    : `SELECT p.id, p.start_time, p.end_time, p.performance_date, bp.name
-       FROM performances p
-       JOIN band_profiles bp ON p.band_profile_id = bp.id
-       WHERE p.event_id = ? AND p.venue_id = ?`;
-
-  const bindings = excludePerformanceId ? [eventId, venueId, excludePerformanceId] : [eventId, venueId];
-
-  const { results: existingBands } = await DB.prepare(query)
-    .bind(...bindings)
-    .all();
-  const newIntervals = buildIntervals(startTime, endTime);
-  // Festival-day scoping (#540): two sets on different festival days never
-  // conflict, even at the same venue and clock time. Falls back to eventDate
-  // for NULL performance_date, so single-day events (both sides NULL → same
-  // day) keep conflicting exactly as before. Mirrors detectConflicts in
-  // frontend/src/admin/utils/timeUtils.js (#538).
-  const candidateDay = performanceDate || eventDate;
-  const conflicts = [];
-
-  for (const band of existingBands) {
-    if (!band.start_time || !band.end_time) continue;
-    const otherDay = band.performance_date || eventDate;
-    if (candidateDay && otherDay && candidateDay !== otherDay) continue;
-    const bandIntervals = buildIntervals(band.start_time, band.end_time);
-    const hasOverlap = bandIntervals.some((b) => newIntervals.some((a) => intervalsOverlap(a, b)));
-    if (hasOverlap) {
-      conflicts.push({
-        id: band.id,
-        name: band.name,
-        startTime: band.start_time,
-        endTime: band.end_time,
-        type: band.start_time === startTime && band.end_time === endTime ? "conflict" : "overlap",
-      });
-    }
-  }
-
-  return conflicts;
 }
 
 // PUT - Update band
@@ -385,18 +331,17 @@ export async function onRequestPut(context) {
     // Check for conflicts only if we have all required scheduling fields
     let conflicts = [];
     if (actualVenueId && actualStartTime && actualEndTime && performance.event_id) {
-      conflicts = await checkConflicts(
-        DB,
-        performance.event_id,
-        actualVenueId,
-        actualStartTime,
-        actualEndTime,
-        performanceId,
+      conflicts = await checkConflicts(DB, {
+        eventId: performance.event_id,
+        venueId: actualVenueId,
+        startTime: actualStartTime,
+        endTime: actualEndTime,
+        excludePerformanceId: performanceId,
         // The performance's festival day after this update: the newly supplied
         // day if it's being changed, otherwise the day it already had.
-        performanceDate !== undefined ? resolvedPerformanceDate : performance.performance_date,
-        linkedEvent.date,
-      );
+        performanceDate: performanceDate !== undefined ? resolvedPerformanceDate : performance.performance_date,
+        eventDate: linkedEvent.date,
+      });
     }
 
     if (conflicts.length > 0) {

--- a/functions/utils/__tests__/timeConflicts.test.js
+++ b/functions/utils/__tests__/timeConflicts.test.js
@@ -5,6 +5,7 @@ import {
   buildIntervals,
   intervalsOverlap,
   computeNewEndTime,
+  checkConflicts,
   detectBulkConflicts,
 } from "../timeConflicts.js";
 import { createTestEnv, insertBand, insertEvent, insertVenue } from "../../api/test-utils.js";
@@ -85,10 +86,174 @@ describe("computeNewEndTime", () => {
 });
 
 // ---------------------------------------------------------------------------
+// checkConflicts — single create/update conflict check (#540)
+//
+// Shared by the admin create (bands.js) and update (bands/[id].js) write
+// paths. Day-scoped since #540: same venue + clock time on different festival
+// days is a distinct slot, not a conflict.
+// ---------------------------------------------------------------------------
+
+describe("checkConflicts", () => {
+  function fixture() {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, {
+      name: "Conflict Check Event",
+      slug: "conflict-check-event",
+      date: "2026-08-01",
+    });
+    const venue = insertVenue(rawDb, { name: "Conflict Check Venue" });
+    return { env, rawDb, event, venue };
+  }
+
+  it("returns a conflict entry with type conflict for the exact same time", async () => {
+    const { env, rawDb, event, venue } = fixture();
+    insertBand(rawDb, {
+      name: "Existing Set",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+
+    const conflicts = await checkConflicts(env.DB, {
+      eventId: event.id,
+      venueId: venue.id,
+      startTime: "20:00",
+      endTime: "21:00",
+      eventDate: event.date,
+    });
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({
+      name: "Existing Set",
+      startTime: "20:00",
+      endTime: "21:00",
+      type: "conflict",
+    });
+    expect(conflicts[0].id).toBeTypeOf("number");
+  });
+
+  it("returns type overlap for a non-exact overlap", async () => {
+    const { env, rawDb, event, venue } = fixture();
+    insertBand(rawDb, {
+      name: "Existing Set",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+
+    const conflicts = await checkConflicts(env.DB, {
+      eventId: event.id,
+      venueId: venue.id,
+      startTime: "20:30",
+      endTime: "21:30",
+      eventDate: event.date,
+    });
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].type).toBe("overlap");
+  });
+
+  it("scopes to venue and event", async () => {
+    const { env, rawDb, event, venue } = fixture();
+    const otherVenue = insertVenue(rawDb, { name: "Other Venue" });
+    const otherEvent = insertEvent(rawDb, {
+      name: "Other Event",
+      slug: "other-event",
+      date: "2026-08-01",
+    });
+    insertBand(rawDb, {
+      name: "Elsewhere Set",
+      event_id: otherEvent.id,
+      venue_id: otherVenue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+
+    const conflicts = await checkConflicts(env.DB, {
+      eventId: event.id,
+      venueId: venue.id,
+      startTime: "20:00",
+      endTime: "21:00",
+      eventDate: event.date,
+    });
+
+    expect(conflicts).toEqual([]);
+  });
+
+  it("ignores the excluded performance (self during update)", async () => {
+    const { env, rawDb, event, venue } = fixture();
+    const existing = insertBand(rawDb, {
+      name: "Self",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+
+    const conflicts = await checkConflicts(env.DB, {
+      eventId: event.id,
+      venueId: venue.id,
+      startTime: "20:00",
+      endTime: "21:00",
+      excludePerformanceId: existing.id,
+      eventDate: event.date,
+    });
+
+    expect(conflicts).toEqual([]);
+  });
+
+  it("different festival days at the same venue and time do NOT conflict (#540)", async () => {
+    const { env, rawDb, event, venue } = fixture();
+    const day1 = insertBand(rawDb, {
+      name: "Day One Set",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    rawDb.prepare("UPDATE performances SET performance_date=? WHERE id=?").run("2026-08-01", day1.id);
+
+    const conflicts = await checkConflicts(env.DB, {
+      eventId: event.id,
+      venueId: venue.id,
+      startTime: "20:00",
+      endTime: "21:00",
+      performanceDate: "2026-08-02",
+      eventDate: event.date,
+    });
+
+    expect(conflicts).toEqual([]);
+  });
+
+  it("NULL performance_date on both sides falls back to event date and still conflicts (single-day)", async () => {
+    const { env, rawDb, event, venue } = fixture();
+    insertBand(rawDb, {
+      name: "Single Day Set",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+
+    const conflicts = await checkConflicts(env.DB, {
+      eventId: event.id,
+      venueId: venue.id,
+      startTime: "20:00",
+      endTime: "21:00",
+      eventDate: event.date,
+    });
+
+    expect(conflicts).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // detectBulkConflicts — festival-day scoping (#551)
 //
-// #540 day-scoped the single create/update conflict check (checkConflicts in
-// functions/api/admin/bands.js). detectBulkConflicts (bulk move_venue /
+// #540 day-scoped the single create/update conflict check (checkConflicts, now
+// in this file). detectBulkConflicts (bulk move_venue /
 // change_time) was left out of that scope: it matched purely on
 // event_id + venue_id + clock overlap, so a multi-day event's bulk move/retime
 // would false-conflict against a different festival day. These tests cover

--- a/functions/utils/timeConflicts.js
+++ b/functions/utils/timeConflicts.js
@@ -33,6 +33,71 @@ export function computeNewEndTime(oldStart, oldEnd, newStart) {
 }
 
 /**
+ * Check a single performance's proposed time against existing sets at the same
+ * venue and festival day. Used by the admin create and update write paths
+ * (bands.js and bands/[id].js); callers return a 409 when it finds anything.
+ *
+ * @param {Object} DB - Cloudflare env DB binding
+ * @param {Object} opts
+ * @param {number} opts.eventId
+ * @param {number} opts.venueId
+ * @param {string} opts.startTime - "HH:MM"
+ * @param {string} opts.endTime - "HH:MM"
+ * @param {number|null} [opts.excludePerformanceId] - performance to ignore (the set being updated)
+ * @param {string|null} [opts.performanceDate] - candidate festival day ("YYYY-MM-DD")
+ * @param {string|null} [opts.eventDate] - event date fallback for NULL performance_date
+ * @returns {Promise<Array>} Conflicts as { id, name, startTime, endTime, type: "conflict" | "overlap" }
+ */
+export async function checkConflicts(
+  DB,
+  { eventId, venueId, startTime, endTime, excludePerformanceId = null, performanceDate = null, eventDate = null },
+) {
+  let query = `
+    SELECT p.id, p.start_time, p.end_time, p.performance_date, bp.name
+    FROM performances p
+    JOIN band_profiles bp ON p.band_profile_id = bp.id
+    WHERE p.event_id = ? AND p.venue_id = ?
+  `;
+  const bindings = [eventId, venueId];
+  if (excludePerformanceId) {
+    query += ` AND p.id != ?`;
+    bindings.push(excludePerformanceId);
+  }
+
+  const { results: existingPerformances } = await DB.prepare(query)
+    .bind(...bindings)
+    .all();
+  const newIntervals = buildIntervals(startTime, endTime);
+  // Festival-day scoping (#540): two sets on different festival days never
+  // conflict, even at the same venue and clock time (a Day-1 8 PM and a Day-2
+  // 8 PM set at the same venue are distinct slots). Falls back to eventDate for
+  // NULL performance_date, so single-day events (both sides NULL → same day)
+  // keep conflicting exactly as before. Mirrors detectConflicts in
+  // frontend/src/admin/utils/timeUtils.js (#538).
+  const candidateDay = performanceDate || eventDate;
+  const conflicts = [];
+
+  for (const perf of existingPerformances) {
+    if (!perf.start_time || !perf.end_time) continue;
+    const otherDay = perf.performance_date || eventDate;
+    if (candidateDay && otherDay && candidateDay !== otherDay) continue;
+    const perfIntervals = buildIntervals(perf.start_time, perf.end_time);
+    const hasOverlap = perfIntervals.some((b) => newIntervals.some((a) => intervalsOverlap(a, b)));
+    if (hasOverlap) {
+      conflicts.push({
+        id: perf.id,
+        name: perf.name,
+        startTime: perf.start_time,
+        endTime: perf.end_time,
+        type: perf.start_time === startTime && perf.end_time === endTime ? "conflict" : "overlap",
+      });
+    }
+  }
+
+  return conflicts;
+}
+
+/**
  * Detect scheduling conflicts for a bulk move_venue or change_time operation.
  *
  * Encapsulates the DB queries, existing-performance checks, and within-batch
@@ -69,7 +134,7 @@ export async function detectBulkConflicts(env, { action, bandIds, params }) {
 
   // Festival-day scoping (#551): two sets on different festival days never
   // conflict, even at the same venue and clock time (mirrors checkConflicts in
-  // functions/api/admin/bands.js, #540). Falls back to the event's date for a
+  // this file, #540). Falls back to the event's date for a
   // NULL performance_date, so single-day events (both sides NULL → same day)
   // conflict exactly as before. move_venue/change_time never mutate
   // performance_date, so a batch member's festival day is just its stored value.


### PR DESCRIPTION
## Summary

Merges the two semantically identical private `checkConflicts` copies — `functions/api/admin/bands.js:71` (create path) and `functions/api/admin/bands/[id].js:36` (update path) — into one exported `checkConflicts(DB, opts)` in `functions/utils/timeConflicts.js`, the file both already imported `buildIntervals`/`intervalsOverlap` from. Per #679, the merged function replaces the 8 positional params (3 nullable) with an options object so the call sites no longer require jumping to the definition.

Part of #679 — **does not close it.** #679 is a tracking issue with eight
workstreams; this PR completes exactly one (the duplicated `checkConflicts`).
Still open there: the five oversized functions, the `normalizeEndMinutes`
cross-boundary divergence, scattered date parsing, the abandoned
`fetchPublicJson` abstraction, band/artist/performer naming, the half-finished
`admin/` directory reorg, and the six `it.todo` stubs.

## What changed

| File | Change |
|------|--------|
| `functions/utils/timeConflicts.js` | Exported `checkConflicts(DB, opts)` — merged copy (bands.js variant's wording and query style, behavior identical); updated `detectBulkConflicts`' cross-file comment now that the sibling lives in the same file |
| `functions/api/admin/bands.js` | Private copy deleted; import swapped to `checkConflicts`; call site now passes an options object |
| `functions/api/admin/bands/[id].js` | Private copy deleted; import swapped to `checkConflicts`; call site now passes an options object (festival-day comment preserved) |
| `functions/utils/__tests__/timeConflicts.test.js` | 6 new direct unit tests for the merged contract (exact-conflict type, overlap type, venue/event scoping, `excludePerformanceId`, #540 festival-day scoping, single-day NULL fallback); stale cross-file comment updated |

The `normalizeEndMinutes` cross-boundary divergence (backend `<=` vs frontend `<`) is deliberately untouched — #679 calls that a product decision, not a refactor.

## Security / correctness notes

None. Behavior-preserving refactor: identical query, bindings, festival-day scoping (#540), and conflict/overlap classification; the existing endpoint conflict tests (create + update paths) all still pass.

## Verification

- [x] Tests: 1155 backend tests pass (1149 passed + 6 todo), 0 failures — incl. full `bands.test.js` conflicts suite and 6 new `checkConflicts` unit tests; 1049 frontend tests pass
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: n/a (`docs/api-spec.yaml` unchanged)
- [x] Manual smoke: n/a — unit-level; endpoint behavior unchanged and covered by existing 115 passing API tests
- [x] Mutation-proven: each of the 3 mutations (day-scoping removed, type classification flipped, `excludePerformanceId` filter removed) failed exactly the tests guarding it, then reverted

---
Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conflict detection when creating or updating performances.
  * Correctly identifies exact and overlapping schedule conflicts by venue and event.
  * Handles festival-day scheduling, including cases where performance dates are unavailable.
  * Prevents false conflicts when updating an existing performance or moving performances between venues.

* **Tests**
  * Added comprehensive coverage for schedule conflicts, venue changes, date handling, and bulk updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
