### PR TITLE
fix(cache): correct the misclassified band-detail TTL, and guard the double opt-in gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,6 +421,33 @@ All interactions go through `frontend/src/utils/scheduleStorage.js`. Do not writ
 
 ---
 
+## Public cache TTLs — two tiers, one home
+
+`functions/utils/cacheHeaders.js` owns both public-GET cache values, split by one
+question: **can this change while a show is running?** `CACHE_SHOW_CRITICAL`
+(60s) is for anything rendering live show state — set times, cancellations,
+venue assignments; `CACHE_BROWSE` (300s) is for aggregate-only browse surfaces.
+Deliberately no `stale-while-revalidate`: inside the SWR window a cache serves
+the *stale* body, so a fan opening the page once still reads a cancelled set as
+playing — see the module header for the full rationale.
+
+**Judge the projection, not the route name.** `api/bands/stats/[name].js` is
+named for its aggregates but returns per-performance rows, so it is
+show-critical. Its sibling `api/bands/[name].js` was the same shape and sat at a
+hardcoded 300s until the tiers were wired up — a cancelled set read as playing
+for up to five minutes.
+
+That drift was possible because `CACHE_BROWSE` was **exported and imported by
+nothing** while five endpoints hardcoded its exact string. The constant existed;
+the callers copy-pasted the value. `functions/utils/__tests__/cacheHeaders.test.js`
+now scans source for both halves: no API route may hardcode a `max-age` a tier
+already names, and any route projecting `p.start_time`/`p.is_cancelled` must
+import `CACHE_SHOW_CRITICAL`. Three routes are exempt **by name, with reasons**
+in the test — `schedule.js` (env-tunable, already defaults to 60s), `ical.js`
+(a subscribed feed; clients poll on their own schedule and cancellations travel
+as RFC 5545 `STATUS:CANCELLED`), and `events/[id]/recap.js` (gated by
+`concludedEventSql()`, so it can only serve an event that already ended).
+
 ## Metrics & Analytics
 
 Metrics write to D1 daily-aggregate tables (`page_views_daily`, `artist_daily_stats`) via `POST /api/metrics`, plus an optional Cloudflare Analytics Engine sink (`env.ANALYTICS`, configured in `wrangler.toml`). Ingestion is best-effort and fire-and-forget; failures must not surface to users.
@@ -477,6 +504,8 @@ The human-facing version of this, plus what to do when a set time changes or som
 ## Band Announcements
 
 Band follows are **double opt-in**: `POST /api/bands/:name/follow` creates the row `verified = 0` with a `verification_token` and sends only a confirmation email. Clicking the link hits `GET /api/bands/:name/confirm-follow?token=…`, which sets `verified = 1` and clears the token (idempotent). Announcement emails target `verified = 1` followers **only** (the `WHERE … verified = 1` filter in `admin/bands/[id].js` and `resend-announcement.js`), so an address the submitter doesn't control can never be enrolled in the announcement stream — it receives at most one confirmation email. **Do not revert follow to auto-verify (`verified = 1` on insert)** — it reopens the email-bombing vector.
+
+**The gate is now guarded by `functions/api/admin/bands/__tests__/announce-double-opt-in.test.js`, and it was previously unguarded.** Until that file existed, deleting `AND verified = 1` from *either* recipient query left all 1,169 backend tests green: ten announce-related test files seed followers, and every one of them wrote `verified = 1`, so no fixture could ever distinguish a gated query from an ungated one. The suite looked thorough and proved nothing about the property it most needed to prove. The new tests seed an **unverified** follower and assert they are never queued or emailed, one case per call site — verified by mutation, not by passing. **A third sender means a third case here**; a fixture-only suite is how this went unnoticed for so long.
 
 When a performance is announced (`is_announced` 0→1), verified followers of that band are emailed once. Delivery is tracked **per-follower** in `band_follow_notifications (performance_id, band_follow_id)`: the announce records each *successful* send. Failed sends leave no row, so `POST /api/admin/bands/:id/resend-announcement` recovers them by emailing only followers without a notification row (never double-sending). Shared send+record logic lives in `functions/utils/bandFollowNotify.js`. **Do not reintroduce a fire-once latch without per-follower tracking** — it silently drops fans whose first send failed (the bug this replaced).
 

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -17,16 +17,25 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       exclude: ['node_modules/', 'src/test/', '*.config.js', 'dist/'],
-      // Ratchet baseline re-measured 2026-07-05 (stmts 59.68 / branch 52.23 /
-      // funcs 62.05 / lines 60.71) after adding util tests in #519. Thresholds
-      // are set to actuals minus a margin for run-to-run variance. This blocks
-      // regressions without being an aspiration — raise deliberately, never
-      // lower silently (#478 item 9, ratcheted by #519).
+      // Ratchet re-measured 2026-08-20 (stmts 65.22 / branch 58.84 /
+      // funcs 67.44 / lines 65.82). Thresholds are set to actuals minus a
+      // margin for run-to-run variance. This blocks regressions without
+      // being an aspiration — raise deliberately, never lower silently
+      // (#478 item 9, ratcheted by #519).
+      //
+      // The previous baseline (57/50/60/58, measured 2026-07-05) had drifted
+      // ~7 points below actual, so it would have passed a seven-point
+      // regression in silence. Re-measure whenever coverage rises.
+      //
+      // Watch the denominator here: frontend coverage counts only files a test
+      // loads, so a new test that imports a large untested component can drop
+      // the global percentage while strictly adding coverage. Prefer extracting
+      // and testing a small unit over importing a 1,000-line tab component.
       thresholds: {
-        statements: 57,
-        branches: 50,
-        functions: 60,
-        lines: 58,
+        statements: 63,
+        branches: 56,
+        functions: 65,
+        lines: 63,
       },
     },
   },

--- a/functions/api/admin/__tests__/middleware.test.js
+++ b/functions/api/admin/__tests__/middleware.test.js
@@ -62,4 +62,23 @@ describe("auditLog (#671)", () => {
       warnSpy.mockRestore();
     }
   });
+
+  test("resolves even when the logger itself throws — the contract is unconditional", async () => {
+    const { env } = createTestEnv({ role: "admin" });
+    const throwingLogger = {
+      warn: () => {
+        throw new Error("logger exploded");
+      },
+    };
+
+    // user_id 99999 doesn't exist, so the FK-constrained INSERT throws, which
+    // drives execution into the catch block and then into the logger.
+    //
+    // This matters because all 38 call sites await auditLog with no .catch().
+    // A throw from the catch block would 500 a request whose work already
+    // succeeded (an email sent, a digest flushed) and invite a retry of it.
+    await expect(
+      auditLog(env, 99999, "test.action", "test_resource", 1, null, "127.0.0.1", throwingLogger),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/functions/api/admin/__tests__/middleware.test.js
+++ b/functions/api/admin/__tests__/middleware.test.js
@@ -65,8 +65,10 @@ describe("auditLog (#671)", () => {
 
   test("resolves even when the logger itself throws — the contract is unconditional", async () => {
     const { env } = createTestEnv({ role: "admin" });
+    let warnCalled = false;
     const throwingLogger = {
       warn: () => {
+        warnCalled = true;
         throw new Error("logger exploded");
       },
     };
@@ -74,11 +76,16 @@ describe("auditLog (#671)", () => {
     // user_id 99999 doesn't exist, so the FK-constrained INSERT throws, which
     // drives execution into the catch block and then into the logger.
     //
-    // This matters because all 38 call sites await auditLog with no .catch().
-    // A throw from the catch block would 500 a request whose work already
-    // succeeded (an email sent, a digest flushed) and invite a retry of it.
+    // Every call site awaits auditLog with no .catch(), so a throw from the
+    // catch block would 500 a request whose work already succeeded (an email
+    // sent, a digest flushed) and invite a retry of it.
     await expect(
       auditLog(env, 99999, "test.action", "test_resource", 1, null, "127.0.0.1", throwingLogger),
     ).resolves.toBeUndefined();
+
+    // Without this the test is vacuous: if the FK fixture ever stopped
+    // throwing, auditLog would resolve WITHOUT entering the catch block and
+    // this test would still pass, having exercised nothing.
+    expect(warnCalled, "the logger failure path was never reached").toBe(true);
   });
 });

--- a/functions/api/admin/_middleware.js
+++ b/functions/api/admin/_middleware.js
@@ -224,12 +224,9 @@ export async function auditLog(env, userId, action, resourceType, resourceId, de
     // Never throws: audit logging must not fail the request it records.
     //
     // The inner guard makes that unconditional rather than merely intended.
-    // All 38 call sites `await auditLog(...)` with no `.catch()`, so anything
-    // this catch block throws would surface as a 500 on a request whose work
-    // already succeeded — an email sent, a digest flushed — and invite a retry
-    // of work that is already done. The logger is circular-safe today
-    // (serializeMetadata falls back to "[Unserializable]"), so this is defence
-    // against a future logger, not a live bug.
+    // Every call site awaits this with no `.catch()`, so anything the catch
+    // block throws would surface as a 500 on a request whose work already
+    // succeeded — an email sent, a digest flushed — and invite a retry of it.
     try {
       const l = log ?? logger;
       l.warn("Audit log write failed", { action, resourceType, resourceId, error });

--- a/functions/api/admin/_middleware.js
+++ b/functions/api/admin/_middleware.js
@@ -222,8 +222,21 @@ export async function auditLog(env, userId, action, resourceType, resourceId, de
       .run();
   } catch (error) {
     // Never throws: audit logging must not fail the request it records.
-    const l = log ?? logger;
-    l.warn("Audit log write failed", { action, resourceType, resourceId, error });
+    //
+    // The inner guard makes that unconditional rather than merely intended.
+    // All 38 call sites `await auditLog(...)` with no `.catch()`, so anything
+    // this catch block throws would surface as a 500 on a request whose work
+    // already succeeded — an email sent, a digest flushed — and invite a retry
+    // of work that is already done. The logger is circular-safe today
+    // (serializeMetadata falls back to "[Unserializable]"), so this is defence
+    // against a future logger, not a live bug.
+    try {
+      const l = log ?? logger;
+      l.warn("Audit log write failed", { action, resourceType, resourceId, error });
+    } catch {
+      // The reporting channel is what failed; there is nothing left to report
+      // with. Swallowing is the contract.
+    }
   }
 }
 

--- a/functions/api/admin/bands/[id]/resend-announcement.js
+++ b/functions/api/admin/bands/[id]/resend-announcement.js
@@ -77,7 +77,7 @@ export async function onRequestPost(context) {
     performanceId,
     { sent, failed, band_name: perf.band_name },
     ipAddress,
-  ).catch(() => {});
+  );
 
   return json({ success: true, sent, failed });
 }

--- a/functions/api/admin/bands/__tests__/announce-double-opt-in.test.js
+++ b/functions/api/admin/bands/__tests__/announce-double-opt-in.test.js
@@ -1,0 +1,162 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("../../_middleware.js", () => ({
+  checkPermission: async (context) => {
+    const role = context?.data?.user?.role || context?.request?.headers?.get("x-test-role");
+    if (!role) {
+      return {
+        error: true,
+        response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      };
+    }
+    return { error: false, user: { userId: 1, email: "admin@x.co", role }, userId: 1 };
+  },
+  auditLog: vi.fn(async () => {}),
+}));
+
+vi.mock("../../../../utils/email.js", () => ({
+  isEmailConfigured: () => true,
+  sendEmail: vi.fn(() => Promise.resolve({ delivered: true })),
+}));
+
+import { onRequestPost as resendAnnouncement } from "../[id]/resend-announcement.js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils.js";
+
+/**
+ * Band follows are double opt-in: `POST /api/bands/:name/follow` writes the row
+ * `verified = 0` and sends only a confirmation email. Announcement mail targets
+ * `verified = 1` rows ONLY, so an address the submitter does not control can
+ * never be enrolled in the announcement stream — it receives at most one
+ * confirmation. That is the whole anti-email-bombing property.
+ *
+ * Every other follower fixture in this suite seeds `verified = 1`, which means
+ * deleting `AND verified = 1` from either recipient query left all 1,169
+ * backend tests green. These tests exist to fail in exactly that case: each one
+ * seeds an UNVERIFIED follower and asserts they are not reached.
+ *
+ * Two call sites carry the gate and both are covered here — the announce
+ * transition in `bands/[id].js` and the recovery path in
+ * `bands/[id]/resend-announcement.js`. Adding a third sender means adding a
+ * third case here.
+ */
+describe("double opt-in gate — unverified followers are never enrolled in announcements", () => {
+  test("announce transition does not queue an unverified follower", async () => {
+    const bandIdHandler = await import("../[id].js");
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const event = insertEvent(rawDb, { name: "Vol18", slug: "vol18-double-opt-in" });
+    const venue = insertVenue(rawDb, { name: "Blue Room" });
+    const perf = insertBand(rawDb, {
+      name: "Opt In Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
+
+    const unverifiedId = rawDb
+      .prepare(
+        "INSERT INTO band_follows (email, band_profile_id, verified, verification_token, unsubscribe_token) VALUES (?, ?, 0, ?, ?)",
+      )
+      .run("not-mine@example.com", perf.band_profile_id, "pending-token", "unsub-unverified").lastInsertRowid;
+
+    const res = await bandIdHandler.onRequestPatch({
+      request: new Request(`https://example.test/api/admin/bands/${perf.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", ...headers },
+        body: JSON.stringify({ is_announced: true }),
+      }),
+      env,
+      data: { user: { role: "editor", id: 2 } },
+    });
+
+    expect(res.status).toBe(200);
+
+    const queued = rawDb.prepare("SELECT * FROM band_announce_queue WHERE band_follow_id=?").all(unverifiedId);
+    expect(queued).toHaveLength(0);
+
+    // With no eligible recipient the latch must stay clear, so confirming later
+    // and re-announcing still reaches the (by then verified) follower.
+    const perfRow = rawDb.prepare("SELECT band_follow_notified FROM performances WHERE id=?").get(perf.id);
+    expect(perfRow.band_follow_notified).toBe(0);
+  });
+
+  test("announce transition queues only the verified follower when both exist", async () => {
+    const bandIdHandler = await import("../[id].js");
+    const { env, rawDb, headers } = createTestEnv({ role: "editor" });
+    const event = insertEvent(rawDb, { name: "Vol18", slug: "vol18-mixed-followers" });
+    const venue = insertVenue(rawDb, { name: "Room 47" });
+    const perf = insertBand(rawDb, {
+      name: "Mixed Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+    rawDb.prepare("UPDATE performances SET is_announced=0 WHERE id=?").run(perf.id);
+
+    const verifiedId = rawDb
+      .prepare("INSERT INTO band_follows (email, band_profile_id, verified, unsubscribe_token) VALUES (?, ?, 1, ?)")
+      .run("confirmed@example.com", perf.band_profile_id, "unsub-verified").lastInsertRowid;
+    const unverifiedId = rawDb
+      .prepare(
+        "INSERT INTO band_follows (email, band_profile_id, verified, verification_token, unsubscribe_token) VALUES (?, ?, 0, ?, ?)",
+      )
+      .run("not-mine@example.com", perf.band_profile_id, "pending-token", "unsub-unverified").lastInsertRowid;
+
+    await bandIdHandler.onRequestPatch({
+      request: new Request(`https://example.test/api/admin/bands/${perf.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", ...headers },
+        body: JSON.stringify({ is_announced: true }),
+      }),
+      env,
+      data: { user: { role: "editor", id: 2 } },
+    });
+
+    const queuedFollowIds = rawDb
+      .prepare("SELECT band_follow_id FROM band_announce_queue WHERE performance_id=?")
+      .all(perf.id)
+      .map((r) => r.band_follow_id);
+
+    expect(queuedFollowIds).toEqual([verifiedId]);
+    expect(queuedFollowIds).not.toContain(unverifiedId);
+  });
+
+  test("resend-announcement does not email an unverified follower", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Fest", slug: "fest-double-opt-in" });
+    const venue = insertVenue(rawDb, { name: "Hall" });
+    const perf = insertBand(rawDb, {
+      name: "The Band",
+      event_id: event.id,
+      venue_id: venue.id,
+    });
+
+    const unverifiedId = rawDb
+      .prepare(
+        "INSERT INTO band_follows (email, band_profile_id, verified, verification_token, unsubscribe_token) VALUES (?, ?, 0, ?, ?)",
+      )
+      .run("not-mine@example.com", perf.band_profile_id, "pending-token", "unsub-unverified").lastInsertRowid;
+
+    const res = await resendAnnouncement({
+      request: new Request(`https://example.test/api/admin/bands/${perf.id}/resend-announcement`, {
+        method: "POST",
+        headers: { "x-test-role": "editor" },
+      }),
+      params: { id: String(perf.id) },
+      env,
+      data: { user: { userId: 1, email: "admin@x.co", role: "editor" } },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.failed).toBe(0);
+
+    const notified = rawDb
+      .prepare("SELECT band_follow_id FROM band_follow_notifications WHERE performance_id = ?")
+      .all(perf.id);
+    expect(notified).toHaveLength(0);
+    expect(notified.map((r) => r.band_follow_id)).not.toContain(unverifiedId);
+  });
+});

--- a/functions/api/admin/flush-announce-digest.js
+++ b/functions/api/admin/flush-announce-digest.js
@@ -41,7 +41,7 @@ export async function onRequestPost(context) {
     null,
     { sent, failed, skipped },
     getClientIP(request),
-  ).catch(() => {});
+  );
 
   return json({ success: true, sent, failed, skipped });
 }

--- a/functions/api/artists.js
+++ b/functions/api/artists.js
@@ -6,6 +6,7 @@
 // PUBLIC_DATA_PUBLISH_ENABLED switch as the rest of the public data.
 
 import { getPublicDataGateResponse } from "../utils/publicGate.js";
+import { CACHE_BROWSE } from "../utils/cacheHeaders.js";
 import { safeReflectSocialLinks } from "../utils/validation.js";
 import { sortableName } from "../utils/sortableName.js";
 import { publicEventStatusSql } from "../utils/eventVisibility.js";
@@ -101,7 +102,7 @@ export async function onRequestGet(context) {
       status: 200,
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, max-age=300",
+        "Cache-Control": CACHE_BROWSE,
       },
     });
   } catch (error) {

--- a/functions/api/bands/[name].js
+++ b/functions/api/bands/[name].js
@@ -1,4 +1,5 @@
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
+import { CACHE_SHOW_CRITICAL } from "../../utils/cacheHeaders.js";
 import { normalizeBandName } from "../../utils/bandName.js";
 import { safeReflectSocialLinks } from "../../utils/validation.js";
 import { eventLocalFestivalToday } from "../../utils/eventDay.js";
@@ -183,7 +184,7 @@ export async function onRequestGet(context) {
       status: 200,
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, max-age=300",
+        "Cache-Control": CACHE_SHOW_CRITICAL,
       },
     });
   } catch (error) {

--- a/functions/api/events/public.js
+++ b/functions/api/events/public.js
@@ -3,6 +3,7 @@
 // Rate limited to prevent abuse
 
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
+import { CACHE_BROWSE } from "../../utils/cacheHeaders.js";
 import { normalizeHttpUrl } from "../../utils/validation.js";
 import { publicEventStatusSql } from "../../utils/eventVisibility.js";
 
@@ -114,7 +115,7 @@ export async function onRequestGet(context) {
           // Intentional wildcard: this is a public, credential-free, read-only endpoint.
           // Do NOT add Access-Control-Allow-Credentials: true here.
           "Access-Control-Allow-Origin": "*",
-          "Cache-Control": "public, max-age=300", // Cache for 5 minutes
+          "Cache-Control": CACHE_BROWSE,
         },
       },
     );

--- a/functions/api/feeds/__tests__/ical-cancelled.test.js
+++ b/functions/api/feeds/__tests__/ical-cancelled.test.js
@@ -25,7 +25,8 @@ describe("GET /api/feeds/ical — cancelled sets", () => {
     });
     rawDb.prepare("UPDATE performances SET is_cancelled = 1 WHERE id = ?").run(cancelledPerf.id);
 
-    const scheduledPerf = insertBand(rawDb, {
+    // Inserted for its side effect only — the assertions below find it by name.
+    insertBand(rawDb, {
       name: "Sam Nabi",
       event_id: event.id,
       venue_id: venue.id,

--- a/functions/api/feeds/ical.js
+++ b/functions/api/feeds/ical.js
@@ -4,6 +4,7 @@
 
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
 import { publicEventStatusSql } from "../../utils/eventVisibility.js";
+import { nextCalendarDay } from "../../utils/eventDay.js";
 
 function sanitizeFilenamePart(value) {
   return (
@@ -156,16 +157,6 @@ function generateICal(bands, city, genre) {
   ical.push("END:VCALENDAR");
 
   return ical.join("\r\n");
-}
-
-/**
- * YYYY-MM-DD → the following calendar day, DST-proof via UTC math (the
- * string is a date literal, not a moment in time).
- */
-function nextCalendarDay(dateStr) {
-  const next = new Date(`${dateStr}T00:00:00Z`);
-  next.setUTCDate(next.getUTCDate() + 1);
-  return next.toISOString().slice(0, 10);
 }
 
 function escapeIcal(text) {

--- a/functions/api/stats/public.js
+++ b/functions/api/stats/public.js
@@ -14,6 +14,7 @@
 // Bands/venues/events are public data, so their names/counts are fine.
 
 import { getPublicDataGateResponse } from "../../utils/publicGate.js";
+import { CACHE_BROWSE } from "../../utils/cacheHeaders.js";
 import { publicEventStatusSql } from "../../utils/eventVisibility.js";
 
 const TOP_BANDS_LIMIT = 8;
@@ -93,7 +94,7 @@ export async function onRequestGet(context) {
       status: 200,
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, max-age=300",
+        "Cache-Control": CACHE_BROWSE,
       },
     });
   } catch (error) {

--- a/functions/api/venues.js
+++ b/functions/api/venues.js
@@ -5,6 +5,7 @@
 // so venues are discoverable. Gated by PUBLIC_DATA_PUBLISH_ENABLED.
 
 import { getPublicDataGateResponse } from "../utils/publicGate.js";
+import { CACHE_BROWSE } from "../utils/cacheHeaders.js";
 import { publicEventStatusSql } from "../utils/eventVisibility.js";
 
 const DEFAULT_LIMIT = 24;
@@ -75,7 +76,7 @@ export async function onRequestGet(context) {
       status: 200,
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, max-age=300",
+        "Cache-Control": CACHE_BROWSE,
       },
     });
   } catch (error) {

--- a/functions/event/[slug].js
+++ b/functions/event/[slug].js
@@ -5,7 +5,12 @@ import { isPublicDataEnabled } from "../utils/publicGate.js";
 import { escapeAttr, toPlainText, serveWithInjectedMeta, CANONICAL_HOST, DEFAULT_OG_IMAGE } from "../utils/ssrMeta.js";
 import { normalizeHttpUrl } from "../utils/validation.js";
 import { sortableName } from "../utils/sortableName.js";
-import { torontoUtcOffset, AFTER_MIDNIGHT_THRESHOLD_HOUR } from "../utils/eventDay.js";
+import {
+  torontoUtcOffset,
+  AFTER_MIDNIGHT_THRESHOLD_HOUR,
+  nextCalendarDay,
+  previousCalendarDay,
+} from "../utils/eventDay.js";
 import { publicEventStatusSql } from "../utils/eventVisibility.js";
 
 // Sets starting before 06:00 are after-midnight sets that belong to the
@@ -23,24 +28,6 @@ function startHour(startTime) {
   const timePart = startTime.includes(" ") ? startTime.split(" ")[1] : startTime;
   const hour = Number.parseInt((timePart ?? "").slice(0, 2), 10);
   return Number.isFinite(hour) ? hour : null;
-}
-
-/**
- * YYYY-MM-DD -> the following calendar day, DST-proof via UTC math (the
- * string is a date literal, not a moment in time). Mirrors nextCalendarDay in
- * functions/api/feeds/ical.js.
- */
-function nextCalendarDay(dateStr) {
-  const next = new Date(`${dateStr}T00:00:00Z`);
-  next.setUTCDate(next.getUTCDate() + 1);
-  return next.toISOString().slice(0, 10);
-}
-
-/** YYYY-MM-DD -> the preceding calendar day. See nextCalendarDay. */
-function previousCalendarDay(dateStr) {
-  const prev = new Date(`${dateStr}T00:00:00Z`);
-  prev.setUTCDate(prev.getUTCDate() - 1);
-  return prev.toISOString().slice(0, 10);
 }
 
 /**

--- a/functions/utils/__tests__/cacheHeaders.test.js
+++ b/functions/utils/__tests__/cacheHeaders.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { CACHE_BROWSE, CACHE_SHOW_CRITICAL } from "../cacheHeaders.js";
 
 /**
@@ -19,7 +20,10 @@ import { CACHE_BROWSE, CACHE_SHOW_CRITICAL } from "../cacheHeaders.js";
  * via the constant (which the literal scan cannot see).
  */
 
-const API_ROOT = join(import.meta.dirname, "../../api");
+// fileURLToPath rather than import.meta.dirname, matching the sibling guards
+// (opencodeInstructions.test.js, staticPageMeta.test.js). import.meta.dirname
+// needs Node >= 20.11 and the repo documents a Node 20+ baseline.
+const API_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../api");
 
 function collectJsFiles(dir) {
   const out = [];

--- a/functions/utils/__tests__/cacheHeaders.test.js
+++ b/functions/utils/__tests__/cacheHeaders.test.js
@@ -47,6 +47,18 @@ const apiFiles = collectJsFiles(API_ROOT).map((path) => ({
 
 // Both tiers state a max-age; a route hardcoding either value has bypassed the
 // module. Derived from the constants so bumping a TTL cannot silently un-guard.
+/**
+ * True only when the file ASSIGNS the tier to a Cache-Control header.
+ *
+ * Occurrence alone is not enough: a comment naming the tier, or an import kept
+ * after the assignment changed, would satisfy a substring check while the route
+ * served a different value entirely. That is the vacuous-guard class -- an
+ * assertion that survives both the correct and the broken implementation.
+ */
+function assignsTier(source, constant) {
+  return new RegExp(`["']Cache-Control["']\\s*[:,]\\s*${constant}\\b`).test(source);
+}
+
 const TIER_MAX_AGES = [CACHE_BROWSE, CACHE_SHOW_CRITICAL].map((value) => value.match(/max-age=(\d+)/)[1]);
 
 describe("cache tier constants are the single source of truth", () => {
@@ -56,10 +68,14 @@ describe("cache tier constants are the single source of truth", () => {
     expect(showCritical).toBeLessThan(browse);
   });
 
-  it("both tiers are imported by at least one route", () => {
+  it("both tiers are actually ASSIGNED to a Cache-Control by at least one route", () => {
+    // `source.includes(constant)` was the first version and was vacuous: a
+    // comment naming the tier, or an import left behind after the assignment
+    // changed, satisfied it. Match the assignment instead — that is the only
+    // form that proves the constant reaches a response header.
     for (const constant of ["CACHE_BROWSE", "CACHE_SHOW_CRITICAL"]) {
-      const importers = apiFiles.filter((f) => f.source.includes(constant));
-      expect(importers.length, `${constant} is exported but no route imports it`).toBeGreaterThan(0);
+      const users = apiFiles.filter((f) => assignsTier(f.source, constant));
+      expect(users.length, `${constant} is exported but no route assigns it to a Cache-Control`).toBeGreaterThan(0);
     }
   });
 
@@ -101,7 +117,7 @@ describe("cache tier constants are the single source of truth", () => {
     const offenders = apiFiles
       .filter((f) => LIVE_STATE_COLUMNS.test(f.source))
       .filter((f) => f.source.includes("Cache-Control"))
-      .filter((f) => !f.source.includes("CACHE_SHOW_CRITICAL"))
+      .filter((f) => !assignsTier(f.source, "CACHE_SHOW_CRITICAL"))
       .map((f) => f.rel)
       .filter((rel) => !EXEMPT.has(rel));
 

--- a/functions/utils/__tests__/cacheHeaders.test.js
+++ b/functions/utils/__tests__/cacheHeaders.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { CACHE_BROWSE, CACHE_SHOW_CRITICAL } from "../cacheHeaders.js";
+
+/**
+ * Source-scanning guard, not a behavioural test — the failure it prevents is a
+ * copy-pasted string, which no request-level assertion can see.
+ *
+ * `cacheHeaders.js` documents two tiers, but `CACHE_BROWSE` was exported and
+ * never imported by anything while five endpoints hardcoded its exact value.
+ * With the constant bypassed, `api/bands/[name].js` drifted to the browse TTL
+ * even though it projects live per-performance state, so a cancelled set could
+ * read as playing for up to five minutes — the precise failure the two-tier
+ * split exists to prevent.
+ *
+ * Both halves below are needed. The first stops the literal from coming back;
+ * the second catches a route that carries live state and picked the wrong tier
+ * via the constant (which the literal scan cannot see).
+ */
+
+const API_ROOT = join(import.meta.dirname, "../../api");
+
+function collectJsFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "__tests__") continue;
+      out.push(...collectJsFiles(full));
+    } else if (entry.endsWith(".js")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const apiFiles = collectJsFiles(API_ROOT).map((path) => ({
+  path,
+  rel: path.slice(path.indexOf("functions/")),
+  source: readFileSync(path, "utf-8"),
+}));
+
+// Both tiers state a max-age; a route hardcoding either value has bypassed the
+// module. Derived from the constants so bumping a TTL cannot silently un-guard.
+const TIER_MAX_AGES = [CACHE_BROWSE, CACHE_SHOW_CRITICAL].map((value) => value.match(/max-age=(\d+)/)[1]);
+
+describe("cache tier constants are the single source of truth", () => {
+  it("exports two distinct tiers with show-critical the shorter one", () => {
+    const browse = Number(CACHE_BROWSE.match(/max-age=(\d+)/)[1]);
+    const showCritical = Number(CACHE_SHOW_CRITICAL.match(/max-age=(\d+)/)[1]);
+    expect(showCritical).toBeLessThan(browse);
+  });
+
+  it("both tiers are imported by at least one route", () => {
+    for (const constant of ["CACHE_BROWSE", "CACHE_SHOW_CRITICAL"]) {
+      const importers = apiFiles.filter((f) => f.source.includes(constant));
+      expect(importers.length, `${constant} is exported but no route imports it`).toBeGreaterThan(0);
+    }
+  });
+
+  it("no API route hardcodes a max-age that a tier constant already names", () => {
+    const offenders = [];
+    for (const file of apiFiles) {
+      for (const age of TIER_MAX_AGES) {
+        // Only Cache-Control values, so an unrelated `max-age` (HSTS) is ignored.
+        if (new RegExp(`"Cache-Control":\\s*\`?"?public,\\s*max-age=${age}`).test(file.source)) {
+          offenders.push(`${file.rel} hardcodes max-age=${age}`);
+        }
+      }
+    }
+    expect(offenders, `use the cacheHeaders.js constant instead:\n${offenders.join("\n")}`).toEqual([]);
+  });
+
+  it("routes projecting live per-performance state use the show-critical tier", () => {
+    // A route selecting a cancellation flag or a set time is show-critical by
+    // the module's own rule, whatever the route is named.
+    const LIVE_STATE_COLUMNS = /\bp\.is_cancelled\b|\bp\.start_time\b|\bp\.end_time\b/;
+
+    // Exempt by design, named rather than pattern-matched so adding one is a
+    // deliberate edit:
+    //   schedule.js  — env-tunable TTL that already DEFAULTS to 60s, i.e. the
+    //                  show-critical value; the knob is the point.
+    //   ical.js      — a calendar feed, not a page fetch. Subscribers poll on
+    //                  their client's own schedule (15 min to 24 h) and cache
+    //                  independently, so this TTL does not govern what a fan
+    //                  sees. Cancellations travel as RFC 5545 STATUS:CANCELLED.
+    //   recap.js     — gated by concludedEventSql(), so it can only ever serve
+    //                  an event that has already ended. Nothing it returns can
+    //                  change while a show is running; that is the whole test.
+    const EXEMPT = new Set([
+      "functions/api/schedule.js",
+      "functions/api/feeds/ical.js",
+      "functions/api/events/[id]/recap.js",
+    ]);
+
+    const offenders = apiFiles
+      .filter((f) => LIVE_STATE_COLUMNS.test(f.source))
+      .filter((f) => f.source.includes("Cache-Control"))
+      .filter((f) => !f.source.includes("CACHE_SHOW_CRITICAL"))
+      .map((f) => f.rel)
+      .filter((rel) => !EXEMPT.has(rel));
+
+    expect(
+      offenders,
+      `these project live performance state but are not on CACHE_SHOW_CRITICAL:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/functions/utils/cacheHeaders.js
+++ b/functions/utils/cacheHeaders.js
@@ -44,5 +44,16 @@ export const CACHE_SHOW_CRITICAL = "public, max-age=60";
  * aggregates but also returns upcoming and past performances, cancellations and
  * venue assignments, so it belongs to CACHE_SHOW_CRITICAL. Any response that
  * carries live performance state does, whatever it is called.
+ *
+ * Its sibling `api/bands/[name].js` sat at a hardcoded 300s for the same
+ * reason the stats route once did — the name says "band profile", but the
+ * projection includes `p.start_time`, `p.end_time`, `p.is_cancelled` and the
+ * venue name. Both now use CACHE_SHOW_CRITICAL. Judge the projection, not the
+ * route name.
+ *
+ * `cacheHeaders.test.js` enforces this by scanning source: a public GET may not
+ * hardcode a `max-age` matching either tier's value, and any route projecting
+ * per-performance columns must import CACHE_SHOW_CRITICAL. Copy-pasting the
+ * literal is what let the two tiers drift apart in the first place.
  */
 export const CACHE_BROWSE = "public, max-age=300";

--- a/functions/utils/eventDay.js
+++ b/functions/utils/eventDay.js
@@ -138,3 +138,37 @@ export function torontoUtcOffset(dateStr) {
   const gmt = TORONTO_OFFSET.formatToParts(probe).find((p) => p.type === "timeZoneName")?.value;
   return gmt ? gmt.replace("GMT", "") : "-05:00";
 }
+
+/**
+ * YYYY-MM-DD → the following calendar day.
+ *
+ * DST-proof because the input is a date *literal*, not a moment in time: it is
+ * read at UTC midnight and stepped with UTC math, so it never crosses a Toronto
+ * DST boundary and gains or loses an hour. `torontoUtcOffset` above is the tool
+ * for the opposite question — where a real instant falls.
+ *
+ * Lived in `api/feeds/ical.js` and `event/[slug].js` as byte-identical copies,
+ * the second carrying a "mirrors the other one" comment. Unlike `parseOrigin`
+ * and `sortableName`, nothing forced that split — both callers are inside
+ * `functions/`, so no build boundary separates them.
+ *
+ * @param {string} dateStr - YYYY-MM-DD
+ * @returns {string} YYYY-MM-DD
+ */
+export function nextCalendarDay(dateStr) {
+  const next = new Date(`${dateStr}T00:00:00Z`);
+  next.setUTCDate(next.getUTCDate() + 1);
+  return next.toISOString().slice(0, 10);
+}
+
+/**
+ * YYYY-MM-DD → the preceding calendar day. See {@link nextCalendarDay}.
+ *
+ * @param {string} dateStr - YYYY-MM-DD
+ * @returns {string} YYYY-MM-DD
+ */
+export function previousCalendarDay(dateStr) {
+  const prev = new Date(`${dateStr}T00:00:00Z`);
+  prev.setUTCDate(prev.getUTCDate() - 1);
+  return prev.toISOString().slice(0, 10);
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -13,16 +13,21 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],
-      // Ratchet baseline measured 2026-07-04 (stmts 70.1 / branch 60.5 /
-      // funcs 79.7 / lines 70.8). Thresholds are set to actuals minus a
+      // Ratchet re-measured 2026-08-20 (stmts 77.7 / branch 70.7 /
+      // funcs 86.8 / lines 78.5). Thresholds are set to actuals minus a
       // margin for run-to-run variance. This blocks regressions without
       // being an aspiration — raise deliberately, never lower silently
       // (#478 item 9).
+      //
+      // The previous baseline (68/58/77/68, measured 2026-07-04) had drifted
+      // ~10 points below actual, so it would have passed a ten-point
+      // regression in silence. A ratchet only ratchets if it is re-measured
+      // when coverage rises; treat re-measuring as part of adding tests.
       thresholds: {
-        statements: 68,
-        branches: 58,
-        functions: 77,
-        lines: 68,
+        statements: 75,
+        branches: 68,
+        functions: 84,
+        lines: 76,
       },
       exclude: [
         "node_modules/",


### PR DESCRIPTION
## Summary

A report-card audit of the repo surfaced two defects that no existing gate could see, plus three smaller cleanups. Both defects are now fixed **and guarded**, with each guard proven by mutation — broken deliberately, confirmed red, restored — rather than trusted because it passed.

No issue to close: these were found and fixed during the audit itself. The audit's *remaining* findings were filed separately as #900–#911.

## What changed

| File | Change |
|------|--------|
| `functions/api/admin/bands/__tests__/announce-double-opt-in.test.js` | **New.** Guards the `verified = 1` gate on both announcement senders |
| `functions/api/bands/[name].js` | Moved to `CACHE_SHOW_CRITICAL` (300s → 60s) — it projects live per-performance state |
| `functions/utils/__tests__/cacheHeaders.test.js` | **New.** Source-scanning guard: no hardcoded tier `max-age`, and live-state routes must use the show-critical tier |
| `functions/api/{venues,artists,stats/public,events/public}.js` | Import `CACHE_BROWSE` instead of hardcoding its exact string (byte-identical output) |
| `functions/utils/cacheHeaders.js` | Documents the reclassification and the "judge the projection, not the route name" rule |
| `functions/utils/eventDay.js` | Now owns `nextCalendarDay` / `previousCalendarDay` |
| `functions/api/feeds/ical.js`, `functions/event/[slug].js` | Import them instead of each defining a byte-identical copy |
| `functions/api/admin/{flush-announce-digest.js,bands/[id]/resend-announcement.js}` | Dropped `.catch(() => {})` on `auditLog`, which cannot reject |
| `vitest.config.js`, `frontend/vitest.config.js` | Coverage ratchets re-baselined to actual − margin |
| `functions/api/feeds/__tests__/ical-cancelled.test.js` | Removed an unused binding — backend lint is now 0 problems |
| `CLAUDE.md` | New cache-tier section; records why the old announce suite could not catch the gate regression |

## Security / correctness notes

**The double opt-in gate had no test.** `band_follows.verified = 1` is the only thing keeping an address the submitter does not control out of the announcement stream — CLAUDE.md names reverting it as an email-bombing vector. Deleting `AND verified = 1` from **either** recipient query left all 1,169 backend tests green.

Root cause is worth recording: all ten announce-related test files seed followers, and **every fixture wrote `verified = 1`**, so no test could distinguish a gated query from an ungated one. The suite looked exhaustive while proving nothing about the property it most needed to prove. The new tests seed an *unverified* follower and assert they are never queued or emailed — one case per call site, because a sibling sweep found the second sender the original mutation did not.

**A cancelled set could read as playing for up to 5 minutes.** `api/bands/[name].js` served `p.start_time`, `p.end_time`, `p.is_cancelled` and venue name on the 300s browse TTL. Its sibling `bands/stats/[name].js` was already at 60s for exactly this reason. The drift was possible because `CACHE_BROWSE` was exported and imported by nothing while five endpoints hardcoded its value.

The new guard found **three more** routes carrying live state. Rather than loosen the rule, each was investigated and exempted **by name with a stated reason**: `schedule.js` (env-tunable, already defaults to 60s), `ical.js` (a subscribed feed — clients poll on their own schedule, cancellations travel as RFC 5545 `STATUS:CANCELLED`), and `events/[id]/recap.js` (gated by `concludedEventSql()`, can only serve an event that already ended).

**Coverage ratchets had stopped ratcheting.** Backend sat at 68/58/77/68 against an actual of 77.7/70.7/86.8/78.5 — a ten-point regression would have passed silently. Both re-baselined; the mechanism was confirmed to bite (threshold above actual → exit 1).

## Verification

- [x] Tests: 1,176 backend + 1,093 frontend pass, 0 failures
- [x] ESLint: 0 errors (backend now 0 *problems*; the 2 remaining frontend warnings are pre-existing and tracked in #903)
- [x] Format check: clean, both stacks
- [x] Build: green
- [x] `validate:openapi`: no drift (spec unchanged; re-run anyway — 72 documented + 1 allowlisted, no drift)
- [x] `make gate`: exit 0
- [x] `make review` (CodeRabbit): run pre-open; its one finding — `LIVE_STATE_COLUMNS` omitted `p.end_time`, so a route selecting only that column would slip past — is fixed in this branch
- [x] Manual smoke: not browser-verified. Backend-only change; the cache header value is asserted by unit test and the TTL reduction cannot alter response bodies

**Mutation evidence** (the claim this PR rests on):

| Mutation | Result |
|---|---|
| Drop `AND verified = 1` from `bands/[id].js:782` | 2 of 3 new tests fail |
| Drop `AND bf.verified = 1` from `resend-announcement.js:59` | the third fails |
| Revert `bands/[name].js` to the hardcoded 300s | both halves of the cache guard fail |
| Set a coverage threshold above actual | exit 1 |

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized caching across public browse and show-critical endpoints for consistent content freshness.
  - Improved audit logging reliability and error handling.
  - Shared calendar date handling supports accurate overnight event and iCal scheduling.

- **Bug Fixes**
  - Unverified followers are excluded from announcement emails, including resends.

- **Tests**
  - Added regression coverage for announcement recipient filtering.
  - Strengthened cache-policy enforcement and increased coverage thresholds.

- **Documentation**
  - Documented cache tiers, intended usage, and coverage considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->