### PR TITLE
fix(e2e): scope the admin-header assertion so "Loading admin panel..." cannot collide

### DIFF
--- a/e2e/login.spec.js
+++ b/e2e/login.spec.js
@@ -24,7 +24,7 @@ test.describe("Admin Login", () => {
     // Should see the admin header. Scope to the banner's <h1>: a bare
     // getByText("Admin") also matched "Loading admin panel..." (getByText is
     // substring + case-insensitive), a strict-mode violation that persisted
-    // for the whole initial-load window and flaked CI.
+    // for the whole initial-load window and flaked CI. See #865.
     const adminHeading = page.getByRole("banner").getByRole("heading", { level: 1 });
     await expect(adminHeading).toContainText("SetTimes");
     await expect(adminHeading).toContainText("Admin");

--- a/e2e/login.spec.js
+++ b/e2e/login.spec.js
@@ -21,9 +21,13 @@ test.describe("Admin Login", () => {
     // Should redirect to admin panel
     await expect(page).toHaveURL(/\/admin$/);
 
-    // Should see the admin header
-    await expect(page.getByText("SetTimes")).toBeVisible();
-    await expect(page.getByText("Admin")).toBeVisible();
+    // Should see the admin header. Scope to the banner's <h1>: a bare
+    // getByText("Admin") also matched "Loading admin panel..." (getByText is
+    // substring + case-insensitive), a strict-mode violation that persisted
+    // for the whole initial-load window and flaked CI.
+    const adminHeading = page.getByRole("banner").getByRole("heading", { level: 1 });
+    await expect(adminHeading).toContainText("SetTimes");
+    await expect(adminHeading).toContainText("Admin");
   });
 
   test("should show error for invalid credentials", async ({ page }) => {


### PR DESCRIPTION
## Summary

`e2e/login.spec.js` asserted the admin header with `page.getByText("Admin")`. Playwright's `getByText(string)` matches by **case-insensitive substring**, so it also resolved `"Loading admin panel..."` — two matches, which strict mode rejects outright. The assertion therefore only passed when the admin panel's initial fetch completed inside the 5s assertion budget, silently making an assertion timeout double as a load-time budget. On a contended CI runner the load overran and all three retries failed together ([run 32146824690](https://github.com/BreakableHoodie/settimesdotca/actions/runs/32146824690/job/95742497308)), while the *same commit* had passed twice minutes earlier.

This scopes the assertion to the banner's `<h1>`. The loading `<p>` renders inside `#main-content`, a **sibling** of `<header>`, so the scoped locator structurally cannot reach it — the assertion stops depending on load timing altogether, rather than merely being given a longer window to win the race.

Closes #865

## What changed

| File | Change |
|------|--------|
| `e2e/login.spec.js` | Replace two bare `getByText` assertions with one `getByRole("banner").getByRole("heading", { level: 1 })` locator asserted via `toContainText`, plus a comment recording why the bare form flaked |

No source files changed — this is test-only.

## Verified by reproduction

Against a static mirror of `AdminPanel.jsx`'s DOM (header `<h1>` at :268, loading `<p>` at :395 as siblings):

```
OLD getByText("Admin") count=2
  <span class="ml-2">Admin</span>
  <p class="text-lg font-medium">Loading admin panel...</p>
OLD strict-mode outcome: Error: strict mode violation: getByText('Admin') resolved to 2 elements
NEW banner>h1 count=1
```

That reproduces CI's exact error and shows the scoped locator resolving to exactly one element.

## Sibling sweep

Swept all 25 unscoped `getByText(` call sites in `e2e/`. **This is the only one with a live collision** — the rest are either container-scoped (`dialog.getByText`, `card.getByText`, `liveCard.getByText`) or use strings with no second match on the page.

`e2e/cancelled-set.spec.js:116` already carries a comment recording this same bug class (*"literally named 'Cancelled Openers' makes getByText('Cancelled') match"*), fixed there by scoping; login was missed in that pass.

**No source-scanning guard added, deliberately.** A rule banning bare `getByText` would fire on ~20 legitimate call sites, making it noise rather than a gate. The durable protection here is the scoping convention.

## Security / correctness notes

None. Test-only change; no source, schema, auth, or API surface touched. It strengthens an assertion (the heading must now contain both strings *and* live in the banner landmark) rather than weakening one.

## Verification

- [x] Tests: backend 1149 passed | 6 todo (115 files); frontend 1051 passed (93 files); 0 failures (`make gate`)
- [x] ESLint: 0 errors (`npm run lint`) — pre-existing warnings only, none in this file
- [x] Format check: clean, both stacks (`npm run format:check`)
- [x] Build: green (`npm run build --prefix frontend`, ✓ built in 2.57s)
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] Manual smoke: ran the real spec locally against wrangler + local D1 — `e2e/login.spec.js --project=chromium-unauth`, **2 passed**; plus the static-DOM reproduction above
- [x] CodeRabbit (`make review`): **no findings**

---
Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved admin login test coverage by verifying the banner’s primary heading.
  - Confirmed the heading includes both “SetTimes” and “Admin” for more reliable validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->