### PR TITLE
chore(deps): bump wrangler 4.123.0 → 4.124.0 to test the Lighthouse crash

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,7 +57,7 @@
         "vite": "^8.2.1",
         "vite-bundle-visualizer": "^1.0.0",
         "vitest": "^4.1.10",
-        "wrangler": "^4.123.0"
+        "wrangler": "^4.124.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -443,9 +443,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz",
-      "integrity": "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260815.1.tgz",
+      "integrity": "sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g==",
       "cpu": [
         "x64"
       ],
@@ -460,9 +460,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz",
-      "integrity": "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==",
       "cpu": [
         "arm64"
       ],
@@ -477,9 +477,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz",
-      "integrity": "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260815.1.tgz",
+      "integrity": "sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw==",
       "cpu": [
         "x64"
       ],
@@ -494,9 +494,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz",
-      "integrity": "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg==",
       "cpu": [
         "arm64"
       ],
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz",
-      "integrity": "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260815.1.tgz",
+      "integrity": "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==",
       "cpu": [
         "x64"
       ],
@@ -9019,16 +9019,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260811.1-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260811.1-alpha.tgz",
-      "integrity": "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==",
+      "version": "5.20260815.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260815.0-alpha.tgz",
+      "integrity": "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260811.1",
+        "workerd": "1.20260815.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -12711,9 +12711,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260811.1.tgz",
-      "integrity": "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260815.1.tgz",
+      "integrity": "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -12724,17 +12724,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260811.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260811.1",
-        "@cloudflare/workerd-linux-64": "1.20260811.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260811.1",
-        "@cloudflare/workerd-windows-64": "1.20260811.1"
+        "@cloudflare/workerd-darwin-64": "1.20260815.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260815.1",
+        "@cloudflare/workerd-linux-64": "1.20260815.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260815.1",
+        "@cloudflare/workerd-windows-64": "1.20260815.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.123.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.123.0.tgz",
-      "integrity": "sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==",
+      "version": "4.124.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.124.0.tgz",
+      "integrity": "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -12742,10 +12742,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260811.1-alpha",
+        "miniflare": "5.20260815.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260811.1"
+        "workerd": "1.20260815.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -12759,7 +12759,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260811.1"
+        "@cloudflare/workers-types": "^5.20260815.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,7 @@
     "vite": "^8.2.1",
     "vite-bundle-visualizer": "^1.0.0",
     "vitest": "^4.1.10",
-    "wrangler": "^4.123.0"
+    "wrangler": "^4.124.0"
   },
   "overrides": {
     "@lhci/cli": {


### PR DESCRIPTION
## Summary

Bumps wrangler **4.123.0 → 4.124.0** to test whether it resolves the Lighthouse crash in #878.

Refs #878

## Why this version specifically

#879's diagnostics established the failure is a **crash, not a hang** — no wrangler or workerd process survives, nothing is listening, and the connection is refused in **0.2 ms**. wrangler's own dying output was:

```
[wrangler:info] GET /assets/index-DRysnVVK.js 200 OK (19ms)
✘ [ERROR]
Note that there is a newer version of Wrangler available (4.124.0).
Consider checking whether upgrading resolves this error.
```

**The error text is empty** — wrangler printed `✘ [ERROR]` with no message — so there is nothing more specific to act on. Taking the tool's own suggestion is the cheapest available probe.

## What rides along

| | |
|---|---|
| wrangler | 4.123.0 → 4.124.0 |
| **workerd** | **1.20260811.1 → 1.20260815.1** |

The workerd bump is plausibly the load-bearing half: **workerd is the process that holds `:8788` and the one that actually died**, not the wrangler CLI wrapper.

## This is a probe, not a proven fix

The failure is intermittent (~1 run in 10) and environment-dependent. **A green Lighthouse run on this PR proves nothing on its own** — the previous harness passed repeatedly between failures too.

#878 stays **open** until the rate is observed across several runs. If it recurs, #879's diagnostics will now capture it with the newer versions in play, which is a strictly better position than before either change.

## Verification

- [x] `wrangler --version` reports **4.124.0**
- [x] Dev server boots on the new version; homepage **200**, `/api/events/timeline` **200**, static asset **200**
- [x] Tests: backend 1165 passed | 6 todo; frontend 1093 passed — `make gate`, exit 0
- [x] ESLint 0 errors · Format check clean · Build green
- [x] CodeRabbit (`make review`): **no findings**

**Cannot be verified here:** that the crash is actually fixed. That requires observing the failure rate over time, which is why #878 remains open rather than being closed by this PR.

## Security / correctness notes

Dev/CI dependency only — wrangler is not shipped to users and is not in the production bundle. `package-lock.json` regenerated by `npm install wrangler@^4.124.0`; the only version changes are wrangler and its workerd platform binaries.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal development tooling to the latest supported version.
  - No user-facing features or behaviour changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->