### PR TITLE
ci(lighthouse): capture memory and OOM evidence when the gate fails

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -266,6 +266,29 @@ jobs:
             curl --connect-timeout 2 --max-time 5 -sS -o /dev/null \
               -w '  status=%{http_code} time=%{time_total}s\n' http://localhost:8788/ || echo "  no response within 5s"
             echo "::endgroup::"
+            # Three occurrences of #878 have now shown the same shape -- two clean
+            # Lighthouse runs, then a silent abort mid-asset-serving on the third,
+            # process gone and the port refused in ~0.2ms. That is an abort, not a
+            # hang, but the two candidate causes (kernel OOM kill vs a workerd
+            # crash) are indistinguishable from what this step captures today.
+            # These probes are what tells them apart. wrangler 4.124.0 did NOT
+            # fix it, so the version hypothesis is spent.
+            echo "::group::resources"
+            echo "memory:"
+            # Capture, then decide -- `free | sed || echo` takes the PIPELINE's
+            # status, which is sed's success, so the fallback never fires and the
+            # section prints nothing at all. Same trap as the listener check above.
+            mem=$(free -m 2>/dev/null || true)
+            if [ -n "$mem" ]; then printf '%s\n' "$mem" | sed 's/^/  /'; else echo "  (free unavailable)"; fi
+            echo "load average:"
+            sed 's/^/  /' /proc/loadavg 2>/dev/null || echo "  (unavailable)"
+            echo "kernel OOM kills (the question three runs have failed to answer):"
+            # dmesg is often restricted to root on hosted runners; sudo -n so a
+            # missing grant fails immediately instead of prompting and hanging.
+            oom=$( { sudo -n dmesg 2>/dev/null || dmesg 2>/dev/null; } \
+              | grep -iE 'out of memory|oom[-_]kill|killed process' | tail -20 || true )
+            if [ -n "$oom" ]; then printf '%s\n' "$oom" | sed 's/^/  /'; else echo "  none found (or dmesg not readable)"; fi
+            echo "::endgroup::"
 
       - name: Upload Lighthouse results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -281,7 +281,13 @@ jobs:
             mem=$(free -m 2>/dev/null || true)
             if [ -n "$mem" ]; then printf '%s\n' "$mem" | sed 's/^/  /'; else echo "  (free unavailable)"; fi
             echo "load average:"
-            sed 's/^/  /' /proc/loadavg 2>/dev/null || echo "  (unavailable)"
+            # Same capture-then-decide as memory and OOM below. `sed` exits 0 on a
+            # file that exists but is EMPTY, so the `||` fallback never fires and
+            # the section prints blank -- and blank is the one output a diagnostic
+            # must never produce. I fixed two of the three probes in this block
+            # and left this one, which is exactly how the trap survives.
+            load=$(sed 's/^/  /' /proc/loadavg 2>/dev/null || true)
+            if [ -n "$load" ]; then printf '%s\n' "$load"; else echo "  (unavailable)"; fi
             echo "kernel OOM kills (the question three runs have failed to answer):"
             # dmesg is often restricted to root on hosted runners; sudo -n so a
             # missing grant fails immediately instead of prompting and hanging.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -281,11 +281,10 @@ jobs:
             mem=$(free -m 2>/dev/null || true)
             if [ -n "$mem" ]; then printf '%s\n' "$mem" | sed 's/^/  /'; else echo "  (free unavailable)"; fi
             echo "load average:"
-            # Same capture-then-decide as memory and OOM below. `sed` exits 0 on a
-            # file that exists but is EMPTY, so the `||` fallback never fires and
-            # the section prints blank -- and blank is the one output a diagnostic
-            # must never produce. I fixed two of the three probes in this block
-            # and left this one, which is exactly how the trap survives.
+            # Capture before deciding, as every probe in this block does: `sed`
+            # exits 0 on a file that exists but is EMPTY, so a `|| echo` fallback
+            # would never fire and the section would print blank -- the one output
+            # a diagnostic must never produce.
             load=$(sed 's/^/  /' /proc/loadavg 2>/dev/null || true)
             if [ -n "$load" ]; then printf '%s\n' "$load"; else echo "  (unavailable)"; fi
             echo "kernel OOM kills (the question three runs have failed to answer):"


### PR DESCRIPTION
## Summary

**wrangler 4.124.0 did not fix #878.** This adds the diagnostics needed to answer the question three occurrences have now failed to answer.

Refs #878

## The negative result

The crash recurred on #885, which carries the bump:

```
wrangler 4.124.0
Run #1...done.  Run #2...done.  Run #3...failed!
CHROME_INTERSTITIAL_ERROR
listeners: none · processes: none running · status=000 (0.16ms, refused)
last: GET /assets/plus-DUNf9PmK.js 200 OK (38ms)   <end of log>
```

Identical signature. The version hypothesis is spent, and wrangler's own *"upgrading may resolve this error"* hint was a red herring — the empty `✘ [ERROR]` carrying it appears in only **one of three** occurrences.

Worth noting #880 passed Lighthouse **twice** on 4.124.0 before this. That is exactly what a ~1-in-10 flake looks like, and why its PR said a green run would prove nothing.

## What three occurrences agree on

| Observation | Rules out |
|---|---|
| Always run **#3**, never #1 or #2 | needs sustained load |
| All requests `200 OK` at normal timings right up to the end | gradual degradation |
| Process **gone**, port refused in ~0.2ms | a hang / wedge |
| No error output in 2 of 3 | a handled error path |

Healthy, then an instantaneous silent exit. That is an **abort** — and the two remaining candidates, a **kernel OOM kill** versus a **workerd crash**, need different fixes and are indistinguishable from what the step captures today.

## What this adds

`free -m`, `/proc/loadavg`, and a `dmesg` scan for OOM kills, inside the existing `if: failure()` step. `sudo -n` so a missing grant fails immediately rather than prompting and hanging — `dmesg` is often root-only on hosted runners.

## A bug caught by running it

Each probe **captures before deciding** rather than piping into a fallback. My first draft had:

```bash
free -m 2>/dev/null | sed 's/^/  /' || echo "  (free unavailable)"
```

That takes the **pipeline's** status — `sed`'s success — so the fallback never fires and the memory section prints **nothing at all**. Caught by running it on a host without `free`.

It is the identical trap to the listener check two commits earlier, which is why the comment names it rather than just fixing it. For a diagnostic, silence is the worst output: indistinguishable from "the tool wasn't there".

## Verification

- [x] Probes exercised on a host lacking `free`, `/proc` and readable `dmesg` — **every section prints something**, completes in 0.04s, no hang
- [x] `actionlint` clean
- [x] `make gate`: exit 0
- [x] CodeRabbit (`make review`): **no findings**
- [x] `if: failure()` — no effect on a passing run

**Cannot be verified here:** that it captures a real OOM. That needs the crash to recur, which is the point.

## Security / correctness notes

None. CI-only, failure-path only. Prints memory stats and kernel log lines; no secrets involved.

---
Built by Theo · 🤖 [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Lighthouse failure diagnostics with system resource details, including memory usage, load average, and recent out-of-memory events.
  * Added fallback handling when resource information is unavailable or cannot be read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->