### PR TITLE
test(admin): extract UserManagement's roster logic and cover it with 24 tests

### DIFF
--- a/frontend/src/admin/UserManagement.jsx
+++ b/frontend/src/admin/UserManagement.jsx
@@ -4,6 +4,7 @@ import RoleBadge from './components/RoleBadge'
 import UserFormModal from './components/UserFormModal'
 import ConfirmDialog from '../components/ui/ConfirmDialog'
 import { usersApi } from '../utils/adminApi'
+import { filterUsers, resolveUserDisplayName, sortUsers } from './utils/userRoster'
 
 function SortIcon({ col, sortConfig }) {
   return (
@@ -30,62 +31,14 @@ export default function UserManagement({ showToast }) {
   const [pendingToggle, setPendingToggle] = useState(null)
   const [pendingInviteUrl, setPendingInviteUrl] = useState(null)
 
-  const resolveDisplayName = user => {
-    if (user?.firstName || user?.lastName) {
-      return [user.firstName, user.lastName].filter(Boolean).join(' ')
-    }
-    return user?.name || ''
-  }
+  const resolveDisplayName = resolveUserDisplayName
 
-  const filteredUsers = useMemo(() => {
-    let list = users
-    if (searchTerm.trim()) {
-      const query = searchTerm.trim().toLowerCase()
-      list = list.filter(user => {
-        const name = resolveDisplayName(user).toLowerCase()
-        const email = (user.email || '').toLowerCase()
-        return name.includes(query) || email.includes(query)
-      })
-    }
-    if (roleFilter !== 'all') {
-      list = list.filter(user => user.role === roleFilter)
-    }
-    if (statusFilter !== 'all') {
-      const shouldBeActive = statusFilter === 'active'
-      list = list.filter(user => Boolean(user.isActive) === shouldBeActive)
-    }
-    return list
-  }, [users, searchTerm, roleFilter, statusFilter])
+  const filteredUsers = useMemo(
+    () => filterUsers(users, { searchTerm, roleFilter, statusFilter }),
+    [users, searchTerm, roleFilter, statusFilter]
+  )
 
-  const sortedUsers = useMemo(() => {
-    if (!sortConfig.key) return filteredUsers
-    const direction = sortConfig.direction === 'asc' ? 1 : -1
-    return [...filteredUsers].sort((a, b) => {
-      if (sortConfig.key === 'status') {
-        const aVal = a.isActive ? 1 : 0
-        const bVal = b.isActive ? 1 : 0
-        return (aVal - bVal) * direction
-      }
-      if (sortConfig.key === 'last_login') {
-        const aVal = a.last_login ? new Date(a.last_login).getTime() : 0
-        const bVal = b.last_login ? new Date(b.last_login).getTime() : 0
-        return (aVal - bVal) * direction
-      }
-      if (sortConfig.key === 'role') {
-        const order = { admin: 3, editor: 2, viewer: 1 }
-        const aVal = order[a.role] || 0
-        const bVal = order[b.role] || 0
-        return (aVal - bVal) * direction
-      }
-      if (sortConfig.key === 'email') {
-        return (a.email || '').localeCompare(b.email || '') * direction
-      }
-
-      const aVal = resolveDisplayName(a).toLowerCase()
-      const bVal = resolveDisplayName(b).toLowerCase()
-      return aVal.localeCompare(bVal) * direction
-    })
-  }, [filteredUsers, sortConfig])
+  const sortedUsers = useMemo(() => sortUsers(filteredUsers, sortConfig), [filteredUsers, sortConfig])
 
   const handleSort = key => {
     setSortConfig(prev => ({

--- a/frontend/src/admin/utils/__tests__/userRoster.test.js
+++ b/frontend/src/admin/utils/__tests__/userRoster.test.js
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest'
+import { filterUsers, resolveUserDisplayName, sortUsers } from '../userRoster'
+
+const user = (id, over = {}) => ({
+  id,
+  email: `user${id}@example.test`,
+  role: 'viewer',
+  isActive: true,
+  ...over,
+})
+
+describe('resolveUserDisplayName', () => {
+  it('joins firstName and lastName when both are present', () => {
+    expect(resolveUserDisplayName(user(1, { firstName: 'Jamie', lastName: 'Fox' }))).toBe('Jamie Fox')
+  })
+
+  it('falls back to firstName alone when lastName is missing', () => {
+    expect(resolveUserDisplayName(user(1, { firstName: 'Jamie', lastName: '' }))).toBe('Jamie')
+  })
+
+  it('falls back to lastName alone when firstName is missing', () => {
+    expect(resolveUserDisplayName(user(1, { firstName: '', lastName: 'Fox' }))).toBe('Fox')
+  })
+
+  it('falls back to the legacy freeform name when neither structured field is set', () => {
+    expect(resolveUserDisplayName(user(1, { name: 'Legacy Name' }))).toBe('Legacy Name')
+  })
+
+  it('prefers firstName/lastName over the legacy name when both exist', () => {
+    // A user mid-migration to the structured fields carries both; the
+    // structured value is the newer one and must win.
+    expect(resolveUserDisplayName(user(1, { firstName: 'Jamie', lastName: 'Fox', name: 'Legacy Name' }))).toBe(
+      'Jamie Fox'
+    )
+  })
+
+  it('returns empty string when no name field is set at all', () => {
+    expect(resolveUserDisplayName(user(1, {}))).toBe('')
+  })
+
+  it('returns empty string for null/undefined rather than throwing', () => {
+    expect(resolveUserDisplayName(null)).toBe('')
+    expect(resolveUserDisplayName(undefined)).toBe('')
+  })
+})
+
+describe('filterUsers', () => {
+  const users = [
+    user(1, { firstName: 'Jamie', lastName: 'Fox', email: 'jamie@blue.test', role: 'admin', isActive: 1 }),
+    user(2, { name: 'Sam Nabi', email: 'sam@room47.test', role: 'editor', isActive: 0 }),
+    user(3, { firstName: 'Deer', lastName: 'Fang', email: 'deer@roost.test', role: 'viewer', isActive: true }),
+  ]
+
+  it('returns everything for an empty or whitespace-only search', () => {
+    expect(filterUsers(users, { searchTerm: '' })).toHaveLength(3)
+    expect(filterUsers(users, { searchTerm: '   ' })).toHaveLength(3)
+  })
+
+  it('matches search case-insensitively against the resolved display name', () => {
+    // "jamie" only matches via firstName/lastName resolution, not a raw `name`
+    // field — user 1 has no `name` at all.
+    expect(filterUsers(users, { searchTerm: 'JAMIE' }).map(u => u.id)).toEqual([1])
+  })
+
+  it('matches search against email', () => {
+    expect(filterUsers(users, { searchTerm: 'room47' }).map(u => u.id)).toEqual([2])
+  })
+
+  it('filters by role', () => {
+    expect(filterUsers(users, { roleFilter: 'editor' }).map(u => u.id)).toEqual([2])
+  })
+
+  it('coerces isActive with Boolean(), matching integer 1/0 as well as true/false', () => {
+    // The API returns isActive as an integer. A strict `user.isActive === true`
+    // comparison would silently drop user 1 (isActive: 1) from the active set.
+    expect(filterUsers(users, { statusFilter: 'active' }).map(u => u.id)).toEqual([1, 3])
+    expect(filterUsers(users, { statusFilter: 'inactive' }).map(u => u.id)).toEqual([2])
+  })
+
+  it('composes search, role, and status filters', () => {
+    const result = filterUsers(users, { searchTerm: 'e', roleFilter: 'viewer', statusFilter: 'active' })
+    expect(result.map(u => u.id)).toEqual([3])
+  })
+
+  it('does not mutate the input', () => {
+    const input = [...users]
+    filterUsers(input, { searchTerm: 'jamie' })
+    expect(input).toHaveLength(3)
+  })
+
+  it('does not throw on users with missing optional fields', () => {
+    expect(() =>
+      filterUsers([{ id: 9 }], { searchTerm: 'x', roleFilter: 'admin', statusFilter: 'active' })
+    ).not.toThrow()
+  })
+})
+
+describe('sortUsers', () => {
+  it('returns the list untouched when no sort key is set', () => {
+    const users = [user(2, { name: 'Zed' }), user(1, { name: 'Alpha' })]
+    expect(sortUsers(users, { key: null }).map(u => u.id)).toEqual([2, 1])
+  })
+
+  it('sorts by status, coercing isActive with Boolean() for integers and booleans alike', () => {
+    // Mixed representations by design: id order (1,2,3,4) must NOT equal the
+    // sorted order, so a test that forgot to coerce truthiness would still
+    // produce a plausible-looking but wrong order.
+    const users = [
+      user(1, { isActive: 1 }),
+      user(2, { isActive: false }),
+      user(3, { isActive: 0 }),
+      user(4, { isActive: true }),
+    ]
+    const result = sortUsers(users, { key: 'status', direction: 'asc' }, {}).map(u => u.id)
+    expect(result.slice(0, 2).sort()).toEqual([2, 3])
+    expect(result.slice(2).sort()).toEqual([1, 4])
+  })
+
+  it('sorts by last_login chronologically, treating a missing value as earliest', () => {
+    const users = [
+      user(1, { last_login: '2026-01-15T10:00:00Z' }),
+      user(2, { last_login: null }),
+      user(3, { last_login: '2020-06-01T00:00:00Z' }),
+    ]
+    // id order is 1,2,3 but chronological order is 2 (none => 0), 3 (2020), 1 (2026).
+    expect(sortUsers(users, { key: 'last_login', direction: 'asc' }).map(u => u.id)).toEqual([2, 3, 1])
+    expect(sortUsers(users, { key: 'last_login', direction: 'desc' }).map(u => u.id)).toEqual([1, 3, 2])
+  })
+
+  it('sorts by role RANK, not alphabetically', () => {
+    // Alphabetical would read admin, editor, viewer — identical to rank order,
+    // so use id order that disagrees with rank order to catch a swapped map,
+    // and include an unrecognised role that must sort below all three.
+    const users = [
+      user(1, { role: 'admin' }),
+      user(2, { role: 'viewer' }),
+      user(3, { role: 'editor' }),
+      user(4, { role: 'nobody' }),
+    ]
+    expect(sortUsers(users, { key: 'role', direction: 'asc' }).map(u => u.id)).toEqual([4, 2, 3, 1])
+  })
+
+  it('sorts by email', () => {
+    const users = [user(1, { email: 'zed@example.test' }), user(2, { email: 'alpha@example.test' })]
+    expect(sortUsers(users, { key: 'email', direction: 'asc' }).map(u => u.id)).toEqual([2, 1])
+  })
+
+  it('falls back to display-name order for an unrecognised key, using the RESOLVED name', () => {
+    // One user has only firstName/lastName, the other only the legacy `name` —
+    // proves the default branch goes through resolveUserDisplayName rather
+    // than reading `user.name` directly.
+    const users = [user(1, { firstName: 'Zebra' }), user(2, { name: 'Alpha' })]
+    expect(sortUsers(users, { key: 'name', direction: 'asc' }).map(u => u.id)).toEqual([2, 1])
+  })
+
+  it('reverses on desc', () => {
+    const users = [user(1, { firstName: 'Alpha' }), user(2, { firstName: 'Zebra' })]
+    expect(sortUsers(users, { key: 'name', direction: 'desc' }).map(u => u.id)).toEqual([2, 1])
+  })
+
+  it('does not mutate the input array', () => {
+    const users = [user(2, { firstName: 'Zebra' }), user(1, { firstName: 'Alpha' })]
+    sortUsers(users, { key: 'name', direction: 'asc' })
+    expect(users.map(u => u.id)).toEqual([2, 1])
+  })
+
+  it('does not throw on users with missing optional fields', () => {
+    const users = [{ id: 1 }, { id: 2 }]
+    expect(() => sortUsers(users, { key: 'last_login', direction: 'asc' })).not.toThrow()
+    expect(() => sortUsers(users, { key: 'role', direction: 'asc' })).not.toThrow()
+    expect(() => sortUsers(users, { key: 'email', direction: 'asc' })).not.toThrow()
+    expect(() => sortUsers(users, { key: 'name', direction: 'asc' })).not.toThrow()
+  })
+})

--- a/frontend/src/admin/utils/__tests__/userRoster.test.js
+++ b/frontend/src/admin/utils/__tests__/userRoster.test.js
@@ -84,8 +84,10 @@ describe('filterUsers', () => {
 
   it('does not mutate the input', () => {
     const input = [...users]
+    // Length alone misses reordering and in-place object mutation.
+    const snapshot = input.map(item => ({ ...item }))
     filterUsers(input, { searchTerm: 'jamie' })
-    expect(input).toHaveLength(3)
+    expect(input).toEqual(snapshot)
   })
 
   it('does not throw on users with missing optional fields', () => {
@@ -160,8 +162,11 @@ describe('sortUsers', () => {
 
   it('does not mutate the input array', () => {
     const users = [user(2, { firstName: 'Zebra' }), user(1, { firstName: 'Alpha' })]
+    // Full contents, not just id order: an id check misses a sort that reorders
+    // correctly while mutating an element in place.
+    const snapshot = users.map(item => ({ ...item }))
     sortUsers(users, { key: 'name', direction: 'asc' })
-    expect(users.map(u => u.id)).toEqual([2, 1])
+    expect(users).toEqual(snapshot)
   })
 
   it('does not throw on users with missing optional fields', () => {

--- a/frontend/src/admin/utils/userRoster.js
+++ b/frontend/src/admin/utils/userRoster.js
@@ -1,0 +1,109 @@
+/**
+ * Pure roster logic for UserManagement — display name resolution, search /
+ * role / status filtering, and sort ordering for the admin user list.
+ *
+ * Extracted so it can be tested without mounting a 576-line component (#905),
+ * which currently loads in zero tests. Mounting it to reach this logic would
+ * pull its whole uncovered surface into the coverage denominator while only
+ * exercising this slice.
+ *
+ * Every function here takes its collaborators as arguments instead of closing
+ * over component state, so a test supplies them without a render.
+ */
+
+/**
+ * Resolve a user's display name.
+ *
+ * `firstName`/`lastName` win whenever either is present, even the legacy
+ * freeform `name` is also set — a user mid-migration to the structured fields
+ * still shows the newer value. Falls through to `''` rather than throwing
+ * when a caller passes null/undefined.
+ *
+ * @param {object|null|undefined} user
+ * @returns {string}
+ */
+export function resolveUserDisplayName(user) {
+  if (user?.firstName || user?.lastName) {
+    return [user.firstName, user.lastName].filter(Boolean).join(' ')
+  }
+  return user?.name || ''
+}
+
+/**
+ * Narrow the roster by a single search box (name + email), a role filter, and
+ * an active/inactive status filter.
+ *
+ * The search matches against the RESOLVED display name, not the raw `name`
+ * field, so a user with only `firstName`/`lastName` set is still searchable.
+ * `statusFilter` coerces `isActive` with `Boolean(...)` before comparing —
+ * the API returns it as an integer (`1`/`0`), not a boolean, so a strict
+ * `=== true` compare would silently match nothing.
+ *
+ * @param {Array<object>} users
+ * @param {object} [options]
+ * @param {string} [options.searchTerm]
+ * @param {string} [options.roleFilter] - 'all' for no filter
+ * @param {string} [options.statusFilter] - 'all' | 'active' | 'inactive'
+ * @returns {Array<object>}
+ */
+export function filterUsers(users, { searchTerm, roleFilter, statusFilter } = {}) {
+  let list = users ?? []
+  if (searchTerm?.trim()) {
+    const query = searchTerm.trim().toLowerCase()
+    list = list.filter(user => {
+      const name = resolveUserDisplayName(user).toLowerCase()
+      const email = (user.email || '').toLowerCase()
+      return name.includes(query) || email.includes(query)
+    })
+  }
+  if (roleFilter !== undefined && roleFilter !== 'all') {
+    list = list.filter(user => user.role === roleFilter)
+  }
+  if (statusFilter !== undefined && statusFilter !== 'all') {
+    const shouldBeActive = statusFilter === 'active'
+    list = list.filter(user => Boolean(user.isActive) === shouldBeActive)
+  }
+  return list
+}
+
+/**
+ * Order the roster. With no sort key set, the list is returned as-is — the
+ * caller (search/filter) has already decided the order in that case.
+ *
+ * @param {Array<object>} users
+ * @param {{key: string|null, direction: 'asc'|'desc'}} sortConfig
+ * @returns {Array<object>} a new array; the input is not mutated
+ */
+export function sortUsers(users, sortConfig) {
+  const list = users ?? []
+  if (!sortConfig?.key) return list
+  const direction = sortConfig.direction === 'asc' ? 1 : -1
+
+  return [...list].sort((a, b) => {
+    if (sortConfig.key === 'status') {
+      const aVal = a.isActive ? 1 : 0
+      const bVal = b.isActive ? 1 : 0
+      return (aVal - bVal) * direction
+    }
+    if (sortConfig.key === 'last_login') {
+      const aVal = a.last_login ? new Date(a.last_login).getTime() : 0
+      const bVal = b.last_login ? new Date(b.last_login).getTime() : 0
+      return (aVal - bVal) * direction
+    }
+    if (sortConfig.key === 'role') {
+      // Rank order, not alphabetical — admin outranks editor outranks viewer.
+      // An unrecognised role sorts below all three rather than throwing.
+      const order = { admin: 3, editor: 2, viewer: 1 }
+      const aVal = order[a.role] || 0
+      const bVal = order[b.role] || 0
+      return (aVal - bVal) * direction
+    }
+    if (sortConfig.key === 'email') {
+      return (a.email || '').localeCompare(b.email || '') * direction
+    }
+
+    const aVal = resolveUserDisplayName(a).toLowerCase()
+    const bVal = resolveUserDisplayName(b).toLowerCase()
+    return aVal.localeCompare(bVal) * direction
+  })
+}


### PR DESCRIPTION
## Summary

Third and final extractable surface for #905, after LineupTab (#920) and VenuesTab (#922).

Refs #905

## What changed

| File | Change |
|------|--------|
| `frontend/src/admin/utils/userRoster.js` | **New.** Display name, filter, sort |
| `frontend/src/admin/utils/__tests__/userRoster.test.js` | **New.** 24 tests |
| `frontend/src/admin/UserManagement.jsx` | −47 lines; inline copies deleted |

## The three tests worth having

Each mutation-verified:

- **Role sorts by RANK** (admin > editor > viewer), not alphabetically. Alphabetical puts admin first *by accident* and looks correct until someone checks editor against viewer.
- **The status filter coerces with `Boolean()`**, matching integer `1`/`0` as well as `true`/`false`. The API returns integers; a strict `===` against a boolean silently matches nothing.
- **`firstName`/`lastName` wins over the legacy `name`** when a row carries both — which is exactly what a half-migrated user looks like.

## Delegation note

Implemented by a delegated Sonnet run. Per the repo's standing rule the delegate does not commit — I reviewed and re-verified before this landed:

- **Read the full diff.** A faithful lift; no behaviour change.
- **Checked the one claim that could have hidden a bug.** The report described `filterUsers` as using `!== undefined` guards where the component used `!== 'all'`. If it had *replaced* the check, `roleFilter === 'all'` would have filtered for users whose role is literally `"all"` — zero results. It kept **both** conditions, so the component's default still bypasses filtering correctly.
- **Re-ran a mutation independently** (role rank → alphabetical): fails exactly one test.
- **Re-ran `make gate`** myself: exit 0.

## Verification

- [x] Tests: 1,201 backend + **1,118** frontend, 0 failures
- [x] ESLint: 0 errors, 0 warnings
- [x] Format check: clean, both stacks
- [x] Build: green
- [x] `validate:openapi`: n/a
- [x] `make gate`: exit 0 (run by me, not only the delegate)
- [x] `make review` (CodeRabbit): **no findings**
- [x] Manual smoke: not browser-verified — mechanical extraction, inline originals deleted rather than duplicated, `resolveDisplayName` kept as a local alias so JSX call sites are untouched

## Scope note

This closes the *extractable* part of #905. **BandForm and EventFormModal are not extractable** — BandForm is 684 lines with 268 of JSX and three one-line helpers; extracting those would produce a module that exists only so a test can point at it. Filed as **#923** for real component tests. Both stay on #921's `ALLOWED` list until then, which is the correct signal.

---
Built by Sonny · Reviewed by Theo + CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved user roster management with filtering by search, role, and active status.
  * Added sorting by status, last login, role, email, and display name.
  * Improved display-name handling for structured, legacy, and incomplete user records.

* **Bug Fixes**
  * Improved handling of missing fields, status values, unknown roles, and unsorted results.
  * Improved consistency when applying combined filters and sorting user records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->