### PR TITLE
fix(ci): measure Lighthouse against a served app, not an API-less static build

### DIFF
--- a/.github/actions/e2e-env/action.yml
+++ b/.github/actions/e2e-env/action.yml
@@ -95,10 +95,6 @@ runs:
 
         - name: Initialize D1 database with schema
           shell: bash
-          env:
-              E2E_ADMIN_PASSWORD: ${{ inputs.e2e-admin-password }}
-              E2E_ADMIN_EMAIL: ${{ inputs.e2e-admin-email }}
-              SEED_ADMIN: ${{ inputs.seed-admin }}
           run: |
               printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\nENVIRONMENT="development"\n' > .dev.vars
 
@@ -108,24 +104,35 @@ runs:
               echo "Seeding test data (venues, events, bands)..."
               ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/seed-test-data.sql
 
+              echo "✓ Schema and test data loaded"
+
+        # Split out of the step above so the admin credentials are exposed ONLY
+        # to the step that needs them: a public-only consumer (seed-admin:
+        # 'false') never has them in its environment at all.
+        - name: Seed E2E admin user
+          if: inputs.seed-admin == 'true'
+          shell: bash
+          env:
+              E2E_ADMIN_PASSWORD: ${{ inputs.e2e-admin-password }}
+              E2E_ADMIN_EMAIL: ${{ inputs.e2e-admin-email }}
+          run: |
               # Fail closed rather than proceeding with whatever the seed files
               # happen to contain: "we deliberately want no admin" and "the
               # secret is missing" used to be indistinguishable, and the second
               # only surfaced later as a confusing auth failure.
-              if [ "$SEED_ADMIN" = "true" ]; then
-                  if [ -z "$E2E_ADMIN_PASSWORD" ] || [ -z "$E2E_ADMIN_EMAIL" ]; then
-                      echo "✗ seed-admin is 'true' but e2e-admin-email/e2e-admin-password are empty." >&2
-                      echo "  Pass both secrets, or set seed-admin: 'false' for public-only jobs." >&2
-                      exit 1
-                  fi
-                  echo "Creating E2E admin user..."
-                  SEED_SQL=$(node scripts/seed-e2e-admin.mjs --email "$E2E_ADMIN_EMAIL" --password "$E2E_ADMIN_PASSWORD")
-                  ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="$SEED_SQL"
-                  echo "✓ E2E admin user created: $E2E_ADMIN_EMAIL"
-              else
-                  echo "• seed-admin='false' — no admin account seeded (public-only job)."
+              if [ -z "$E2E_ADMIN_PASSWORD" ] || [ -z "$E2E_ADMIN_EMAIL" ]; then
+                  echo "✗ seed-admin is 'true' but e2e-admin-email/e2e-admin-password are empty." >&2
+                  echo "  Pass both secrets, or set seed-admin: 'false' for public-only jobs." >&2
+                  exit 1
               fi
+              echo "Creating E2E admin user..."
+              SEED_SQL=$(node scripts/seed-e2e-admin.mjs --email "$E2E_ADMIN_EMAIL" --password "$E2E_ADMIN_PASSWORD")
+              ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="$SEED_SQL"
+              echo "✓ E2E admin user created: $E2E_ADMIN_EMAIL"
 
+        - name: Report seeded database users
+          shell: bash
+          run: |
               echo "Database users:"
               ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="SELECT id, email, role FROM users;"
 

--- a/.github/actions/e2e-env/action.yml
+++ b/.github/actions/e2e-env/action.yml
@@ -28,6 +28,25 @@ inputs:
 runs:
     using: composite
     steps:
+        # Runs first, before anything it guards. Both inputs are compared as
+        # strings elsewhere, so any typo ('ture') would silently take the
+        # false branch — skipping the admin seed AND its credential check,
+        # which is the exact fail-open this guard exists to close.
+        - name: Validate action inputs
+          shell: bash
+          env:
+              INSTALL_PLAYWRIGHT: ${{ inputs.install-playwright }}
+              SEED_ADMIN: ${{ inputs.seed-admin }}
+          run: |
+              case "$INSTALL_PLAYWRIGHT" in
+                  true|false) ;;
+                  *) echo "✗ install-playwright must be 'true' or 'false' (got '$INSTALL_PLAYWRIGHT')." >&2; exit 1 ;;
+              esac
+              case "$SEED_ADMIN" in
+                  true|false) ;;
+                  *) echo "✗ seed-admin must be 'true' or 'false' (got '$SEED_ADMIN')." >&2; exit 1 ;;
+              esac
+
         - name: Setup Node
           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
           with:

--- a/.github/actions/e2e-env/action.yml
+++ b/.github/actions/e2e-env/action.yml
@@ -10,6 +10,10 @@ inputs:
         description: Admin email to seed
         required: false
         default: ''
+    install-playwright:
+        description: Whether to install Playwright browsers
+        required: false
+        default: 'true'
 
 runs:
     using: composite
@@ -33,6 +37,7 @@ runs:
           run: npm ci
 
         - name: Cache Playwright browsers
+          if: inputs.install-playwright == 'true'
           id: playwright-cache
           uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
           with:
@@ -42,6 +47,7 @@ runs:
                   playwright-${{ runner.os }}-
 
         - name: Install Playwright browsers
+          if: inputs.install-playwright == 'true'
           shell: bash
           env:
               CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}

--- a/.github/actions/e2e-env/action.yml
+++ b/.github/actions/e2e-env/action.yml
@@ -14,6 +14,16 @@ inputs:
         description: Whether to install Playwright browsers
         required: false
         default: 'true'
+    seed-admin:
+        description: >
+            Whether this consumer needs an admin account seeded. 'true' (the
+            default) requires e2e-admin-email/password and FAILS the job if
+            either is empty, so a misconfigured secret surfaces immediately
+            instead of silently producing a DB with no admin. Set to 'false'
+            for jobs that only exercise public pages and must not be handed
+            admin credentials (least privilege).
+        required: false
+        default: 'true'
 
 runs:
     using: composite
@@ -69,6 +79,7 @@ runs:
           env:
               E2E_ADMIN_PASSWORD: ${{ inputs.e2e-admin-password }}
               E2E_ADMIN_EMAIL: ${{ inputs.e2e-admin-email }}
+              SEED_ADMIN: ${{ inputs.seed-admin }}
           run: |
               printf 'CSRF_SECRET="e2e-test-csrf-secret-for-ci"\nPUBLIC_DATA_PUBLISH_ENABLED="true"\nENVIRONMENT="development"\n' > .dev.vars
 
@@ -78,13 +89,22 @@ runs:
               echo "Seeding test data (venues, events, bands)..."
               ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --file=database/seed-test-data.sql
 
-              if [ -n "$E2E_ADMIN_PASSWORD" ] && [ -n "$E2E_ADMIN_EMAIL" ]; then
+              # Fail closed rather than proceeding with whatever the seed files
+              # happen to contain: "we deliberately want no admin" and "the
+              # secret is missing" used to be indistinguishable, and the second
+              # only surfaced later as a confusing auth failure.
+              if [ "$SEED_ADMIN" = "true" ]; then
+                  if [ -z "$E2E_ADMIN_PASSWORD" ] || [ -z "$E2E_ADMIN_EMAIL" ]; then
+                      echo "✗ seed-admin is 'true' but e2e-admin-email/e2e-admin-password are empty." >&2
+                      echo "  Pass both secrets, or set seed-admin: 'false' for public-only jobs." >&2
+                      exit 1
+                  fi
                   echo "Creating E2E admin user..."
                   SEED_SQL=$(node scripts/seed-e2e-admin.mjs --email "$E2E_ADMIN_EMAIL" --password "$E2E_ADMIN_PASSWORD")
                   ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="$SEED_SQL"
                   echo "✓ E2E admin user created: $E2E_ADMIN_EMAIL"
               else
-                  echo "⚠ E2E credentials not set, using default test accounts"
+                  echo "• seed-admin='false' — no admin account seeded (public-only job)."
               fi
 
               echo "Database users:"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -204,9 +204,6 @@ jobs:
     name: Lighthouse CI
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    defaults:
-      run:
-        working-directory: frontend
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -217,20 +214,13 @@ jobs:
         working-directory: .
         run: google-chrome --version
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: Prepare E2E environment
+        uses: ./.github/actions/e2e-env
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
+          install-playwright: 'false'
 
       - name: Run Lighthouse CI
+        working-directory: frontend
         run: npm run lighthouse
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -218,6 +218,9 @@ jobs:
         uses: ./.github/actions/e2e-env
         with:
           install-playwright: 'false'
+          # Lighthouse only loads public pages and never authenticates, so this
+          # job is deliberately not handed admin credentials.
+          seed-admin: 'false'
 
       - name: Run Lighthouse CI
         working-directory: frontend

--- a/frontend/lighthouserc.json
+++ b/frontend/lighthouserc.json
@@ -1,9 +1,8 @@
 {
   "ci": {
     "collect": {
-      "url": ["http://localhost:5000"],
+      "url": ["http://localhost:8788"],
       "numberOfRuns": 3,
-      "startServerCommand": "npx serve dist -l 5000",
       "wait": "3000"
     },
     "assert": {


### PR DESCRIPTION
## Summary

`frontend/lighthouserc.json` served the app with `npx serve dist` — **static assets only, no Pages Functions, no D1**. So every homepage API call failed in CI: `EventTimeline` rendered its tall `EventsPageSkeleton`, the fetch failed fast, the skeleton collapsed into a short error state, and `<Footer />` (its sibling in `EventsPage`'s `<main>`) moved. Lighthouse reported that as a **0.2007 layout shift**.

That shift does not exist for users. This points the gate at the app served by wrangler with a seeded D1 — the environment the E2E suite already builds — so Lighthouse measures a page someone could actually load.

Refs #854, #851

## Measurements

Lighthouse 12.8.2, mobile, `--throttling-method=simulate`, 3 runs each, idle host:

| harness | perf | CLS |
|---|---|---|
| static `dist` (**before**) | 0.86 / 0.86 / 0.96 | 0.2011 / 0.2011 / 0.0000 |
| `https://settimes.ca` (**reference**) | 0.90 / 0.90 | 0.0004 |
| wrangler + D1 (**after**) | **0.96 / 0.94 / 0.94** | **0.0004** |

The new harness reproduces production's CLS exactly — 0.0004, the same trivial header `h1` shift — and scores **0.94–0.96**.

The intermittency in the "before" column is the tell: the one static run that recorded **zero** shift scored **0.96**, and the two that recorded 0.2011 scored 0.86. The shift and the ~0.10 score deficit were the same phenomenon.

## What changed

| File | Change |
|------|--------|
| `frontend/lighthouserc.json` | Point at `http://localhost:8788`; drop `startServerCommand` (the composite action owns the server). **No assertion threshold changed.** |
| `.github/workflows/quality.yml` | `lighthouse` job uses `./.github/actions/e2e-env` with `install-playwright: 'false'`, `seed-admin: 'false'`. Removes the job-level `working-directory: frontend` default (it would re-root the action's steps) in favour of an explicit one on the Lighthouse step. |
| `.github/actions/e2e-env/action.yml` | New `install-playwright` and `seed-admin` inputs (both default `'true'`); input validation step; admin seeding split into its own gated step. |

The `'true'` defaults mean `e2e-tests.yml`, `e2e-a11y-visual.yml` and `update-visual-snapshots.yml` are untouched behaviourally.

## Security / correctness notes

Three review findings from CodeRabbit, handled across commits:

1. **Admin credentials for a public-only job.** The Lighthouse job never authenticates, so it is passed `seed-admin: 'false'` and no secrets — least privilege. The credentials are now scoped to the single gated `Seed E2E admin user` step, so a consumer with `seed-admin: 'false'` never has them in scope at all.
2. **Fail closed.** `seed-admin: 'true'` now **requires** both credentials and exits 1 if either is empty. Previously "we want no admin" and "the secret is misconfigured" were indistinguishable, and the latter surfaced later as a confusing auth failure. The three existing consumers gain this check.
3. **Boolean inputs validated.** Both inputs are compared as strings, so `seed-admin: 'ture'` would have taken the false branch and skipped *both* the seed and its credential check. A validation step now runs **first** and rejects anything that is not exactly `true`/`false` (`'TRUE'` included — the comparisons downstream are case-sensitive).

**Deliberately not fixed here:** `scripts/seed-e2e-admin.mjs` takes `--password` via argv, visible to `ps`. Real, but pre-existing and untouched by this PR; fixing it means changing that script plus its callers. Filed as **#867** rather than expanding a CI-harness change into an auth-script refactor.

## Budget thresholds deliberately unchanged

`CLAUDE.md` records this budget dropping 0.90 → 0.85 (#532) → 0.80 (#728), each time to stop CI flaking. On this evidence **both reductions were absorbing a measurement artifact**, not a real regression — the page scores 0.94–0.96 once measured representatively, above the *original* 0.90.

Raising it back is a separate decision and is not made here. The gate simply passes with margin now. Whoever takes that decision should re-measure first, as `CLAUDE.md` requires.

## Verification

- [x] Tests: backend 1149 passed | 6 todo (115 files); frontend 1052 passed (94 files); 0 failures (`make gate`, exit 0)
- [x] ESLint: 0 errors · Format check: clean, both stacks
- [x] Build: green (`✓ built in 2.54s`)
- [x] `actionlint`: clean on `quality.yml` (only pre-existing shellcheck infos in `zap-baseline.yml` repo-wide)
- [x] Composite action parses; step list confirms `E2E_ADMIN_*` appears only on the gated seeding step
- [x] Input validation behaviour: `true`→accept, `false`→accept, `ture`/``/`TRUE`→reject
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] Manual smoke: ran the full new harness locally (wrangler + seeded D1 on :8788, API confirmed responding) and measured Lighthouse 3× — table above
- [x] CodeRabbit (`make review`): no new findings

**Cannot be verified locally:** GitHub Actions workflow execution. The `Lighthouse CI` job on this PR is the real check — that number is the one that matters, and it should land ~0.94.

---
Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved end-to-end test environment setup with optional Playwright installation and administrator seeding.
  - Public-only test runs no longer receive administrator credentials.
  - Added validation and clearer failure handling when required seeding credentials are missing.

- **Chores**
  - Streamlined Lighthouse CI setup by using the shared test environment configuration.
  - Updated Lighthouse audits to run against the correct local application address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->