### PR TITLE
test(e2e): unwrap 13 entry-point guards that made whole tests skippable

### DIFF
--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -308,20 +308,20 @@ test.describe("Band Profile Viewing", () => {
     await expect(bandLink).toBeVisible();
     await bandLink.click();
 
-    // Look for event listings in band profile
-    const eventCard = page.locator('[data-testid="event-card"]').or(page.locator(".event-card")).first();
+    await page.waitForURL(/\/band(s)?\//);
 
-    if (await eventCard.isVisible()) {
-      const eventTitle = ((await eventCard.locator('h3, h2, [class*="title"]').first().textContent()) ?? "").trim();
-      // An empty title matched EVERY heading through the old RegExp, and a title
-      // containing `[` made the RegExp constructor throw outright.
-      expect(eventTitle).not.toBe("");
-      await eventCard.click();
+    // BandProfilePage links each performance with `<Link to={`/event/${slug}`}>`,
+    // which renders a plain anchor. It renders NO [data-testid="event-card"] and
+    // no .event-card, so the guard this replaces could never match and the whole
+    // test skipped every run -- vacuity one level below the one #898 removed.
+    const eventLink = page.locator('main a[href^="/event/"]').first();
+    await expect(eventLink).toBeVisible();
+    await eventLink.click();
 
-      // exact: true -- a string role name is substring-matched by default, so a
-      // short title would match a longer unrelated heading.
-      await expect(page.getByRole("heading", { name: eventTitle, exact: true })).toBeVisible();
-    }
+    // The navigation is the assertion: this test exists to prove a fan can get
+    // from an artist to the event they are playing.
+    await expect(page).toHaveURL(/\/event\//);
+    await expect(page.locator("main h1")).toBeVisible();
   });
 
   test("should display band member information if available", async ({ page }) => {

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -13,11 +13,11 @@ test.describe("Band Profile Viewing", () => {
     // into a silent pass instead of a failure (#895). Seed data always has bands.
     await expect(bandLink).toBeVisible();
     {
-      const bandName = ((await bandLink.textContent()) ?? "").trim();
-      // Reject an empty name before it is used as an assertion: toContainText("")
-      // passes against any heading, which would quietly restore the vacuity this
-      // test was just fixed for.
-      expect(bandName).not.toBe("");
+      // The anchor can wrap a whole card (name + venue + time + genre), so this
+      // is not necessarily just the name -- hence the containment direction used
+      // below. Empty is rejected because it would make that check vacuous.
+      const linkText = ((await bandLink.textContent()) ?? "").trim();
+      expect(linkText).not.toBe("");
       await bandLink.click();
 
       // Scope to the main h1: the Header carries its own "SetTimes" h1, and the
@@ -25,7 +25,11 @@ test.describe("Band Profile Viewing", () => {
       // match is a strict-mode violation waiting for a second element (#895).
       // toContainText takes a STRING, so a band name containing regex
       // metacharacters cannot corrupt the pattern the way `new RegExp(name)` did.
-      await expect(page.locator("main h1")).toContainText(bandName);
+      const heading = page.locator("main h1");
+      await expect(heading).toBeVisible();
+      const headingText = ((await heading.textContent()) ?? "").trim();
+      expect(headingText).not.toBe("");
+      expect(linkText).toContain(headingText);
 
       // Should NOT redirect to login
       await expect(page).not.toHaveURL(/\/admin\/login/);

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -119,9 +119,8 @@ test.describe("Band Profile Viewing", () => {
   test("should list upcoming band events", async ({ page }) => {
     await page.goto("/");
 
-    // Enter through the SEEDED event's card, so the artist is deterministic --
-    // the same reason public-timeline.spec.js pins by name (#895). Taking any
-    // band link couples this test to whichever events happen to exist.
+    // Enter through the seeded event's card: that fixes WHICH artist this test
+    // opens, and guarantees they have an upcoming performance to list.
     const seededCard = page.locator('[data-testid="event-card"]').filter({ hasText: SEEDED_EVENT }).first();
     await expect(seededCard).toBeVisible();
     await seededCard.getByRole("button", { name: /view details/i }).click();
@@ -131,15 +130,8 @@ test.describe("Band Profile Viewing", () => {
     await bandLink.click();
     await page.waitForURL(/\/band(s)?\//);
 
-    // Unconditional, and it can be: this test entered through the SEEDED event's
-    // card, so the artist provably plays an upcoming event. The old form guarded
-    // on a loose heading match (/upcoming|shows|events|performances/i) after
-    // entering via whatever band link happened to be first -- so which artist it
-    // landed on depended on what events existed, and a miss silently skipped.
-    //
-    // The listing is a set of performance links. BandProfilePage renders no
-    // [data-testid="event-card"] and no .event-card, so the locator this replaces
-    // counted zero every run and everything nested under it never executed.
+    // BandProfilePage lists performances as `<Link to={`/event/${slug}`}>` and
+    // renders no [data-testid="event-card"] -- do not reach for one here.
     const eventList = page.locator('main a[href^="/event/"]');
     await expect(eventList.first()).toBeVisible();
     await expect(eventList.first()).toHaveText(/\S/);

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -1,5 +1,9 @@
 import { test, expect } from "@playwright/test";
 
+// The seeded upcoming event (database/seed-test-data.sql). Entering through its
+// card makes "which artist" deterministic instead of order-dependent.
+const SEEDED_EVENT = "Future Fest E2E";
+
 test.describe("Band Profile Viewing", () => {
   test("should display band profile without authentication", async ({ page }) => {
     // Navigate to public homepage first to get a band
@@ -115,31 +119,30 @@ test.describe("Band Profile Viewing", () => {
   test("should list upcoming band events", async ({ page }) => {
     await page.goto("/");
 
-    // Navigate to band profile
-    const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
+    // Enter through the SEEDED event's card, so the artist is deterministic --
+    // the same reason public-timeline.spec.js pins by name (#895). Taking any
+    // band link couples this test to whichever events happen to exist.
+    const seededCard = page.locator('[data-testid="event-card"]').filter({ hasText: SEEDED_EVENT }).first();
+    await expect(seededCard).toBeVisible();
+    await seededCard.getByRole("button", { name: /view details/i }).click();
+
+    const bandLink = seededCard.locator('a[href*="/band/"]').first();
     await expect(bandLink).toBeVisible();
     await bandLink.click();
+    await page.waitForURL(/\/band(s)?\//);
 
-    // Look for upcoming events section
-    const upcomingSection = page
-      .locator('[data-testid="upcoming-events"]')
-      .or(page.getByRole("heading", { name: /upcoming|shows|events|performances/i }))
-      .first();
-
-    if (await upcomingSection.isVisible()) {
-      // The listing is a set of performance links. BandProfilePage renders no
-      // [data-testid="event-card"] and no .event-card, so the locator this
-      // replaces counted zero on every run and everything nested under it --
-      // including the date check -- never executed.
-      const eventList = page.locator('main a[href^="/event/"]');
-      await expect(eventList.first()).toBeVisible();
-
-      // The row names the event it links to. Asserting it is non-empty is a
-      // deliberately smaller claim than the date pattern it replaces, which
-      // matched any single digit anywhere in the row and would have passed on
-      // almost any content had it ever run.
-      await expect(eventList.first()).not.toBeEmpty();
-    }
+    // Unconditional, and it can be: this test entered through the SEEDED event's
+    // card, so the artist provably plays an upcoming event. The old form guarded
+    // on a loose heading match (/upcoming|shows|events|performances/i) after
+    // entering via whatever band link happened to be first -- so which artist it
+    // landed on depended on what events existed, and a miss silently skipped.
+    //
+    // The listing is a set of performance links. BandProfilePage renders no
+    // [data-testid="event-card"] and no .event-card, so the locator this replaces
+    // counted zero every run and everything nested under it never executed.
+    const eventList = page.locator('main a[href^="/event/"]');
+    await expect(eventList.first()).toBeVisible();
+    await expect(eventList.first()).toHaveText(/\S/);
   });
 
   test("should show past performance history", async ({ page }) => {

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -13,7 +13,11 @@ test.describe("Band Profile Viewing", () => {
     // into a silent pass instead of a failure (#895). Seed data always has bands.
     await expect(bandLink).toBeVisible();
     {
-      const bandName = await bandLink.textContent();
+      const bandName = ((await bandLink.textContent()) ?? "").trim();
+      // Reject an empty name before it is used as an assertion: toContainText("")
+      // passes against any heading, which would quietly restore the vacuity this
+      // test was just fixed for.
+      expect(bandName).not.toBe("");
       await bandLink.click();
 
       // Scope to the main h1: the Header carries its own "SetTimes" h1, and the
@@ -21,7 +25,7 @@ test.describe("Band Profile Viewing", () => {
       // match is a strict-mode violation waiting for a second element (#895).
       // toContainText takes a STRING, so a band name containing regex
       // metacharacters cannot corrupt the pattern the way `new RegExp(name)` did.
-      await expect(page.locator("main h1")).toContainText((bandName || "").trim());
+      await expect(page.locator("main h1")).toContainText(bandName);
 
       // Should NOT redirect to login
       await expect(page).not.toHaveURL(/\/admin\/login/);

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -8,12 +8,20 @@ test.describe("Band Profile Viewing", () => {
     // Click on first band link (may be in event card or band list)
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
 
-    if (await bandLink.isVisible()) {
+    // Unconditional, for the same reason as public-timeline.spec.js: an
+    // `if (await bandLink.isVisible())` wrapper turns "no band link on the page"
+    // into a silent pass instead of a failure (#895). Seed data always has bands.
+    await expect(bandLink).toBeVisible();
+    {
       const bandName = await bandLink.textContent();
       await bandLink.click();
 
-      // Verify band profile page loads
-      await expect(page.getByRole("heading", { name: new RegExp(bandName || "", "i") })).toBeVisible();
+      // Scope to the main h1: the Header carries its own "SetTimes" h1, and the
+      // page can show the band name in more than one heading, so an unscoped
+      // match is a strict-mode violation waiting for a second element (#895).
+      // toContainText takes a STRING, so a band name containing regex
+      // metacharacters cannot corrupt the pattern the way `new RegExp(name)` did.
+      await expect(page.locator("main h1")).toContainText((bandName || "").trim());
 
       // Should NOT redirect to login
       await expect(page).not.toHaveURL(/\/admin\/login/);

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -97,13 +97,15 @@ test.describe("Band Profile Viewing", () => {
     await bandLink.click();
 
     // Look for official website link
+    // .first() on the union: `or()` can resolve to several elements, and
+    // isVisible() on a multi-match locator raises a strict-mode error rather
+    // than returning false.
     const websiteLink = page
       .locator('a[data-testid="band-website"]')
-      .or(page.locator('a:has-text("Website")').or(page.locator('a[class*="website"]')));
+      .or(page.locator('a:has-text("Website")').or(page.locator('a[class*="website"]')))
+      .first();
 
     if (await websiteLink.isVisible()) {
-      await expect(websiteLink).toBeVisible();
-
       // Verify link has valid URL
       const href = await websiteLink.getAttribute("href");
       expect(href).toMatch(/^https?:\/\//);
@@ -121,7 +123,8 @@ test.describe("Band Profile Viewing", () => {
     // Look for upcoming events section
     const upcomingSection = page
       .locator('[data-testid="upcoming-events"]')
-      .or(page.getByRole("heading", { name: /upcoming|shows|events|performances/i }));
+      .or(page.getByRole("heading", { name: /upcoming|shows|events|performances/i }))
+      .first();
 
     if (await upcomingSection.isVisible()) {
       await expect(upcomingSection).toBeVisible();
@@ -155,7 +158,8 @@ test.describe("Band Profile Viewing", () => {
     // Look for past performances section
     const pastSection = page
       .locator('[data-testid="past-events"]')
-      .or(page.getByRole("heading", { name: /past|previous|history/i }));
+      .or(page.getByRole("heading", { name: /past|previous|history/i }))
+      .first();
 
     if (await pastSection.isVisible()) {
       await expect(pastSection).toBeVisible();
@@ -178,11 +182,10 @@ test.describe("Band Profile Viewing", () => {
     if (await bandPhoto.first().isVisible()) {
       await expect(bandPhoto.first()).toBeVisible();
 
-      // Verify image has proper alt text for accessibility
-      const altText = await bandPhoto.first().getAttribute("alt");
-      if (altText) {
-        expect(altText.length).toBeGreaterThan(0);
-      }
+      // A missing alt returns null and an empty alt returns "", and the previous
+      // `if (altText)` skipped BOTH -- the two cases the check exists to catch.
+      // \S requires at least one non-whitespace character.
+      await expect(bandPhoto.first()).toHaveAttribute("alt", /\S/);
     }
   });
 
@@ -194,18 +197,23 @@ test.describe("Band Profile Viewing", () => {
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
     await expect(bandLink).toBeVisible();
-    const bandName = (await bandLink.textContent())?.trim() || "";
+    // The anchor wraps the whole card, so this is name + venue + time + genre --
+    // never just the name. Hence the containment direction used below.
+    const linkText = ((await bandLink.textContent()) ?? "").trim();
+    expect(linkText).not.toBe("");
     await bandLink.click();
     await page.waitForURL(/\/band(s)?\//);
 
-    // Verify the band profile heading renders on mobile. Wait generously: the
-    // profile route is lazy-loaded and fetches its data, which can exceed the
-    // default 5s timeout on a cold CI mobile run. Match the band name robustly
-    // (regex-escaped), and allow multiple headings via .first().
-    const headingName = bandName ? new RegExp(bandName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i") : /.+/;
-    await expect(page.getByRole("heading", { name: headingName }).first()).toBeVisible({
-      timeout: 15000,
-    });
+    // Wait generously: the profile route is lazy-loaded and fetches its data,
+    // which can exceed the default 5s timeout on a cold CI mobile run.
+    const heading = page.locator("main h1");
+    await expect(heading).toBeVisible({ timeout: 15000 });
+    const headingText = ((await heading.textContent()) ?? "").trim();
+    expect(headingText).not.toBe("");
+    // Identity of the profile that opened, matching the pattern the first test
+    // uses. The old form built a RegExp out of the full card text, which could
+    // not match the heading and threw on titles containing metacharacters.
+    expect(linkText).toContain(headingText);
 
     // Verify content is readable on mobile
     const contentArea = page.locator('main, [role="main"], article').first();
@@ -304,11 +312,15 @@ test.describe("Band Profile Viewing", () => {
     const eventCard = page.locator('[data-testid="event-card"]').or(page.locator(".event-card")).first();
 
     if (await eventCard.isVisible()) {
-      const eventTitle = await eventCard.locator('h3, h2, [class*="title"]').first().textContent();
+      const eventTitle = ((await eventCard.locator('h3, h2, [class*="title"]').first().textContent()) ?? "").trim();
+      // An empty title matched EVERY heading through the old RegExp, and a title
+      // containing `[` made the RegExp constructor throw outright.
+      expect(eventTitle).not.toBe("");
       await eventCard.click();
 
-      // Verify event details page/modal opens
-      await expect(page.getByRole("heading", { name: new RegExp(eventTitle || "", "i") })).toBeVisible();
+      // exact: true -- a string role name is substring-matched by default, so a
+      // short title would match a longer unrelated heading.
+      await expect(page.getByRole("heading", { name: eventTitle, exact: true })).toBeVisible();
     }
   });
 
@@ -323,7 +335,8 @@ test.describe("Band Profile Viewing", () => {
     // Look for band members section
     const membersSection = page
       .locator('[data-testid="band-members"]')
-      .or(page.getByRole("heading", { name: /members|lineup|artists/i }));
+      .or(page.getByRole("heading", { name: /members|lineup|artists/i }))
+      .first();
 
     if (await membersSection.isVisible()) {
       await expect(membersSection).toBeVisible();
@@ -336,16 +349,19 @@ test.describe("Band Profile Viewing", () => {
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
     await expect(bandLink).toBeVisible();
-    const bandName = await bandLink.textContent();
     await bandLink.click();
 
     // Wait for page to fully load
     await page.waitForLoadState("networkidle");
 
-    // Verify page title includes band name (SEO)
-    const title = await page.title();
-    if (bandName && title) {
-      expect(title.toLowerCase()).toContain(bandName.toLowerCase());
-    }
+    // Compare the title against the profile's OWN h1, not the anchor text: the
+    // anchor carries venue, time and genre too, so the old check could only ever
+    // pass by accident. The `if (bandName && title)` around it also made a blank
+    // title a silent pass -- on the one assertion here that is SEO-critical.
+    const heading = page.locator("main h1");
+    await expect(heading).toBeVisible({ timeout: 15000 });
+    const headingText = ((await heading.textContent()) ?? "").trim();
+    expect(headingText).not.toBe("");
+    expect((await page.title()).toLowerCase()).toContain(headingText.toLowerCase());
   });
 });

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -42,23 +42,22 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Verify bio/description is displayed
-      const bioText = page
-        .locator('[data-testid="band-bio"]')
-        .or(page.locator('[class*="bio"]').or(page.locator("p, div").filter({ hasText: /\w{20,}/ })));
+    // Verify bio/description is displayed
+    const bioText = page
+      .locator('[data-testid="band-bio"]')
+      .or(page.locator('[class*="bio"]').or(page.locator("p, div").filter({ hasText: /\w{20,}/ })));
 
-      if (await bioText.first().isVisible()) {
-        await expect(bioText.first()).toBeVisible();
-      }
+    if (await bioText.first().isVisible()) {
+      await expect(bioText.first()).toBeVisible();
+    }
 
-      // Verify genre information
-      const genreInfo = page.locator('[data-testid="band-genre"]').or(page.locator('[class*="genre"]'));
-      if (await genreInfo.first().isVisible()) {
-        await expect(genreInfo.first()).toBeVisible();
-      }
+    // Verify genre information
+    const genreInfo = page.locator('[data-testid="band-genre"]').or(page.locator('[class*="genre"]'));
+    if (await genreInfo.first().isVisible()) {
+      await expect(genreInfo.first()).toBeVisible();
     }
   });
 
@@ -67,25 +66,24 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Check for social media links
-      const socialLinks = page.locator(
-        'a[href*="instagram.com"], a[href*="facebook.com"], a[href*="spotify.com"], a[href*="youtube.com"], a[href*="bandcamp.com"], a[href*="soundcloud.com"]',
-      );
+    // Check for social media links
+    const socialLinks = page.locator(
+      'a[href*="instagram.com"], a[href*="facebook.com"], a[href*="spotify.com"], a[href*="youtube.com"], a[href*="bandcamp.com"], a[href*="soundcloud.com"]',
+    );
 
-      const linkCount = await socialLinks.count();
-      if (linkCount > 0) {
-        // Verify at least one social link is visible
-        await expect(socialLinks.first()).toBeVisible();
+    const linkCount = await socialLinks.count();
+    if (linkCount > 0) {
+      // Verify at least one social link is visible
+      await expect(socialLinks.first()).toBeVisible();
 
-        // Verify links open in new tab (external links)
-        const firstLink = socialLinks.first();
-        const target = await firstLink.getAttribute("target");
-        if (target) {
-          expect(target).toBe("_blank");
-        }
+      // Verify links open in new tab (external links)
+      const firstLink = socialLinks.first();
+      const target = await firstLink.getAttribute("target");
+      if (target) {
+        expect(target).toBe("_blank");
       }
     }
   });
@@ -95,21 +93,20 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Look for official website link
-      const websiteLink = page
-        .locator('a[data-testid="band-website"]')
-        .or(page.locator('a:has-text("Website")').or(page.locator('a[class*="website"]')));
+    // Look for official website link
+    const websiteLink = page
+      .locator('a[data-testid="band-website"]')
+      .or(page.locator('a:has-text("Website")').or(page.locator('a[class*="website"]')));
 
-      if (await websiteLink.isVisible()) {
-        await expect(websiteLink).toBeVisible();
+    if (await websiteLink.isVisible()) {
+      await expect(websiteLink).toBeVisible();
 
-        // Verify link has valid URL
-        const href = await websiteLink.getAttribute("href");
-        expect(href).toMatch(/^https?:\/\//);
-      }
+      // Verify link has valid URL
+      const href = await websiteLink.getAttribute("href");
+      expect(href).toMatch(/^https?:\/\//);
     }
   });
 
@@ -118,31 +115,30 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Look for upcoming events section
-      const upcomingSection = page
-        .locator('[data-testid="upcoming-events"]')
-        .or(page.getByRole("heading", { name: /upcoming|shows|events|performances/i }));
+    // Look for upcoming events section
+    const upcomingSection = page
+      .locator('[data-testid="upcoming-events"]')
+      .or(page.getByRole("heading", { name: /upcoming|shows|events|performances/i }));
 
-      if (await upcomingSection.isVisible()) {
-        await expect(upcomingSection).toBeVisible();
+    if (await upcomingSection.isVisible()) {
+      await expect(upcomingSection).toBeVisible();
 
-        // Verify event listings
-        const eventList = page.locator('[data-testid="event-card"]').or(page.locator(".event-card"));
-        const eventCount = await eventList.count();
+      // Verify event listings
+      const eventList = page.locator('[data-testid="event-card"]').or(page.locator(".event-card"));
+      const eventCount = await eventList.count();
 
-        if (eventCount > 0) {
-          // Verify first event has date and venue
-          const firstEvent = eventList.first();
-          await expect(firstEvent).toBeVisible();
+      if (eventCount > 0) {
+        // Verify first event has date and venue
+        const firstEvent = eventList.first();
+        await expect(firstEvent).toBeVisible();
 
-          // Check for date information
-          const dateInfo = firstEvent.locator("text=/\\d{1,2}|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/i");
-          if (await dateInfo.isVisible()) {
-            await expect(dateInfo).toBeVisible();
-          }
+        // Check for date information
+        const dateInfo = firstEvent.locator("text=/\\d{1,2}|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/i");
+        if (await dateInfo.isVisible()) {
+          await expect(dateInfo).toBeVisible();
         }
       }
     }
@@ -153,17 +149,16 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Look for past performances section
-      const pastSection = page
-        .locator('[data-testid="past-events"]')
-        .or(page.getByRole("heading", { name: /past|previous|history/i }));
+    // Look for past performances section
+    const pastSection = page
+      .locator('[data-testid="past-events"]')
+      .or(page.getByRole("heading", { name: /past|previous|history/i }));
 
-      if (await pastSection.isVisible()) {
-        await expect(pastSection).toBeVisible();
-      }
+    if (await pastSection.isVisible()) {
+      await expect(pastSection).toBeVisible();
     }
   });
 
@@ -172,22 +167,21 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Look for band photo/image
-      const bandPhoto = page
-        .locator('[data-testid="band-photo"]')
-        .or(page.locator('img[alt*="band"]').or(page.locator('[class*="photo"], [class*="image"]').locator("img")));
+    // Look for band photo/image
+    const bandPhoto = page
+      .locator('[data-testid="band-photo"]')
+      .or(page.locator('img[alt*="band"]').or(page.locator('[class*="photo"], [class*="image"]').locator("img")));
 
-      if (await bandPhoto.first().isVisible()) {
-        await expect(bandPhoto.first()).toBeVisible();
+    if (await bandPhoto.first().isVisible()) {
+      await expect(bandPhoto.first()).toBeVisible();
 
-        // Verify image has proper alt text for accessibility
-        const altText = await bandPhoto.first().getAttribute("alt");
-        if (altText) {
-          expect(altText.length).toBeGreaterThan(0);
-        }
+      // Verify image has proper alt text for accessibility
+      const altText = await bandPhoto.first().getAttribute("alt");
+      if (altText) {
+        expect(altText.length).toBeGreaterThan(0);
       }
     }
   });
@@ -199,25 +193,24 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      const bandName = (await bandLink.textContent())?.trim() || "";
-      await bandLink.click();
-      await page.waitForURL(/\/band(s)?\//);
+    await expect(bandLink).toBeVisible();
+    const bandName = (await bandLink.textContent())?.trim() || "";
+    await bandLink.click();
+    await page.waitForURL(/\/band(s)?\//);
 
-      // Verify the band profile heading renders on mobile. Wait generously: the
-      // profile route is lazy-loaded and fetches its data, which can exceed the
-      // default 5s timeout on a cold CI mobile run. Match the band name robustly
-      // (regex-escaped), and allow multiple headings via .first().
-      const headingName = bandName ? new RegExp(bandName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i") : /.+/;
-      await expect(page.getByRole("heading", { name: headingName }).first()).toBeVisible({
-        timeout: 15000,
-      });
+    // Verify the band profile heading renders on mobile. Wait generously: the
+    // profile route is lazy-loaded and fetches its data, which can exceed the
+    // default 5s timeout on a cold CI mobile run. Match the band name robustly
+    // (regex-escaped), and allow multiple headings via .first().
+    const headingName = bandName ? new RegExp(bandName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i") : /.+/;
+    await expect(page.getByRole("heading", { name: headingName }).first()).toBeVisible({
+      timeout: 15000,
+    });
 
-      // Verify content is readable on mobile
-      const contentArea = page.locator('main, [role="main"], article').first();
-      if (await contentArea.isVisible()) {
-        await expect(contentArea).toBeVisible();
-      }
+    // Verify content is readable on mobile
+    const contentArea = page.locator('main, [role="main"], article').first();
+    if (await contentArea.isVisible()) {
+      await expect(contentArea).toBeVisible();
     }
   });
 
@@ -226,22 +219,21 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Look for back button or home link
-      const backButton = page
-        .locator('button:has-text("Back")')
-        .or(
-          page.locator('a[href="/"]').or(page.locator('a:has-text("Home")').or(page.locator('a:has-text("Schedule")'))),
-        );
+    // Look for back button or home link
+    const backButton = page
+      .locator('button:has-text("Back")')
+      .or(
+        page.locator('a[href="/"]').or(page.locator('a:has-text("Home")').or(page.locator('a:has-text("Schedule")'))),
+      );
 
-      if (await backButton.first().isVisible()) {
-        await backButton.first().click();
+    if (await backButton.first().isVisible()) {
+      await backButton.first().click();
 
-        // Verify we're back on timeline
-        await expect(page.getByRole("heading", { name: /schedule/i })).toBeVisible();
-      }
+      // Verify we're back on timeline
+      await expect(page.getByRole("heading", { name: /schedule/i })).toBeVisible();
     }
   });
 
@@ -269,17 +261,16 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Look for contact information
-      const contactInfo = page
-        .locator('[data-testid="band-contact"]')
-        .or(page.locator("text=/contact|booking|management|email/i"));
+    // Look for contact information
+    const contactInfo = page
+      .locator('[data-testid="band-contact"]')
+      .or(page.locator("text=/contact|booking|management|email/i"));
 
-      if (await contactInfo.first().isVisible()) {
-        await expect(contactInfo.first()).toBeVisible();
-      }
+    if (await contactInfo.first().isVisible()) {
+      await expect(contactInfo.first()).toBeVisible();
     }
   });
 
@@ -288,17 +279,16 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Look for formation year or history information
-      const historyInfo = page
-        .locator('[data-testid="band-formed"]')
-        .or(page.locator("text=/formed|since|est\\.|established|\\d{4}/i"));
+    // Look for formation year or history information
+    const historyInfo = page
+      .locator('[data-testid="band-formed"]')
+      .or(page.locator("text=/formed|since|est\\.|established|\\d{4}/i"));
 
-      if (await historyInfo.first().isVisible()) {
-        await expect(historyInfo.first()).toBeVisible();
-      }
+    if (await historyInfo.first().isVisible()) {
+      await expect(historyInfo.first()).toBeVisible();
     }
   });
 
@@ -307,19 +297,18 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Look for event listings in band profile
-      const eventCard = page.locator('[data-testid="event-card"]').or(page.locator(".event-card")).first();
+    // Look for event listings in band profile
+    const eventCard = page.locator('[data-testid="event-card"]').or(page.locator(".event-card")).first();
 
-      if (await eventCard.isVisible()) {
-        const eventTitle = await eventCard.locator('h3, h2, [class*="title"]').first().textContent();
-        await eventCard.click();
+    if (await eventCard.isVisible()) {
+      const eventTitle = await eventCard.locator('h3, h2, [class*="title"]').first().textContent();
+      await eventCard.click();
 
-        // Verify event details page/modal opens
-        await expect(page.getByRole("heading", { name: new RegExp(eventTitle || "", "i") })).toBeVisible();
-      }
+      // Verify event details page/modal opens
+      await expect(page.getByRole("heading", { name: new RegExp(eventTitle || "", "i") })).toBeVisible();
     }
   });
 
@@ -328,17 +317,16 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
 
-      // Look for band members section
-      const membersSection = page
-        .locator('[data-testid="band-members"]')
-        .or(page.getByRole("heading", { name: /members|lineup|artists/i }));
+    // Look for band members section
+    const membersSection = page
+      .locator('[data-testid="band-members"]')
+      .or(page.getByRole("heading", { name: /members|lineup|artists/i }));
 
-      if (await membersSection.isVisible()) {
-        await expect(membersSection).toBeVisible();
-      }
+    if (await membersSection.isVisible()) {
+      await expect(membersSection).toBeVisible();
     }
   });
 
@@ -347,18 +335,17 @@ test.describe("Band Profile Viewing", () => {
 
     // Navigate to band profile
     const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
-    if (await bandLink.isVisible()) {
-      const bandName = await bandLink.textContent();
-      await bandLink.click();
+    await expect(bandLink).toBeVisible();
+    const bandName = await bandLink.textContent();
+    await bandLink.click();
 
-      // Wait for page to fully load
-      await page.waitForLoadState("networkidle");
+    // Wait for page to fully load
+    await page.waitForLoadState("networkidle");
 
-      // Verify page title includes band name (SEO)
-      const title = await page.title();
-      if (bandName && title) {
-        expect(title.toLowerCase()).toContain(bandName.toLowerCase());
-      }
+    // Verify page title includes band name (SEO)
+    const title = await page.title();
+    if (bandName && title) {
+      expect(title.toLowerCase()).toContain(bandName.toLowerCase());
     }
   });
 });

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -127,23 +127,18 @@ test.describe("Band Profile Viewing", () => {
       .first();
 
     if (await upcomingSection.isVisible()) {
-      await expect(upcomingSection).toBeVisible();
+      // The listing is a set of performance links. BandProfilePage renders no
+      // [data-testid="event-card"] and no .event-card, so the locator this
+      // replaces counted zero on every run and everything nested under it --
+      // including the date check -- never executed.
+      const eventList = page.locator('main a[href^="/event/"]');
+      await expect(eventList.first()).toBeVisible();
 
-      // Verify event listings
-      const eventList = page.locator('[data-testid="event-card"]').or(page.locator(".event-card"));
-      const eventCount = await eventList.count();
-
-      if (eventCount > 0) {
-        // Verify first event has date and venue
-        const firstEvent = eventList.first();
-        await expect(firstEvent).toBeVisible();
-
-        // Check for date information
-        const dateInfo = firstEvent.locator("text=/\\d{1,2}|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/i");
-        if (await dateInfo.isVisible()) {
-          await expect(dateInfo).toBeVisible();
-        }
-      }
+      // The row names the event it links to. Asserting it is non-empty is a
+      // deliberately smaller claim than the date pattern it replaces, which
+      // matched any single digit anywhere in the row and would have passed on
+      // almost any content had it ever run.
+      await expect(eventList.first()).not.toBeEmpty();
     }
   });
 

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -1,12 +1,21 @@
 import { test, expect } from "@playwright/test";
 
-// During show hours, EventTimeline.jsx auto-expands a live event
-// (`useState(isLive)`), so its "View Details" toggle already reads "Hide
-// Details". Plain `[data-testid="event-card"]').first()` can therefore grab
-// an already-expanded card and time out waiting for a "View Details" button
-// that isn't there (#602 — CI-only, time-of-day dependent). Filtering to a
-// card that still shows the collapsed affordance keeps these specs
-// deterministic regardless of clock/live state.
+// Pinned by NAME, never by position. Taking the first card couples every
+// assertion below to "no other spec has created an event", which is false:
+// several specs create events dated TODAY, which sort ahead of the seeded
+// fixtures and take the slot (#895). Locally, where D1 persists between runs,
+// those accumulate until these tests fail outright; in CI it is a live race
+// within a single run rather than a certainty, which is worse — it looks like
+// flake. admin-surfaces.spec.js already selects its event by name for the
+// same reason.
+//
+// This supersedes the #602 fix it replaces rather than dropping it. That bug
+// was `.first()` grabbing a LIVE event, which EventTimeline auto-expands
+// (`useState(isLive)`), so its "View Details" toggle already read "Hide
+// Details" and the click timed out — CI-only and time-of-day dependent. The
+// seeded event is dated two weeks out and is never live, so the card is
+// reliably collapsed; naming it removes the whole class rather than filtering
+// around it.
 //
 // Playwright locators are lazy/live, not snapshots: a `.filter({ has: ... })`
 // locator re-runs its condition on every query. Once the returned card is
@@ -15,10 +24,13 @@ import { test, expect } from "@playwright/test";
 // re-resolve to a *different* card. So resolve the filter once to a stable
 // DOM index and hand back an `nth()` locator, which stays pinned to that
 // card's position regardless of its later expanded/collapsed state.
-async function collapsedEventCard(page) {
+const SEEDED_EVENT = "Future Fest E2E";
+
+async function seededEventCard(page) {
   const allCards = page.locator('[data-testid="event-card"]');
-  const collapsed = allCards.filter({ has: page.getByRole("button", { name: /view details/i }) }).first();
-  const index = await collapsed.evaluate(
+  const target = allCards.filter({ hasText: SEEDED_EVENT }).first();
+  await expect(target).toBeVisible();
+  const index = await target.evaluate(
     (el, testid) => Array.from(document.querySelectorAll(`[data-testid="${testid}"]`)).indexOf(el),
     "event-card",
   );
@@ -39,7 +51,7 @@ test.describe("Public Timeline Viewing", () => {
   test("should show event details when clicked", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Verify the card expanded (button flips to Hide Details)
@@ -62,7 +74,7 @@ test.describe("Public Timeline Viewing", () => {
   test("should display event venue information", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Seed data guarantees the upcoming event has venues
@@ -73,7 +85,7 @@ test.describe("Public Timeline Viewing", () => {
   test("should show band/performer information in events", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Seed data guarantees the upcoming event has performers
@@ -84,19 +96,26 @@ test.describe("Public Timeline Viewing", () => {
   test("should navigate to band profile from event", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
+    // NOT wrapped in `if (await bandLink.isVisible())`. It was, and that made the
+    // whole assertion block skippable: whenever the card under test had no band
+    // links the test passed having checked nothing (#895). The seeded event always
+    // has performers, so absence is a failure, not a reason to skip.
     const bandLink = firstEvent.locator('a[href*="/band/"]').first();
-    if (await bandLink.isVisible()) {
-      await bandLink.click();
-      await expect(page).toHaveURL(/\/band\//);
-      // Wait for the band profile to fully render before asserting content.
-      // toHaveTitle waits for the useEffect title update; only then is the page settled.
-      // Scoping to main h1 avoids the Header's "SetTimes" h1 (strict mode violation).
-      await expect(page).toHaveTitle(/- Band Profile \| SetTimes$/);
-      await expect(page.locator("main h1")).toBeVisible();
-    }
+    await expect(bandLink).toBeVisible();
+    await bandLink.click();
+    await expect(page).toHaveURL(/\/band\//);
+    // The LOADED title, not the pre-load fallback. BandProfilePage sets
+    // 'Band Profile | SetTimes' while the fetch is in flight and only then
+    // replicates the SSR formula, `{name} — {genre} in Waterloo Region | SetTimes`
+    // (functions/band/[id].js). The old pattern matched the fallback, so it could
+    // only ever pass while the page was still loading — which is the opposite of
+    // the "wait until settled" this line is here to do.
+    await expect(page).toHaveTitle(/ in Waterloo Region \| SetTimes$/);
+    // Scoping to main h1 avoids the Header's "SetTimes" h1 (strict mode violation).
+    await expect(page.locator("main h1")).toBeVisible();
   });
 
   test("should display timeline content", async ({ page }) => {
@@ -116,7 +135,7 @@ test.describe("Public Timeline Viewing", () => {
     const eventCards = page.locator('[data-testid="event-card"]');
     await expect(eventCards.first()).toBeVisible();
 
-    const mobileCard = await collapsedEventCard(page);
+    const mobileCard = await seededEventCard(page);
     await mobileCard.getByRole("button", { name: /view details/i }).click();
     await page.waitForTimeout(500);
   });
@@ -141,7 +160,7 @@ test.describe("Public Timeline Viewing", () => {
   test("should display event duration and time details", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     const timeRange = firstEvent.locator("text=/\\d{2}:\\d{2}\\s*-\\s*\\d{2}:\\d{2}/");
@@ -166,7 +185,7 @@ test.describe("Public Timeline Viewing", () => {
   test("should show venue location details in event view", async ({ page }) => {
     await page.goto("/");
 
-    const firstEvent = await collapsedEventCard(page);
+    const firstEvent = await seededEventCard(page);
     await firstEvent.getByRole("button", { name: /view details/i }).click();
 
     // Seed data guarantees the upcoming event has venues

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -105,6 +105,12 @@ test.describe("Public Timeline Viewing", () => {
     // has performers, so absence is a failure, not a reason to skip.
     const bandLink = firstEvent.locator('a[href*="/band/"]').first();
     await expect(bandLink).toBeVisible();
+    // Captured BEFORE navigating, so the profile can be checked to be the one
+    // that was clicked rather than merely "a band profile".
+    const bandName = ((await bandLink.textContent()) ?? "").trim();
+    // An empty name would make the `main h1` assertion below vacuous —
+    // toContainText("") passes against any heading at all.
+    expect(bandName).not.toBe("");
     await bandLink.click();
     await expect(page).toHaveURL(/\/band\//);
     // The LOADED title, not the pre-load fallback. BandProfilePage sets
@@ -115,7 +121,9 @@ test.describe("Public Timeline Viewing", () => {
     // the "wait until settled" this line is here to do.
     await expect(page).toHaveTitle(/ in Waterloo Region \| SetTimes$/);
     // Scoping to main h1 avoids the Header's "SetTimes" h1 (strict mode violation).
-    await expect(page.locator("main h1")).toBeVisible();
+    // Asserting the NAME, not just visibility: a generic "a profile rendered"
+    // check passes even if the wrong link were followed.
+    await expect(page.locator("main h1")).toContainText(bandName);
   });
 
   test("should display timeline content", async ({ page }) => {

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -17,24 +17,24 @@ import { test, expect } from "@playwright/test";
 // reliably collapsed; naming it removes the whole class rather than filtering
 // around it.
 //
-// Playwright locators are lazy/live, not snapshots: a `.filter({ has: ... })`
-// locator re-runs its condition on every query. Once the returned card is
-// clicked open, its button flips to "Hide Details" and it stops matching the
-// "View Details" filter — a later `firstEvent.getByRole(...)` would silently
-// re-resolve to a *different* card. So resolve the filter once to a stable
-// DOM index and hand back an `nth()` locator, which stays pinned to that
-// card's position regardless of its later expanded/collapsed state.
+// Returns the live filter, deliberately NOT an `nth()` index.
+//
+// The previous helper resolved to a DOM index on purpose: its filter matched
+// the "View Details" button, which STOPS matching the moment the card is
+// clicked open, so a lazy locator would have re-resolved to a different card.
+// Filtering on the event NAME has no such problem — the name stays in the card
+// whether it is collapsed or expanded — which makes the index dance obsolete.
+//
+// It is also now the riskier of the two. EventTimeline re-polls every 60s, and
+// a card moving between the now/upcoming/past buckets shifts positions; a
+// pinned `nth(index)` would then address whatever had moved into that slot,
+// while the name filter still finds the right card.
 const SEEDED_EVENT = "Future Fest E2E";
 
 async function seededEventCard(page) {
-  const allCards = page.locator('[data-testid="event-card"]');
-  const target = allCards.filter({ hasText: SEEDED_EVENT }).first();
-  await expect(target).toBeVisible();
-  const index = await target.evaluate(
-    (el, testid) => Array.from(document.querySelectorAll(`[data-testid="${testid}"]`)).indexOf(el),
-    "event-card",
-  );
-  return allCards.nth(index);
+  const card = page.locator('[data-testid="event-card"]').filter({ hasText: SEEDED_EVENT }).first();
+  await expect(card).toBeVisible();
+  return card;
 }
 
 test.describe("Public Timeline Viewing", () => {

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -17,18 +17,11 @@ import { test, expect } from "@playwright/test";
 // reliably collapsed; naming it removes the whole class rather than filtering
 // around it.
 //
-// Returns the live filter, deliberately NOT an `nth()` index.
-//
-// The previous helper resolved to a DOM index on purpose: its filter matched
-// the "View Details" button, which STOPS matching the moment the card is
-// clicked open, so a lazy locator would have re-resolved to a different card.
-// Filtering on the event NAME has no such problem — the name stays in the card
-// whether it is collapsed or expanded — which makes the index dance obsolete.
-//
-// It is also now the riskier of the two. EventTimeline re-polls every 60s, and
-// a card moving between the now/upcoming/past buckets shifts positions; a
-// pinned `nth(index)` would then address whatever had moved into that slot,
-// while the name filter still finds the right card.
+// Return the live name filter, never a resolved `nth()` index: EventTimeline
+// re-polls every 60s and a card moving between the now/upcoming/past buckets
+// shifts positions, so a pinned index can end up addressing a different event.
+// The name filter is safe to keep live because the name stays in the card
+// whether it is collapsed or expanded.
 const SEEDED_EVENT = "Future Fest E2E";
 
 async function seededEventCard(page) {

--- a/e2e/public-timeline.spec.js
+++ b/e2e/public-timeline.spec.js
@@ -106,11 +106,14 @@ test.describe("Public Timeline Viewing", () => {
     const bandLink = firstEvent.locator('a[href*="/band/"]').first();
     await expect(bandLink).toBeVisible();
     // Captured BEFORE navigating, so the profile can be checked to be the one
-    // that was clicked rather than merely "a band profile".
-    const bandName = ((await bandLink.textContent()) ?? "").trim();
-    // An empty name would make the `main h1` assertion below vacuous —
-    // toContainText("") passes against any heading at all.
-    expect(bandName).not.toBe("");
+    // that was clicked rather than merely "a band profile". This is the whole
+    // CARD's text, not just the name -- the anchor wraps venue, time and genre
+    // too ("The Time TravellersWaterloo Music Hall7:00 PM - 7:45 PMIndie Rock"),
+    // which is why the comparison below runs link-contains-heading rather than
+    // the other way round.
+    const linkText = ((await bandLink.textContent()) ?? "").trim();
+    // An empty capture would make the comparison below vacuous.
+    expect(linkText).not.toBe("");
     await bandLink.click();
     await expect(page).toHaveURL(/\/band\//);
     // The LOADED title, not the pre-load fallback. BandProfilePage sets
@@ -121,9 +124,15 @@ test.describe("Public Timeline Viewing", () => {
     // the "wait until settled" this line is here to do.
     await expect(page).toHaveTitle(/ in Waterloo Region \| SetTimes$/);
     // Scoping to main h1 avoids the Header's "SetTimes" h1 (strict mode violation).
-    // Asserting the NAME, not just visibility: a generic "a profile rendered"
-    // check passes even if the wrong link were followed.
-    await expect(page.locator("main h1")).toContainText(bandName);
+    const heading = page.locator("main h1");
+    await expect(heading).toBeVisible();
+    const headingText = ((await heading.textContent()) ?? "").trim();
+    // Guard both sides: an empty heading would make the containment check pass
+    // against anything, which is the vacuity this test was just fixed for.
+    expect(headingText).not.toBe("");
+    // Identity, not just "a profile rendered" -- that passes even if the wrong
+    // link were followed.
+    expect(linkText).toContain(headingText);
   });
 
   test("should display timeline content", async ({ page }) => {


### PR DESCRIPTION
## Summary

Thirteen tests in `band-profile-viewing.spec.js` wrapped their **entire body** in `if (await bandLink.isVisible())`. With no band link on the page the body never ran and the test passed having asserted nothing — reported green, indistinguishable from a real pass.

Each guard is now `await expect(bandLink).toBeVisible()`: absence is a failure, not a reason to skip.

Closes #898 · Builds on #897 (branched from it — same file)

## Inner guards are deliberately kept

`if (await bioText.isVisible())` and its siblings cover genuinely optional content — a band may have no bio, website, photo or members list. **The entry point is the bug; optional-content guards are legitimate**, and flattening them would produce tests that fail on correct data.

## Proved by mutation, not by a green run

A green run is exactly what these tests produced *before* the fix. Pointing the band locator at a route that doesn't exist:

**14 of 16 tests fail.** Before the unwrap, that same mutation left every one of them passing. The two that still pass never depended on a band link.

## What the unwrap exposed

Making dormant assertions live surfaced five real defects that nothing could notice while they were being skipped:

| defect | why it never failed |
|---|---|
| **Two more RegExp-from-anchor-text bugs** (mobile, metadata) | Built a pattern from the *whole card* — `"The Time TravellersWaterloo Music Hall7:00 PM - 7:45 PMIndie Rock"` — and matched it against a heading that is only the name. Couldn't match; threw on metacharacters. Identical to the #897 defect — my sibling sweep stopped at the file boundary. |
| **SEO title check wrapped in `if (bandName && title)`** | A blank title was a silent pass, on the assertion in this file that most needs to fail loudly. |
| **Photo alt text** | `getAttribute("alt")` returns `null` when missing and `""` when empty — `if (altText)` skipped **both**, i.e. exactly the cases the check exists to catch. Now `toHaveAttribute("alt", /\S/)`. |
| **Event title** | Empty title matched *every* heading via `new RegExp(title \|\| "")`; a `[` threw. Now rejected when blank, matched with `exact: true`. |
| **`.event-card` locators ×3** | BandProfilePage renders **no** `[data-testid="event-card"]` and no `.event-card`. `count()` was always 0 and `isVisible()` always false, so those bodies never ran either — vacuity one level below the one being removed. Now target the real `<Link to={/event/…}>` anchors. |

Union locators (`or()`) also got `.first()` — `isVisible()` on a multi-match locator raises a strict-mode error rather than returning false.

## One assertion deliberately weakened

The old date check matched `\d{1,2}` or any month abbreviation anywhere in the row — it would have passed on almost any content had it ever run. I replaced it with a non-empty check rather than import a near-vacuous assertion. A real date assertion needs the day-label format and deserves doing deliberately.

## Test plan

- [x] `make gate` green
- [x] `make review` (CodeRabbit) — clean after 6 findings across 3 rounds
- [x] 16/16 against a live wrangler + D1
- [x] Entry-point unwrap mutation-proved (14/16 fail when the link vanishes)
- [x] Event-navigation test mutation-proved separately
- [x] Swept the file: no `event-card` locators remain outside an explanatory comment

## Note

Branched from #897 because both touch this file. Merge #897 first, or this rebases cleanly.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened end-to-end coverage for band profile viewing across desktop and mobile.
  * Improved validation of profile headings, metadata, accessibility, navigation, URLs, band links, and performance links.
  * Updated upcoming-event checks to use a seeded event and verify available event links.
  * Preserved conditional validation for optional profile sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->