### PR TITLE
chore(lint): fix both exhaustive-deps warnings and drop --max-warnings to 0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "psi": "node scripts/run-psi.mjs",
     "psi:dev": "npm run psi -- --url https://dev.settimesdotca.pages.dev",
     "psi:prod": "npm run psi -- --url https://settimes.ca",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 5",
+    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext js,jsx --fix",
     "format": "prettier --write \"src/**/*.{js,jsx,json,css}\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,json,css}\"",

--- a/frontend/src/admin/AdminPanel.jsx
+++ b/frontend/src/admin/AdminPanel.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { eventsApi } from '../utils/adminApi'
 import EventsTab from './EventsTab'
 import VenuesTab from './VenuesTab'
@@ -217,17 +217,22 @@ export default function AdminPanel({ currentUser, onLogout }) {
 
   const selectedEvent = events.find(e => e.id === selectedEventId)
 
-  // Dynamic Tabs Configuration
-  const tabs = [
-    { id: 'events', label: 'Events' },
-    // Only show Lineup if an event is selected
-    ...(selectedEventId ? [{ id: 'lineup', label: 'Lineup' }] : []),
-    { id: 'roster', label: 'Roster' },
-    { id: 'venues', label: 'Venues' },
-    ...(canManageUsers ? [{ id: 'users', label: 'Users' }] : []),
-    { id: 'settings', label: 'Settings' },
-    ...(isAdmin ? [{ id: 'platform', label: 'Platform' }] : []),
-  ]
+  // Dynamic Tabs Configuration. Memoized because the effect below depends on
+  // `tabs`: rebuilt inline it is a fresh array every render, so the effect
+  // re-ran on every render instead of only when the tab set actually changes.
+  const tabs = useMemo(
+    () => [
+      { id: 'events', label: 'Events' },
+      // Only show Lineup if an event is selected
+      ...(selectedEventId ? [{ id: 'lineup', label: 'Lineup' }] : []),
+      { id: 'roster', label: 'Roster' },
+      { id: 'venues', label: 'Venues' },
+      ...(canManageUsers ? [{ id: 'users', label: 'Users' }] : []),
+      { id: 'settings', label: 'Settings' },
+      ...(isAdmin ? [{ id: 'platform', label: 'Platform' }] : []),
+    ],
+    [selectedEventId, canManageUsers, isAdmin]
+  )
 
   useEffect(() => {
     if (tabs.some(tab => tab.id === activeTab)) {

--- a/frontend/src/admin/UserManagement.jsx
+++ b/frontend/src/admin/UserManagement.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { Key, Pencil, Plus, Trash, UserCheck, UserX } from 'lucide-react'
 import RoleBadge from './components/RoleBadge'
 import UserFormModal from './components/UserFormModal'
@@ -94,7 +94,10 @@ export default function UserManagement({ showToast }) {
     }))
   }
 
-  const fetchUsers = async () => {
+  // useCallback so the mount effect can declare it as a dependency without
+  // re-running every render. `showToast` is itself useCallback-wrapped by
+  // AdminPanel, so this identity is stable.
+  const fetchUsers = useCallback(async () => {
     try {
       const data = await usersApi.getAll()
       setUsers(data.users)
@@ -104,11 +107,11 @@ export default function UserManagement({ showToast }) {
     } finally {
       setLoading(false)
     }
-  }
+  }, [showToast])
 
   useEffect(() => {
     fetchUsers()
-  }, [])
+  }, [fetchUsers])
 
   const handleCreateUser = async userData => {
     setActionLoading(true)


### PR DESCRIPTION
## Summary

Fixes the two `react-hooks/exhaustive-deps` warnings that had been sitting under the `--max-warnings 5` allowance, then closes the allowance so the next one cannot arrive silently.

Closes #903

## What changed

| File | Change |
|------|--------|
| `frontend/src/admin/AdminPanel.jsx` | `tabs` wrapped in `useMemo` |
| `frontend/src/admin/UserManagement.jsx` | `fetchUsers` wrapped in `useCallback`, declared as the effect's dep |
| `frontend/package.json` | `--max-warnings 5` → `--max-warnings 0` |

## Security / correctness notes

Both warnings were real, not noise:

- **`AdminPanel.jsx:221`** — `tabs` was rebuilt inline on every render while the effect immediately below lists `tabs` as a dependency. A fresh array identity each render meant that effect ran on **every render** rather than when the tab set actually changed. Now memoized on `selectedEventId`, `canManageUsers`, `isAdmin`.

- **`UserManagement.jsx:111`** — `fetchUsers` was recreated every render and invoked from a `[]`-dependency effect: the classic stale-closure setup, where the effect captures the first render's closure forever. Now `useCallback([showToast])` and declared as the dependency.

  Checked before wiring it up: `showToast` is itself `useCallback`-wrapped at `AdminPanel.jsx:88`, so its identity is stable and adding it cannot produce a fetch loop. That was the risk worth verifying — a naive `useCallback` around an unstable prop would have turned a lint warning into an infinite refetch.

**The threshold change is the actual point.** An allowance of 5 meant the *next* warning would also land silently — which is precisely how these two survived. At 0, the gate fails on the first one.

## Verification

- [x] Tests: 1,169 backend + 1,093 frontend pass, 0 failures
- [x] ESLint: 0 errors **and 0 warnings**, both stacks
- [x] Format check: clean, both stacks
- [x] Build: green
- [x] `validate:openapi`: n/a (spec unchanged)
- [x] `make gate`: exit 0
- [x] Manual smoke: not browser-verified — see note below

**Proof the tightened threshold bites** (rather than assuming a config change works):

| State | `npm run lint` exit |
|---|---|
| Reintroduce the exact `UserManagement` warning just fixed | **1** |
| Restored | **0** |

**On manual smoke:** these are hook-dependency corrections, so the risk is behavioural (an effect that no longer fires, or fires too often), not visual. The `AdminPanel` change makes an effect run *less* often — only when the tab set changes — and the tab-switching logic it guards is covered by the existing suite. The `UserManagement` change preserves mount-time fetch semantics exactly, since `fetchUsers`'s identity is stable. Worth a click through the admin tabs before merge if you want belt-and-braces; `UserManagement.jsx` has no dedicated test (tracked in #905).

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved responsiveness in the administration panel by reducing unnecessary updates when switching events or viewing permitted sections.
  - Improved user management reliability by ensuring user information refreshes consistently when notifications change.

- **Quality Improvements**
  - Strengthened code quality checks by requiring linting to complete without warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->