### PR TITLE
test(e2e): make the a11y skip flag work for chromium, and share one session helper

### DIFF
--- a/e2e/accessibility/admin-surfaces.spec.js
+++ b/e2e/accessibility/admin-surfaces.spec.js
@@ -15,7 +15,7 @@
 
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from "../credentials";
+import { loginAsAdmin } from "../utils/session";
 
 // Seeded by database/seed-test-data.sql and the only seeded event with
 // performances, so it is what makes the Lineup audit non-empty.
@@ -41,24 +41,8 @@ const getViolationSummary = (violations) =>
     targets: nodes.map(({ target }) => target),
   }));
 
-// The saved storageState cannot be trusted. `lucia.invalidateUserSessions()`
-// runs on every re-authentication (CLAUDE.md), so login.spec.js logging in kills
-// the session auth.setup.js saved -- this spec then lands on the login form,
-// where there are no tabs. Every other admin spec carries the same defensive
-// helper for the same reason. Running this spec alone hides it completely.
-const ensureAdminSession = async (page) => {
-  await page.goto("/admin");
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
-  if (await page.locator('input[type="email"]').isVisible()) {
-    await page.fill('input[type="email"]', ADMIN_EMAIL);
-    await page.fill('input[type="password"]', ADMIN_PASSWORD);
-    await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
-  }
-};
-
 const openSurface = async (page, surface) => {
-  await ensureAdminSession(page);
+  await loginAsAdmin(page);
   await expect(page.getByRole("tab", { name: "Events", exact: true })).toBeVisible({ timeout: 15000 });
 
   if (surface.id === "lineup") {

--- a/e2e/band-management.spec.js
+++ b/e2e/band-management.spec.js
@@ -1,17 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
-
-const loginAsAdmin = async (page) => {
-  await page.goto("/admin");
-  // Wait for either admin tab buttons (valid session) or login form (session expired/invalidated)
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
-  if (await page.locator('input[type="email"]').isVisible()) {
-    await page.fill('input[type="email"]', ADMIN_EMAIL);
-    await page.fill('input[type="password"]', ADMIN_PASSWORD);
-    await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
-  }
-};
+import { loginAsAdmin } from "./utils/session";
 
 const openRosterTab = async (page) => {
   await page.click('button:has-text("Roster")');

--- a/e2e/cancelled-set.spec.js
+++ b/e2e/cancelled-set.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
+import { loginAsAdmin } from "./utils/session";
 
 /**
  * Cancellation feature — E2E rendering + accessibility coverage (#732).
@@ -19,23 +19,6 @@ import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
 
 const THEME_STORAGE_KEY = "settimes-theme";
 const THEMES = ["midnight-ember", "arctic-night", "daybreak", "silver-lining"];
-
-// Idempotent, matching e2e/band-management.spec.js. The chromium project
-// loads a saved storageState (playwright.config.js), so the context usually
-// arrives ALREADY authenticated -- navigating to /admin/login then redirects
-// straight to /admin and there is no form to fill. An unconditional login
-// therefore hangs on `page.fill` until the 30s test timeout. Wait for either
-// outcome and only log in when the form is actually present.
-const loginAsAdmin = async (page) => {
-  await page.goto("/admin");
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
-  if (await page.locator('input[type="email"]').isVisible()) {
-    await page.fill('input[type="email"]', ADMIN_EMAIL);
-    await page.fill('input[type="password"]', ADMIN_PASSWORD);
-    await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
-  }
-};
 
 const getCsrfToken = async (page) => {
   const cookies = await page.context().cookies();

--- a/e2e/event-creation.spec.js
+++ b/e2e/event-creation.spec.js
@@ -1,17 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
-
-const loginAsAdmin = async (page) => {
-  await page.goto("/admin");
-  // Wait for either admin tab buttons (valid session) or login form (session expired/invalidated)
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
-  if (await page.locator('input[type="email"]').isVisible()) {
-    await page.fill('input[type="email"]', ADMIN_EMAIL);
-    await page.fill('input[type="password"]', ADMIN_PASSWORD);
-    await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
-  }
-};
+import { loginAsAdmin } from "./utils/session";
 
 const openEventsTab = async (page) => {
   await page.click('button:has-text("Events")');

--- a/e2e/event-wizard.spec.js
+++ b/e2e/event-wizard.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
+import { loginAsAdmin } from "./utils/session";
 
 const uniqueSuffix = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
 
@@ -8,17 +8,6 @@ const futureDate = () => {
   const d = new Date();
   d.setDate(d.getDate() + 90);
   return d.toISOString().slice(0, 10);
-};
-
-const loginAsAdmin = async (page) => {
-  await page.goto("/admin");
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
-  if (await page.locator('input[type="email"]').isVisible()) {
-    await page.fill('input[type="email"]', ADMIN_EMAIL);
-    await page.fill('input[type="password"]', ADMIN_PASSWORD);
-    await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
-  }
 };
 
 const getCsrfToken = async (page) => {

--- a/e2e/live-experience.spec.js
+++ b/e2e/live-experience.spec.js
@@ -1,21 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
-
-// Re-establish the admin session in THIS context. Another spec's admin login
-// invalidates the shared storageState session (lucia.invalidateUserSessions on
-// re-auth), so admin-mutating specs must log in themselves. The dark-pinned
-// admin panel isn't reliable at a mobile width, so this runs at desktop; the
-// test switches to a phone viewport for the fan-facing flow afterwards.
-const loginAsAdmin = async (page) => {
-  await page.goto("/admin");
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
-  if (await page.locator('input[type="email"]').isVisible()) {
-    await page.fill('input[type="email"]', ADMIN_EMAIL);
-    await page.fill('input[type="password"]', ADMIN_PASSWORD);
-    await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
-  }
-};
+import { loginAsAdmin } from "./utils/session";
 
 /**
  * Live-experience lifecycle walkthrough (#554).

--- a/e2e/offline-experience.spec.js
+++ b/e2e/offline-experience.spec.js
@@ -1,20 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
-
-// Re-establish the admin session in THIS context. The shared storageState
-// session (from auth.setup) is invalidated whenever another spec logs in —
-// lucia.invalidateUserSessions() kills all other sessions on re-auth — so
-// admin-mutating specs must log in themselves. Mirrors event-creation.spec.js.
-const loginAsAdmin = async (page) => {
-  await page.goto("/admin");
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
-  if (await page.locator('input[type="email"]').isVisible()) {
-    await page.fill('input[type="email"]', ADMIN_EMAIL);
-    await page.fill('input[type="password"]', ADMIN_PASSWORD);
-    await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
-  }
-};
+import { loginAsAdmin } from "./utils/session";
 
 /**
  * Offline resilience (#578, #554).

--- a/e2e/user-management.spec.js
+++ b/e2e/user-management.spec.js
@@ -1,17 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from "./credentials";
-
-const loginAsAdmin = async (page) => {
-  await page.goto("/admin");
-  // Wait for either admin tab buttons (valid session) or login form (session expired/invalidated)
-  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
-  if (await page.locator('input[type="email"]').isVisible()) {
-    await page.fill('input[type="email"]', ADMIN_EMAIL);
-    await page.fill('input[type="password"]', ADMIN_PASSWORD);
-    await page.click('button[type="submit"]');
-    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
-  }
-};
+import { loginAsAdmin } from "./utils/session";
 
 const openUsersTab = async (page) => {
   await page.click('button:has-text("Users")');

--- a/e2e/utils/session.js
+++ b/e2e/utils/session.js
@@ -1,0 +1,25 @@
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from "../credentials";
+
+// The storageState saved by auth.setup.js cannot be trusted to still be valid.
+// `lucia.invalidateUserSessions()` runs on every re-authentication (see
+// functions/utils/auth.js and CLAUDE.md), so login.spec.js logging in KILLS the
+// session auth.setup.js saved. A spec running afterwards then lands on the login
+// form, where there are no tabs and every `getByRole("tab")` times out.
+//
+// The failure is order-dependent, which is what makes it expensive: running an
+// affected spec on its own passes and hides the problem completely. That is how
+// #885's CI failure started its diagnosis in the wrong place.
+//
+// This is the single home for that behaviour -- eight specs each carried their
+// own copy before #888. Do not reintroduce a local one.
+export const loginAsAdmin = async (page) => {
+  await page.goto("/admin");
+  // Wait for either admin tab buttons (valid session) or login form (session expired/invalidated)
+  await page.waitForSelector('button[role="tab"], input[type="email"]', { state: "visible", timeout: 15000 });
+  if (await page.locator('input[type="email"]').isVisible()) {
+    await page.fill('input[type="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForSelector('button[role="tab"]', { state: "visible", timeout: 15000 });
+  }
+};

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,7 +31,10 @@ export default defineConfig({
     },
     {
       name: 'chromium',
-      testIgnore: /.*login\.spec\.js/,
+      testIgnore: [
+        /.*login\.spec\.js/,
+        ...(skipA11yVisual ? [/accessibility\//, /visual-regression\.spec\.js/] : []),
+      ],
       use: { ...devices['Desktop Chrome'], storageState: storageStatePath },
       dependencies: ['setup'],
     },


### PR DESCRIPTION
## Summary

Two fixes from #885's CI failure.

Closes #888

## 1. The skip flag never worked for the `chromium` project

`playwright.config.js` set a **top-level** `testIgnore` when `PLAYWRIGHT_SKIP_A11Y_VISUAL` is on, but the `chromium` project declares its own `testIgnore` for `login.spec.js` — and a project-level `testIgnore` **replaces** the top-level one rather than merging. So `accessibility/` and `visual-regression.spec.js` were never ignored there.

The `e2e` job sets the flag and ran them anyway:

- `e2e` and `e2e-a11y-visual` each paid for the whole accessibility suite
- a failure surfaced in a job whose name says it doesn't run those tests — which is exactly how #885's diagnosis started in the wrong place

### Verification — the arithmetic closes exactly

| | before | after |
|---|---|---|
| flag OFF | 125 tests / 16 files | **125 / 16** (unchanged) |
| flag ON | 120 tests / 15 files | **63 / 11** |

`125 − 63 = 62`, and there are **exactly 62** accessibility+visual tests, with **0** surviving the flag. So the drop is accounted for precisely rather than approximately — nothing else was collaterally excluded. `login.spec.js` remains absent from `chromium` in both states.

`chromium-unauth` was checked for the same shadowing and does not have it.

## 2. Eight specs carried the same session helper

Seven defined `loginAsAdmin`; `accessibility/admin-surfaces.spec.js` defined `ensureAdminSession`. **All eight bodies were byte-identical** — confirmed by extracting each from git rather than by eye — differing only in name and whether the explanatory comment was present.

They now import one `e2e/utils/session.js`. Its header carries the *fullest* version of the explanation rather than the shortest, since it's now the only home for it:

- the `lucia.invalidateUserSessions()` cause (login.spec.js kills the session `auth.setup.js` saved)
- the **order-dependence** that makes the failure hide when a spec runs alone
- a note not to reintroduce a local copy

## Test plan

- [x] `make gate` green
- [x] `make review` (CodeRabbit) — **no findings**
- [x] `playwright test --list` verified under both flag values, counts reconciled exactly
- [x] All 8 original helper bodies diffed from git to confirm no behaviour was flattened
- [ ] CI `e2e` job should now skip the a11y suite — visible as a shorter run

## Risk

Low, and asymmetric: if the ignore were wrong, tests would *stop running* rather than start failing — which is why the count reconciliation above is the real check, not the gate.

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized administrator authentication across end-to-end test scenarios.
  * Improved handling of expired sessions by automatically re-authenticating when required.
  * Refined test selection so login tests are consistently excluded, with optional accessibility and visual tests.
  * Existing accessibility, event, experience, and management coverage remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->