### PR TITLE
chore(validation): use undefined for an absent error, and track the report-card prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Use the Makefile — it exists so every agent runs the same gates with real exit
 - `make build` — frontend production build
 - `make e2e` — full local E2E: builds, seeds an isolated D1, serves wrangler on :8788, runs Playwright, cleans up
 - `make review` — **AI code review before opening a PR** (CodeRabbit CLI; `make review-wip` for uncommitted changes). Run it *before* the PR — the same review runs on the PR anyway, so findings after opening cost a fix plus a force-push. Not part of `make gate`: `gate` stays fast and offline, `review` needs the network.
+- **Codebase report card** — `docs/REPORT_CARD_REVIEW.md`. Whole-repo grade + safe fixes, run at the start of a release cycle or ~quarterly. Not a per-PR gate; it reads the whole tree. See CLAUDE.md for cadence and caveats.
 - `make schema-check` — after touching `migrations/`: regenerates `setup-complete.sql` and checks drift (its schema section is generated — never hand-edit)
 - `make validate-openapi` — if `docs/api-spec.yaml` changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,45 @@ Invoke these without being asked — don't wait for the user to request them:
 | After editing `frontend/src/` public pages (outside `admin/`) | Scan for `text-white`/`bg-white` theme violations before finishing |
 | After adding/editing anything in `migrations/` | Run `node scripts/regenerate-setup-complete.mjs` then `node scripts/check-schema-drift.mjs` — `setup-complete.sql`'s schema section is generated, never hand-edit it (CI enforces via quality.yml) |
 | When SEO-relevant pages change (band pages, event pages, venue pages) | Check structured data and `document.title` assignments |
+| **Start of a release cycle, or ~quarterly** | Run the codebase report card — `docs/REPORT_CARD_REVIEW.md` (see below) |
 
 The `hooks` in `.claude/settings.local.json` automate the mechanical parts (prettier, ESLint, pre-PR gate). The triggers above require judgment — apply them proactively.
 
 **CodeRabbit is the standing gate; the code-reviewer agent is trigger-only.** CodeRabbit is diff-scoped and reliably catches convention breaks, unscoped test selectors, dead code, and latent time-bombs — and it runs on the PR regardless, so `make review` beforehand only saves a force-push cycle. The code-reviewer agent reads across files and earns its cost when the question is "does this violate an invariant or drift from the architecture." Don't block on Copilot; in practice it duplicates CodeRabbit.
+
+### The codebase report card — run it on a cadence
+
+`docs/REPORT_CARD_REVIEW.md` grades the whole repo across nine
+categories, fixes what is safe, and re-grades. It is **tracked in this repo on
+purpose**: the original lived outside the working tree, where a fresh clone,
+CI, or a delegated run would never find it — the same failure as the untracked
+`instructions/` tree in #818.
+
+**Cadence: at the start of a release cycle, or roughly quarterly — whichever
+comes first.** It is deliberately not a per-PR gate. It reads the whole tree and
+runs every gate, so it costs real time; CodeRabbit and the trigger-based agents
+above cover the per-change surface. Run it when the question is *"what has
+drifted while we were shipping?"*, not *"is this diff correct?"*.
+
+**Run it after a season ends, before the next edition's build-out starts.** That
+is when accumulated drift is cheapest to fix and least likely to collide with
+event-critical work.
+
+**What it is for, and what it is not.** It catches the class of problem no
+diff-scoped reviewer can see: a coverage ratchet that drifted ten points below
+actual and would have passed a double-digit regression; a two-tier cache module
+whose second tier was exported and imported by nothing while five endpoints
+copy-pasted its value; a dependency override pinned *inside* its own vulnerable
+range; a security control with zero test coverage because every fixture in ten
+files seeded the passing case. None of those appear in any single diff. All four
+were found by the first run (2026-08-20, #900–#917).
+
+**Its findings are claims until verified.** That first run also produced three
+wrong assertions that reached filed issues — "nothing validates zero-length
+sets" (three of five write paths did), "these components have no tests" (a bad
+`find`), "the roster query is unbounded" (capped at 500) — and three vacuous
+tests of its own. Treat the output as a lead list to check, not a verdict, and
+correct the record on the issue when a lead does not survive contact.
 
 ### Sweep for siblings
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,13 @@ purpose**: the original lived outside the working tree, where a fresh clone,
 CI, or a delegated run would never find it — the same failure as the untracked
 `instructions/` tree in #818.
 
+**Tracked in git, deliberately excluded from the published site** (owner decision,
+2026-08-20). `docs/*.md` is published to docs.settimes.ca regardless of the mkdocs
+`nav`, so the exclusion is what keeps it internal — it is listed in `mkdocs.yml`'s
+`exclude_docs` block. The doc names past security gaps by name, which is what makes
+it useful to us and not something to serve publicly. Do not "fix" the missing nav
+entry by adding one; the file is meant to be absent from the site, not unlinked in it.
+
 **Cadence: at the start of a release cycle, or roughly quarterly — whichever
 comes first.** It is deliberately not a per-PR gate. It reads the whole tree and
 runs every gate, so it costs real time; CodeRabbit and the trigger-based agents

--- a/docs/REPORT_CARD_REVIEW.md
+++ b/docs/REPORT_CARD_REVIEW.md
@@ -1,6 +1,12 @@
 # Codebase Report Card
 
-Read this repo's AGENTS.md or CLAUDE.md first — use it for stack, conventions, and any stated priorities. Then review the codebase and grade it like a report card, using the categories below. Ground every grade in specific files/lines, not vibes.
+Read **both** `AGENTS.md` and `CLAUDE.md` first — this repo has both and they are not
+interchangeable. `AGENTS.md` is the short entry point and defers to `CLAUDE.md` in three
+places, including for this review's own cadence and caveats; `CLAUDE.md` holds the full
+invariant catalogue you are grading against. Reading only one skips the constraints that
+make the grade meaningful. Use them for stack, conventions, and stated priorities. Then
+review the codebase and grade it like a report card, using the categories below. Ground
+every grade in specific files/lines, not vibes.
 
 ## Categories (grade each A–F)
 

--- a/docs/REPORT_CARD_REVIEW.md
+++ b/docs/REPORT_CARD_REVIEW.md
@@ -1,0 +1,112 @@
+# Codebase Report Card
+
+Read this repo's AGENTS.md or CLAUDE.md first — use it for stack, conventions, and any stated priorities. Then review the codebase and grade it like a report card, using the categories below. Ground every grade in specific files/lines, not vibes.
+
+## Categories (grade each A–F)
+
+- **Architecture & organization** — module boundaries, coupling, whether structure matches what AGENTS.md/CLAUDE.md describes.
+- **Code quality & readability** — naming, duplication, dead code, complexity.
+- **Test coverage & quality** — what's tested, what's not, whether tests actually catch regressions or just pad coverage.
+- **Error handling & resilience** — failure modes, edge cases, what happens when external calls fail.
+- **Security** — secrets handling, input validation, auth, injection risk, dependency vulnerabilities.
+- **Performance** — obvious inefficiencies, N+1s, unbounded loops/queries, anything that won't scale.
+- **Documentation** — README accuracy, inline comments where logic isn't self-evident, whether AGENTS.md/CLAUDE.md matches reality.
+- **Dependency health** — outdated/abandoned packages, unnecessary bloat, version conflicts.
+- **Consistency with stated conventions** — does the code actually follow what AGENTS.md/CLAUDE.md says it should?
+
+## Step 1: Grade
+
+For each category give: letter grade, 2–3 sentence justification, and the worst 1–3 concrete examples (file + line). No generic praise or generic criticism — if you can't point to a specific line, don't claim it.
+
+Then give an overall grade and a one-paragraph summary of the biggest risk in this codebase right now.
+
+## Step 2: Fix what you can safely fix
+
+Rank all issues found by impact-to-effort ratio. Then actually fix the ones that are safe: no breaking changes, no unrequested architecture rewrites, no guessing at business logic you don't have context for. For anything riskier, leave it as a recommendation instead of touching it — flag why you're not fixing it.
+
+Show your work: what you changed and why, file by file.
+
+## Step 3: Re-grade
+
+After fixes, re-run the same categories and give updated grades. Call out what moved and what didn't. End with a short list of what's still holding the grade down — the stuff that needs a human decision (real refactors, product/business logic calls, anything ambiguous) rather than an agent's judgment call.
+
+---
+
+## Project-specific rules for this repo
+
+Added after the first run (2026-08-20). Each one exists because the first run got
+it wrong, not because it sounded good.
+
+### Measure, don't estimate
+
+Run the real gates before grading anything: `make gate`, `npm run test:coverage`
+in both stacks, `npm audit` in **both** root and `frontend/`, `node
+scripts/check-schema-drift.mjs`, `npm run validate:openapi`. A grade for "test
+coverage" that never ran the suite is a vibe.
+
+### Grade against this repo's own invariants, not generic best practice
+
+`CLAUDE.md` states its invariants precisely enough to falsify — "8 files guard
+`is_announced`", "exactly one `_routes.json`", "four routes write `status`". Check
+them. On the first run every numeric claim held, which is itself a finding.
+
+### Verify test QUALITY by mutation, never by the suite passing
+
+Break an invariant and confirm the suite goes red. On the first run this is what
+separated real guards from decorative ones: mutating the after-midnight threshold
+failed 10 tests, mutating event visibility failed 14 — but **deleting `AND
+verified = 1`, the entire anti-email-bombing control, left all 1,169 tests
+green**. Every follower fixture in ten test files seeded `verified = 1`, so no
+test could tell a gated query from an ungated one.
+
+A suite that looks exhaustive can prove nothing about the property it most needs
+to prove. Passing is not evidence.
+
+### Mutate the FIXTURES too, not just the code
+
+The first run mutated production code diligently and still shipped three vacuous
+tests of its own, all caught in review:
+
+| Vacuity | Why it passed |
+|---|---|
+| `source.includes(CONST)` | satisfied by a comment or a leftover import |
+| a hand-listed file inventory | cannot fail for a path nobody added to it |
+| a fixture that short-circuited | the code under test never ran; only status was asserted |
+
+The pattern is asserting on a **proxy** — a substring, a status range, a curated
+list — instead of the outcome. Derive inventories from source, assert on
+persisted state, and check that reverting the fixture makes the test fail.
+
+### Sweep for siblings, then guard the class
+
+One fixed instance of a systemic bug is a false sense of completion. Deriving the
+write-path list from source instead of hand-listing it is what exposed a second
+missing validation call that four rounds of manual review had missed. Prefer a
+source-scanning guard over a repeat audit.
+
+### Audit production before shipping a new constraint
+
+A new validation rule can make existing rows uneditable. Query D1 first
+(`mcp__settimesdotca__queryDB`, read-only) and report counts. The zero-length-set
+rule shipped only because the audit showed 0 of 283 affected rows — and it kept
+`end < start` and NULL `end_time` legal because 5 and 175 rows respectively
+depend on that.
+
+### Check whether it is already tracked
+
+Search issues before filing. The first run found a stalled tracking issue where
+**three of eight items were already done or no longer reproducible** — filing
+against it blind would have duplicated closed work.
+
+### Correct yourself in public
+
+The first run made three wrong claims that survived into filed issues: "nothing
+validates zero-length sets" (three of five paths did), "these components have no
+tests" (a bad `find`), "the roster query is unbounded" (capped at 500). Post the
+correction on the issue. A confidently wrong report card is worse than none.
+
+### Then run the standing gates
+
+`make review` (CodeRabbit) before opening each PR. Note the CLI does **not** load
+`.github/instructions/**` while the PR bot does, so a post-open finding is
+expected, not a gate failure.

--- a/docs/REPORT_CARD_REVIEW.md
+++ b/docs/REPORT_CARD_REVIEW.md
@@ -60,7 +60,7 @@ coverage" that never ran the suite is a vibe.
 That target regenerates `setup-complete.sql` *before* drift-checking it, so it
 compares a freshly generated file against the migrations that just generated it.
 It is the right command when you have edited `migrations/` and want the file
-brought back in step; it is the wrong one for an audit, because it repairs the
+brought back in step; it is the wrong one for an audit because it repairs the
 drift instead of reporting it. Measured on artificial drift (a removed index):
 the raw check exits **1**, `make schema-check` exits **0**. Do not "fix" this to
 use the Make target.

--- a/docs/REPORT_CARD_REVIEW.md
+++ b/docs/REPORT_CARD_REVIEW.md
@@ -30,6 +30,12 @@ Then give an overall grade and a one-paragraph summary of the biggest risk in th
 
 Rank all issues found by impact-to-effort ratio. Then actually fix the ones that are safe: no breaking changes, no unrequested architecture rewrites, no guessing at business logic you don't have context for. For anything riskier, leave it as a recommendation instead of touching it — flag why you're not fixing it.
 
+**File every deferred finding as a GitHub issue and reference it from the PR.** A
+recommendation that lives only in the report card is lost the moment the session ends —
+which is the failure this whole review exists to catch, reproduced by the review itself.
+Search existing issues first: the first run found a stalled tracking issue where three of
+eight items were already done or no longer reproducible.
+
 Show your work: what you changed and why, file by file.
 
 ## Step 3: Re-grade
@@ -49,6 +55,15 @@ Run the real gates before grading anything: `make gate`, `npm run test:coverage`
 in both stacks, `npm audit` in **both** root and `frontend/`, `node
 scripts/check-schema-drift.mjs`, `npm run validate:openapi`. A grade for "test
 coverage" that never ran the suite is a vibe.
+
+**The schema gate is the raw script here, deliberately — not `make schema-check`.**
+That target regenerates `setup-complete.sql` *before* drift-checking it, so it
+compares a freshly generated file against the migrations that just generated it.
+It is the right command when you have edited `migrations/` and want the file
+brought back in step; it is the wrong one for an audit, because it repairs the
+drift instead of reporting it. Measured on artificial drift (a removed index):
+the raw check exits **1**, `make schema-check` exits **0**. Do not "fix" this to
+use the Make target.
 
 ### Grade against this repo's own invariants, not generic best practice
 

--- a/functions/utils/__tests__/validation.test.js
+++ b/functions/utils/__tests__/validation.test.js
@@ -1,3 +1,6 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 // Tests for validation utilities
 import { describe, it, expect } from "vitest";
 import {
@@ -238,9 +241,9 @@ describe("validateDoorsJson (#569)", () => {
   const multiDayEvent = { date: "2026-07-10", end_date: "2026-07-11" };
 
   it("absent/null/empty doors_json is valid (no doors info)", () => {
-    expect(validateDoorsJson(undefined, singleDayEvent)).toEqual({ valid: true, error: null, value: null });
-    expect(validateDoorsJson(null, singleDayEvent)).toEqual({ valid: true, error: null, value: null });
-    expect(validateDoorsJson("", singleDayEvent)).toEqual({ valid: true, error: null, value: null });
+    expect(validateDoorsJson(undefined, singleDayEvent)).toEqual({ valid: true, error: undefined, value: null });
+    expect(validateDoorsJson(null, singleDayEvent)).toEqual({ valid: true, error: undefined, value: null });
+    expect(validateDoorsJson("", singleDayEvent)).toEqual({ valid: true, error: undefined, value: null });
   });
 
   it("accepts a valid single-day map", () => {
@@ -303,7 +306,7 @@ describe("validateDoorsJson (#569)", () => {
   });
 
   it("normalizes an empty object to null", () => {
-    expect(validateDoorsJson("{}", singleDayEvent)).toEqual({ valid: true, error: null, value: null });
+    expect(validateDoorsJson("{}", singleDayEvent)).toEqual({ valid: true, error: undefined, value: null });
   });
 
   it("rejects oversize input (cap ~2000 chars)", () => {
@@ -454,5 +457,41 @@ describe("sanitizeOptionalHandle write-path scheme guard (#483, via sanitizeBand
   it("still accepts a normal @handle", () => {
     const result = sanitizeBandSocialLinks({ instagram: "@ok_handle" });
     expect(JSON.parse(result).instagram).toBe("@ok_handle");
+  });
+});
+
+describe("validator results use undefined, not null, for an absent error (#917)", () => {
+  // Source scan. `.github/instructions/nodejs-javascript-vitest.instructions.md`
+  // says never use `null` for an optional value, and validation.js contradicted
+  // it in 11 places -- which surfaced as a repeat review finding on three
+  // separate PRs before anyone fixed it.
+  //
+  // Scoped to the `error:` key deliberately. The 16 `value: null` returns in the
+  // same file are NOT the same case: several are a NULL bound straight into a
+  // nullable column, and D1 round-trips `null`, not `undefined`. Widening this
+  // scan to `value` would demand a change that breaks writes.
+  const FUNCTIONS_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+  function collectJsFiles(dir) {
+    const out = [];
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        if (entry === "__tests__" || entry === "node_modules") continue;
+        out.push(...collectJsFiles(full));
+      } else if (entry.endsWith(".js")) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  it("no file in functions/ returns `error: null`", () => {
+    const offenders = collectJsFiles(FUNCTIONS_ROOT)
+      .map((full) => ({ rel: full.slice(FUNCTIONS_ROOT.length + 1), source: readFileSync(full, "utf-8") }))
+      .filter((f) => /\berror:\s*null\b/.test(f.source))
+      .map((f) => f.rel);
+
+    expect(offenders, `use \`error: undefined\` — see #917:\n${offenders.join("\n")}`).toEqual([]);
   });
 });

--- a/functions/utils/validation.js
+++ b/functions/utils/validation.js
@@ -633,7 +633,7 @@ export function isValidTime(time) {
     return { valid: false, error: "Minutes must be between 00 and 59" };
   }
 
-  return { valid: true, error: null };
+  return { valid: true, error: undefined };
 }
 
 /**
@@ -668,12 +668,12 @@ export function isValidTime(time) {
  */
 export function validateSetTimes(startTime, endTime) {
   if (!startTime || !endTime) {
-    return { valid: true, error: null };
+    return { valid: true, error: undefined };
   }
   if (startTime === endTime) {
     return { valid: false, error: "Start and end time cannot be the same" };
   }
-  return { valid: true, error: null };
+  return { valid: true, error: undefined };
 }
 
 /**
@@ -719,7 +719,7 @@ export function validateDate(dateString) {
   }
 
   const date = new Date(dateString);
-  return { valid: true, error: null, date };
+  return { valid: true, error: undefined, date };
 }
 
 /**
@@ -742,7 +742,7 @@ export function validateDate(dateString) {
  */
 export function validatePerformanceDate(performanceDate, event) {
   if (performanceDate === undefined || performanceDate === null || performanceDate === "") {
-    return { valid: true, error: null, value: null };
+    return { valid: true, error: undefined, value: null };
   }
 
   if (typeof performanceDate !== "string") {
@@ -765,7 +765,7 @@ export function validatePerformanceDate(performanceDate, event) {
     };
   }
 
-  return { valid: true, error: null, value: performanceDate };
+  return { valid: true, error: undefined, value: performanceDate };
 }
 
 /**
@@ -785,7 +785,7 @@ export function validatePerformanceDate(performanceDate, event) {
  */
 export function validateDoorsJson(doorsJson, event) {
   if (doorsJson === undefined || doorsJson === null || doorsJson === "") {
-    return { valid: true, error: null, value: null };
+    return { valid: true, error: undefined, value: null };
   }
 
   let parsed;
@@ -814,7 +814,7 @@ export function validateDoorsJson(doorsJson, event) {
 
   const entries = Object.entries(parsed);
   if (entries.length === 0) {
-    return { valid: true, error: null, value: null };
+    return { valid: true, error: undefined, value: null };
   }
 
   const minDate = event?.date || null;
@@ -848,7 +848,7 @@ export function validateDoorsJson(doorsJson, event) {
     };
   }
 
-  return { valid: true, error: null, value: serialized };
+  return { valid: true, error: undefined, value: serialized };
 }
 
 /**
@@ -866,7 +866,7 @@ export function validateId(id) {
     return { valid: false, value: null, error: "ID must be a positive integer" };
   }
 
-  return { valid: true, value: numId, error: null };
+  return { valid: true, value: numId, error: undefined };
 }
 
 /**
@@ -914,7 +914,7 @@ export function validateIdArray(ids, options = {}) {
     return { valid: false, values: null, error: "Array contains duplicate IDs" };
   }
 
-  return { valid: true, values, error: null };
+  return { valid: true, values, error: undefined };
 }
 
 /**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ exclude_docs: |
   ux/
   superpowers/
   adr/adr-*.md
+  REPORT_CARD_REVIEW.md
   SETTIMES_V2_IMPLEMENTATION_PLAN.md
   SETTIMES_V2_UX_BRIEF.md
   SETTIMES_V2_WIREFRAMES.md


### PR DESCRIPTION
## Summary

Two things: the mechanical half of #917, and moving the report-card prompt into the repo with a documented cadence.

Partially closes #917 — **the `error` half only.** The 16 `value: null` returns are deliberately untouched and the issue stays open for them.

## What changed

| File | Change |
|------|--------|
| `functions/utils/validation.js` | 11 × `error: null` → `error: undefined` |
| `functions/utils/__tests__/validation.test.js` | 4 assertions updated + a source-scan guard so it can't drift back |
| `docs/REPORT_CARD_REVIEW.md` | **New.** The report-card prompt, now tracked, with a project-specific addendum |
| `mkdocs.yml` | Excludes it from the published site |
| `CLAUDE.md` / `AGENTS.md` | Cadence + caveats |

## Security / correctness notes

**The swap is behaviour-neutral, and I verified that rather than assuming it:**

- **No caller compares against `null`** — a repo-wide grep for `error === null` / `error !== null` returns nothing. Every consumer branches on `.valid` and reads `.error` only when it's a string.
- **No validator result reaches a response body.** This was the real risk: `JSON.stringify` *omits* `undefined` keys but emits `"error":null`, so a validator result returned directly would change the API payload. The only two `...result` spreads (`admin/venues.js:204`, `admin/venues/[id].js:276`) spread **D1 rows**, not validator results.

Four assertions pinned the old shape via `toEqual`. Confirmed they were load-bearing before trusting them: reverting only the test file fails 2 blocks, so `toEqual` is strict here and all pinning assertions were found.

**Scoped to `error` on purpose.** The 16 `value: null` returns are a different case — several are a NULL bound straight into a nullable column, and D1 round-trips `null`, not `undefined`. Widening this would break writes. The frontend's one `error: null` is `ErrorBoundary` component state, not a validator result.

A source scan now fails on any `error: null` in `functions/`, mutation-verified.

## The prompt file — and the trap it nearly fell into

It lived in a sibling directory **outside the working tree**, where a fresh clone, CI, or a delegated run would never find it — the same failure as the untracked `instructions/` tree in #818.

`docs/prompts/` was the obvious home and is **gitignored** (`.gitignore:66` matches any `prompts/`), which would have reproduced exactly the problem I was fixing. Caught it because `git add` refused the path.

It now sits at `docs/` top level with the other tracked docs, and is added to `mkdocs.yml`'s existing `exclude_docs` block — matching that block's stated purpose, *"Confidential/internal planning docs … stay out of the built site without being removed from the repo."* That matters: `docs/*.md` is published to docs.settimes.ca regardless of nav, and this doc candidly names past security gaps.

Verified both ways: `git ls-files` finds it, a strict mkdocs build does not emit it.

**The addendum** encodes what the first run got wrong — measure with the real gates, verify test quality by mutation, mutate *fixtures* and not just code, audit production before shipping a constraint, and correct filed issues when a lead doesn't survive contact.

**Cadence: start of a release cycle or roughly quarterly**, explicitly not a per-PR gate — it reads the whole tree and runs every gate. CLAUDE.md also records that its findings are *leads to verify*, not verdicts, since the first run produced three wrong claims that reached filed issues.

## Verification

- [x] Tests: 1,201 backend + 1,094 frontend pass, 0 failures
- [x] ESLint: 0 errors, 0 warnings
- [x] Format check: clean, both stacks
- [x] Build: green
- [x] `validate:openapi`: n/a (spec unchanged)
- [x] `make gate`: exit 0
- [x] `mkdocs build --strict`: exit 0, file correctly absent from output
- [x] `make review` (CodeRabbit): **no findings**
- [x] Manual smoke: n/a — no runtime behaviour changes (proven above)

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a repository-wide report card review guide covering quality, security, performance, testing, resilience, documentation, and risk assessment.
  - Documented recommended review timing, including release cycles and approximately quarterly reviews.
  - Added guidance for verifying findings, prioritizing safe fixes, and confirming improvements after changes.
  - Kept the review guide out of the published documentation site.

- **Bug Fixes**
  - Standardized successful validation responses to use an undefined error value instead of null, without changing validation rules or results.
  - Added automated checks to prevent inconsistent error values from being reintroduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->