### PR TITLE
ci(lighthouse): restore the performance budget to 0.90

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,14 +480,22 @@ The old column is the whole story: the one run recording **zero** shift scored
 were one phenomenon. **So #851's question is answered — ~0.84 was never a
 regression**, and CLS was never a real defect (#854).
 
-**The budget is still 0.80, and raising it needs CI samples, not local ones.**
-Both past reductions (0.90 → 0.85 in #532/#534, → 0.80 in #728) were, on this
-evidence, absorbing that artifact. But **do not raise it from a local number**:
-`lhci` collects all four categories, while an ad-hoc
-`lighthouse --only-categories=performance` does not, so the two are not
-comparable. On 2026-08-18 the same commit measured **0.94–0.96** raw,
-**0.94** in CI, and **0.74 / 0.84** through local `lhci` on a busy machine.
-Collect several CI runs before moving the floor.
+**The budget is back to 0.90**, restored on 2026-08-18 from five CI runs on the
+fixed harness: **0.94 / 0.95 / 0.95 / 0.95 / 0.96** (median LHRs; the gate
+asserts `optimistic`, so the gated value is at or above these). Both past
+reductions — 0.90 → 0.85 in #532/#534, → 0.80 in #728 — were absorbing the
+static-build artifact, not a real regression, so this is a restoration rather
+than a raise.
+
+**0.90, not 0.95, is deliberate.** A floor at the observed ceiling flakes with
+no code cause; ~5 points of headroom matches the ±2–3 point runner noise
+documented below.
+
+**Never move this floor from a local number.** `lhci` collects all four
+categories, while an ad-hoc `lighthouse --only-categories=performance` does
+not, so the two are not comparable. On 2026-08-18 the same commit measured
+**0.94–0.96** raw, **0.94–0.96** in CI, and **0.74 / 0.84** through local
+`lhci` on a busy machine. Only CI samples count.
 
 **`cumulative-layout-shift` is asserted at ≤ 0.1 with
 `aggregationMethod: "pessimistic"`** so the artifact cannot return silently — it

--- a/frontend/lighthouserc.json
+++ b/frontend/lighthouserc.json
@@ -7,7 +7,7 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.80, "aggregationMethod": "optimistic" }],
+        "categories:performance": ["error", { "minScore": 0.90, "aggregationMethod": "optimistic" }],
         "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1, "aggregationMethod": "pessimistic" }],
         "categories:accessibility": ["error", { "minScore": 0.9 }],
         "categories:best-practices": ["error", { "minScore": 0.9 }],


### PR DESCRIPTION
## Summary

Restores the Lighthouse performance budget to **0.90**, backed by five CI runs on the harness fixed in #869.

Closes #851

## Evidence

| run | perf | CLS | LCP |
|---|---|---|---|
| #869 | 0.94 | 0.0008 | 2.51s |
| #870 | 0.95 | 0.0008 | 2.41s |
| #870 | 0.95 | 0.0008 | 2.38s |
| #871 | 0.95 | 0.0008 | 2.40s |
| #871 | 0.96 | 0.0008 | 2.38s |

Median **0.95**, spread **0.02**, CLS identical to four decimal places across all five. These are the uploaded *median* LHRs; the gate asserts `optimistic` (best of 3), so the value the assertion actually sees is at or above each figure.

## This is a restoration, not a raise

`CLAUDE.md` records the budget dropping 0.90 → 0.85 (#532/#534) → 0.80 (#728), each time to stop CI flaking. Both reductions were absorbing the static-build artifact that #869 removed — the gate was measuring a page with no API, where the homepage skeleton collapsed and produced a phantom 0.2 CLS costing ~0.10 of the score.

**#851 asked whether ~0.84 was a regression from ~0.90. It was not.** The page has been scoring ~0.95 the whole time; only the harness was wrong.

## Why 0.90 and not 0.95

A floor at the observed ceiling flakes with no code cause — which is precisely how this budget got moved twice. ~5 points of headroom matches the ±2–3 point runner noise documented in `CLAUDE.md`. Setting 0.95 would trade one failure mode for the original one.

## Why not in #870

#870 deliberately left the budget alone because only **one** CI sample existed at that point, and raising a floor on one datapoint against documented runner noise is exactly the mistake that caused the earlier reductions. Five samples is enough; one was not.

## Verification

- [x] Tests: backend 1163 passed | 6 todo (116 files); frontend 1052 passed (94 files) (`make gate`, exit 0)
- [x] ESLint 0 errors · Format check clean, both stacks · Build green
- [x] Five CI Lighthouse samples read from the uploaded LHR JSON directly, not inferred from green checks
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] CodeRabbit (`make review`)

**Cannot be verified locally:** local `lhci` is not comparable to CI (it collects all four categories; a busy host scored 0.74/0.84 on the same commit that CI scored 0.94–0.96). The Lighthouse job on this PR is the real check — it must pass at the new 0.90 floor.

## Security / correctness notes

None. One JSON threshold and a documentation update. The change makes a gate **stricter**, never weaker.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the Lighthouse performance score requirement from 0.80 to 0.90.
  - Kept all other performance checks unchanged.

- **Documentation**
  - Clarified that the 0.90 threshold preserves performance headroom.
  - Documented that future adjustments should be based on CI Lighthouse results rather than local measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->