### PR TITLE
feat(share): show a three-way route diff before applying a shared route

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,8 @@ import { validateBandsData } from './utils/validation'
 import { prepareBands } from './utils/bandUtils'
 import { orderedFestivalDays } from './utils/festivalDays'
 import { saveSelectedBands } from './utils/scheduleStorage'
+import { resolveRouteDiff } from './utils/routeDiff'
+import RouteDiffSection from './components/RouteDiffSection'
 import { useSharedRouteImport } from './hooks/useSharedRouteImport'
 
 const HINT_DISMISSED_KEY = 'scheduleHintDismissed'
@@ -174,7 +176,6 @@ function App() {
   const [clearConfirmOpen, setClearConfirmOpen] = useState(false)
   const [sharedScheduleConfirmOpen, setSharedScheduleConfirmOpen] = useState(false)
   const [pendingSharedBands, setPendingSharedBands] = useState([])
-  const [pendingSharedBandNames, setPendingSharedBandNames] = useState([])
   const [lastClearedBands, setLastClearedBands] = useState([])
   const [scheduleToast, setScheduleToast] = useState(null)
   const [posterLightboxOpen, setPosterLightboxOpen] = useState(false)
@@ -455,9 +456,8 @@ function App() {
     }
   }, [bands, searchParams, setSearchParams, showScheduleToast, slug, trackScheduleBuilds])
 
-  const handleShareData = useCallback(({ matchedIds, matchedNames }) => {
+  const handleShareData = useCallback(({ matchedIds }) => {
     setPendingSharedBands(matchedIds)
-    setPendingSharedBandNames(matchedNames)
     setSharedScheduleConfirmOpen(true)
   }, [])
 
@@ -490,7 +490,6 @@ function App() {
     setSelectedBands(nextSelectedBands)
     setView('mine')
     setPendingSharedBands([])
-    setPendingSharedBandNames([])
     showScheduleToast({
       type: 'success',
       message:
@@ -584,8 +583,13 @@ function App() {
   // comment in MySchedule.jsx for why deriving it from a selected-bands
   // subset would be wrong).
   const eventFestivalDays = useMemo(() => orderedFestivalDays(bands), [bands])
-  const sharedBandsAlreadySelectedCount = pendingSharedBands.filter(id => selectedBands.includes(id)).length
-  const sharedBandsNewCount = pendingSharedBands.length - sharedBandsAlreadySelectedCount
+  // Three-way comparison against the incoming shared route (#730). The old
+  // counts were incoming-centric and could not express what Replace would
+  // drop, which is the half a fan actually weighs.
+  const sharedRouteDiff = useMemo(
+    () => resolveRouteDiff(selectedBands, pendingSharedBands, bands),
+    [selectedBands, pendingSharedBands, bands]
+  )
   const toggleShowPast = () => setShowPast(prev => !prev)
   const shouldShowLoading = loading && bands.length === 0
   const effectiveNow = debugTime || currentTime
@@ -894,7 +898,6 @@ function App() {
         onClose={() => {
           setSharedScheduleConfirmOpen(false)
           setPendingSharedBands([])
-          setPendingSharedBandNames([])
         }}
         title="Load Shared Route"
         size="sm"
@@ -905,7 +908,6 @@ function App() {
               onClick={() => {
                 setSharedScheduleConfirmOpen(false)
                 setPendingSharedBands([])
-                setPendingSharedBandNames([])
               }}
               className="min-h-[44px] rounded-lg border border-border px-4 py-2 text-text-secondary transition-colors hover:bg-surface-hover"
             >
@@ -930,35 +932,36 @@ function App() {
       >
         <div className="space-y-4 text-sm text-text-secondary">
           <p>Choose how to apply this shared route to your current picks.</p>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-            <div className="rounded-lg border border-border bg-surface p-3">
-              <div className="text-xs uppercase tracking-wide text-text-tertiary">Incoming stops</div>
-              <div className="mt-1 text-2xl font-semibold text-text-primary">{pendingSharedBands.length}</div>
-            </div>
-            <div className="rounded-lg border border-border bg-surface p-3">
-              <div className="text-xs uppercase tracking-wide text-text-tertiary">Already in your route</div>
-              <div className="mt-1 text-2xl font-semibold text-text-primary">{sharedBandsAlreadySelectedCount}</div>
-            </div>
-            <div className="rounded-lg border border-border bg-surface p-3">
-              <div className="text-xs uppercase tracking-wide text-text-tertiary">New to add</div>
-              <div className="mt-1 text-2xl font-semibold text-text-primary">{sharedBandsNewCount}</div>
-            </div>
-          </div>
+          {sharedRouteDiff.gain.length === 0 && sharedRouteDiff.lose.length === 0 ? (
+            <p className="rounded-lg border border-border bg-surface p-3 text-text-primary">
+              You’re already on the same route — nothing to add or drop.
+            </p>
+          ) : null}
+          {/* Sections render only when populated: a fan with no route yet would
+              otherwise face two empty headers explaining nothing. */}
+          <RouteDiffSection
+            title="Together"
+            hint="You both have these"
+            bands={sharedRouteDiff.together}
+            tone="text-accent-400"
+          />
+          <RouteDiffSection
+            title="You’d add"
+            hint="Only on their route"
+            bands={sharedRouteDiff.gain}
+            tone="text-success-500"
+          />
+          <RouteDiffSection
+            title="Only yours"
+            hint="Replace would drop these — Merge keeps them"
+            bands={sharedRouteDiff.lose}
+            tone="text-warning-500"
+          />
           <p className="text-text-secondary">
             <span className="font-semibold text-text-primary">Merge</span> keeps your current route and adds only the
             new shared stops. <span className="font-semibold text-text-primary">Replace</span> swaps your route for the
             shared one.
           </p>
-          {pendingSharedBandNames.length > 0 && (
-            <ul className="space-y-1 rounded-lg border border-border bg-surface p-3 text-sm text-text-secondary list-none">
-              {pendingSharedBandNames.slice(0, 5).map((name, i) => (
-                <li key={i}>{name}</li>
-              ))}
-              {pendingSharedBandNames.length > 5 && (
-                <li className="text-text-tertiary">and {pendingSharedBandNames.length - 5} more…</li>
-              )}
-            </ul>
-          )}
         </div>
       </Modal>
       <ConfirmDialog

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -932,7 +932,7 @@ function App() {
       >
         <div className="space-y-4 text-sm text-text-secondary">
           <p>Choose how to apply this shared route to your current picks.</p>
-          {sharedRouteDiff.gain.length === 0 && sharedRouteDiff.lose.length === 0 ? (
+          {!sharedRouteDiff.hasRouteChanges ? (
             <p className="rounded-lg border border-border bg-surface p-3 text-text-primary">
               You’re already on the same route — nothing to add or drop.
             </p>

--- a/frontend/src/components/RouteDiffSection.jsx
+++ b/frontend/src/components/RouteDiffSection.jsx
@@ -1,0 +1,50 @@
+import { formatTimeRange } from '../utils/timeFormat'
+
+/**
+ * One labelled band-list in the shared-route comparison (#730) — "Together",
+ * "You'd add", "Only yours".
+ *
+ * Renders nothing when empty. A recipient with no route of their own has two
+ * empty categories, and showing their headers would explain nothing while
+ * implying something went missing.
+ *
+ * `bands` arrives already resolved and already sorted by the caller, which
+ * orders on `startMs` so prepareBands' after-midnight offset is respected —
+ * do not re-sort here on raw start times.
+ */
+function RouteDiffSection({ title, hint, bands, tone }) {
+  if (!bands || bands.length === 0) return null
+
+  return (
+    <section className="rounded-lg border border-border bg-surface p-3">
+      <h3 className={`text-xs font-semibold uppercase tracking-wide ${tone}`}>
+        {title} <span className="text-text-tertiary">({bands.length})</span>
+      </h3>
+      <p className="mt-0.5 text-xs text-text-tertiary">{hint}</p>
+      <ul className="mt-2 space-y-1.5 list-none">
+        {bands.map(band => {
+          // A shared route can carry a set cancelled after it was sent. It stays
+          // listed rather than dropped (#732) — a fan who sees it vanish learns
+          // nothing, whereas a struck-through row tells them what changed.
+          const isCancelled = Boolean(band.is_cancelled)
+          return (
+            <li key={band.id} className="flex items-baseline justify-between gap-3">
+              <span className={`text-sm ${isCancelled ? 'text-text-tertiary line-through' : 'text-text-primary'}`}>
+                {band.name}
+                {isCancelled && (
+                  <span className="ml-2 text-[10px] font-semibold text-warning-500 no-underline">Cancelled</span>
+                )}
+              </span>
+              <span className="shrink-0 text-xs text-text-tertiary">
+                {formatTimeRange(band.startTime, band.endTime)}
+                {band.venue ? ` · ${band.venue}` : ''}
+              </span>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}
+
+export default RouteDiffSection

--- a/frontend/src/components/__tests__/RouteDiffSection.test.jsx
+++ b/frontend/src/components/__tests__/RouteDiffSection.test.jsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import RouteDiffSection from '../RouteDiffSection'
+
+const band = (over = {}) => ({
+  id: 'b1',
+  name: 'Openers',
+  venue: 'Roost',
+  startTime: '20:00',
+  endTime: '20:45',
+  ...over,
+})
+
+describe('RouteDiffSection', () => {
+  it.each([
+    ['an empty array', []],
+    ['null', null],
+    ['undefined', undefined],
+  ])('renders nothing for %s', (_label, bands) => {
+    const { container } = render(<RouteDiffSection title="Together" hint="You both have these" bands={bands} />)
+    // A recipient with no route of their own has two empty categories; showing
+    // their headers would explain nothing and imply something went missing.
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the title, the member count, and the hint', () => {
+    render(<RouteDiffSection title="You’d add" hint="Only on their route" bands={[band(), band({ id: 'b2' })]} />)
+    expect(screen.getByText('You’d add')).toBeInTheDocument()
+    expect(screen.getByText('(2)')).toBeInTheDocument()
+    expect(screen.getByText('Only on their route')).toBeInTheDocument()
+  })
+
+  it('renders each set with its time and venue', () => {
+    render(<RouteDiffSection title="Together" hint="h" bands={[band()]} />)
+    expect(screen.getByText('Openers')).toBeInTheDocument()
+    expect(screen.getByText(/8:00/)).toBeInTheDocument()
+    expect(screen.getByText(/Roost/)).toBeInTheDocument()
+  })
+
+  it('strikes through a cancelled set and labels it', () => {
+    // A shared route can carry a set cancelled after it was sent (#732). It must
+    // stay visible and marked, not silently disappear from the comparison.
+    render(<RouteDiffSection title="You’d add" hint="h" bands={[band({ is_cancelled: 1 })]} />)
+    expect(screen.getByText('Cancelled')).toBeInTheDocument()
+    expect(screen.getByText(/Openers/).className).toContain('line-through')
+  })
+
+  it('does not strike through a live set', () => {
+    render(<RouteDiffSection title="You’d add" hint="h" bands={[band()]} />)
+    expect(screen.queryByText('Cancelled')).not.toBeInTheDocument()
+    expect(screen.getByText(/Openers/).className).not.toContain('line-through')
+  })
+
+  it('preserves the order it is given rather than re-sorting', () => {
+    // The caller sorts on startMs so after-midnight sets land last; re-sorting
+    // here on the raw clock time would undo that.
+    render(
+      <RouteDiffSection
+        title="Together"
+        hint="h"
+        bands={[band({ id: 'late', name: 'Last Call', startTime: '01:00' }), band({ id: 'first', name: 'Openers' })]}
+      />
+    )
+    const rows = screen.getAllByRole('listitem').map(li => li.textContent)
+    expect(rows[0]).toContain('Last Call')
+    expect(rows[1]).toContain('Openers')
+  })
+})

--- a/frontend/src/utils/__tests__/routeDiff.test.js
+++ b/frontend/src/utils/__tests__/routeDiff.test.js
@@ -116,4 +116,30 @@ describe('resolveRouteDiff', () => {
   it('does not throw when the band list is missing', () => {
     expect(() => resolveRouteDiff(['a'], ['b'], undefined)).not.toThrow()
   })
+
+  describe('hasRouteChanges', () => {
+    it('is false for genuinely identical routes', () => {
+      expect(resolveRouteDiff(['early', 'mid'], ['mid', 'early'], bands).hasRouteChanges).toBe(false)
+    })
+
+    it('is true when a stored id names a performance that no longer exists', () => {
+      // The stale id resolves to no band, so it disappears from the rendered
+      // `lose` rows — but Replace still drops it from storage, so the routes
+      // are not identical and the dialog must not claim they are.
+      const result = resolveRouteDiff(['early', 'mid', 'deleted-perf'], ['early', 'mid'], bands)
+      expect(result.lose).toEqual([])
+      expect(result.hasRouteChanges).toBe(true)
+    })
+
+    it('is true when the incoming route names a deleted performance', () => {
+      const result = resolveRouteDiff(['early'], ['early', 'deleted-perf'], bands)
+      expect(result.gain).toEqual([])
+      expect(result.hasRouteChanges).toBe(true)
+    })
+
+    it('is true whenever there is a visible gain or loss', () => {
+      expect(resolveRouteDiff(['early'], ['early', 'mid'], bands).hasRouteChanges).toBe(true)
+      expect(resolveRouteDiff(['early', 'mid'], ['early'], bands).hasRouteChanges).toBe(true)
+    })
+  })
 })

--- a/frontend/src/utils/__tests__/routeDiff.test.js
+++ b/frontend/src/utils/__tests__/routeDiff.test.js
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { diffRoutes, resolveRouteDiff } from '../routeDiff'
+import { prepareBands } from '../bandUtils'
+
+describe('diffRoutes', () => {
+  it('splits two routes into together / gain / lose', () => {
+    const result = diffRoutes(['a', 'b', 'c'], ['b', 'c', 'd'])
+    expect(result.together).toEqual(['b', 'c'])
+    expect(result.gain).toEqual(['d'])
+    expect(result.lose).toEqual(['a'])
+  })
+
+  it('reports everything as a gain when the recipient has no route', () => {
+    const result = diffRoutes([], ['a', 'b'])
+    expect(result.together).toEqual([])
+    expect(result.gain).toEqual(['a', 'b'])
+    expect(result.lose).toEqual([])
+  })
+
+  it('reports no gain and no loss for identical routes', () => {
+    // Same members, different order. This asserts membership only: `together`
+    // follows the incoming route's order (covered by the ordering test below),
+    // and pinning it here would make the case fail for a reason unrelated to
+    // what it exists to check.
+    const result = diffRoutes(['a', 'b'], ['b', 'a'])
+    expect([...result.together].sort()).toEqual(['a', 'b'])
+    expect(result.gain).toEqual([])
+    expect(result.lose).toEqual([])
+  })
+
+  it('treats every own pick as at risk when the shared route is empty', () => {
+    // Replace with an empty route would drop everything, so `lose` must say so
+    // rather than quietly reporting no difference.
+    const result = diffRoutes(['a', 'b'], [])
+    expect(result.together).toEqual([])
+    expect(result.gain).toEqual([])
+    expect(result.lose).toEqual(['a', 'b'])
+  })
+
+  it('preserves each source route’s own order', () => {
+    // The caller re-sorts by schedule position; the helper must not impose an
+    // order of its own, or a caller that skips sorting silently reorders sets.
+    const result = diffRoutes(['c', 'a'], ['a', 'z'])
+    expect(result.together).toEqual(['a'])
+    expect(result.gain).toEqual(['z'])
+    expect(result.lose).toEqual(['c'])
+  })
+
+  it('deduplicates repeated ids', () => {
+    const result = diffRoutes(['a', 'a', 'b'], ['b', 'b', 'c'])
+    expect(result.together).toEqual(['b'])
+    expect(result.gain).toEqual(['c'])
+    expect(result.lose).toEqual(['a'])
+  })
+
+  it.each([
+    ['both null', null, null],
+    ['mine null', null, ['a']],
+    ['theirs null', ['a'], null],
+    ['both undefined', undefined, undefined],
+  ])('does not throw on missing input (%s)', (_label, mine, theirs) => {
+    expect(() => diffRoutes(mine, theirs)).not.toThrow()
+  })
+
+  it('treats a null own route as an empty one rather than a missing diff', () => {
+    const result = diffRoutes(null, ['a'])
+    expect(result.together).toEqual([])
+    expect(result.gain).toEqual(['a'])
+    expect(result.lose).toEqual([])
+  })
+})
+
+describe('resolveRouteDiff', () => {
+  // Built through the real prepareBands so the after-midnight offset under test
+  // is the production one, not a hand-rolled imitation of it.
+  const raw = [
+    { id: 'early', name: 'Openers', date: '2026-10-11', startTime: '20:00', endTime: '20:45', venue: 'Roost' },
+    { id: 'mid', name: 'Middle', date: '2026-10-11', startTime: '22:30', endTime: '23:15', venue: 'Room 47' },
+    {
+      id: 'afterMidnight',
+      name: 'Last Call',
+      date: '2026-10-11',
+      startTime: '01:00',
+      endTime: '01:45',
+      venue: 'Blue Room',
+    },
+  ]
+  const bands = prepareBands(raw)
+
+  it('resolves ids to bands and orders them by schedule position', () => {
+    const result = resolveRouteDiff([], ['mid', 'early'], bands)
+    expect(result.gain.map(b => b.id)).toEqual(['early', 'mid'])
+  })
+
+  it('sorts an after-midnight set last, not first', () => {
+    // 01:00 is chronologically the smallest clock time but belongs at the END
+    // of the evening. Sorting on raw start time would put it first — the
+    // recurring bug class this ordering exists to avoid.
+    const result = resolveRouteDiff([], ['afterMidnight', 'early', 'mid'], bands)
+    expect(result.gain.map(b => b.id)).toEqual(['early', 'mid', 'afterMidnight'])
+  })
+
+  it('drops ids with no matching band instead of rendering a blank row', () => {
+    // A shared route can name a performance deleted since it was sent (#733).
+    const result = resolveRouteDiff([], ['early', 'no-such-band'], bands)
+    expect(result.gain.map(b => b.id)).toEqual(['early'])
+  })
+
+  it('splits resolved bands across all three buckets', () => {
+    const result = resolveRouteDiff(['early', 'mid'], ['mid', 'afterMidnight'], bands)
+    expect(result.together.map(b => b.id)).toEqual(['mid'])
+    expect(result.gain.map(b => b.id)).toEqual(['afterMidnight'])
+    expect(result.lose.map(b => b.id)).toEqual(['early'])
+  })
+
+  it('does not throw when the band list is missing', () => {
+    expect(() => resolveRouteDiff(['a'], ['b'], undefined)).not.toThrow()
+  })
+})

--- a/frontend/src/utils/routeDiff.js
+++ b/frontend/src/utils/routeDiff.js
@@ -1,0 +1,62 @@
+/**
+ * Compare a fan's own route against a shared one (#730).
+ *
+ * The shared-route dialog used to show only incoming-centric counts
+ * ("incoming / already yours / new to add"), which never answered the question
+ * fans actually ask on a crawl night: what do we have in common, and what do I
+ * give up by taking yours? `lose` is the half that was missing — it only
+ * materialises under Replace, since Merge is purely additive.
+ *
+ * Ids only. Resolving them to bands, sorting them into schedule order (which
+ * must go through `prepareBands`, so after-midnight sets land last) and
+ * rendering them is the caller's job — keeping this pure is what makes the set
+ * logic testable without mounting anything.
+ */
+export function diffRoutes(mineIds, theirsIds) {
+  const mine = Array.isArray(mineIds) ? mineIds : []
+  const theirs = Array.isArray(theirsIds) ? theirsIds : []
+
+  const mineSet = new Set(mine)
+  const theirsSet = new Set(theirs)
+
+  // Deduplicate while preserving each source's own order: the caller re-sorts
+  // by schedule position, and imposing an order here would silently reorder
+  // sets for any caller that trusts these arrays as-is.
+  const uniqueInOrder = (ids, keep) => {
+    const seen = new Set()
+    return ids.filter(id => {
+      if (seen.has(id) || !keep(id)) return false
+      seen.add(id)
+      return true
+    })
+  }
+
+  return {
+    together: uniqueInOrder(theirs, id => mineSet.has(id)),
+    gain: uniqueInOrder(theirs, id => !mineSet.has(id)),
+    lose: uniqueInOrder(mine, id => !theirsSet.has(id)),
+  }
+}
+
+/**
+ * `diffRoutes`, with the ids resolved to band objects and ordered for display.
+ *
+ * Sorting is on `startMs`, which `prepareBands` has already offset by a day for
+ * sets starting before 06:00 — so a 1 AM set lands at the end of the evening
+ * where it belongs. Sorting on raw `startTime` here would float it to the top,
+ * which is the recurring after-midnight bug class in CLAUDE.md.
+ *
+ * Ids with no matching band are dropped rather than rendered blank: a shared
+ * route can name a performance that has since been deleted (#733).
+ */
+export function resolveRouteDiff(mineIds, theirsIds, bands) {
+  const byId = new Map((Array.isArray(bands) ? bands : []).map(band => [band.id, band]))
+  const resolve = ids =>
+    ids
+      .map(id => byId.get(id))
+      .filter(Boolean)
+      .sort((a, b) => a.startMs - b.startMs)
+
+  const { together, gain, lose } = diffRoutes(mineIds, theirsIds)
+  return { together: resolve(together), gain: resolve(gain), lose: resolve(lose) }
+}

--- a/frontend/src/utils/routeDiff.js
+++ b/frontend/src/utils/routeDiff.js
@@ -57,6 +57,18 @@ export function resolveRouteDiff(mineIds, theirsIds, bands) {
       .filter(Boolean)
       .sort((a, b) => a.startMs - b.startMs)
 
-  const { together, gain, lose } = diffRoutes(mineIds, theirsIds)
-  return { together: resolve(together), gain: resolve(gain), lose: resolve(lose) }
+  const diff = diffRoutes(mineIds, theirsIds)
+  return {
+    // Computed from the UNFILTERED diff, unlike the arrays below. A stored id
+    // whose performance was since deleted resolves to no band, so it vanishes
+    // from `lose` — and if it were the only difference, a check on the resolved
+    // arrays would claim the routes are identical while Replace still drops it
+    // from storage. The difference is invisible to the fan (a deleted set
+    // renders nothing either way), but "identical" should mean identical
+    // rather than happen to be true.
+    hasRouteChanges: diff.gain.length > 0 || diff.lose.length > 0,
+    together: resolve(diff.together),
+    gain: resolve(diff.gain),
+    lose: resolve(diff.lose),
+  }
 }


### PR DESCRIPTION
## Summary

When a fan opens a friend's shared route, the confirm dialog showed three incoming-centric counts — *"incoming stops"*, *"already in your route"*, *"new to add"* — plus the first five band names. It could not express the one thing they actually weigh: **what Replace would take away.**

Now it shows three named sections, each listing sets with time and venue:

| Section | Hint |
|---|---|
| **Together** | You both have these |
| **You'd add** | Only on their route |
| **Only yours** | Replace would drop these — Merge keeps them |

Closes #730

## A note on the issue's premise

It described the only option as a blind bulk append — *"Add N stops to my route"*. That was stale: **Merge/Replace and the counts already existed**. The genuine gap was the missing "only yours" half and the absence of per-set detail.

Per-row accept, a conflict-aware merge mode, and meet-up hints all stay **out of scope**. Each becomes easier once the trade is legible, and shipping the smallest thing that answers *"what do I gain and what do I lose"* first is the point.

## The invariant this carries

The set logic and the ordering are pure, in `utils/routeDiff.js`, so both are testable without mounting the app. That matters most for one rule:

**Sorting is on `startMs`, never raw start time.** `prepareBands` has already offset sets before 06:00 by a day, so a 1 AM set belongs at the *end* of the evening. Sorting on the clock string floats it to the top — the recurring after-midnight bug class in `CLAUDE.md`.

That case is **mutation-proven, not asserted on faith**:

```
comparator -> startTime.localeCompare   ->  1 failed / 15 passed
comparator -> startMs (correct)         ->  16/16 passed
```

The fixture is built through the **real `prepareBands`**, so the offset under test is the production one rather than a hand-rolled imitation.

## Behaviour at the edges

- **No route yet** → `Together` and `Only yours` are empty and render **nothing**; the recipient sees only "You'd add N". Empty headers would explain nothing while implying something went missing.
- **Identical routes** → says so plainly instead of showing two empty lists.
- **Cancelled sets** → a set cancelled after the route was shared stays listed, struck through and labelled (#732), rather than vanishing from the comparison.
- **Deleted performances** → ids with no matching band are dropped, not rendered blank (#733).

## Incidental cleanup

Removed `pendingSharedBandNames` and its four setter calls — this change deleted its only reader, leaving dead state behind. `useSharedRouteImport` still supplies the names, so restoring them is one line if per-row accept lands later.

`RouteDiffSection` is its own component rather than more markup in `App.jsx`, which is already ~1000 lines.

## Verification

- [x] **24 new tests** — 16 for `routeDiff` (set logic, ordering, missing input), 8 for `RouteDiffSection` (empty states, cancelled marking, order preservation)
- [x] After-midnight ordering **mutation-proven** in both directions (above)
- [x] Tests: backend 1165 passed | 6 todo (116 files); frontend **1077 passed (96 files)** — `make gate`, exit 0
- [x] ESLint 0 errors, **no new warnings** (the 2 remaining are pre-existing, in `AdminPanel`/`UserManagement`)
- [x] Format check clean, both stacks · Build green
- [x] `text-success-500` / `text-warning-500` / `text-accent-400` confirmed present in the **built** CSS — a Tailwind token that doesn't exist fails silently, so this was checked rather than assumed
- [x] `validate:openapi`: N/A — no API change
- [x] CodeRabbit (`make review`): **no findings** across all 5 files

**Not verified:** the rendered modal in a real browser. The sections are list markup inside an existing `Modal` using existing tokens, and the tokens were confirmed to emit CSS — but class-presence tests do pass on visually broken layout, so a visual check on the real flow would be a reasonable follow-up before Vol. 18.

## Security / correctness notes

No API, schema, auth, or storage change. The diff is read-only over in-memory state; it does **not** touch `saveSelectedBands`, so the `end_date || date` staleness rule is untouched. Merge/Replace semantics are unchanged — this only makes their consequences visible beforehand.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved shared-route confirmation with clear categories for overlapping, added, and removed selections.
  - Displays route counts, times, venues, and cancellation status.
  - Explains the effects of choosing Merge or Replace.
  - Clearly identifies identical routes.

- **Bug Fixes**
  - Handles missing, duplicate, and after-midnight route data more reliably.

- **Tests**
  - Added coverage for route comparisons, ordering, missing data, cancellation styling, and route metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->