### PR TITLE
feat(metrics): completion rate + route-size distribution, and fix a mislabelled counter

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -820,10 +820,26 @@ alongside `performances` and `band_profiles` in one `DB.batch()`:
 
 ```sql
 SELECT COUNT(*) as total_schedule_builds,
-       COUNT(DISTINCT user_session) as unique_visitors,
+       COUNT(DISTINCT user_session) as route_builders,
        MAX(created_at) as last_updated
 FROM schedule_builds WHERE event_id = ?;
 ```
+
+Note the two counters measure different things, and neither is a visitor
+count. `schedule_builds` holds **one row per performance picked**, so
+`COUNT(*)` is total picks while `COUNT(DISTINCT user_session)` is the number
+of fans who built a route. The latter was called `unique_visitors` until
+#704 — a misnomer, since a session only lands in this table once it has
+already picked a set, so every fan who viewed the page and bounced was
+excluded from a field named as though it counted them.
+
+The completion rate therefore draws its denominator from a different table,
+`event_daily_stats.event_views` (#706), which is event_id-keyed. Do **not**
+use `page_views_daily` for this: that table is path-keyed (`/event/<slug>`)
+and still holds legacy rows under a second synthetic key format (`event:20`)
+from the double-counting bug fixed in #445. `event_views` also counts views
+rather than distinct people, so the rate can exceed 100% and is capped for
+display.
 
 ## Schema drift protection
 

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -3891,8 +3891,38 @@ components:
           properties:
             totalScheduleBuilds:
               type: integer
-            uniqueVisitors:
+              description: >-
+                Total sets picked across all fans. schedule_builds holds one
+                row per performance picked, so this counts picks, not routes.
+            routeBuilders:
               type: integer
+              description: >-
+                Distinct sessions that picked at least one set. Formerly
+                (mis)named uniqueVisitors, which implied it counted everyone
+                who viewed the page; it never did — a session only appears
+                here once it has already converted.
+            completionRate:
+              type: number
+              format: float
+              description: >-
+                routeBuilders divided by event page views, as a percentage.
+                Omitted entirely when there are no recorded views. The
+                denominator is event_daily_stats.event_views — page views,
+                NOT unique people — so the value can exceed 100 and is
+                capped for display.
+            routeSizeDistribution:
+              type: array
+              description: >-
+                Route sizes bucketed by sets per session. Always contains all
+                five buckets, zero-filled.
+              items:
+                type: object
+                properties:
+                  bucket:
+                    type: string
+                    enum: ["1", "2-3", "4-6", "7-11", "12+"]
+                  route_count:
+                    type: integer
             lastUpdated:
               type: string
               nullable: true

--- a/frontend/src/admin/MetricsDashboard.jsx
+++ b/frontend/src/admin/MetricsDashboard.jsx
@@ -27,16 +27,30 @@ export default function MetricsDashboard({ eventId }) {
       <h3 className="text-xl font-bold text-white">Event Metrics</h3>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {/* Schedule Builds */}
+        {/* Sets Picked */}
         <div className="bg-bg-purple rounded-lg p-4">
-          <div className="text-gray-400 text-sm">Schedule Builds</div>
+          <div className="text-gray-400 text-sm">Sets Picked</div>
           <div className="text-3xl font-bold text-white mt-2">{metrics.totalScheduleBuilds}</div>
         </div>
 
-        {/* Unique Visitors */}
+        {/* Route Builders */}
         <div className="bg-bg-purple rounded-lg p-4">
-          <div className="text-gray-400 text-sm">Unique Visitors</div>
-          <div className="text-3xl font-bold text-white mt-2">{metrics.uniqueVisitors}</div>
+          <div className="text-gray-400 text-sm">Fans Who Built a Route</div>
+          <div className="text-3xl font-bold text-white mt-2">{metrics.routeBuilders}</div>
+        </div>
+
+        {/* Route Completion Rate */}
+        <div className="bg-bg-purple rounded-lg p-4">
+          <div className="text-gray-400 text-sm">Route Completion Rate</div>
+          <div className="text-3xl font-bold text-white mt-2">
+            {typeof metrics.completionRate === 'number'
+              ? `${Math.min(metrics.completionRate, 100).toFixed(1)}%`
+              : 'n/a'}
+          </div>
+          <p className="text-gray-400 text-xs mt-2">
+            Routes built ÷ event page views, not unique visitors. Page-view history may be shorter than the event
+            page&apos;s full history.
+          </p>
         </div>
 
         {/* Last Updated */}
@@ -63,6 +77,23 @@ export default function MetricsDashboard({ eventId }) {
         <div className="bg-bg-purple rounded-lg p-4">
           <div className="text-gray-400 text-sm">Shares Imported</div>
           <div className="text-3xl font-bold text-white mt-2">{metrics.totalShareImports ?? 0}</div>
+        </div>
+      </div>
+
+      {/* Route-size distribution */}
+      <div className="bg-bg-purple rounded-lg p-4">
+        <h4 className="text-white font-semibold mb-3">Route Size Distribution</h4>
+        <div className="space-y-2">
+          {(metrics.routeSizeDistribution || []).map(route => (
+            <div key={route.bucket} className="flex justify-between text-sm">
+              <span className="text-white">
+                {route.bucket} {route.bucket === '1' ? 'set' : 'sets'}
+              </span>
+              <span className="text-gray-400">
+                {route.route_count} {route.route_count === 1 ? 'route' : 'routes'}
+              </span>
+            </div>
+          ))}
         </div>
       </div>
 

--- a/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
+++ b/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
@@ -15,7 +15,15 @@ describe('MetricsDashboard', () => {
     eventsApi.getMetrics.mockResolvedValue({
       metrics: {
         totalScheduleBuilds: 10,
-        uniqueVisitors: 7,
+        routeBuilders: 7,
+        completionRate: 25,
+        routeSizeDistribution: [
+          { bucket: '1', route_count: 1 },
+          { bucket: '2-3', route_count: 2 },
+          { bucket: '4-6', route_count: 0 },
+          { bucket: '7-11', route_count: 0 },
+          { bucket: '12+', route_count: 0 },
+        ],
         lastUpdated: '2026-06-18 12:00:00',
         popularBands: [],
         totalShares: 3,
@@ -31,6 +39,10 @@ describe('MetricsDashboard', () => {
     render(<MetricsDashboard eventId={1} />)
 
     expect(await screen.findByText('Shares Created')).toBeInTheDocument()
+    expect(screen.getByText('Fans Who Built a Route')).toBeInTheDocument()
+    expect(screen.getByText('25.0%')).toBeInTheDocument()
+    expect(screen.getByText('Route Size Distribution')).toBeInTheDocument()
+    expect(screen.getByText(/Page-view history may be shorter/)).toBeInTheDocument()
     expect(screen.getByText('3')).toBeInTheDocument()
     expect(screen.getByText('Share Views')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
@@ -60,7 +72,9 @@ describe('MetricsDashboard', () => {
     eventsApi.getMetrics.mockResolvedValue({
       metrics: {
         totalScheduleBuilds: 0,
-        uniqueVisitors: 0,
+        routeBuilders: 0,
+        completionRate: undefined,
+        routeSizeDistribution: [],
         lastUpdated: null,
         popularBands: [],
         totalShares: 0,
@@ -72,11 +86,49 @@ describe('MetricsDashboard', () => {
     render(<MetricsDashboard eventId={1} />)
 
     expect(await screen.findByText('Shares Imported')).toBeInTheDocument()
+    expect(screen.getByText('Route Completion Rate')).toBeInTheDocument()
+    expect(screen.getByText('n/a')).toBeInTheDocument()
     const shareImportsLabel = screen.getByText('Shares Imported')
     expect(shareImportsLabel.parentElement.textContent).toContain('0')
     // An empty topSharedRoutes must show the empty state, not a bare heading.
     // The endpoint filters to view_count > 0, so "no rows" is the normal
     // between-seasons case rather than an error — it needs to read that way.
     expect(screen.getByText('No shared routes with views yet')).toBeInTheDocument()
+  })
+
+  // Not a hypothetical edge case — it is the state of live data. The
+  // denominator is event_daily_stats.event_views, which only began recording
+  // with #706, while schedule_builds goes back years. Measured in production
+  // 2026-08-18: event 1 (lwbc15) has 20 route builders against 2 recorded
+  // views, i.e. 1000%. The API deliberately returns the raw ratio (capping a
+  // stored metric would destroy information); the clamp is presentation-only,
+  // so it has to be asserted here or nothing covers it.
+  it('caps a completion rate above 100% for display', async () => {
+    eventsApi.getMetrics.mockResolvedValue({
+      metrics: {
+        totalScheduleBuilds: 40,
+        routeBuilders: 20,
+        completionRate: 1000,
+        routeSizeDistribution: [
+          { bucket: '1', route_count: 20 },
+          { bucket: '2-3', route_count: 0 },
+          { bucket: '4-6', route_count: 0 },
+          { bucket: '7-11', route_count: 0 },
+          { bucket: '12+', route_count: 0 },
+        ],
+        lastUpdated: '2026-08-18 12:00:00',
+        popularBands: [],
+        totalShares: 0,
+        totalShareViews: 0,
+        topSharedRoutes: [],
+      },
+    })
+
+    render(<MetricsDashboard eventId={1} />)
+
+    expect(await screen.findByText('Route Completion Rate')).toBeInTheDocument()
+    expect(screen.getByText('100.0%')).toBeInTheDocument()
+    // The uncapped figure must not reach the page.
+    expect(screen.queryByText('1000.0%')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
+++ b/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
@@ -42,6 +42,16 @@ describe('MetricsDashboard', () => {
     expect(screen.getByText('Fans Who Built a Route')).toBeInTheDocument()
     expect(screen.getByText('25.0%')).toBeInTheDocument()
     expect(screen.getByText('Route Size Distribution')).toBeInTheDocument()
+    // Assert the rows, not just the heading: a heading-only check still passes
+    // if the buckets stop rendering or `route_count` is read wrongly. These
+    // also exercise both pluralisation branches ('set'/'sets', 'route'/'routes')
+    // and the ELSE bucket, so a broken ternary or a dropped bucket goes red.
+    expect(screen.getByText('1 set')).toBeInTheDocument()
+    expect(screen.getByText('1 route')).toBeInTheDocument()
+    expect(screen.getByText('2-3 sets')).toBeInTheDocument()
+    expect(screen.getByText('2 routes')).toBeInTheDocument()
+    expect(screen.getByText('12+ sets')).toBeInTheDocument()
+    expect(screen.getAllByText('0 routes')).toHaveLength(3)
     expect(screen.getByText(/Page-view history may be shorter/)).toBeInTheDocument()
     expect(screen.getByText('3')).toBeInTheDocument()
     expect(screen.getByText('Share Views')).toBeInTheDocument()

--- a/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
+++ b/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
@@ -42,10 +42,8 @@ describe('MetricsDashboard', () => {
     expect(screen.getByText('Fans Who Built a Route')).toBeInTheDocument()
     expect(screen.getByText('25.0%')).toBeInTheDocument()
     expect(screen.getByText('Route Size Distribution')).toBeInTheDocument()
-    // Assert the rows, not just the heading: a heading-only check still passes
-    // if the buckets stop rendering or `route_count` is read wrongly. These
-    // also exercise both pluralisation branches ('set'/'sets', 'route'/'routes')
-    // and the ELSE bucket, so a broken ternary or a dropped bucket goes red.
+    // Contract: every bucket renders, its count comes from `route_count`, and
+    // both label pluralisations resolve. A heading-only check satisfies none.
     expect(screen.getByText('1 set')).toBeInTheDocument()
     expect(screen.getByText('1 route')).toBeInTheDocument()
     expect(screen.getByText('2-3 sets')).toBeInTheDocument()

--- a/functions/api/admin/events/[id]/metrics.js
+++ b/functions/api/admin/events/[id]/metrics.js
@@ -20,16 +20,47 @@ export async function onRequestGet(context) {
   }
 
   try {
-    const [metricsRes, popularBandsRes, shareStatsRes, topRoutesRes, announcementPlanningRes, telemetryStatsRes] =
-      await DB.batch([
-        DB.prepare(
-          `SELECT COUNT(*) as total_schedule_builds,
-                COUNT(DISTINCT user_session) as unique_visitors,
+    const [
+      metricsRes,
+      routeSizeRes,
+      popularBandsRes,
+      shareStatsRes,
+      topRoutesRes,
+      announcementPlanningRes,
+      telemetryStatsRes,
+    ] = await DB.batch([
+      DB.prepare(
+        `SELECT COUNT(*) as total_schedule_builds,
+                COUNT(DISTINCT user_session) as route_builders,
                 MAX(created_at) as last_updated
          FROM schedule_builds WHERE event_id = ?`,
-        ).bind(eventId),
-        DB.prepare(
-          `SELECT bp.id as band_id, bp.name as band_name,
+      ).bind(eventId),
+      DB.prepare(
+        `SELECT CASE
+                    WHEN route_size = 1 THEN '1'
+                    WHEN route_size BETWEEN 2 AND 3 THEN '2-3'
+                    WHEN route_size BETWEEN 4 AND 6 THEN '4-6'
+                    WHEN route_size BETWEEN 7 AND 11 THEN '7-11'
+                    ELSE '12+'
+                  END AS bucket,
+                  COUNT(*) AS route_count
+           FROM (
+             SELECT user_session, COUNT(*) AS route_size
+             FROM schedule_builds
+             WHERE event_id = ?
+             GROUP BY user_session
+           )
+           GROUP BY bucket
+           ORDER BY CASE bucket
+             WHEN '1' THEN 1
+             WHEN '2-3' THEN 2
+             WHEN '4-6' THEN 3
+             WHEN '7-11' THEN 4
+             ELSE 5
+           END`,
+      ).bind(eventId),
+      DB.prepare(
+        `SELECT bp.id as band_id, bp.name as band_name,
                 COUNT(sb.performance_id) as schedule_count
          FROM schedule_builds sb
          JOIN performances p ON sb.performance_id = p.id
@@ -38,25 +69,25 @@ export async function onRequestGet(context) {
          GROUP BY bp.id, bp.name
          ORDER BY schedule_count DESC
          LIMIT 10`,
-        ).bind(eventId),
-        DB.prepare(
-          `SELECT COUNT(*) AS total_shares,
+      ).bind(eventId),
+      DB.prepare(
+        `SELECT COUNT(*) AS total_shares,
                 COALESCE(SUM(view_count), 0) AS total_share_views,
                 COALESCE(SUM(import_count), 0) AS total_share_imports
          FROM share_links WHERE event_id = ?`,
-        ).bind(eventId),
-        DB.prepare(
-          `SELECT slug, view_count, band_names, created_at FROM share_links
+      ).bind(eventId),
+      DB.prepare(
+        `SELECT slug, view_count, band_names, created_at FROM share_links
          WHERE event_id = ? AND view_count > 0
          ORDER BY view_count DESC, created_at DESC
          LIMIT 10`,
-        ).bind(eventId),
-        // Announcement planning: per-performance follower engagement signals for
-        // organizers deciding what to announce next. COUNT-based only against
-        // band_follows (verified = 1) — never selects email/tokens/consent_ip.
-        // See PRIVACY CONTRACT in functions/api/stats/public.js for the same discipline.
-        DB.prepare(
-          `SELECT
+      ).bind(eventId),
+      // Announcement planning: per-performance follower engagement signals for
+      // organizers deciding what to announce next. COUNT-based only against
+      // band_follows (verified = 1) — never selects email/tokens/consent_ip.
+      // See PRIVACY CONTRACT in functions/api/stats/public.js for the same discipline.
+      DB.prepare(
+        `SELECT
            p.id AS performance_id,
            bp.id AS band_id,
            bp.name AS band_name,
@@ -76,19 +107,27 @@ export async function onRequestGet(context) {
          JOIN band_profiles bp ON p.band_profile_id = bp.id
          WHERE p.event_id = ?
          ORDER BY p.is_announced ASC, follower_count DESC, bp.name`,
-        ).bind(eventId),
-        // Telemetry-derived counts (#706): event_view / ticket_click from
-        // functions/api/metrics.js, aggregated per event_id in event_daily_stats.
-        // Summed across all dates for this event — best-effort ingestion means
-        // this is a floor, not an exact count (see CLAUDE.md "Metrics & Analytics").
-        DB.prepare(
-          `SELECT COALESCE(SUM(event_views), 0) AS total_event_views,
+      ).bind(eventId),
+      // Telemetry-derived counts (#706): event_view / ticket_click from
+      // functions/api/metrics.js, aggregated per event_id in event_daily_stats.
+      // Summed across all dates for this event — best-effort ingestion means
+      // this is a floor, not an exact count (see CLAUDE.md "Metrics & Analytics").
+      DB.prepare(
+        `SELECT COALESCE(SUM(event_views), 0) AS total_event_views,
                 COALESCE(SUM(ticket_clicks), 0) AS total_ticket_clicks
          FROM event_daily_stats WHERE event_id = ?`,
-        ).bind(eventId),
-      ]);
+      ).bind(eventId),
+    ]);
 
     const metrics = metricsRes.results?.[0];
+    const routeBuilders = metrics?.route_builders || 0;
+    const totalEventViews = telemetryStatsRes.results?.[0]?.total_event_views || 0;
+    const completionRate = totalEventViews > 0 ? (routeBuilders / totalEventViews) * 100 : undefined;
+    const routeSizeCounts = new Map((routeSizeRes.results || []).map((row) => [row.bucket, row.route_count]));
+    const routeSizeDistribution = ["1", "2-3", "4-6", "7-11", "12+"].map((bucket) => ({
+      bucket,
+      route_count: routeSizeCounts.get(bucket) || 0,
+    }));
     const popularBands = popularBandsRes.results || [];
     const shareStats = shareStatsRes.results?.[0];
     const topSharedRoutes = (topRoutesRes.results || []).map((row) => {
@@ -130,7 +169,9 @@ export async function onRequestGet(context) {
         success: true,
         metrics: {
           totalScheduleBuilds: metrics?.total_schedule_builds || 0,
-          uniqueVisitors: metrics?.unique_visitors || 0,
+          routeBuilders: routeBuilders,
+          completionRate: completionRate,
+          routeSizeDistribution: routeSizeDistribution,
           lastUpdated: metrics?.last_updated,
           popularBands: popularBands,
           totalShares: shareStats?.total_shares || 0,

--- a/functions/api/admin/events/__tests__/metrics.test.js
+++ b/functions/api/admin/events/__tests__/metrics.test.js
@@ -185,7 +185,7 @@ describe("GET /api/admin/events/[id]/metrics", () => {
     expect(body.metrics.totalShareImports).toBe(0);
   });
 
-  test("popularBands is ordered by schedule_count desc and totalScheduleBuilds/uniqueVisitors reflect inserted rows", async () => {
+  test("returns set picks, route builders, completion rate, and route-size buckets", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "Band Fest", slug: "band-fest" });
 
@@ -222,8 +222,60 @@ describe("GET /api/admin/events/[id]/metrics", () => {
 
     // totalScheduleBuilds: 4 rows inserted
     expect(body.metrics.totalScheduleBuilds).toBe(4);
-    // uniqueVisitors: 3 distinct sessions
-    expect(body.metrics.uniqueVisitors).toBe(3);
+    // Three distinct sessions built routes; no event page views were recorded.
+    expect(body.metrics.routeBuilders).toBe(3);
+    expect(body.metrics.completionRate).toBeUndefined();
+    expect(body.metrics.routeSizeDistribution).toEqual([
+      { bucket: "1", route_count: 2 },
+      { bucket: "2-3", route_count: 1 },
+      { bucket: "4-6", route_count: 0 },
+      { bucket: "7-11", route_count: 0 },
+      { bucket: "12+", route_count: 0 },
+    ]);
+  });
+
+  test("calculates completion rate from event page views and buckets a 12-set route", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Completion Fest", slug: "completion-fest" });
+    const performances = Array.from({ length: 12 }, (_, index) =>
+      insertBand(rawDb, { name: `Band ${index}`, event_id: event.id }),
+    );
+
+    const insertBuild = rawDb.prepare(
+      "INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)",
+    );
+    performances.forEach((performance) => insertBuild.run(event.id, performance.id, "large-route"));
+    insertBuild.run(event.id, performances[0].id, "small-route");
+    rawDb
+      .prepare("INSERT INTO event_daily_stats (event_id, date, event_views) VALUES (?, ?, ?)")
+      .run(event.id, "2026-08-18", 4);
+
+    const body = await (await call(env, event.id)).json();
+    expect(body.metrics.routeBuilders).toBe(2);
+    expect(body.metrics.completionRate).toBe(50);
+    expect(body.metrics.routeSizeDistribution).toEqual([
+      { bucket: "1", route_count: 1 },
+      { bucket: "2-3", route_count: 0 },
+      { bucket: "4-6", route_count: 0 },
+      { bucket: "7-11", route_count: 0 },
+      { bucket: "12+", route_count: 1 },
+    ]);
+  });
+
+  test("returns no completion rate for an event with zero views", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "No Views Fest", slug: "no-views-fest" });
+    const performance = insertBand(rawDb, { name: "Solo Band", event_id: event.id });
+    rawDb
+      .prepare("INSERT INTO schedule_builds (event_id, performance_id, user_session) VALUES (?, ?, ?)")
+      .run(event.id, performance.id, "builder");
+    rawDb
+      .prepare("INSERT INTO event_daily_stats (event_id, date, event_views) VALUES (?, ?, ?)")
+      .run(event.id, "2026-08-18", 0);
+
+    const body = await (await call(env, event.id)).json();
+    expect(body.metrics.routeBuilders).toBe(1);
+    expect(body.metrics.completionRate).toBeUndefined();
   });
 
   describe("telemetry-derived totals (#706)", () => {


### PR DESCRIPTION
## Summary

Adds a completion-rate metric and a route-size distribution to the admin event metrics, and fixes a counter that was reporting the wrong thing under the wrong name.

Closes #704

**Provenance:** this work was authored on `feat/704-completion-rate` (in a stale worktree) and never landed. Rather than rebuild it, it was cherry-picked onto current `main`, re-verified end to end, and put up here. The commit message is the original author's analysis, retained.

## The counter was lying

`metrics.js` returned `uniqueVisitors`, and `MetricsDashboard` rendered it under a card labelled **"Unique Visitors"**. It was neither.

Both it and `totalScheduleBuilds` came from `schedule_builds`, which holds one row per performance picked — so it counted only sessions that had *already picked a set*. Every fan who viewed the event page and bounced was missing from a field named as though it included them.

That also makes **the formula this issue originally proposed unbuildable**: "schedule builds / unique visitors" over those two fields computes picks ÷ builders, which is average route size and is ≥ 1 by construction. It can never be a rate.

Renamed to `routeBuilders` / "Fans Who Built a Route", and `totalScheduleBuilds` is now labelled **"Sets Picked"** — it was never a count of schedules either.

## Completion rate

`routeBuilders / SUM(event_daily_stats.event_views)`, reusing the telemetry statement already in the batch rather than adding a query.

`page_views_daily` is deliberately **not** used: it is path-keyed (`/event/<slug>`) and still holds legacy rows under a second synthetic key format (`event:20`) from the double-counting bug fixed in #445. `event_daily_stats` is `event_id`-keyed and clean.

## Route-size distribution

Buckets sessions by how many sets they picked (`1`, `2-3`, `4-6`, `7-11`, `12+`) so the shape of fan behaviour is visible, not just the average. Added as one more statement inside the existing `DB.batch()` — atomic, and no extra round trip.

## Verification

- [x] Tests: backend **1165** passed | 6 todo (116 files); frontend **1053** passed (94 files) — `make gate`, exit 0. Net +3 tests from this change.
- [x] ESLint 0 errors · Format check clean, both stacks · Build green
- [x] `validate:openapi`: **clean** — "72 documented + 1 internal (allowlisted) = 73 route files, no drift" (required: `docs/api-spec.yaml` changed)
- [x] CodeRabbit (`make review`): **no findings** across all 6 files
- [x] Cherry-pick applied with no conflicts onto `main` @ the merge of #872

## Security / correctness notes

Admin-only endpoint, already behind `checkPermission`. Read-only — `SELECT`s inside the existing `DB.batch()`, no writes, no schema change. The new subquery groups `schedule_builds` by `user_session` for the same `event_id` that the surrounding statements already bind, so it adds no new data exposure.

One correctness note worth stating plainly: this **renames a response field** (`uniqueVisitors` → `routeBuilders`). The dashboard is the only consumer and is updated in the same change; `docs/api-spec.yaml` and `docs/DATABASE.md` are updated too.

---
Built by Dre · Rebased & reviewed by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Sets Picked,” “Fans Who Built a Route,” and route completion-rate metrics to the admin dashboard.
  * Added route-size distribution reporting, including routes with 12 or more performances.
  * Added clearer explanations of event views, route builders, total picks, and completion rates.

* **Bug Fixes**
  * Completion rates now display as unavailable when view data is missing and are capped at 100%.
  * Updated metrics documentation and API descriptions to reflect the revised terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->