### PR TITLE
ci(lighthouse): assert CLS directly, and document why the budget stays at 0.80

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,17 +451,23 @@ Requires a running wrangler dev server or uses it automatically via `playwright.
 no D1 — so every homepage API call failed in CI. `EventTimeline` rendered its tall
 `EventsPageSkeleton`, the fetch failed fast, the skeleton collapsed into a short
 error state, and `<Footer />` (its sibling in `EventsPage`'s `<main>`) moved.
-Lighthouse scored that as a **0.2007 layout shift** that no user has ever seen.
+Lighthouse scored that as a **total CLS of 0.2011**, of which **0.2007** was
+the footer element's own shift score — a shift no user has ever seen.
 
 It now points at `http://localhost:8788`, served by `.github/actions/e2e-env`
 (wrangler + a seeded D1 — the same environment E2E uses). Measured 2026-08-18,
 Lighthouse 12.8.2, mobile, `--throttling-method=simulate`, 3 runs each:
 
-| harness | perf | CLS |
+| harness | perf (raw runs) | CLS (raw runs) |
 |---|---|---|
 | static `dist` (old) | 0.86 / 0.86 / 0.96 | 0.2011 / 0.2011 / 0.0000 |
-| `https://settimes.ca` | 0.90 / 0.90 | 0.0004 |
-| wrangler + D1 (current) | CI median **0.94** | **0.0008** |
+| `https://settimes.ca` | 0.90 / 0.90 | 0.0004 / 0.0004 |
+| wrangler + D1 (current) | CI **median** 0.94 | CI **median** 0.0008 |
+
+Three runs each. The `settimes.ca` row lists only two: its first run was a
+contended outlier (LCP 8.3 s, TBT 21 s) and is excluded rather than averaged in.
+The current row reports CI's uploaded median LHR, not raw runs — that is the
+number the gate actually saw.
 
 The old column is the whole story: the one run recording **zero** shift scored
 **0.96**; the two recording 0.2011 scored 0.86. The shift and the ~0.10 deficit
@@ -477,10 +483,18 @@ comparable. On 2026-08-18 the same commit measured **0.94–0.96** raw,
 **0.94** in CI, and **0.74 / 0.84** through local `lhci` on a busy machine.
 Collect several CI runs before moving the floor.
 
-**`cumulative-layout-shift` is asserted at ≤ 0.1** so the artifact cannot return
-silently — it sat at 2× the failing threshold for months with nothing going red,
-because only the four category scores were gated. Current value is 0.0008, so the
-margin is ~125×; a failure there means something real.
+**`cumulative-layout-shift` is asserted at ≤ 0.1 with
+`aggregationMethod: "pessimistic"`** so the artifact cannot return silently — it
+sat at 2× the failing threshold for months with nothing going red, because only
+the four category scores were gated. Current value is 0.0008, a ~125× margin.
+
+**The `pessimistic` there is load-bearing, and differs deliberately from the
+performance assertion's `optimistic`.** `optimistic` picks the most favourable
+run *before* comparing, so against the old `0.2011 / 0.2011 / 0.0000` it would
+aggregate to `0.0000` and pass — the guard would not have caught the very
+artifact it exists to prevent. `pessimistic` takes the worst run, so any single
+shifting run fails the gate. That is safe here precisely because CLS is stable
+under load (see below); do **not** copy it onto the performance assertion.
 
 The assertion pins **`aggregationMethod: "optimistic"` (best of 3)** — the most
 lenient option. **Do not switch it to `median`:** median ≤ max, so that only ever

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,7 +452,10 @@ no D1 — so every homepage API call failed in CI. `EventTimeline` rendered its 
 `EventsPageSkeleton`, the fetch failed fast, the skeleton collapsed into a short
 error state, and `<Footer />` (its sibling in `EventsPage`'s `<main>`) moved.
 Lighthouse scored that as a **total CLS of 0.2011**, of which **0.2007** was
-the footer element's own shift score — a shift no user has ever seen.
+the footer element's own shift score — an artefact of that static-build harness,
+not of the wrangler-served app. Production measured 0.0004 on 2026-08-18 (3 runs,
+same Lighthouse version and flags), so the shift did not reproduce there; that is
+one dated measurement of one page, not a claim about every user's experience.
 
 It now points at `http://localhost:8788`, served by `.github/actions/e2e-env`
 (wrangler + a seeded D1 — the same environment E2E uses). Measured 2026-08-18,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,8 +466,11 @@ Lighthouse 12.8.2, mobile, `--throttling-method=simulate`, 3 runs each:
 
 Three runs each. The `settimes.ca` row lists only two: its first run was a
 contended outlier (LCP 8.3 s, TBT 21 s) and is excluded rather than averaged in.
-The current row reports CI's uploaded median LHR, not raw runs — that is the
-number the gate actually saw.
+The current row reports CI's **uploaded median LHR** — which is what gets
+published for humans to read, and is *not* what the assertions compare against:
+performance aggregates `optimistic` (best run) and CLS `pessimistic` (worst),
+so neither gated value is the median. Read the median for a sense of the page;
+read the assert step's output for what actually passed or failed.
 
 The old column is the whole story: the one run recording **zero** shift scored
 **0.96**; the two recording 0.2011 scored 0.86. The shift and the ~0.10 deficit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,46 +444,56 @@ npx playwright test
 ```
 Requires a running wrangler dev server or uses it automatically via `playwright.config.js`. Run `npm run build --prefix frontend` first.
 
-### Lighthouse CI performance assertion (#728)
+### Lighthouse CI performance assertion (#728, #854, #851)
 
-`frontend/lighthouserc.json` gates performance at **0.80** — deliberately below the
-observed CI noise floor (0.83–0.84). Lighthouse on shared GitHub runners fluctuates
-±2–3 points, so a floor at the observed ceiling flakes with no code cause. The
-assertion pins **`aggregationMethod: "optimistic"` (best of 3 runs)** — the most
-lenient option available. **Do not switch it to `median`:** median ≤ max, so that
-change only ever makes the gate *stricter* and would re-introduce the flake (#728's
-original proposed "fix" was exactly this, caught in the issue's own follow-up). A
-genuine regression must now push the best-of-3 below 0.80 — a sustained drop, not a
-contended runner. The other categories (accessibility, best-practices, seo) stay at
-0.90 and use the default aggregation: they have not been observed to flake here,
-being far less sensitive to runner contention than performance. That is an
-observation, not a guarantee — if one starts flaking, measure it before moving it.
+**The harness measures a served app, not a static build (#869).** Until then,
+`lighthouserc.json` ran `npx serve dist` — static assets only, no Pages Functions,
+no D1 — so every homepage API call failed in CI. `EventTimeline` rendered its tall
+`EventsPageSkeleton`, the fetch failed fast, the skeleton collapsed into a short
+error state, and `<Footer />` (its sibling in `EventsPage`'s `<main>`) moved.
+Lighthouse scored that as a **0.2007 layout shift** that no user has ever seen.
 
-**This is the budget's second reduction, and both were deliberate.** It was 0.90
-until 4235c1b (#534, 2026-07-05) — a squash whose second commit is an explicit
-`perf(ci): right-size the Lighthouse performance budget to 0.85 (#532)`, citing
-measured CI variance of 0.72 / 0.89 / 0.88 in a single 3-run pass. Reading only the
-first commit of that squash makes the change look incidental; it was not.
+It now points at `http://localhost:8788`, served by `.github/actions/e2e-env`
+(wrangler + a seeded D1 — the same environment E2E uses). Measured 2026-08-18,
+Lighthouse 12.8.2, mobile, `--throttling-method=simulate`, 3 runs each:
 
-**0.90 was not reached locally either, not merely missed by CI.** On 2026-08-14
-(#851, static build served by `npx serve dist`, Lighthouse CLI mobile with
-`--throttling-method=simulate`, 3 runs) the scores were **0.85 / 0.85 / 0.86**.
-Under that setup a 0.90 budget fails on a dev machine, not only on a contended
-runner — which is why retiring it was correct. One machine on one day is not
-proof it can never be reached; it is enough to stop treating 0.90 as a floor the
-current shell is quietly falling short of.
+| harness | perf | CLS |
+|---|---|---|
+| static `dist` (old) | 0.86 / 0.86 / 0.96 | 0.2011 / 0.2011 / 0.0000 |
+| `https://settimes.ca` | 0.90 / 0.90 | 0.0004 |
+| wrangler + D1 (current) | CI median **0.94** | **0.0008** |
 
-Drift since July is real and small: index chunk 338 → **354 kB** (+16 kB), which
-the build alone reproduces, and LCP 2.2 → **2.4 s**, which needs that same serve
-and throttling setup to reproduce — a raw build says nothing about LCP. The
-larger score drag is **CLS at 0.20–0.23** (component score 0.61, one mount-time
-shift) — that fails Core Web Vitals outright and is tracked in #854, separate
-from the budget. All three figures come from that single measurement; re-measure
-rather than cite them as standing values.
+The old column is the whole story: the one run recording **zero** shift scored
+**0.96**; the two recording 0.2011 scored 0.86. The shift and the ~0.10 deficit
+were one phenomenon. **So #851's question is answered — ~0.84 was never a
+regression**, and CLS was never a real defect (#854).
 
-So the budget is not chasing an unmeasured regression. Still: **do not lower it a
-third time without re-measuring locally first** — that measurement is cheap and is
-what turns a budget change from erosion into a decision.
+**The budget is still 0.80, and raising it needs CI samples, not local ones.**
+Both past reductions (0.90 → 0.85 in #532/#534, → 0.80 in #728) were, on this
+evidence, absorbing that artifact. But **do not raise it from a local number**:
+`lhci` collects all four categories, while an ad-hoc
+`lighthouse --only-categories=performance` does not, so the two are not
+comparable. On 2026-08-18 the same commit measured **0.94–0.96** raw,
+**0.94** in CI, and **0.74 / 0.84** through local `lhci` on a busy machine.
+Collect several CI runs before moving the floor.
+
+**`cumulative-layout-shift` is asserted at ≤ 0.1** so the artifact cannot return
+silently — it sat at 2× the failing threshold for months with nothing going red,
+because only the four category scores were gated. Current value is 0.0008, so the
+margin is ~125×; a failure there means something real.
+
+The assertion pins **`aggregationMethod: "optimistic"` (best of 3)** — the most
+lenient option. **Do not switch it to `median`:** median ≤ max, so that only ever
+makes the gate stricter and would re-introduce the flake (#728's original proposed
+"fix" was exactly this, caught in the issue's own follow-up). Accessibility,
+best-practices and seo stay at 0.90 on default aggregation; they have not been
+observed to flake here. That is an observation, not a guarantee — if one starts
+flaking, measure it before moving it.
+
+**Performance numbers are contention-sensitive; CLS is not.** Across this
+session's measurements CLS was stable to 4 decimal places while the perf score
+swung 0.63 → 0.96 on identical code, purely with machine load. Measure perf on an
+idle host or take CI's number; never re-baseline it from a laptop doing other work.
 
 ### Before every commit — required checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,7 +496,7 @@ performance assertion's `optimistic`.** `optimistic` picks the most favourable
 run *before* comparing, so against the old `0.2011 / 0.2011 / 0.0000` it would
 aggregate to `0.0000` and pass — the guard would not have caught the very
 artifact it exists to prevent. `pessimistic` takes the worst run, so any single
-shifting run fails the gate. That is safe here precisely because CLS is stable
+run above 0.1 fails the gate. That is safe here precisely because CLS is stable
 under load (see below); do **not** copy it onto the performance assertion.
 
 The assertion pins **`aggregationMethod: "optimistic"` (best of 3)** — the most
@@ -507,10 +507,13 @@ best-practices and seo stay at 0.90 on default aggregation; they have not been
 observed to flake here. That is an observation, not a guarantee — if one starts
 flaking, measure it before moving it.
 
-**Performance numbers are contention-sensitive; CLS is not.** Across this
-session's measurements CLS was stable to 4 decimal places while the perf score
-swung 0.63 → 0.96 on identical code, purely with machine load. Measure perf on an
-idle host or take CI's number; never re-baseline it from a laptop doing other work.
+**Performance numbers look contention-sensitive; CLS did not.** Across one
+session's measurements (2026-08-18) CLS stayed within 0.0000–0.0008 while the
+perf score ranged 0.63 → 0.96 on identical code, **correlating with** host load
+— the runs were not controlled for other variables, so treat this as an observed
+correlation rather than a demonstrated cause. It is still enough to act on:
+measure perf on an idle host or take CI's number, and never re-baseline it from
+a laptop doing other work.
 
 ### Before every commit — required checklist
 

--- a/frontend/lighthouserc.json
+++ b/frontend/lighthouserc.json
@@ -8,7 +8,7 @@
     "assert": {
       "assertions": {
         "categories:performance": ["error", { "minScore": 0.80, "aggregationMethod": "optimistic" }],
-        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1, "aggregationMethod": "optimistic" }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1, "aggregationMethod": "pessimistic" }],
         "categories:accessibility": ["error", { "minScore": 0.9 }],
         "categories:best-practices": ["error", { "minScore": 0.9 }],
         "categories:seo": ["error", { "minScore": 0.9 }],

--- a/frontend/lighthouserc.json
+++ b/frontend/lighthouserc.json
@@ -8,6 +8,7 @@
     "assert": {
       "assertions": {
         "categories:performance": ["error", { "minScore": 0.80, "aggregationMethod": "optimistic" }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1, "aggregationMethod": "optimistic" }],
         "categories:accessibility": ["error", { "minScore": 0.9 }],
         "categories:best-practices": ["error", { "minScore": 0.9 }],
         "categories:seo": ["error", { "minScore": 0.9 }],


### PR DESCRIPTION
## Summary

Follow-up to #869. That PR fixed the Lighthouse harness; this adds the guard #854 asked for, and rewrites the `CLAUDE.md` section that #869 made out of date.

**It does not raise the performance budget** — see below. That was the original intent, and the evidence did not support it.

Refs #851, #854

## What changed

| File | Change |
|------|--------|
| `frontend/lighthouserc.json` | Add `cumulative-layout-shift ≤ 0.1` with `aggregationMethod: "pessimistic"` |
| `CLAUDE.md` | Rewrite the Lighthouse section: harness fix, the artifact, why the budget stays, and the perf/CLS aggregation asymmetry |

## Why the CLS assertion, and why `pessimistic`

Only the four **category scores** were gated, so a CLS sitting at 2× the Core Web Vitals failing threshold went months without turning anything red. Current value is 0.0008 — a ~125× margin, so a failure means something real rather than runner noise.

The aggregation is load-bearing, and CodeRabbit caught me getting it wrong first time. I originally wrote `optimistic`, which selects the most **favourable** run before comparing. Against the exact historical data this guard exists to catch — `0.2011 / 0.2011 / 0.0000` — it would have aggregated to `0.0000` and **passed**, while two of three runs sat at 2× the threshold. That is a guard that passes under both the correct and the broken implementation: vacuous, and worse than none because it looks like cover.

`pessimistic` takes the worst run. Verified non-vacuous rather than assumed:

```
CLS per run:          0.0004, 0.0000, 0.0000
pessimistic (worst):  0.0004  vs 0.1 threshold -> PASS
optimistic  (best):   0.0000  <- what would have hidden a 0.2011 regression
```

**The asymmetry with performance (`optimistic`) is deliberate and documented**: CLS held within 0.0000–0.0008 across every measurement, while the perf score ranged 0.63 → 0.96 on identical code. Strict where the metric is stable, lenient where it is noisy. Do not copy `pessimistic` onto the performance assertion.

## Why the performance budget stays at 0.80

Both past reductions (0.90 → 0.85 in #532/#534, → 0.80 in #728) were, on #851's evidence, absorbing the static-build artifact rather than a real regression — so restoring 0.90 is justified *in principle*.

It is not done here, because there is exactly **one** trustworthy sample: CI's 0.94 median on #869. The local numbers do not support it and are not comparable:

| measurement | perf |
|---|---|
| `lighthouse --only-categories=performance`, idle host | 0.94 / 0.96 |
| CI `lhci` (all four categories) | 0.94 median |
| local `lhci` (all four categories), busy host | 0.74, then 0.84 |

`lhci` collects all four categories; an ad-hoc single-category run does not, so my earlier 0.94–0.96 was never comparable to the gate. Raising a floor to 0.90 on one sample, against ±2–3 points of documented runner noise, is how this budget got into trouble the first time.

Collect several CI runs at ≥0.93 first, then raise it. Deliberately left as a separate decision.

## Security / correctness notes

None — a JSON assertion threshold and a documentation file. No source, schema, auth, or API surface touched. The change makes a gate stricter, never weaker.

## Verification

- [x] `lhci assert`: **exit 0** with the new assertion, run against real collected LHRs
- [x] Guard proven non-vacuous by computing both aggregations over the raw runs (above)
- [x] Tests: backend 1149 passed | 6 todo (115 files); frontend 1052 passed (94 files) (`make gate`, exit 0)
- [x] ESLint 0 errors · Format check clean, both stacks · Build green
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] CodeRabbit (`make review`): 6 findings across iterations, all addressed — vacuous aggregation, median-vs-gated-value, and two overclaims in my own prose

Note on the gate: an earlier run showed 2 frontend failures, both #868 (`EventTimeline` `waitFor` timeouts) with the host at load average 14. Those files pass 26/26 in 1.43s isolated versus ~25s inside the loaded parallel run, and this diff touches only a JSON threshold and a markdown file. The final `make gate` on a quiet host was clean.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Lighthouse CI guidance to use a served application with seeded data.
  - Documented revised performance and cumulative layout shift (CLS) measurements, including separate optimistic performance and pessimistic CLS aggregation.
  - Clarified that the previous CLS shift was specific to the static-build test harness and may not apply universally.
  - Added guidance on local contention and avoiding local rebaselining.

- **Tests**
  - Added an automated Lighthouse CI check requiring CLS to remain at or below 0.1.
  - Retained performance and CLS budgets of 0.80 and 0.1, respectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->