### PR TITLE
docs: record that make review cannot see .github/instructions/**

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,6 +567,10 @@ Requires the CodeRabbit CLI (`brew install --cask coderabbit`, then `coderabbit 
 
 **Run this before opening the PR, not after.** The same review runs automatically on the PR, so anything it finds post-open costs a fix plus a force-push round trip. Findings it has caught that the local gates did not: assertions that pass on the wrong branch's output, a spy recording statement *preparation* rather than *execution*, and a SQL guard that stayed inert for legacy rows after a write-side fix.
 
+**`make review` is a strict subset of the PR review, and the gap is structural — not flake.** The CLI does not load `.github/instructions/**`; the PR bot does. That is why `coderabbit review` has a `-c, --config <files...>` flag for "additional instructions" at all. Three findings on 2026-08-19 (#866, #873 ×2) appeared only post-open and every one cited *"As per coding guidelines"*, tracing to rules in that directory — e.g. `nodejs-javascript-vitest.instructions.md`'s "Write tests for all new features and bug fixes". **So a post-open `Minor` is expected, not a sign the pre-PR gate failed.** The CLI *does* read `.coderabbit.yaml` and the `knowledge_base.learnings` (its output says "Based on learnings"); only the instruction files are missing.
+
+**Passing `-c .github/instructions/*.md` was tried and is NOT adopted.** In the one run measured, it failed to reproduce the PR's actual finding and instead emitted a false **critical** — claiming Vitest could not parse a file that parsed and passed 3/3 — on a run whose log was full of `fetchWithRetry` errors. A gate that emits false criticals trains you to skim the actionable bucket, which is the same "signal drowns" failure the streaming-link audit hit in #871. One degraded trial is not proof the flag is broken; it is enough not to wire it into a standing gate unmeasured. Re-test properly (several runs, good network) before revisiting.
+
 `make gate` deliberately does **not** include it — `gate` must stay fast and offline-capable; `review` needs the network and takes minutes.
 
 ### Before every push (including follow-up commits during PR review)


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s AI-review-gate section implied a clean `make review` should prevent post-open findings — *"anything it finds post-open costs a fix plus a force-push round trip."* Three findings on 2026-08-19 (#866, and two on #873) say otherwise, and the cause is **structural, not flake**.

Docs-only.

## What was traced

The CLI does **not** load `.github/instructions/**`; the PR bot does. That is why `coderabbit review` carries a `-c, --config <files...>` flag for *"additional instructions"* at all.

All three post-open findings cited **"As per coding guidelines"**, each tracing to a rule in that directory — for example `nodejs-javascript-vitest.instructions.md:21`, *"Write tests for all new features and bug fixes"*, which produced the vacuous-test finding on #873.

**So a post-open `Minor` is expected, not a failed gate.** That reframing is the point of the change: without it, the next session either distrusts `make review` or burns time re-running it.

## A correction, recorded deliberately

While diagnosing this I asserted the CLI has no access to `knowledge_base.learnings`. **That was wrong** — its output says *"Based on learnings: …"*. Only the instruction files are missing. The doc now says so, because a half-right diagnosis left in a reference file is worse than none.

## Why `-c` was tried and rejected

The obvious fix is to pass the instruction files to the CLI. I tested it rather than shipping it. In the one run measured it:

- did **not** reproduce the PR's actual finding, and
- emitted a false **`critical`** — claiming Vitest could not parse a file that parses and passes **3/3** — on a run whose log was full of `fetchWithRetry` errors.

A gate that emits false criticals trains you to skim the actionable bucket, which is the same *"signal drowns"* failure #871 just fixed in the streaming-link audit. One degraded trial does not prove the flag broken; it is enough not to wire it into a standing gate unmeasured. The doc says to re-test properly before revisiting.

## Verification

- [x] Tests: backend 1165 passed | 6 todo (116 files); frontend 1053 passed (94 files) — `make gate`, exit 0
- [x] ESLint 0 errors · Format check clean, both stacks · Build green
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] CodeRabbit (`make review`): **no findings**
- [x] Manual smoke: N/A — documentation only

## Security / correctness notes

None. Documentation only; no source, schema, CI, or runtime behaviour changed.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified differences between local review results and pull request reviews.
  * Documented expected minor findings after opening a pull request.
  * Recorded guidance on instruction-file handling and review-gate expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->