### PR TITLE
test(e2e): pin timeline specs to the seeded event, not to whatever sorts first

### DIFF
--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -13,11 +13,11 @@ test.describe("Band Profile Viewing", () => {
     // into a silent pass instead of a failure (#895). Seed data always has bands.
     await expect(bandLink).toBeVisible();
     {
-      const bandName = ((await bandLink.textContent()) ?? "").trim();
-      // Reject an empty name before it is used as an assertion: toContainText("")
-      // passes against any heading, which would quietly restore the vacuity this
-      // test was just fixed for.
-      expect(bandName).not.toBe("");
+      // The anchor can wrap a whole card (name + venue + time + genre), so this
+      // is not necessarily just the name -- hence the containment direction used
+      // below. Empty is rejected because it would make that check vacuous.
+      const linkText = ((await bandLink.textContent()) ?? "").trim();
+      expect(linkText).not.toBe("");
       await bandLink.click();
 
       // Scope to the main h1: the Header carries its own "SetTimes" h1, and the
@@ -25,7 +25,11 @@ test.describe("Band Profile Viewing", () => {
       // match is a strict-mode violation waiting for a second element (#895).
       // toContainText takes a STRING, so a band name containing regex
       // metacharacters cannot corrupt the pattern the way `new RegExp(name)` did.
-      await expect(page.locator("main h1")).toContainText(bandName);
+      const heading = page.locator("main h1");
+      await expect(heading).toBeVisible();
+      const headingText = ((await heading.textContent()) ?? "").trim();
+      expect(headingText).not.toBe("");
+      expect(linkText).toContain(headingText);
 
       // Should NOT redirect to login
       await expect(page).not.toHaveURL(/\/admin\/login/);

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -13,7 +13,11 @@ test.describe("Band Profile Viewing", () => {
     // into a silent pass instead of a failure (#895). Seed data always has bands.
     await expect(bandLink).toBeVisible();
     {
-      const bandName = await bandLink.textContent();
+      const bandName = ((await bandLink.textContent()) ?? "").trim();
+      // Reject an empty name before it is used as an assertion: toContainText("")
+      // passes against any heading, which would quietly restore the vacuity this
+      // test was just fixed for.
+      expect(bandName).not.toBe("");
       await bandLink.click();
 
       // Scope to the main h1: the Header carries its own "SetTimes" h1, and the
@@ -21,7 +25,7 @@ test.describe("Band Profile Viewing", () => {
       // match is a strict-mode violation waiting for a second element (#895).
       // toContainText takes a STRING, so a band name containing regex
       // metacharacters cannot corrupt the pattern the way `new RegExp(name)` did.
-      await expect(page.locator("main h1")).toContainText((bandName || "").trim());
+      await expect(page.locator("main h1")).toContainText(bandName);
 
       // Should NOT redirect to login
       await expect(page).not.toHaveURL(/\/admin\/login/);

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -8,12 +8,20 @@ test.describe("Band Profile Viewing", () => {
     // Click on first band link (may be in event card or band list)
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
 
-    if (await bandLink.isVisible()) {
+    // Unconditional, for the same reason as public-timeline.spec.js: an
+    // `if (await bandLink.isVisible())` wrapper turns "no band link on the page"
+    // into a silent pass instead of a failure (#895). Seed data always has bands.
+    await expect(bandLink).toBeVisible();
+    {
       const bandName = await bandLink.textContent();
       await bandLink.click();
 
-      // Verify band profile page loads
-      await expect(page.getByRole("heading", { name: new RegExp(bandName || "", "i") })).toBeVisible();
+      // Scope to the main h1: the Header carries its own "SetTimes" h1, and the
+      // page can show the band name in more than one heading, so an unscoped
+      // match is a strict-mode violation waiting for a second element (#895).
+      // toContainText takes a STRING, so a band name containing regex
+      // metacharacters cannot corrupt the pattern the way `new RegExp(name)` did.
+      await expect(page.locator("main h1")).toContainText((bandName || "").trim());
 
       // Should NOT redirect to login
       await expect(page).not.toHaveURL(/\/admin\/login/);

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -1,12 +1,21 @@
 import { test, expect } from "@playwright/test";
 
-// During show hours, EventTimeline.jsx auto-expands a live event
-// (`useState(isLive)`), so its "View Details" toggle already reads "Hide
-// Details". Plain `[data-testid="event-card"]').first()` can therefore grab
-// an already-expanded card and time out waiting for a "View Details" button
-// that isn't there (#602 — CI-only, time-of-day dependent). Filtering to a
-// card that still shows the collapsed affordance keeps these specs
-// deterministic regardless of clock/live state.
+// Pinned by NAME, never by position. Taking the first card couples every
+// assertion below to "no other spec has created an event", which is false:
+// several specs create events dated TODAY, which sort ahead of the seeded
+// fixtures and take the slot (#895). Locally, where D1 persists between runs,
+// those accumulate until these tests fail outright; in CI it is a live race
+// within a single run rather than a certainty, which is worse — it looks like
+// flake. admin-surfaces.spec.js already selects its event by name for the
+// same reason.
+//
+// This supersedes the #602 fix it replaces rather than dropping it. That bug
+// was `.first()` grabbing a LIVE event, which EventTimeline auto-expands
+// (`useState(isLive)`), so its "View Details" toggle already read "Hide
+// Details" and the click timed out — CI-only and time-of-day dependent. The
+// seeded event is dated two weeks out and is never live, so the card is
+// reliably collapsed; naming it removes the whole class rather than filtering
+// around it.
 //
 // Playwright locators are lazy/live, not snapshots: a `.filter({ has: ... })`
 // locator re-runs its condition on every query. Once the returned card is
@@ -15,10 +24,13 @@ import { test, expect } from "@playwright/test";
 // re-resolve to a *different* card. So resolve the filter once to a stable
 // DOM index and hand back an `nth()` locator, which stays pinned to that
 // card's position regardless of its later expanded/collapsed state.
-async function collapsedEventCard(page) {
+const SEEDED_EVENT = "Future Fest E2E";
+
+async function seededEventCard(page) {
   const allCards = page.locator('[data-testid="event-card"]');
-  const collapsed = allCards.filter({ has: page.getByRole("button", { name: /view details/i }) }).first();
-  const index = await collapsed.evaluate(
+  const target = allCards.filter({ hasText: SEEDED_EVENT }).first();
+  await expect(target).toBeVisible();
+  const index = await target.evaluate(
     (el, testid) => Array.from(document.querySelectorAll(`[data-testid="${testid}"]`)).indexOf(el),
     "event-card",
   );
@@ -39,7 +51,7 @@ test.describe("Public Timeline Viewing", () => {
   test("should show event details when clicked", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Verify the card expanded (button flips to Hide Details)
@@ -62,7 +74,7 @@ test.describe("Public Timeline Viewing", () => {
   test("should display event venue information", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Seed data guarantees the upcoming event has venues
@@ -73,7 +85,7 @@ test.describe("Public Timeline Viewing", () => {
   test("should show band/performer information in events", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Seed data guarantees the upcoming event has performers
@@ -84,19 +96,26 @@ test.describe("Public Timeline Viewing", () => {
   test("should navigate to band profile from event", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
+    // NOT wrapped in `if (await bandLink.isVisible())`. It was, and that made the
+    // whole assertion block skippable: whenever the card under test had no band
+    // links the test passed having checked nothing (#895). The seeded event always
+    // has performers, so absence is a failure, not a reason to skip.
     const bandLink = firstEvent.locator('a[href*="/band/"]').first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
-      await expect(page).toHaveURL(/\/band\//);
-      // Wait for the band profile to fully render before asserting content.
-      // toHaveTitle waits for the useEffect title update; only then is the page settled.
-      // Scoping to main h1 avoids the Header's "SetTimes" h1 (strict mode violation).
-      await expect(page).toHaveTitle(/- Band Profile \| SetTimes$/);
-      await expect(page.locator("main h1")).toBeVisible();
-    }
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
+    await expect(page).toHaveURL(/\/band\//);
+    // The LOADED title, not the pre-load fallback. BandProfilePage sets
+    // 'Band Profile | SetTimes' while the fetch is in flight and only then
+    // replicates the SSR formula, `{name} — {genre} in Waterloo Region | SetTimes`
+    // (functions/band/[id].js). The old pattern matched the fallback, so it could
+    // only ever pass while the page was still loading — which is the opposite of
+    // the "wait until settled" this line is here to do.
+    await expect(page).toHaveTitle(/ in Waterloo Region \| SetTimes$/);
+    // Scoping to main h1 avoids the Header's "SetTimes" h1 (strict mode violation).
+    await expect(page.locator("main h1")).toBeVisible();
   });
 
   test("should display timeline content", async ({ page }) => {
@@ -116,7 +135,7 @@ test.describe("Public Timeline Viewing", () => {
     const eventCards = page.locator('[data-testid="event-card"]');
     await expect(eventCards.first()).toBeVisible();
 
-    const mobileCard = await collapsedEventCard(page);
+    const mobileCard = await seededEventCard(page);
     await mobileCard.getByRole("button", { name: /view details/i }).click();
     await page.waitForTimeout(500);
   });
@@ -141,7 +160,7 @@ test.describe("Public Timeline Viewing", () => {
   test("should display event duration and time details", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     const timeRange = firstEvent.locator("text=/\\d{2}:\\d{2}\\s*-\\s*\\d{2}:\\d{2}/");
@@ -166,7 +185,7 @@ test.describe("Public Timeline Viewing", () => {
   test("should show venue location details in event view", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Seed data guarantees the upcoming event has venues

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -105,6 +105,12 @@ test.describe("Public Timeline Viewing", () => {
     // has performers, so absence is a failure, not a reason to skip.
     const bandLink = firstEvent.locator('a[href*="/band/"]').first();
     await expect(bandLink).toBeVisible();
+    // Captured BEFORE navigating, so the profile can be checked to be the one
+    // that was clicked rather than merely "a band profile".
+    const bandName = ((await bandLink.textContent()) ?? "").trim();
+    // An empty name would make the `main h1` assertion below vacuous —
+    // toContainText("") passes against any heading at all.
+    expect(bandName).not.toBe("");
     await bandLink.click();
     await expect(page).toHaveURL(/\/band\//);
     // The LOADED title, not the pre-load fallback. BandProfilePage sets
@@ -115,7 +121,9 @@ test.describe("Public Timeline Viewing", () => {
     // the "wait until settled" this line is here to do.
     await expect(page).toHaveTitle(/ in Waterloo Region \| SetTimes$/);
     // Scoping to main h1 avoids the Header's "SetTimes" h1 (strict mode violation).
-    await expect(page.locator("main h1")).toBeVisible();
+    // Asserting the NAME, not just visibility: a generic "a profile rendered"
+    // check passes even if the wrong link were followed.
+    await expect(page.locator("main h1")).toContainText(bandName);
   });
 
   test("should display timeline content", async ({ page }) => {

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -17,24 +17,24 @@ import { test, expect } from "@playwright/test";
 // reliably collapsed; naming it removes the whole class rather than filtering
 // around it.
 //
-// Playwright locators are lazy/live, not snapshots: a `.filter({ has: ... })`
-// locator re-runs its condition on every query. Once the returned card is
-// clicked open, its button flips to "Hide Details" and it stops matching the
-// "View Details" filter — a later `firstEvent.getByRole(...)` would silently
-// re-resolve to a *different* card. So resolve the filter once to a stable
-// DOM index and hand back an `nth()` locator, which stays pinned to that
-// card's position regardless of its later expanded/collapsed state.
+// Returns the live filter, deliberately NOT an `nth()` index.
+//
+// The previous helper resolved to a DOM index on purpose: its filter matched
+// the "View Details" button, which STOPS matching the moment the card is
+// clicked open, so a lazy locator would have re-resolved to a different card.
+// Filtering on the event NAME has no such problem — the name stays in the card
+// whether it is collapsed or expanded — which makes the index dance obsolete.
+//
+// It is also now the riskier of the two. EventTimeline re-polls every 60s, and
+// a card moving between the now/upcoming/past buckets shifts positions; a
+// pinned `nth(index)` would then address whatever had moved into that slot,
+// while the name filter still finds the right card.
 const SEEDED_EVENT = "Future Fest E2E";
 
 async function seededEventCard(page) {
-  const allCards = page.locator('[data-testid="event-card"]');
-  const target = allCards.filter({ hasText: SEEDED_EVENT }).first();
-  await expect(target).toBeVisible();
-  const index = await target.evaluate(
-    (el, testid) => Array.from(document.querySelectorAll(`[data-testid="${testid}"]`)).indexOf(el),
-    "event-card",
-  );
-  return allCards.nth(index);
+  const card = page.locator('[data-testid="event-card"]').filter({ hasText: SEEDED_EVENT }).first();
+  await expect(card).toBeVisible();
+  return card;
 }
 
 test.describe("Public Timeline Viewing", () => {

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -17,18 +17,11 @@ import { test, expect } from "@playwright/test";
 // reliably collapsed; naming it removes the whole class rather than filtering
 // around it.
 //
-// Returns the live filter, deliberately NOT an `nth()` index.
-//
-// The previous helper resolved to a DOM index on purpose: its filter matched
-// the "View Details" button, which STOPS matching the moment the card is
-// clicked open, so a lazy locator would have re-resolved to a different card.
-// Filtering on the event NAME has no such problem — the name stays in the card
-// whether it is collapsed or expanded — which makes the index dance obsolete.
-//
-// It is also now the riskier of the two. EventTimeline re-polls every 60s, and
-// a card moving between the now/upcoming/past buckets shifts positions; a
-// pinned `nth(index)` would then address whatever had moved into that slot,
-// while the name filter still finds the right card.
+// Return the live name filter, never a resolved `nth()` index: EventTimeline
+// re-polls every 60s and a card moving between the now/upcoming/past buckets
+// shifts positions, so a pinned index can end up addressing a different event.
+// The name filter is safe to keep live because the name stays in the card
+// whether it is collapsed or expanded.
 const SEEDED_EVENT = "Future Fest E2E";
 
 async function seededEventCard(page) {

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -106,11 +106,14 @@ test.describe("Public Timeline Viewing", () => {
     const bandLink = firstEvent.locator('a[href*="/band/"]').first();
     await expect(bandLink).toBeVisible();
     // Captured BEFORE navigating, so the profile can be checked to be the one
-    // that was clicked rather than merely "a band profile".
-    const bandName = ((await bandLink.textContent()) ?? "").trim();
-    // An empty name would make the `main h1` assertion below vacuous —
-    // toContainText("") passes against any heading at all.
-    expect(bandName).not.toBe("");
+    // that was clicked rather than merely "a band profile". This is the whole
+    // CARD's text, not just the name -- the anchor wraps venue, time and genre
+    // too ("The Time TravellersWaterloo Music Hall7:00 PM - 7:45 PMIndie Rock"),
+    // which is why the comparison below runs link-contains-heading rather than
+    // the other way round.
+    const linkText = ((await bandLink.textContent()) ?? "").trim();
+    // An empty capture would make the comparison below vacuous.
+    expect(linkText).not.toBe("");
     await bandLink.click();
     await expect(page).toHaveURL(/\/band\//);
     // The LOADED title, not the pre-load fallback. BandProfilePage sets
@@ -121,9 +124,15 @@ test.describe("Public Timeline Viewing", () => {
     // the "wait until settled" this line is here to do.
     await expect(page).toHaveTitle(/ in Waterloo Region \| SetTimes$/);
     // Scoping to main h1 avoids the Header's "SetTimes" h1 (strict mode violation).
-    // Asserting the NAME, not just visibility: a generic "a profile rendered"
-    // check passes even if the wrong link were followed.
-    await expect(page.locator("main h1")).toContainText(bandName);
+    const heading = page.locator("main h1");
+    await expect(heading).toBeVisible();
+    const headingText = ((await heading.textContent()) ?? "").trim();
+    // Guard both sides: an empty heading would make the containment check pass
+    // against anything, which is the vacuity this test was just fixed for.
+    expect(headingText).not.toBe("");
+    // Identity, not just "a profile rendered" -- that passes even if the wrong
+    // link were followed.
+    expect(linkText).toContain(headingText);
   });
 
   test("should display timeline content", async ({ page }) => {


### PR DESCRIPTION
## Summary

`public-timeline.spec.js` asserted against the **first** upcoming card and required it to have venues and performers. That silently coupled every one of those assertions to *"no other spec has created an event"* — which is false. Several specs create events during the run, and an upcoming one dated before the seeded fixture takes the slot.

Locally (`--persist-to .wrangler/state` survives between runs) those accumulate until the specs fail outright. In CI it's a race within a single run — **worse**, because it presents as flake.

The fix is the one `admin-surfaces.spec.js` already uses deliberately: **select the event by name.**

Closes #895 (option 2)

## This supersedes #602 rather than dropping it

The old helper filtered to a card still showing "View Details" because `.first()` could grab a **live** event, which `EventTimeline` auto-expands (`useState(isLive)`) — so the click timed out, CI-only and time-of-day dependent. Naming the event removes that class too: the seeded event is two weeks out and never live.

## Reproduced, not assumed

With an upcoming event injected ahead of the fixture:

| helper | result |
|---|---|
| old (first card) | **4 failed**, 9 passed — the exact 4 seen in the wild |
| new (by name) | **13 passed** |

**My first reproduction attempt was vacuous and it's worth recording why.** A *today*-dated polluting event lands in the `now` bucket, where `EventTimeline` auto-expands it — so the old helper's collapsed-card filter correctly skipped it and everything passed. The condition only bites from the `upcoming` bucket. Had I stopped at that first green run I'd have "proved" a fix against a scenario that never breaks.

## A vacuous test this surfaced

`should navigate to band profile from event` wrapped its entire body in `if (await bandLink.isVisible())`. With the old helper the polluting card had no band links, so the block was skipped and the test **passed having checked nothing**. Unwrapped, it failed instantly on a stale expectation:

```
expected  /- Band Profile \| SetTimes$/
actual    "The Time Travellers — Indie Rock in Waterloo Region | SetTimes"
```

`Band Profile | SetTimes` is BandProfilePage's **pre-load fallback**. The loaded title replicates the SSR formula in `functions/band/[id].js`. So that assertion could only ever have passed *while the page was still loading* — the opposite of the "wait until settled" it was written to do.

`band-profile-viewing.spec.js`'s first test had the same shape plus an unscoped `getByRole("heading", { name: new RegExp(bandName) })` — a strict-mode violation whenever two headings match, and a regex built from untrusted text.

## Identity is now asserted in the direction that holds

Both tests capture the link text before navigating and require it to **contain** the profile's `main h1`. The anchor wraps the whole card, so its text is `"The Time TravellersWaterloo Music Hall7:00 PM - 7:45 PMIndie Rock"` — I got this backwards first and the run caught it. Both sides are rejected when empty; an empty heading would make containment pass against anything.

## Sibling sweep

~13 more tests in `band-profile-viewing.spec.js` gate their whole body on `if (await bandLink.isVisible())`. Too large for this PR — **filed separately**.

## Test plan

- [x] `make gate` green
- [x] `make review` (CodeRabbit) — clean after 2 findings addressed
- [x] Live server, clean fixture: **28/28**
- [x] Live server, polluting event injected: **28/28**
- [x] Old helper proved to fail under the same pollution (4 failures)

## Risk

Low, and it removes risk: these specs no longer depend on execution order or on a database's history.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for band profile navigation.
  * Timeline tests now consistently target the seeded “Future Fest E2E” event.
  * Added validation that selected band links and profile headings are visible, non-empty, and correctly matched.
  * Removed conditional skips and unreliable assertions to improve test accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->