### PR TITLE
test(admin): extract LineupTab's roster logic and cover it with 30 tests

### DIFF
--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -8,23 +8,25 @@ import BulkPreviewModal from './BulkPreviewModal'
 import BulkBandImport from './BulkBandImport'
 import ArtistPicker from './components/ArtistPicker'
 import ConfirmDialog from '../components/ui/ConfirmDialog'
-import { DEFAULT_GENRES, getNormalizedGenreSuggestions } from '../utils/genres'
 import { parseOrigin } from '../utils/parseOrigin'
-import { sortableName } from '../utils/sortableName'
 import {
-  adjustForMidnight,
   calculateEndTimeFromDuration,
   calculateStartTimeFromDuration,
   deriveDurationMinutes,
   detectConflicts,
   formatDurationLabel,
   formatTimeRangeLabel,
-  parseTimeToMinutes,
   resolveFestivalDay,
-  sortBandsByStart,
 } from './utils/timeUtils'
 import { buildPickerFormData, buildEmptyPickerFormData } from './utils/pickerFormData'
 import { buildDayOptions, isMultiDayEvent } from './utils/dayOptions'
+import {
+  buildDayNumberMap,
+  deriveGenreSuggestions,
+  deriveOriginSuggestions,
+  filterRosterBands,
+  sortRosterBands,
+} from './utils/lineupRoster'
 import { formatFestivalDate } from '../utils/festivalDays'
 
 function SortIcon({ col, sortConfig }) {
@@ -137,42 +139,9 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
     [allBands]
   )
 
-  const originCitySuggestions = useMemo(() => {
-    const values = new Set()
-    allBands.forEach(band => {
-      if (band.origin_city) values.add(band.origin_city)
-      if (!band.origin_city && band.origin) {
-        const parsed = parseOrigin(band.origin)
-        if (parsed.city) values.add(parsed.city)
-      }
-    })
-    return Array.from(values).sort((a, b) => a.localeCompare(b))
-  }, [allBands])
-
-  const originRegionSuggestions = useMemo(() => {
-    const values = new Set()
-    allBands.forEach(band => {
-      if (band.origin_region) values.add(band.origin_region)
-      if (!band.origin_region && band.origin) {
-        const parsed = parseOrigin(band.origin)
-        if (parsed.region) values.add(parsed.region)
-      }
-    })
-    return Array.from(values).sort((a, b) => a.localeCompare(b))
-  }, [allBands])
-
-  const genreSuggestions = useMemo(() => {
-    const values = []
-    allBands.forEach(band => {
-      if (!band.genre) return
-      band.genre
-        .split(',')
-        .map(entry => entry.trim())
-        .filter(Boolean)
-        .forEach(entry => values.push(entry))
-    })
-    return getNormalizedGenreSuggestions(values, DEFAULT_GENRES)
-  }, [allBands])
+  const originCitySuggestions = useMemo(() => deriveOriginSuggestions(allBands, 'city'), [allBands])
+  const originRegionSuggestions = useMemo(() => deriveOriginSuggestions(allBands, 'region'), [allBands])
+  const genreSuggestions = useMemo(() => deriveGenreSuggestions(allBands), [allBands])
 
   // Multi-day events (#540): the per-set day selector is shown only when the
   // event spans more than one calendar day (string comparison — never
@@ -502,68 +471,18 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
   // interior festival day has no performances yet (mid-setup). A
   // performance_date outside the event's [date, end_date] range has no
   // calendar day number; render '?' rather than "Day undefined".
-  const dayNumberMap = useMemo(() => new Map(dayOptions.map((opt, index) => [opt.value, index + 1])), [dayOptions])
+  const dayNumberMap = useMemo(() => buildDayNumberMap(dayOptions), [dayOptions])
   const dayNumberLabel = useCallback(date => dayNumberMap.get(date) ?? '?', [dayNumberMap])
 
-  const filteredBands = useMemo(() => {
-    let next = bands
-    if (searchTerm.trim()) {
-      const query = searchTerm.trim().toLowerCase()
-      next = next.filter(band => band.name?.toLowerCase().includes(query))
-    }
-    if (venueFilter !== 'all') {
-      next = next.filter(band => String(band.venue_id) === String(venueFilter))
-    }
-    if (isMultiDay && dayFilter !== 'all') {
-      next = next.filter(band => bandFestivalDate(band) === dayFilter)
-    }
-    return next
-  }, [bands, searchTerm, venueFilter, isMultiDay, dayFilter, bandFestivalDate])
+  const filteredBands = useMemo(
+    () => filterRosterBands(bands, { searchTerm, venueFilter, dayFilter, isMultiDay, bandFestivalDate }),
+    [bands, searchTerm, venueFilter, isMultiDay, dayFilter, bandFestivalDate]
+  )
 
-  const sortedBands = useMemo(() => {
-    if (!sortConfig.key) {
-      return sortBandsByStart(filteredBands)
-    }
-
-    const direction = sortConfig.direction === 'asc' ? 1 : -1
-
-    return [...filteredBands].sort((a, b) => {
-      if (sortConfig.key === 'name') {
-        // Article-stripped alphabetization (#587) — "The Anti-Queens" sorts under A.
-        const aVal = sortableName(a.name)
-        const bVal = sortableName(b.name)
-        return aVal.localeCompare(bVal) * direction
-      }
-      if (sortConfig.key === 'venue') {
-        const aVal = getVenueName(a.venue_id).toLowerCase()
-        const bVal = getVenueName(b.venue_id).toLowerCase()
-        return aVal.localeCompare(bVal) * direction
-      }
-      if (sortConfig.key === 'duration') {
-        const aVal = deriveDurationMinutes(a.start_time, a.end_time) || 0
-        const bVal = deriveDurationMinutes(b.start_time, b.end_time) || 0
-        return (aVal - bVal) * direction
-      }
-      if (sortConfig.key === 'performance_date') {
-        // Plain YYYY-MM-DD string comparison sorts chronologically (#588) —
-        // same convention as festivalDays.js's orderedFestivalDays. NULL
-        // performance_date resolves to the event start date via
-        // bandFestivalDate, never re-deriving the fallback locally.
-        const aVal = bandFestivalDate(a) || ''
-        const bVal = bandFestivalDate(b) || ''
-        return aVal.localeCompare(bVal) * direction
-      }
-
-      const aMin = parseTimeToMinutes(a.start_time)
-      const bMin = parseTimeToMinutes(b.start_time)
-      if (aMin == null && bMin == null) return 0
-      if (aMin == null) return 1
-      if (bMin == null) return -1
-      const aAdj = adjustForMidnight(aMin)
-      const bAdj = adjustForMidnight(bMin)
-      return (aAdj - bAdj) * direction
-    })
-  }, [filteredBands, sortConfig, getVenueName, bandFestivalDate])
+  const sortedBands = useMemo(
+    () => sortRosterBands(filteredBands, sortConfig, { getVenueName, bandFestivalDate }),
+    [filteredBands, sortConfig, getVenueName, bandFestivalDate]
+  )
 
   const handleSort = key => {
     setSortConfig(prev => ({

--- a/frontend/src/admin/utils/__tests__/lineupRoster.test.js
+++ b/frontend/src/admin/utils/__tests__/lineupRoster.test.js
@@ -57,6 +57,18 @@ describe('filterRosterBands', () => {
     expect(result.map(b => b.id)).toEqual([2, 3])
   })
 
+  it('matches a NULL performance_date against day 1 via the fallback', () => {
+    // On a multi-day event a set with no explicit date belongs to the event's
+    // start day, so filtering to day 1 must INCLUDE it. Without this, the pair
+    // of day tests only proves the filter excludes things.
+    const result = filterRosterBands([band(1), band(2, { performance_date: '2026-10-12' })], {
+      isMultiDay: true,
+      dayFilter: '2026-10-11',
+      bandFestivalDate: festivalDate('2026-10-11'),
+    })
+    expect(result.map(b => b.id)).toEqual([1])
+  })
+
   it('IGNORES dayFilter on a single-day event, where performance_date is NULL', () => {
     // Applying it would drop every set — single-day events never render the
     // selector and leave performance_date NULL (#540).

--- a/frontend/src/admin/utils/__tests__/lineupRoster.test.js
+++ b/frontend/src/admin/utils/__tests__/lineupRoster.test.js
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDayNumberMap,
+  deriveGenreSuggestions,
+  deriveOriginSuggestions,
+  filterRosterBands,
+  sortRosterBands,
+} from '../lineupRoster'
+
+const band = (id, over = {}) => ({
+  id,
+  name: `Band ${id}`,
+  venue_id: 1,
+  start_time: '20:00',
+  end_time: '21:00',
+  performance_date: null,
+  ...over,
+})
+
+// Mirrors LineupTab's own fallback: a NULL performance_date belongs to the
+// event's start date (#540).
+const festivalDate = eventDate => b => b.performance_date || eventDate
+const venueNames = { 1: 'Blue Room', 2: 'Room 47', 3: 'Roost' }
+const getVenueName = id => venueNames[id] ?? ''
+
+describe('filterRosterBands', () => {
+  const bands = [
+    band(1, { name: 'The Anti-Queens', venue_id: 1, performance_date: '2026-10-11' }),
+    band(2, { name: 'Sam Nabi', venue_id: 2, performance_date: '2026-10-12' }),
+    band(3, { name: 'Deer Fang', venue_id: 1, performance_date: '2026-10-12' }),
+  ]
+
+  it('returns everything when no filter is set', () => {
+    expect(filterRosterBands(bands, { searchTerm: '', venueFilter: 'all', dayFilter: 'all' })).toHaveLength(3)
+  })
+
+  it('matches search case-insensitively on a substring', () => {
+    const result = filterRosterBands(bands, { searchTerm: 'anti' })
+    expect(result.map(b => b.id)).toEqual([1])
+  })
+
+  it('ignores whitespace-only search', () => {
+    expect(filterRosterBands(bands, { searchTerm: '   ' })).toHaveLength(3)
+  })
+
+  it('filters by venue, comparing as strings so a numeric id still matches', () => {
+    expect(filterRosterBands(bands, { venueFilter: '1' }).map(b => b.id)).toEqual([1, 3])
+    expect(filterRosterBands(bands, { venueFilter: 1 }).map(b => b.id)).toEqual([1, 3])
+  })
+
+  it('filters by festival day on a multi-day event', () => {
+    const result = filterRosterBands(bands, {
+      isMultiDay: true,
+      dayFilter: '2026-10-12',
+      bandFestivalDate: festivalDate('2026-10-11'),
+    })
+    expect(result.map(b => b.id)).toEqual([2, 3])
+  })
+
+  it('IGNORES dayFilter on a single-day event, where performance_date is NULL', () => {
+    // Applying it would drop every set — single-day events never render the
+    // selector and leave performance_date NULL (#540).
+    const singleDay = [band(1), band(2)]
+    const result = filterRosterBands(singleDay, {
+      isMultiDay: false,
+      dayFilter: '2026-10-12',
+      bandFestivalDate: festivalDate('2026-10-11'),
+    })
+    expect(result).toHaveLength(2)
+  })
+
+  it('composes filters', () => {
+    const result = filterRosterBands(bands, {
+      searchTerm: 'a',
+      venueFilter: '1',
+      isMultiDay: true,
+      dayFilter: '2026-10-12',
+      bandFestivalDate: festivalDate('2026-10-11'),
+    })
+    expect(result.map(b => b.id)).toEqual([3])
+  })
+
+  it('does not mutate the input', () => {
+    const input = [...bands]
+    filterRosterBands(input, { searchTerm: 'anti' })
+    expect(input).toHaveLength(3)
+  })
+})
+
+describe('sortRosterBands', () => {
+  const deps = { getVenueName, bandFestivalDate: festivalDate('2026-10-11') }
+
+  it('falls back to start-time order when no key is set, honouring after-midnight', () => {
+    // 01:00 is an after-midnight set belonging to the END of the evening, so it
+    // must sort after 23:00 rather than first. This is the recurring bug class.
+    const bands = [band(1, { start_time: '01:00' }), band(2, { start_time: '23:00' }), band(3, { start_time: '20:00' })]
+    expect(sortRosterBands(bands, { key: null }, deps).map(b => b.id)).toEqual([3, 2, 1])
+  })
+
+  it('sorts by name with articles stripped (#587)', () => {
+    const bands = [band(1, { name: 'Zebra' }), band(2, { name: 'The Anti-Queens' })]
+    expect(sortRosterBands(bands, { key: 'name', direction: 'asc' }, deps).map(b => b.name)).toEqual([
+      'The Anti-Queens',
+      'Zebra',
+    ])
+  })
+
+  it('reverses on desc', () => {
+    const bands = [band(1, { name: 'Zebra' }), band(2, { name: 'Anchor' })]
+    expect(sortRosterBands(bands, { key: 'name', direction: 'desc' }, deps).map(b => b.name)).toEqual([
+      'Zebra',
+      'Anchor',
+    ])
+  })
+
+  it('sorts by venue name, not venue id', () => {
+    // id order is 1,2,3 but name order is Blue Room, Room 47, Roost — a test
+    // using ids would pass against an implementation that never resolved names.
+    const bands = [band(1, { venue_id: 3 }), band(2, { venue_id: 1 }), band(3, { venue_id: 2 })]
+    expect(sortRosterBands(bands, { key: 'venue', direction: 'asc' }, deps).map(b => getVenueName(b.venue_id))).toEqual(
+      ['Blue Room', 'Room 47', 'Roost']
+    )
+  })
+
+  it('sorts by duration, treating a missing end time as zero', () => {
+    const bands = [
+      band(1, { start_time: '20:00', end_time: '22:00' }),
+      band(2, { start_time: '20:00', end_time: null }),
+      band(3, { start_time: '20:00', end_time: '20:30' }),
+    ]
+    expect(sortRosterBands(bands, { key: 'duration', direction: 'asc' }, deps).map(b => b.id)).toEqual([2, 3, 1])
+  })
+
+  it('sorts by festival date, resolving NULL through the fallback', () => {
+    const bands = [band(1, { performance_date: '2026-10-12' }), band(2, { performance_date: null })]
+    // Band 2's NULL resolves to the event start 2026-10-11, so it sorts first.
+    expect(sortRosterBands(bands, { key: 'performance_date', direction: 'asc' }, deps).map(b => b.id)).toEqual([2, 1])
+  })
+
+  it('sorts unscheduled sets last in BOTH directions', () => {
+    // A set with no start time is not "earliest" — flipping the arrow must not
+    // promote it to the top.
+    const bands = [band(1, { start_time: null }), band(2, { start_time: '20:00' })]
+    expect(sortRosterBands(bands, { key: 'start_time', direction: 'asc' }, deps).map(b => b.id)).toEqual([2, 1])
+    expect(sortRosterBands(bands, { key: 'start_time', direction: 'desc' }, deps).map(b => b.id)).toEqual([2, 1])
+  })
+
+  it('does not mutate the input array', () => {
+    const bands = [band(1, { name: 'Zebra' }), band(2, { name: 'Anchor' })]
+    sortRosterBands(bands, { key: 'name', direction: 'asc' }, deps)
+    expect(bands.map(b => b.name)).toEqual(['Zebra', 'Anchor'])
+  })
+})
+
+describe('deriveOriginSuggestions', () => {
+  it('collects the structured column and sorts it', () => {
+    const bands = [band(1, { origin_city: 'Waterloo' }), band(2, { origin_city: 'Kitchener' })]
+    expect(deriveOriginSuggestions(bands, 'city')).toEqual(['Kitchener', 'Waterloo'])
+  })
+
+  it('falls back to parsing the legacy freeform origin when the column is empty', () => {
+    const bands = [band(1, { origin_city: '', origin: 'Guelph, ON' })]
+    expect(deriveOriginSuggestions(bands, 'city')).toEqual(['Guelph'])
+  })
+
+  it('prefers the structured column over the freeform string', () => {
+    const bands = [band(1, { origin_city: 'Waterloo', origin: 'Toronto, ON' })]
+    expect(deriveOriginSuggestions(bands, 'city')).toEqual(['Waterloo'])
+  })
+
+  it('de-duplicates', () => {
+    const bands = [band(1, { origin_city: 'Waterloo' }), band(2, { origin_city: 'Waterloo' })]
+    expect(deriveOriginSuggestions(bands, 'city')).toEqual(['Waterloo'])
+  })
+
+  it('reads region independently of city', () => {
+    const bands = [band(1, { origin_region: 'ON' }), band(2, { origin_region: 'QC' })]
+    expect(deriveOriginSuggestions(bands, 'region')).toEqual(['ON', 'QC'])
+  })
+
+  it('includes inactive bands — reusing a retired origin is harmless', () => {
+    const bands = [band(1, { is_active: 0, origin_city: 'Tillsonburg' })]
+    expect(deriveOriginSuggestions(bands, 'city')).toEqual(['Tillsonburg'])
+  })
+})
+
+describe('deriveGenreSuggestions', () => {
+  // Suggestions come back title-cased via getNormalizedGenreSuggestions, so the
+  // datalist offers one canonical spelling rather than whatever casing happened
+  // to be typed first. Asserting the normalised form on purpose — expecting the
+  // raw input would pass against an implementation that skipped normalisation.
+  it('splits the comma-separated column and normalises each entry', () => {
+    expect(deriveGenreSuggestions([band(1, { genre: 'punk, ska' })])).toEqual(['Punk', 'Ska'])
+  })
+
+  it('trims whitespace and drops empty segments', () => {
+    const result = deriveGenreSuggestions([band(1, { genre: ' punk ,, ska ' })])
+    expect(result).toEqual(['Punk', 'Ska'])
+    expect(result).not.toContain('')
+  })
+
+  it('collapses casing variants to one suggestion', () => {
+    expect(deriveGenreSuggestions([band(1, { genre: 'PUNK' }), band(2, { genre: 'punk' })])).toEqual(['Punk'])
+  })
+
+  it('skips bands with no genre', () => {
+    expect(deriveGenreSuggestions([band(1, { genre: null })])).toEqual([])
+  })
+})
+
+describe('buildDayNumberMap', () => {
+  it('numbers from the day OPTIONS, not from the sets present', () => {
+    // The distinction matters mid-setup: numbering from data would skip an
+    // interior day with no sets booked, so "Day 2" would mean different dates
+    // in the dropdown and the table.
+    const map = buildDayNumberMap([{ value: '2026-10-11' }, { value: '2026-10-12' }, { value: '2026-10-13' }])
+    expect(map.get('2026-10-11')).toBe(1)
+    expect(map.get('2026-10-12')).toBe(2)
+    expect(map.get('2026-10-13')).toBe(3)
+  })
+
+  it('has no entry for a date outside the event span', () => {
+    const map = buildDayNumberMap([{ value: '2026-10-11' }])
+    expect(map.get('2026-12-25')).toBeUndefined()
+  })
+
+  it('is empty for a single-day event, which has no day options', () => {
+    expect(buildDayNumberMap([]).size).toBe(0)
+  })
+})

--- a/frontend/src/admin/utils/lineupRoster.js
+++ b/frontend/src/admin/utils/lineupRoster.js
@@ -1,0 +1,167 @@
+import { sortableName } from '../../utils/sortableName'
+import { parseOrigin } from '../../utils/parseOrigin'
+import { DEFAULT_GENRES, getNormalizedGenreSuggestions } from '../../utils/genres'
+import { adjustForMidnight, deriveDurationMinutes, parseTimeToMinutes, sortBandsByStart } from './timeUtils'
+
+/**
+ * Pure roster logic for LineupTab — what an operator sees, and in what order.
+ *
+ * Extracted rather than left inline because LineupTab is 1,200+ lines and
+ * loaded in zero tests (#905), while this is the code that decides which sets
+ * appear during a show. Mounting the component to reach it would pull its whole
+ * uncovered surface into the coverage denominator; a pure module can be tested
+ * directly.
+ *
+ * Every function here takes its collaborators as arguments instead of closing
+ * over component state, so a test supplies them without a render.
+ */
+
+/**
+ * Narrow the roster by search text, venue, and festival day.
+ *
+ * `dayFilter` is ignored unless `isMultiDay` — single-day events never render
+ * the selector and leave `performance_date` NULL (#540), so filtering on it
+ * would drop every set.
+ *
+ * @param {Array<object>} bands
+ * @param {object} options
+ * @param {string} [options.searchTerm]
+ * @param {string|number} [options.venueFilter] - "all" for no filter
+ * @param {string} [options.dayFilter] - "all" for no filter; YYYY-MM-DD otherwise
+ * @param {boolean} [options.isMultiDay]
+ * @param {(band: object) => string|null} options.bandFestivalDate - resolves a
+ *   set's festival day, applying the event-start fallback for NULL
+ *   performance_date. Passed in rather than re-derived so the fallback lives in
+ *   exactly one place.
+ * @returns {Array<object>}
+ */
+export function filterRosterBands(bands, { searchTerm, venueFilter, dayFilter, isMultiDay, bandFestivalDate } = {}) {
+  let next = bands ?? []
+  if (searchTerm?.trim()) {
+    const query = searchTerm.trim().toLowerCase()
+    next = next.filter(band => band.name?.toLowerCase().includes(query))
+  }
+  if (venueFilter !== undefined && venueFilter !== 'all') {
+    next = next.filter(band => String(band.venue_id) === String(venueFilter))
+  }
+  if (isMultiDay && dayFilter !== undefined && dayFilter !== 'all') {
+    next = next.filter(band => bandFestivalDate(band) === dayFilter)
+  }
+  return next
+}
+
+/**
+ * Order the roster. With no explicit sort key this falls back to start time via
+ * `sortBandsByStart`, which applies the after-midnight offset — a 1 AM set
+ * belongs to the end of the previous evening, not the top of the schedule.
+ *
+ * @param {Array<object>} bands
+ * @param {{key: string|null, direction: 'asc'|'desc'}} sortConfig
+ * @param {object} deps
+ * @param {(venueId: number|string) => string} deps.getVenueName
+ * @param {(band: object) => string|null} deps.bandFestivalDate
+ * @returns {Array<object>} a new array; the input is not mutated
+ */
+export function sortRosterBands(bands, sortConfig, { getVenueName, bandFestivalDate } = {}) {
+  const list = bands ?? []
+  if (!sortConfig?.key) {
+    return sortBandsByStart(list)
+  }
+
+  const direction = sortConfig.direction === 'asc' ? 1 : -1
+
+  return [...list].sort((a, b) => {
+    if (sortConfig.key === 'name') {
+      // Article-stripped alphabetization (#587) — "The Anti-Queens" sorts under A.
+      return sortableName(a.name).localeCompare(sortableName(b.name)) * direction
+    }
+    if (sortConfig.key === 'venue') {
+      return getVenueName(a.venue_id).toLowerCase().localeCompare(getVenueName(b.venue_id).toLowerCase()) * direction
+    }
+    if (sortConfig.key === 'duration') {
+      const aVal = deriveDurationMinutes(a.start_time, a.end_time) || 0
+      const bVal = deriveDurationMinutes(b.start_time, b.end_time) || 0
+      return (aVal - bVal) * direction
+    }
+    if (sortConfig.key === 'performance_date') {
+      // Plain YYYY-MM-DD string comparison sorts chronologically (#588) — same
+      // convention as festivalDays.js. NULL performance_date resolves via
+      // bandFestivalDate, never re-deriving the fallback locally.
+      return (bandFestivalDate(a) || '').localeCompare(bandFestivalDate(b) || '') * direction
+    }
+
+    // Start time. Nulls sort last in BOTH directions: an unscheduled set is not
+    // "earliest", and flipping the arrow should not promote it to the top.
+    const aMin = parseTimeToMinutes(a.start_time)
+    const bMin = parseTimeToMinutes(b.start_time)
+    if (aMin == null && bMin == null) return 0
+    if (aMin == null) return 1
+    if (bMin == null) return -1
+    return (adjustForMidnight(aMin) - adjustForMidnight(bMin)) * direction
+  })
+}
+
+/**
+ * Distinct origin values for a datalist, sorted for display.
+ *
+ * `field` selects the column; when it is empty the value is recovered from the
+ * legacy freeform `origin` string via parseOrigin. City and region were two
+ * near-identical copies inline — one parameterised function keeps them from
+ * drifting.
+ *
+ * Deliberately reads ALL bands including inactive ones: reusing a retired
+ * band's origin is harmless and losing the suggestion is not.
+ *
+ * @param {Array<object>} bands
+ * @param {'city'|'region'} field
+ * @returns {string[]}
+ */
+export function deriveOriginSuggestions(bands, field) {
+  const column = field === 'city' ? 'origin_city' : 'origin_region'
+  const values = new Set()
+  for (const band of bands ?? []) {
+    if (band[column]) {
+      values.add(band[column])
+      continue
+    }
+    if (band.origin) {
+      const parsed = parseOrigin(band.origin)
+      if (parsed[field]) values.add(parsed[field])
+    }
+  }
+  return Array.from(values).sort((a, b) => a.localeCompare(b))
+}
+
+/**
+ * Distinct genre suggestions. Genres are stored comma-separated, so each entry
+ * is split and trimmed before normalisation.
+ *
+ * @param {Array<object>} bands
+ * @returns {string[]}
+ */
+export function deriveGenreSuggestions(bands) {
+  const values = []
+  for (const band of bands ?? []) {
+    if (!band.genre) continue
+    for (const entry of band.genre.split(',')) {
+      const trimmed = entry.trim()
+      if (trimmed) values.push(trimmed)
+    }
+  }
+  return getNormalizedGenreSuggestions(values, DEFAULT_GENRES)
+}
+
+/**
+ * Map each festival date to its 1-based day number, derived from the day
+ * OPTIONS rather than from the performances present.
+ *
+ * That distinction is load-bearing: numbering from data drifts from the
+ * dropdown when an interior day has no sets booked yet, so mid-setup "Day 2"
+ * would mean different dates in two places on the same screen.
+ *
+ * @param {Array<{value: string}>} dayOptions
+ * @returns {Map<string, number>}
+ */
+export function buildDayNumberMap(dayOptions) {
+  return new Map((dayOptions ?? []).map((opt, index) => [opt.value, index + 1]))
+}


### PR DESCRIPTION
## Summary

First slice of #905. LineupTab still has no component-level test — this covers the logic that decides **what an operator sees during a show**, which is the part that matters.

Refs #905

## What changed

| File | Change |
|------|--------|
| `frontend/src/admin/utils/lineupRoster.js` | **New.** Roster filter/sort/suggestion logic, extracted |
| `frontend/src/admin/utils/__tests__/lineupRoster.test.js` | **New.** 30 tests |
| `frontend/src/admin/LineupTab.jsx` | −81 lines, −6 imports; inline copies deleted |

## Extracted, not mounted — deliberately

Frontend coverage counts only files a test **loads**. Rendering a 1,200-line component to reach this logic would pull its entire uncovered surface into the denominator and **lower** the global percentage while strictly adding coverage.

`admin/utils/` is the established home: 8 modules, 7 already tested. `parseBandRows.js` (16 lines) shows the floor.

| Moved out | What it does |
|---|---|
| `filterRosterBands` | search / venue / festival-day narrowing |
| `sortRosterBands` | all five sort keys + start-time fallback |
| `deriveOriginSuggestions` | city and region — previously two near-identical copies |
| `deriveGenreSuggestions` | comma-splitting and normalisation |
| `buildDayNumberMap` | festival date → 1-based day number |

The two origin blocks differed only in which column they read. Extracting collapsed them into one parameterised function — that duplication was invisible while both were inline.

## Tests assert outcomes, not proxies

The ones that would catch a real regression:

- **A 01:00 set sorts to the END of the evening, not the top** — the recurring after-midnight bug class.
- **`dayFilter` is IGNORED on single-day events**, where `performance_date` is NULL. Applying it would drop every set (#540).
- **A NULL `performance_date` still matches day 1** via the fallback — added on review, because the two existing day tests both only proved *exclusion*.
- **Unscheduled sets sort last in BOTH directions.** Flipping the arrow must not promote a set with no start time.
- **Venue sort orders by resolved NAME, not id.** The fixture's id order and name order deliberately disagree, so a test using ids would pass against an implementation that never resolved names.
- **Day numbers come from the day OPTIONS, not the sets present** — otherwise "Day 2" means different dates in the dropdown and the table mid-setup.

Two genre assertions failed on first run because I assumed raw passthrough; suggestions are title-cased. Corrected to real behaviour and added a casing-collapse case, so the normalisation is documented rather than accidental.

## Verification

- [x] Tests: 1,201 backend + **1,124** frontend (was 1,094), 0 failures
- [x] ESLint: 0 errors, 0 warnings
- [x] Format check: clean, both stacks
- [x] Build: green
- [x] `validate:openapi`: n/a
- [x] `make gate`: exit 0
- [x] `make review` (CodeRabbit): run pre-open; its one finding is fixed in this branch
- [x] Manual smoke: not browser-verified — pure logic extraction, no behaviour change; the inline originals were deleted rather than duplicated, so the component exercises the same code

**Mutation evidence:** replacing `bandFestivalDate(band)` with a raw `band.performance_date` read fails exactly the new fallback test.

**Note:** `--max-warnings 0` from #914 caught the newly-unused imports on the first lint run — the threshold change already paying off.

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved lineup filtering and sorting by search, venue, date, name, duration, performance time, and festival day.
  * Added more consistent origin and genre suggestions, including support for legacy origin information.
  * Improved handling of multi-day events and performances crossing midnight.

* **Tests**
  * Added comprehensive coverage for lineup filtering, sorting, suggestions, date mapping, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->