### PR TITLE
ci(lighthouse): survive the upstream workerd abort instead of failing on it

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -222,9 +222,73 @@ jobs:
           # job is deliberately not handed admin credentials.
           seed-admin: 'false'
 
+      # Retries ONCE, and only when wrangler has vanished (#878 /
+      # cloudflare/workers-sdk#14926). That upstream bug exits the dev server on a
+      # RECOVERABLE runtime blip -- wrangler does not implement miniflare's
+      # `unsafeHandleRuntimeRestart` hook -- so a gate failing on it is failing for
+      # a reason unrelated to the PR. Measured: 5 occurrences in ~2 weeks, and a
+      # plain re-run of the identical commit passes.
+      #
+      # A score regression must still fail. The discriminator is NOT the exit code
+      # (identical either way) but the SERVER: after the abort there is no listener
+      # and no process, whereas a failed assertion leaves it healthy.
       - name: Run Lighthouse CI
-        working-directory: frontend
-        run: npm run lighthouse
+        working-directory: .
+        run: |
+          set -u
+
+          run_lighthouse() { ( cd frontend && npm run lighthouse ); }
+
+          # True only when BOTH signals agree the server is gone. Requiring both
+          # keeps a merely-slow server (still listening) out of the retry path.
+          server_gone() {
+              listeners=$( { command -v ss >/dev/null && ss -H -lptn 'sport = :8788'; } 2>/dev/null \
+                || netstat -lptn 2>/dev/null \
+                  | grep -E '(^|[[:space:]])[^[:space:]]*:8788([[:space:]]|$)' || true )
+              procs=$(pgrep -f 'wrangler|workerd' 2>/dev/null || true)
+              [ -z "$listeners" ] && [ -z "$procs" ]
+          }
+
+          # Same invocation as .github/actions/e2e-env, enforced by
+          # functions/__tests__/wranglerDevCommand.test.js -- drift there means the
+          # retry would serve something different from the run it is retrying.
+          restart_wrangler() {
+              echo "  restarting wrangler..." >&2
+              ./frontend/node_modules/.bin/wrangler pages dev frontend/dist --port 8788 --persist-to .wrangler/state > /tmp/wrangler-retry.log 2>&1 &
+              i=1
+              while [ $i -le 60 ]; do
+                  if curl -sf -o /dev/null --max-time 2 http://localhost:8788/; then
+                      echo "  server back after $((i * 2))s" >&2
+                      return 0
+                  fi
+                  sleep 2
+                  i=$((i + 1))
+              done
+              echo "  x server did not come back within 120s -- not retrying" >&2
+              tail -50 /tmp/wrangler-retry.log >&2 || true
+              return 1
+          }
+
+          code=0
+          run_lighthouse || code=$?
+          if [ "$code" -eq 0 ]; then exit 0; fi
+
+          if ! server_gone; then
+              echo "x Lighthouse failed with the server still up -- a real failure, not #878." >&2
+              exit "$code"
+          fi
+
+          echo "x Lighthouse failed AND wrangler is gone: the #878 signature." >&2
+          # Preserve the first run's log before the restart overwrites the picture,
+          # so the diagnostics step still shows the abort that started this.
+          cp /tmp/wrangler.log /tmp/wrangler-first-run.log 2>/dev/null || true
+          restart_wrangler || exit "$code"
+
+          echo "  retrying Lighthouse once..." >&2
+          code=0
+          run_lighthouse || code=$?
+          if [ "$code" -eq 0 ]; then echo "+ passed on retry after a #878 abort" >&2; fi
+          exit "$code"
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           CI: true

--- a/functions/__tests__/wranglerDevCommand.test.js
+++ b/functions/__tests__/wranglerDevCommand.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * The Lighthouse gate retries itself when wrangler vanishes mid-run (#891, for
@@ -21,7 +22,10 @@ import { join } from "node:path";
  * wrong thing. Drift fails closed only if something checks.
  */
 
-const repoRoot = join(import.meta.dirname, "..", "..");
+// fileURLToPath rather than import.meta.dirname, matching the sibling guards
+// (opencodeInstructions.test.js, staticPageMeta.test.js). import.meta.dirname
+// needs Node 20.11+, and this repo supports Node 20.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 const readRepoFile = (relativePath) => readFileSync(join(repoRoot, relativePath), "utf8");
 

--- a/functions/__tests__/wranglerDevCommand.test.js
+++ b/functions/__tests__/wranglerDevCommand.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The Lighthouse gate retries itself when wrangler vanishes mid-run (#891, for
+ * the upstream abort in #878 / cloudflare/workers-sdk#14926). To retry it has to
+ * restart the dev server, which means the start command now lives in TWO places:
+ *
+ *   .github/actions/e2e-env/action.yml   starts it for the job
+ *   .github/workflows/quality.yml        restarts it for the retry
+ *
+ * A single shared script would be tidier, but the action is on the critical path
+ * of every E2E job and refactoring it to serve one retry is a poor trade. Two
+ * copies plus this guard is the cheaper arrangement -- provided the copies cannot
+ * silently diverge, which is what this test exists to prevent.
+ *
+ * The failure it guards against is quiet rather than loud: if the port or the
+ * dist path drifted in one file only, the retry would still "work", just against
+ * a different server than the run it is retrying -- and report a score for the
+ * wrong thing. Drift fails closed only if something checks.
+ */
+
+const repoRoot = join(import.meta.dirname, "..", "..");
+
+const readRepoFile = (relativePath) => readFileSync(join(repoRoot, relativePath), "utf8");
+
+// Captures the arguments only, stopping at the redirect: the two call sites
+// deliberately log to different files (wrangler.log vs wrangler-retry.log) so the
+// retry cannot clobber the evidence of the abort that triggered it.
+const WRANGLER_INVOCATION = /\.\/frontend\/node_modules\/\.bin\/wrangler pages dev ([^>]+)>/g;
+
+const invocationsIn = (source) =>
+  [...source.matchAll(WRANGLER_INVOCATION)].map(([, args]) => args.trim().replace(/\s+/g, " "));
+
+describe("wrangler dev invocation stays identical across its two call sites", () => {
+  const actionInvocations = invocationsIn(readRepoFile(".github/actions/e2e-env/action.yml"));
+  const workflowInvocations = invocationsIn(readRepoFile(".github/workflows/quality.yml"));
+
+  it("finds the invocation in the e2e-env action", () => {
+    // Guards the guard: a rename or refactor that moved the command would
+    // otherwise leave this whole file comparing two empty lists and passing.
+    expect(actionInvocations.length).toBeGreaterThan(0);
+  });
+
+  it("finds the invocation in the Lighthouse retry", () => {
+    expect(workflowInvocations.length).toBeGreaterThan(0);
+  });
+
+  it("uses the same arguments in both", () => {
+    const unique = new Set([...actionInvocations, ...workflowInvocations]);
+    expect([...unique]).toHaveLength(1);
+  });
+
+  it("still pins the port the gate and the probes agree on", () => {
+    // 8788 is hard-coded in lighthouserc.json's url, in the liveness probes, and
+    // in the readiness curl. A port change here alone would make the retry serve
+    // on one port while Lighthouse measured another.
+    for (const invocation of [...actionInvocations, ...workflowInvocations]) {
+      expect(invocation).toContain("--port 8788");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The Lighthouse gate fails whenever wrangler exits mid-run. That exit is an **upstream bug we cannot fix**: since miniflare `4.20260722.0`, miniflare auto-restarts workerd after a post-startup crash and exposes an opt-in `unsafeHandleRuntimeRestart` hook — **wrangler doesn't implement it**, so its `ProxyController` keeps pointing at the dead runtime and `emitErrorEvent` escalates a *recoverable* blip into a process exit.

Unfixed across 11+ releases, still present on 4.124.0 ([workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926), where we [added our reproduction](https://github.com/cloudflare/workers-sdk/issues/14926#issuecomment-5356146622)).

Measured here: **5 occurrences in ~2 weeks**, and a plain re-run of the identical commit passes. #894 was the most recent — a PR touching only a test fixture, blocked by a dev-server crash unrelated to it.

Closes #891 · Refs #878

## What makes this a guard, not a blanket retry

**The discriminator is the server, not the exit code.** `lhci` exits non-zero identically for a score regression and for an abort. But after the abort there is **no listener on 8788 AND no wrangler/workerd process**, whereas a failed assertion leaves the server healthy. Both signals must agree before retrying, so a merely-slow server stays out of the retry path.

**Recovery must prove itself first.** If the restarted server doesn't answer within 120s, the original failure is returned and no retry happens. Retrying into a dead server turns a clear failure into a confusing one — the mistake #882 made and #883 fixed.

The first run's `wrangler.log` is copied aside before the restart, so the diagnostics step still shows the abort that started it rather than the replacement server's clean startup.

## Verification — the failure paths were run, not read

This code only executes when something is broken, so a green CI run proves nothing about it. The shipped script was extracted from the workflow and exercised with stubbed externals:

| scenario | lighthouse runs | exit | |
|---|---|---|---|
| passes first time | 1 | 0 | |
| **fails, server UP** | **1** | 1 | **no retry — a real regression still fails** |
| fails, server gone, retry passes | 2 | 0 | recovered |
| fails, server gone, retry fails too | 2 | 1 | not masked |
| **fails, restart never works** | **1** | 1 | **no retry into a dead server** |

Rows 2 and 5 are the ones that matter.

## The workaround I rejected

Pinning `wrangler@4.113.0` is the documented workaround, and unusually it **is** available to us — our `compatibility_date` (2025-10-08) predates the 2026-07-28 cutoff that blocks it for most reporters. I'm not taking it: going back 11 minors to dodge a bug that only affects the **local dev server, never production**, costs more than it saves and would fight Dependabot continuously.

## Drift guard

The retry restarts the dev server, so the start command now lives in two places. `functions/__tests__/wranglerDevCommand.test.js` pins them together.

The drift it guards is **quiet, not loud**: a port or dist-path change in one file only would leave the retry "working" against a different server than the run it's retrying, and report a score for the wrong thing. Mutation-proved by changing the retry's port — 2 of its 4 assertions fail.

## Test plan

- [x] `make gate` green
- [x] `make review` (CodeRabbit) — clean after fixing a Node 20 compat nit
- [x] `actionlint` clean
- [x] All 5 retry paths exercised against the shipped script
- [x] Drift guard mutation-proved
- [ ] Next #878 occurrence should self-recover and log `passed on retry after a #878 abort`

## Risk

Low. On a healthy run the new code is a single `run_lighthouse` call and an `exit 0` — identical to today. Everything else is unreachable unless Lighthouse has already failed.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lighthouse checks by retrying eligible failures and restarting the development server when needed.
  * Preserved initial failure logs to make troubleshooting easier.

* **Tests**
  * Added automated checks to ensure development-server commands use consistent arguments and port 8788 across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->