### PR TITLE
ci(lighthouse): surface wrangler's log and liveness when the gate fails

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -248,7 +248,12 @@ jobs:
             echo "wrangler/workerd processes:"
             pgrep -a -f 'wrangler|workerd' || echo "  none running"
             echo "HTTP probe:"
-            curl -sS -o /dev/null -w '  status=%{http_code} time=%{time_total}s\n' http://localhost:8788/ || echo "  unreachable"
+            # Bounded deliberately: the case this step exists to catch is a
+            # server that accepts the connection and never answers. An unbounded
+            # probe would hang there until the 15-minute job timeout and could
+            # cost the artifact upload -- the diagnostic making the failure worse.
+            curl --connect-timeout 2 --max-time 5 -sS -o /dev/null \
+              -w '  status=%{http_code} time=%{time_total}s\n' http://localhost:8788/ || echo "  no response within 5s"
             echo "::endgroup::"
 
       - name: Upload Lighthouse results

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -229,6 +229,28 @@ jobs:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           CI: true
 
+      # The gate has failed with CHROME_INTERSTITIAL_ERROR mid-pass (#878): the
+      # server serves two Lighthouse runs and is unreachable for the third.
+      # wrangler's own output goes to /tmp/wrangler.log and was never surfaced,
+      # so diagnosing it needed a local reproduction instead of just reading the
+      # failure. Dump it — and say whether the process and port are still alive,
+      # which distinguishes "crashed" from "wedged" and points at different fixes.
+      - name: Wrangler diagnostics on failure
+        if: failure()
+        working-directory: .
+        run: |
+            echo "::group::wrangler.log"
+            if [ -f /tmp/wrangler.log ]; then tail -200 /tmp/wrangler.log; else echo "(no /tmp/wrangler.log)"; fi
+            echo "::endgroup::"
+            echo "::group::server liveness"
+            echo "listeners on :8788:"
+            (command -v ss >/dev/null && ss -lptn 'sport = :8788') || netstat -lptn 2>/dev/null | grep ':8788' || echo "  none"
+            echo "wrangler/workerd processes:"
+            pgrep -a -f 'wrangler|workerd' || echo "  none running"
+            echo "HTTP probe:"
+            curl -sS -o /dev/null -w '  status=%{http_code} time=%{time_total}s\n' http://localhost:8788/ || echo "  unreachable"
+            echo "::endgroup::"
+
       - name: Upload Lighthouse results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -248,8 +248,13 @@ jobs:
             # is listening, so an `|| echo none` chain prints nothing at all --
             # and "no listener" is precisely the crashed-vs-wedged signal this
             # step exists to report. Silence would be the wrong answer here.
-            listeners=$( { command -v ss >/dev/null && ss -lptn 'sport = :8788'; } 2>/dev/null \
-              || netstat -lptn 2>/dev/null | grep ':8788' || true )
+            # -H suppresses ss's header. Without it a no-listener result is a
+            # header row with zero entries -- non-empty, so it printed as though
+            # something WAS listening. Observed in run 32266757116.
+            # netstat's grep is field-bounded so ':8788' cannot match ':87880'.
+            listeners=$( { command -v ss >/dev/null && ss -H -lptn 'sport = :8788'; } 2>/dev/null \
+              || netstat -lptn 2>/dev/null \
+                | grep -E '(^|[[:space:]])[^[:space:]]*:8788([[:space:]]|$)' || true )
             if [ -n "$listeners" ]; then printf '%s\n' "$listeners"; else echo "  none"; fi
             echo "wrangler/workerd processes:"
             pgrep -a -f 'wrangler|workerd' || echo "  none running"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -244,7 +244,13 @@ jobs:
             echo "::endgroup::"
             echo "::group::server liveness"
             echo "listeners on :8788:"
-            (command -v ss >/dev/null && ss -lptn 'sport = :8788') || netstat -lptn 2>/dev/null | grep ':8788' || echo "  none"
+            # Capture, then decide. `ss` exits 0 with EMPTY output when nothing
+            # is listening, so an `|| echo none` chain prints nothing at all --
+            # and "no listener" is precisely the crashed-vs-wedged signal this
+            # step exists to report. Silence would be the wrong answer here.
+            listeners=$( { command -v ss >/dev/null && ss -lptn 'sport = :8788'; } 2>/dev/null \
+              || netstat -lptn 2>/dev/null | grep ':8788' || true )
+            if [ -n "$listeners" ]; then printf '%s\n' "$listeners"; else echo "  none"; fi
             echo "wrangler/workerd processes:"
             pgrep -a -f 'wrangler|workerd' || echo "  none running"
             echo "HTTP probe:"


### PR DESCRIPTION
## Summary

The Lighthouse gate fails intermittently — roughly **1 run in 10** since #869 pointed the harness at wrangler. This adds the diagnostics needed to fix it. It deliberately attempts **no fix**.

Refs #878

## The failure

```
Run #1...done.
Run #2...done.
Run #3...failed!    CHROME_INTERSTITIAL_ERROR
                    mainDocumentUrl: "chrome-error://chromewebdata/"
```

The server handles two Lighthouse runs and is unreachable for the third. `.lighthouseci` ends up empty, so **no assertion ever runs** — this is not the 0.90 budget restored in #872, and not a slow boot (`✓ Server is ready … (attempt 1, 4s)`).

## Why diagnostics rather than a fix

wrangler's output already goes to `/tmp/wrangler.log` inside the `e2e-env` action, but the Lighthouse job never surfaced it. So diagnosing the last occurrence meant attempting a local reproduction — which burned time, did not reproduce the CI symptom, and surfaced only a *different* local issue (an orphaned `workerd` holding `:8788` after its parent was killed).

The step reports whether the process and port are alive, which separates two states the current output cannot:

| | |
|---|---|
| **crashed** | no wrangler/workerd process, nothing listening |
| **wedged** | process alive and listening, but not answering |

Those point at different fixes. Guessing between them is exactly what this exists to prevent.

**No fix is included** because there is no evidence for one yet, and the plausible options are mutually exclusive: retry the step, tune resources, or reduce `numberOfRuns`. That last one especially — cutting runs would trade a visible flake for a quieter, worse measurement, since three runs is what makes the `optimistic` aggregation meaningful.

## Note on the probe

CodeRabbit caught that the probe was unbounded, which is self-referential: the very case this step detects is a server that accepts a connection and never answers, where an unbounded `curl` would hang to the 15-minute job timeout and could cost the `if: always()` artifact upload. Now `--connect-timeout 2 --max-time 5`, with the fallback distinguishing "no response within 5s" from "unreachable".

## Verification

- [x] `actionlint`: clean on `quality.yml`
- [x] `make gate`: exit 0 (backend 1165 passed | 6 todo; frontend 1093 passed)
- [x] Step is `if: failure()`, so it changes nothing on a passing run
- [x] CodeRabbit (`make review`): finding addressed

**Cannot be verified here:** the step only runs on a Lighthouse failure, which is intermittent by nature. Its value is realised at the next occurrence.

## Security / correctness notes

None. CI-only, failure-path only. Prints a local dev-server log and process list; no secrets are involved — the `e2e-env` action writes no credentials to `/tmp/wrangler.log`, and the Lighthouse job is passed `seed-admin: 'false'` with no admin secrets in scope.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic diagnostics when Lighthouse CI fails, including recent logs, local port checks, running process details, and a bounded server connectivity check.
  * Diagnostics now clearly indicate when no process is listening, making failed checks easier to investigate and helping identify local server availability issues more quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->