### PR TITLE
test(a11y): seed a multi-day event so the admin audit reaches the day filter

### DIFF
--- a/database/seed-test-data.sql
+++ b/database/seed-test-data.sql
@@ -97,6 +97,32 @@ INSERT OR REPLACE INTO performances (id, event_id, band_profile_id, venue_id, st
 (3, 28, 3, 2, '21:00', '22:00'),
 (4, 28, 4, 2, '22:00', '23:00');
 
+-- ============================================
+-- MULTI-DAY EVENT (Event 29) — reaches LineupTab's day filter
+-- LineupTab renders its "Filter performers by day" control only when
+-- `isMultiDayEvent(event)` is true, i.e. `end_date > date`. Every other seeded
+-- event is single-day by construction, so before this the admin axe audit could
+-- not reach that control at all (#886).
+--
+-- Dated AFTER Future Fest E2E (+14 days) deliberately. public-timeline.spec.js
+-- asserts against the FIRST collapsed upcoming card and requires it to have
+-- venues and performers; event 28 is that card, and an earlier date here would
+-- silently take its place. This event carries its own venues and performances
+-- anyway, so those assertions would still hold if the ordering ever changed.
+-- ============================================
+
+INSERT OR REPLACE INTO events (id, name, date, end_date, slug, status, description, city, ticket_url) VALUES
+(29, 'Multi-Day Fest E2E', date('now', '+21 days'), date('now', '+22 days'), 'multi-day-fest-e2e', 'published', 'A two-day multi-venue festival used by E2E tests to exercise day-scoped lineup UI.', 'Waterloo', NULL);
+
+-- `performance_date` is what places a set on a specific festival day. Without
+-- it every set renders on the event's start date -- the recurring bug class of
+-- #739/#741/#743 -- and the day filter would have nothing to distinguish.
+INSERT OR REPLACE INTO performances (id, event_id, band_profile_id, venue_id, start_time, end_time, performance_date) VALUES
+(5, 29, 1, 1, '19:00', '19:45', date('now', '+21 days')),
+(6, 29, 2, 1, '20:00', '20:45', date('now', '+21 days')),
+(7, 29, 3, 2, '19:30', '20:15', date('now', '+22 days')),
+(8, 29, 4, 2, '21:00', '22:00', date('now', '+22 days'));
+
 -- Update sqlite_sequence if needed
 DELETE FROM sqlite_sequence WHERE name IN ('venues', 'events', 'band_profiles', 'performances');
-INSERT INTO sqlite_sequence (name, seq) VALUES ('venues', 20), ('events', 28), ('band_profiles', 4), ('performances', 4);
+INSERT INTO sqlite_sequence (name, seq) VALUES ('venues', 20), ('events', 29), ('band_profiles', 4), ('performances', 8);

--- a/e2e/accessibility/admin-surfaces.spec.js
+++ b/e2e/accessibility/admin-surfaces.spec.js
@@ -21,13 +21,31 @@ import { loginAsAdmin } from "../utils/session";
 // performances, so it is what makes the Lineup audit non-empty.
 const SEEDED_EVENT = "Future Fest E2E";
 
+// A two-day event (end_date > date), which is the ONLY way LineupTab renders its
+// day filter -- `isMultiDayEvent()` gates it. Seeded by #886 for exactly this.
+const SEEDED_MULTIDAY_EVENT = "Multi-Day Fest E2E";
+
 const surfaces = [
   { id: "events", label: "Events", heading: "Events" },
   {
     id: "lineup",
     label: "Lineup",
     heading: "Event Lineup",
+    eventName: SEEDED_EVENT,
     readyLocator: (page) => page.locator("#main-content table tbody tr").first(),
+  },
+  {
+    id: "lineup",
+    title: "Lineup (multi-day)",
+    label: "Lineup",
+    heading: "Event Lineup",
+    eventName: SEEDED_MULTIDAY_EVENT,
+    readyLocator: (page) => page.locator("#main-content table tbody tr").first(),
+    // The day filter is the whole point of this case. Asserting it is present
+    // BEFORE analyze() is what stops the test going vacuous: if the fixture
+    // regressed to single-day the control would simply not render, and axe
+    // would report a clean pass for a control it never saw.
+    requiresDayFilter: true,
   },
   { id: "roster", label: "Roster", heading: "Global Artist Roster" },
   { id: "venues", label: "Venues", heading: "Venues" },
@@ -54,7 +72,7 @@ const openSurface = async (page, surface) => {
     // Select by VALUE, resolved from the option text. The option label is
     // `{name} {status}` (e.g. "Future Fest E2E (Published)"), so an exact-label
     // match fails and a status change would silently break it.
-    const option = eventSelector.locator("option", { hasText: SEEDED_EVENT }).first();
+    const option = eventSelector.locator("option", { hasText: surface.eventName ?? SEEDED_EVENT }).first();
     await expect(option).toBeAttached({ timeout: 15000 });
     await eventSelector.selectOption(await option.getAttribute("value"));
   }
@@ -71,11 +89,15 @@ const openSurface = async (page, surface) => {
   if (surface.readyLocator) {
     await expect(surface.readyLocator(page)).toBeVisible({ timeout: 15000 });
   }
+
+  if (surface.requiresDayFilter) {
+    await expect(page.getByLabel("Filter performers by day")).toBeVisible({ timeout: 15000 });
+  }
 };
 
 test.describe("Admin Surfaces - Accessibility", () => {
   for (const surface of surfaces) {
-    test(`${surface.label} tab has no targeted axe violations`, async ({ page }) => {
+    test(`${surface.title ?? surface.label} tab has no targeted axe violations`, async ({ page }) => {
       await openSurface(page, surface);
 
       const results = await new AxeBuilder({ page })


### PR DESCRIPTION
## Summary

`LineupTab` renders its **"Filter performers by day"** control only when `isMultiDayEvent(event)` — i.e. `end_date > date`. Every seeded event was single-day *by construction* (the `events` INSERT didn't even carry an `end_date` column), so #885's admin axe audit could not reach that control at all.

It was fixed in #885 by reading the code beside the two violations axe *did* catch. Nothing guarded it against regressing. Now something does.

Closes #886

## What changed

- **`database/seed-test-data.sql`** — event 29 "Multi-Day Fest E2E" spanning two days, with 4 performances carrying `performance_date` across both. Without `performance_date`, every set renders on the event's start date (the #739/#741/#743 bug class) and the day filter would have nothing to distinguish.
- **`e2e/accessibility/admin-surfaces.spec.js`** — a second Lineup case selecting that event, asserting the day filter is visible **before** `analyze()`.

That ordering is the whole point: if the fixture regressed to single-day, the control simply wouldn't render and axe would report a clean pass for something it never saw.

## Two design decisions

**Dated *after* Future Fest E2E.** `public-timeline.spec.js` asserts against the **first** collapsed upcoming card and requires it to have venues and performers; event 28 is that card. An earlier date would silently take its place.

**A new event rather than making event 28 multi-day** — same reasoning: event 28 keeps its single-day behaviour for every spec already depending on it. The new event carries its own venues and performances regardless, so those assertions would still hold if ordering ever shifted.

## Verification — against live wrangler + seeded D1, not by reading

- All 7 `admin-surfaces` tests pass, including the new **Lineup (multi-day)** case.
- **Mutation-proved:** pointing the new case at the single-day event fails with `getByLabel('Filter performers by day') … element(s) not found`. The guard *can* fail, so its pass means something.
- Confirmed in D1: event 29 has **2 distinct `performance_date`** values; event 28 untouched (`end_date` NULL); upcoming order still puts Future Fest E2E first.

## Local full-suite runs were not clean — and it is not this change

Established by **three controlled A/B pairs** (same specs, same command, event 29 present vs absent), identical every time: **15/15**, **2/2**, **2/2**.

The failures move between runs and have two causes, both local-only:

| Cause | Evidence |
|---|---|
| Persistent local D1 accumulates spec-created events dated **today** | They sort ahead of the seeded events and take over `collapsedEventCard`'s "first card"; clearing them made every `public-timeline` test pass |
| Auth rate limiting | **31 `auth_attempts` per full run**; every failure is `waiting for button[role="tab"]` — the login-didn't-succeed signature |

CI starts from a fresh database each run and accumulates neither. Filing the local-environment problem separately.

## Test plan

- [x] `make gate` green
- [x] `make review` (CodeRabbit) — **no findings**
- [x] `admin-surfaces` 7/7 against live wrangler + D1
- [x] New case mutation-proved
- [x] A/B pairs confirm no regression from this change
- [ ] CI e2e-a11y-visual green

## Risk

Low. Adds one event and four performances to a test-only fixture; no production path touches `seed-test-data.sql`.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for testing multi-day events with performances assigned to specific festival dates.
  * Added accessibility coverage for multi-day Lineup views, including day filtering.

* **Tests**
  * Expanded end-to-end checks to verify event-specific Lineup surfaces and optional titles.
  * Confirmed that day filters appear correctly before accessibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->