### PR TITLE
feat(live): suggestion engine for filling the gap a cancelled set leaves

### DIFF
--- a/frontend/src/utils/__tests__/gapSuggestions.test.js
+++ b/frontend/src/utils/__tests__/gapSuggestions.test.js
@@ -123,6 +123,34 @@ describe('suggestGapFillers', () => {
     expect(suggestions[1].walkMinutes).toBeNull()
   })
 
+  it('breaks a full tie on id so the cap is deterministic', () => {
+    // Equal walk time AND equal start time: without a final tiebreak, which two
+    // survive `maxSuggestions` would depend on the order allBands arrived in.
+    const venue = { venue_lat: 43.4824, venue_lng: -80.52 }
+    const [cancelledBand, charlie, alpha, bravo] = prepare(
+      makeBand('cancelled', '20:00', '23:00', { is_cancelled: 1, ...venue }),
+      makeBand('charlie', '21:00', '21:30', venue),
+      makeBand('alpha', '21:00', '21:30', venue),
+      makeBand('bravo', '21:00', '21:30', venue)
+    )
+
+    const forward = suggestGapFillers({
+      cancelledBand,
+      myBands: [cancelledBand],
+      allBands: [cancelledBand, charlie, alpha, bravo],
+      maxSuggestions: 2,
+    })
+    const reversed = suggestGapFillers({
+      cancelledBand,
+      myBands: [cancelledBand],
+      allBands: [cancelledBand, bravo, alpha, charlie],
+      maxSuggestions: 2,
+    })
+
+    expect(forward.map(s => s.band.id)).toEqual(['alpha', 'bravo'])
+    expect(reversed.map(s => s.band.id)).toEqual(forward.map(s => s.band.id))
+  })
+
   it('respects maxSuggestions', () => {
     const [cancelledBand, first, second] = prepare(
       makeBand('cancelled', '20:00', '23:00', { is_cancelled: 1 }),

--- a/frontend/src/utils/__tests__/gapSuggestions.test.js
+++ b/frontend/src/utils/__tests__/gapSuggestions.test.js
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import { suggestGapFillers } from '../gapSuggestions'
+import { prepareBands } from '../bandUtils'
+
+const date = '2026-08-02'
+
+function makeBand(id, startTime, endTime, overrides = {}) {
+  return {
+    id,
+    name: id,
+    date,
+    startTime,
+    endTime,
+    venue: `Venue ${id}`,
+    venue_lat: 43.48,
+    venue_lng: -80.52,
+    ...overrides,
+  }
+}
+
+function prepare(...bands) {
+  return prepareBands(bands)
+}
+
+describe('suggestGapFillers', () => {
+  it('suggests a set that starts inside the cancelled window', () => {
+    const [cancelledBand, candidate] = prepare(
+      makeBand('cancelled', '20:00', '22:00', { is_cancelled: 1 }),
+      makeBand('candidate', '21:00', '21:30')
+    )
+
+    expect(
+      suggestGapFillers({ cancelledBand, myBands: [cancelledBand], allBands: [cancelledBand, candidate] })
+    ).toEqual([{ band: candidate, walkMinutes: 1, startsAtMs: candidate.startMs }])
+  })
+
+  it('suggests nothing when there is nothing to suggest', () => {
+    const [cancelledBand] = prepare(makeBand('cancelled', '20:00', '22:00', { is_cancelled: 1 }))
+
+    expect(suggestGapFillers({ cancelledBand, myBands: [cancelledBand], allBands: [cancelledBand] })).toEqual([])
+  })
+
+  it('never suggests a cancelled set', () => {
+    const [cancelledBand, candidate] = prepare(
+      makeBand('cancelled', '20:00', '22:00', { is_cancelled: 1 }),
+      makeBand('candidate', '21:00', '21:30', { is_cancelled: 1 })
+    )
+
+    expect(
+      suggestGapFillers({ cancelledBand, myBands: [cancelledBand], allBands: [cancelledBand, candidate] })
+    ).toEqual([])
+  })
+
+  it('never suggests a set the fan already has', () => {
+    const [cancelledBand, candidate] = prepare(
+      makeBand('cancelled', '20:00', '22:00', { is_cancelled: 1 }),
+      makeBand('candidate', '21:00', '21:30')
+    )
+
+    expect(
+      suggestGapFillers({ cancelledBand, myBands: [cancelledBand, candidate], allBands: [cancelledBand, candidate] })
+    ).toEqual([])
+  })
+
+  it('rejects a candidate overlapping another set the fan still holds', () => {
+    const [cancelledBand, heldBand, candidate] = prepare(
+      makeBand('cancelled', '20:00', '22:00', { is_cancelled: 1 }),
+      makeBand('held', '21:30', '22:30'),
+      makeBand('candidate', '21:00', '22:00')
+    )
+
+    expect(
+      suggestGapFillers({
+        cancelledBand,
+        myBands: [cancelledBand, heldBand],
+        allBands: [cancelledBand, heldBand, candidate],
+      })
+    ).toEqual([])
+  })
+
+  it('finds an after-midnight candidate using prepared timestamps', () => {
+    const [cancelledBand, candidate] = prepare(
+      makeBand('cancelled', '23:30', '01:00', { is_cancelled: 1 }),
+      makeBand('candidate', '00:15', '01:00')
+    )
+
+    expect(candidate.startMs).toBeGreaterThan(cancelledBand.startMs)
+    expect(
+      suggestGapFillers({ cancelledBand, myBands: [cancelledBand], allBands: [cancelledBand, candidate] })[0].band
+    ).toBe(candidate)
+  })
+
+  it('orders by walk time, then start time', () => {
+    const [cancelledBand, later, earlier, closest] = prepare(
+      makeBand('cancelled', '20:00', '23:00', { is_cancelled: 1, venue_lat: 43.48, venue_lng: -80.52 }),
+      makeBand('later', '21:30', '22:00', { venue_lat: 43.4824, venue_lng: -80.52 }),
+      makeBand('earlier', '21:00', '21:30', { venue_lat: 43.4824, venue_lng: -80.52 }),
+      makeBand('closest', '22:00', '22:30', { venue_lat: 43.4801, venue_lng: -80.52 })
+    )
+
+    expect(
+      suggestGapFillers({
+        cancelledBand,
+        myBands: [cancelledBand],
+        allBands: [cancelledBand, later, earlier, closest],
+      }).map(suggestion => suggestion.band.id)
+    ).toEqual(['closest', 'earlier', 'later'])
+  })
+
+  it('puts unknown walk times last and includes them', () => {
+    const [cancelledBand, known, unknown] = prepare(
+      makeBand('cancelled', '20:00', '23:00', { is_cancelled: 1 }),
+      makeBand('known', '21:00', '21:30'),
+      makeBand('unknown', '21:30', '22:00', { venue_lat: undefined, venue_lng: undefined })
+    )
+
+    const suggestions = suggestGapFillers({
+      cancelledBand,
+      myBands: [cancelledBand],
+      allBands: [cancelledBand, known, unknown],
+    })
+    expect(suggestions.map(suggestion => suggestion.band.id)).toEqual(['known', 'unknown'])
+    expect(suggestions[1].walkMinutes).toBeNull()
+  })
+
+  it('respects maxSuggestions', () => {
+    const [cancelledBand, first, second] = prepare(
+      makeBand('cancelled', '20:00', '23:00', { is_cancelled: 1 }),
+      makeBand('first', '21:00', '21:30'),
+      makeBand('second', '22:00', '22:30')
+    )
+
+    expect(
+      suggestGapFillers({
+        cancelledBand,
+        myBands: [cancelledBand],
+        allBands: [cancelledBand, first, second],
+        maxSuggestions: 1,
+      })
+    ).toHaveLength(1)
+  })
+
+  it('does not throw on null or empty input', () => {
+    expect(() => suggestGapFillers()).not.toThrow()
+    expect(() => suggestGapFillers({ cancelledBand: null, myBands: [], allBands: [] })).not.toThrow()
+    expect(suggestGapFillers({ cancelledBand: null, myBands: [], allBands: [] })).toEqual([])
+    expect(suggestGapFillers({ cancelledBand: {}, myBands: [], allBands: [] })).toEqual([])
+  })
+})

--- a/frontend/src/utils/gapSuggestions.js
+++ b/frontend/src/utils/gapSuggestions.js
@@ -50,7 +50,14 @@ export function suggestGapFillers({ cancelledBand, myBands, allBands, maxSuggest
     .sort((a, b) => {
       if (a.walkMinutes === null && b.walkMinutes !== null) return 1
       if (a.walkMinutes !== null && b.walkMinutes === null) return -1
-      return a.walkMinutes - b.walkMinutes || a.startsAtMs - b.startsAtMs
+      // id is the final tiebreak so the cap is deterministic: with equal walk
+      // time and equal start time, which candidates survive `slice` would
+      // otherwise depend on the order `allBands` happened to arrive in.
+      return (
+        a.walkMinutes - b.walkMinutes ||
+        a.startsAtMs - b.startsAtMs ||
+        String(a.band.id).localeCompare(String(b.band.id))
+      )
     })
 
   return suggestions.slice(0, limit)

--- a/frontend/src/utils/gapSuggestions.js
+++ b/frontend/src/utils/gapSuggestions.js
@@ -1,0 +1,57 @@
+import { walkMinutesBetween } from './walkTime'
+
+function hasValidWindow(band) {
+  return (
+    band &&
+    Number.isFinite(band.startMs) &&
+    Number.isFinite(band.endMs) &&
+    band.startMs > 0 &&
+    band.endMs > band.startMs
+  )
+}
+
+export function suggestGapFillers({ cancelledBand, myBands, allBands, maxSuggestions = 3 } = {}) {
+  if (!hasValidWindow(cancelledBand) || !Array.isArray(allBands) || !Array.isArray(myBands)) return []
+
+  const limit = Number.isFinite(maxSuggestions) ? Math.max(0, Math.floor(maxSuggestions)) : 0
+  if (limit === 0) return []
+
+  const selectedIds = new Set(myBands.map(band => band?.id).filter(id => id !== undefined && id !== null))
+  const previousBand = myBands
+    .filter(band => !band?.is_cancelled && hasValidWindow(band) && band.startMs < cancelledBand.startMs)
+    .sort((a, b) => b.startMs - a.startMs)[0]
+  const sourceBand = previousBand || cancelledBand
+  const sourceVenue = { latitude: sourceBand.venue_lat, longitude: sourceBand.venue_lng }
+
+  const suggestions = allBands
+    .filter(
+      candidate =>
+        hasValidWindow(candidate) &&
+        !candidate.is_cancelled &&
+        !selectedIds.has(candidate.id) &&
+        cancelledBand.startMs <= candidate.startMs &&
+        candidate.startMs < cancelledBand.endMs &&
+        !myBands.some(
+          band =>
+            !band?.is_cancelled &&
+            hasValidWindow(band) &&
+            candidate.startMs < band.endMs &&
+            band.startMs < candidate.endMs
+        )
+    )
+    .map(band => ({
+      band,
+      walkMinutes: walkMinutesBetween(sourceVenue, {
+        latitude: band.venue_lat,
+        longitude: band.venue_lng,
+      }),
+      startsAtMs: band.startMs,
+    }))
+    .sort((a, b) => {
+      if (a.walkMinutes === null && b.walkMinutes !== null) return 1
+      if (a.walkMinutes !== null && b.walkMinutes === null) return -1
+      return a.walkMinutes - b.walkMinutes || a.startsAtMs - b.startsAtMs
+    })
+
+  return suggestions.slice(0, limit)
+}


### PR DESCRIPTION
## Summary

When a fan's locked-in set is cancelled, it renders struck through — accurate, but it leaves a hole in their night with no help filling it. This is the **selection half**: given the cancelled set, the fan's route and the full lineup, return the sets worth suggesting.

Refs #735

## Engine only — deliberately no UI

Two new files, nothing else touched:

| File | |
|---|---|
| `frontend/src/utils/gapSuggestions.js` | `suggestGapFillers({ cancelledBand, myBands, allBands, maxSuggestions })` |
| `frontend/src/utils/__tests__/gapSuggestions.test.js` | 10 cases |

No rendering, and **no change to the saved lineup** — suggestions stay advisory, per the issue's constraint. How they're surfaced is a product decision better made looking at real output than at a spec, so it's split out rather than guessed at.

## Selection rules

A candidate qualifies only if it:

1. isn't already the fan's,
2. isn't itself cancelled — never suggest another dark set,
3. starts inside the cancelled set's window, and
4. doesn't overlap anything the fan still holds.

Ranked by walk time — reusing the existing `walkMinutesBetween` rather than inventing a second distance model — then start time. Capped at 3.

**Unknown walk times sort last but are still offered.** A venue missing coordinates isn't a reason to withhold a real option; it's a reason to rank it lower.

## The invariant, mutation-proven

**Windows compare `startMs`/`endMs`, never clock strings.** `prepareBands` has already offset sets starting before 06:00 by a full day, so a cancelled **23:30** set and a **00:15** candidate are on the same festival night — comparing `"00:15"` to `"23:30"` as text finds nothing and the fan gets no suggestion exactly when they need one.

```
window check on clock strings  ->  1 failed / 9 passed
window check on startMs        ->  10/10 passed
```

The fixtures are built through the **real `prepareBands`**, so the offset under test is the production one rather than a hand-rolled imitation.

## Degrades to silence

Returns `[]` rather than a weak suggestion — *"a wrong nudge mid-crawl is worse than none"* is the issue's own constraint. Null, empty and degenerate input return `[]` instead of throwing.

## Provenance

Built by **Otto** (OpenCode) against a written brief. I reviewed the diff, re-ran the gates, and re-ran the mutation check here rather than accepting the self-report — `delegate-verify` confirmed exactly the two intended files changed and nothing was committed by the delegate.

## Verification

- [x] 10 new tests, including "suggests nothing when there is nothing to suggest" (explicitly required by the issue)
- [x] After-midnight case **mutation-proven** (above)
- [x] Tests: backend 1165 passed | 6 todo (116 files); frontend **1091 passed (97 files)** — `make gate`, exit 0
- [x] ESLint 0 errors · Format check clean, both stacks · Build green
- [x] `validate:openapi`: N/A — no API change
- [x] CodeRabbit (`make review`): **no findings**

## Security / correctness notes

None. Pure client-side function over in-memory data — no API, schema, storage or auth surface. It reads the fan's route and never writes it.

## Follow-up

The UI that consumes this is not built. #735 stays open for that half; this PR is the engine it will call.

---
Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added suggestions for suitable gap fillers when a scheduled time slot is cancelled.
  - Suggestions exclude cancelled, selected, invalid, and overlapping bands.
  - Results are ranked by walking time, start time, and identifier, with a configurable result limit.
  - Supports overnight schedules and cases where walking-time data is unavailable.

- **Tests**
  - Added comprehensive coverage for candidate selection, exclusions, ordering, limits, cancellation, overlaps, and empty or invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->