### PR TITLE
fix(share): stop the route-diff meta text overflowing the modal on mobile

### DIFF
--- a/frontend/src/components/RouteDiffSection.jsx
+++ b/frontend/src/components/RouteDiffSection.jsx
@@ -33,13 +33,15 @@ function RouteDiffSection({ title, hint, bands, tone }) {
             // not fit beside a band name at 390px — it pushed 57px past the
             // modal edge and clipped the venue. Matches how MySchedule stacks.
             <li key={band.id}>
-              <span
-                className={`block text-sm ${isCancelled ? 'text-text-tertiary line-through' : 'text-text-primary'}`}
-              >
-                {band.name}
-                {isCancelled && (
-                  <span className="ml-2 text-[10px] font-semibold text-warning-500 no-underline">Cancelled</span>
-                )}
+              {/* The strike goes on the name alone. text-decoration inherits to
+                  descendants and a child cannot cancel an ancestor's — nesting
+                  the badge inside struck it through too, which `no-underline`
+                  was powerless to undo. The wrapper keeps them on one line. */}
+              <span className="block text-sm">
+                <span className={isCancelled ? 'text-text-tertiary line-through' : 'text-text-primary'}>
+                  {band.name}
+                </span>
+                {isCancelled && <span className="ml-2 text-[10px] font-semibold text-warning-500">Cancelled</span>}
               </span>
               <span className="block text-xs text-text-tertiary">
                 {formatTimeRange(band.startTime, band.endTime)}

--- a/frontend/src/components/RouteDiffSection.jsx
+++ b/frontend/src/components/RouteDiffSection.jsx
@@ -28,14 +28,20 @@ function RouteDiffSection({ title, hint, bands, tone }) {
           // nothing, whereas a struck-through row tells them what changed.
           const isCancelled = Boolean(band.is_cancelled)
           return (
-            <li key={band.id} className="flex items-baseline justify-between gap-3">
-              <span className={`text-sm ${isCancelled ? 'text-text-tertiary line-through' : 'text-text-primary'}`}>
+            // Stacked, not name-left/meta-right. A side-by-side row needs the
+            // meta to shrink, and "8:00 PM - 8:45 PM · Waterloo Music Hall" does
+            // not fit beside a band name at 390px — it pushed 57px past the
+            // modal edge and clipped the venue. Matches how MySchedule stacks.
+            <li key={band.id}>
+              <span
+                className={`block text-sm ${isCancelled ? 'text-text-tertiary line-through' : 'text-text-primary'}`}
+              >
                 {band.name}
                 {isCancelled && (
                   <span className="ml-2 text-[10px] font-semibold text-warning-500 no-underline">Cancelled</span>
                 )}
               </span>
-              <span className="shrink-0 text-xs text-text-tertiary">
+              <span className="block text-xs text-text-tertiary">
                 {formatTimeRange(band.startTime, band.endTime)}
                 {band.venue ? ` · ${band.venue}` : ''}
               </span>

--- a/frontend/src/components/__tests__/RouteDiffSection.test.jsx
+++ b/frontend/src/components/__tests__/RouteDiffSection.test.jsx
@@ -42,7 +42,19 @@ describe('RouteDiffSection', () => {
     // stay visible and marked, not silently disappear from the comparison.
     render(<RouteDiffSection title="You’d add" hint="h" bands={[band({ is_cancelled: 1 })]} />)
     expect(screen.getByText('Cancelled')).toBeInTheDocument()
-    expect(screen.getByText(/Openers/).className).toContain('line-through')
+    expect(screen.getByText('Openers').className).toContain('line-through')
+  })
+
+  it('keeps the Cancelled label outside the struck-through element', () => {
+    // text-decoration inherits to descendants and a child cannot cancel an
+    // ancestor's, so nesting the badge inside the struck name renders the badge
+    // struck too — `no-underline` on it is powerless. jsdom will not show that
+    // visually, but it can prove the badge is not a descendant.
+    render(<RouteDiffSection title="You’d add" hint="h" bands={[band({ is_cancelled: 1 })]} />)
+    const struck = screen.getByText('Openers')
+    const badge = screen.getByText('Cancelled')
+    expect(struck.className).toContain('line-through')
+    expect(struck.contains(badge)).toBe(false)
   })
 
   it('does not strike through a live set', () => {

--- a/frontend/src/components/__tests__/RouteDiffSection.test.jsx
+++ b/frontend/src/components/__tests__/RouteDiffSection.test.jsx
@@ -54,7 +54,10 @@ describe('RouteDiffSection', () => {
     const struck = screen.getByText('Openers')
     const badge = screen.getByText('Cancelled')
     expect(struck.className).toContain('line-through')
-    expect(struck.contains(badge)).toBe(false)
+    // Siblings, not merely "the badge is not inside the name". A `contains`
+    // check also passes if the badge escapes the wrapper entirely, which would
+    // drop it onto its own line and break the layout this markup exists to hold.
+    expect(badge.parentElement).toBe(struck.parentElement)
   })
 
   it('does not strike through a live set', () => {


### PR DESCRIPTION
## Summary

The route-diff rows shipped in #875 **overflow the modal on mobile**. Caught by a browser check, not by tests.

Refs #730

## Measured, before and after

At 390×844 in Chromium, against a local wrangler + seeded D1, reaching the modal through the real share-import flow:

```
before   modal scrollWidth 398  vs  clientWidth 341   ->  57px horizontal overflow
         span.shrink-0  right=415  (viewport 390)     ->  venue name clipped
after    horizontal overflow 0, zero overflowing elements
```

The row was name-left / meta-right with `shrink-0` on the meta span. `"8:00 PM - 8:45 PM · Waterloo Music Hall"` cannot fit beside a band name at that width, and `shrink-0` forbade it shrinking — so it pushed past the edge and the venue was cut off, with a horizontal scrollbar across the dialog.

**Fix:** stack the row — name on one line, `time · venue` beneath. That's how `MySchedule` already lays out a set, and it removes the side-by-side constraint rather than tuning it.

## Why the tests missed it

All 8 `RouteDiffSection` tests passed against the broken markup, and they were right to: **jsdom has no layout engine.** `getBoundingClientRect` returns zeros there, so class-presence assertions pass on markup that visibly overflows.

The existing tests were not weakened — they were never capable of seeing this. It's the class `CLAUDE.md`'s browser-verify rule exists for, and it's a fair argument for a visual check on any new fan-facing surface before Vol. 18 rather than after.

## Verification

- [x] Measured in a real browser at 390×844: overflow **57px → 0**
- [x] Reached through the genuine flow (`/event/:slug?share=…`), not a mounted component
- [x] All three sections render correctly, including the cancelled set struck through with its badge
- [x] Tests: backend 1165 passed | 6 todo; frontend 1081 passed (96 files) — `make gate`, exit 0
- [x] ESLint 0 errors · Format check clean · Build green
- [x] CodeRabbit (`make review`)

## Security / correctness notes

None — presentational only. No logic, API, storage or behaviour change; the diff computation is untouched.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated route band rows to display the band name and time/venue details in a vertical layout.
  * Refined cancellation styling so only the cancelled band name is struck through.
  * Kept the “Cancelled” badge clearly visible and unaffected by the strikethrough.
* **Bug Fixes**
  * Improved the presentation of cancellation information for clearer route details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->