### PR TITLE
ci(lighthouse): capture wrangler's own log, where #878's cause is

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -239,8 +239,22 @@ jobs:
         if: failure()
         working-directory: .
         run: |
+            # Dump log text WITHOUT letting the runner parse it as workflow
+            # commands. A dumped line starting `::endgroup::` would close our
+            # group early and strand the rest of the diagnostics inside no
+            # group; `::error::` would forge an annotation. The `sed` indent
+            # further down is cosmetic and cannot be relied on as protection.
+            # The token must be unguessable from the log's own contents, so it
+            # is generated per call rather than fixed.
+            dump() {
+              local tok
+              tok="stop-$(date +%s%N)-${RANDOM}${RANDOM}"
+              echo "::stop-commands::${tok}"
+              cat
+              echo "::${tok}::"
+            }
             echo "::group::wrangler.log"
-            if [ -f /tmp/wrangler.log ]; then tail -200 /tmp/wrangler.log; else echo "(no /tmp/wrangler.log)"; fi
+            if [ -f /tmp/wrangler.log ]; then tail -200 /tmp/wrangler.log | dump; else echo "(no /tmp/wrangler.log)"; fi
             echo "::endgroup::"
             echo "::group::wrangler internal log"
             # When wrangler aborts (#878) it prints an [ERROR] with an EMPTY
@@ -258,7 +272,7 @@ jobs:
               # and a diagnostic that aborts the step would take the liveness
               # and resource probes with it -- losing the evidence it exists to
               # collect, on the one run where it matters.
-              tail -200 "$log" 2>/dev/null | sed 's/^/  /' || true
+              tail -200 "$log" 2>/dev/null | sed 's/^/  /' | dump || true
             else
               echo "  (no log under $HOME/.config/.wrangler/logs)"
             fi

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -251,10 +251,14 @@ jobs:
             # /tmp/wrangler.log above is only our stdout redirect, so it has
             # the same blank. This is the file that does not.
             log=$(find "$HOME/.config/.wrangler/logs" -maxdepth 1 -name '*.log' \
-                    -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
+                    -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2- || true)
             if [ -n "$log" ]; then
               echo "  file: $log"
-              tail -200 "$log" | sed 's/^/  /'
+              # Both pipelines are best-effort: the step runs under `bash -e`,
+              # and a diagnostic that aborts the step would take the liveness
+              # and resource probes with it -- losing the evidence it exists to
+              # collect, on the one run where it matters.
+              tail -200 "$log" 2>/dev/null | sed 's/^/  /' || true
             else
               echo "  (no log under $HOME/.config/.wrangler/logs)"
             fi

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -242,6 +242,23 @@ jobs:
             echo "::group::wrangler.log"
             if [ -f /tmp/wrangler.log ]; then tail -200 /tmp/wrangler.log; else echo "(no /tmp/wrangler.log)"; fi
             echo "::endgroup::"
+            echo "::group::wrangler internal log"
+            # When wrangler aborts (#878) it prints an [ERROR] with an EMPTY
+            # body to stdout, then names a log file it wrote the real detail
+            # to. Run 32295262333 captured exactly that: the banner, the
+            # "please file a bug" link, ~9 more successful requests, and then
+            # the process gone -- with the one field that explains it blank.
+            # /tmp/wrangler.log above is only our stdout redirect, so it has
+            # the same blank. This is the file that does not.
+            log=$(find "$HOME/.config/.wrangler/logs" -maxdepth 1 -name '*.log' \
+                    -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
+            if [ -n "$log" ]; then
+              echo "  file: $log"
+              tail -200 "$log" | sed 's/^/  /'
+            else
+              echo "  (no log under $HOME/.config/.wrangler/logs)"
+            fi
+            echo "::endgroup::"
             echo "::group::server liveness"
             echo "listeners on :8788:"
             # Capture, then decide. `ss` exits 0 with EMPTY output when nothing

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -250,11 +250,16 @@ jobs:
               local tok
               tok="stop-$(date +%s%N)-${RANDOM}${RANDOM}"
               echo "::stop-commands::${tok}"
-              cat
+              # The resume marker MUST be emitted even if `cat` fails. While
+              # commands are stopped, every later ::group::/::endgroup:: and
+              # annotation in the JOB is inert -- so returning early here would
+              # silently disable the rest of the diagnostics output, not just
+              # this dump.
+              cat || true
               echo "::${tok}::"
             }
             echo "::group::wrangler.log"
-            if [ -f /tmp/wrangler.log ]; then tail -200 /tmp/wrangler.log | dump; else echo "(no /tmp/wrangler.log)"; fi
+            if [ -f /tmp/wrangler.log ]; then tail -200 /tmp/wrangler.log | dump || true; else echo "(no /tmp/wrangler.log)"; fi
             echo "::endgroup::"
             echo "::group::wrangler internal log"
             # When wrangler aborts (#878) it prints an [ERROR] with an EMPTY
@@ -264,7 +269,7 @@ jobs:
             # the process gone -- with the one field that explains it blank.
             # /tmp/wrangler.log above is only our stdout redirect, so it has
             # the same blank. This is the file that does not.
-            log=$(find "$HOME/.config/.wrangler/logs" -maxdepth 1 -name '*.log' \
+            log=$(find "$HOME/.config/.wrangler/logs" -maxdepth 1 -type f -name '*.log' \
                     -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2- || true)
             if [ -n "$log" ]; then
               echo "  file: $log"


### PR DESCRIPTION
## Summary

#887's diagnostics paid off immediately — run [32295262333](https://github.com/BreakableHoodie/settimesdotca/actions/runs/32295262333) showed the shape of #878, and it is not what the remaining hypotheses predicted:

```
✘ [ERROR]                        ← wrangler's own handler, EMPTY body
  If you think this is a bug then please create an issue at
  https://github.com/cloudflare/workers-sdk/issues/new/choose
[wrangler:info] GET /assets/…    ← kept serving ~9 more requests
(then gone: no listener, no process, connect refused in 0.166ms)
```

The resource probes added in #887 ruled out everything else in the same run:

| Probe | Value | Verdict |
|---|---|---|
| memory | 14800 MB available of 15989 | not memory |
| load average | 1.63 | not contention |
| kernel OOM kills | none found | not the kernel |
| wrangler version | 4.124.0 | not the version (#878 predates and survives the bump) |

So **workerd is aborting on its own** — and wrangler knows why. It just prints the reason as an empty string to stdout, and writes the detail to a file it names on the way out:

```
🪵 Logs were written to "~/.config/.wrangler/logs/wrangler-<ts>.log"
```

`/tmp/wrangler.log` is only our stdout redirect, so it carries the same blank. This PR tails the newest file in that directory — the one place the cause could still be.

Refs #878

## Verification

The selector was tested on **Linux**, since macOS `find` has no `-printf` and testing it on this host would have proved nothing:

| Case | Result |
|---|---|
| newest of three logs | picked the newest ✔ |
| directory missing | empty → fallback message fires ✔ |
| directory empty | empty → fallback message fires ✔ |
| filename containing spaces | kept intact by `cut -d' ' -f2-` ✔ |

Second commit makes both pipelines best-effort: the step runs under `bash -e`, so a diagnostic that exits non-zero would abort the step and take the liveness and resource probes with it — losing the evidence it exists to collect, on the one run where it matters. That matches how the resource probes in the same step are already written.

## Test plan

- [x] `make gate` green
- [x] `make review` (CodeRabbit) — no new findings
- [x] `actionlint` clean
- [x] Selector verified on Linux (table above)
- [ ] Next #878 occurrence should print the wrangler log body — that is the deliverable

## Risk

None to the gate. Diagnostics-only, runs on failure, and now cannot itself fail the step.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lighthouse failure diagnostics by locating and reporting the newest available Wrangler log.
  * Displays the final 200 lines in a safer, clearly formatted way.
  * Clearly indicates the log path or when no diagnostic log is available.
  * Ensures diagnostic and resource checks continue when log discovery or reading fails.
  * Prevents log contents from being interpreted as workflow commands during reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->