### PR TITLE
fix(validation): strip tracking params, implementing the clean-links doctrine

### DIFF
--- a/functions/utils/__tests__/cleanLinks.test.js
+++ b/functions/utils/__tests__/cleanLinks.test.js
@@ -37,13 +37,22 @@ describe("clean-links doctrine is implemented, not just documented", () => {
     const documented = [...line.matchAll(/`([a-z_*]+)=?`/g)].map((m) => m[1]);
     expect(documented.length).toBeGreaterThanOrEqual(5);
 
-    for (const name of documented) {
-      if (name.endsWith("*")) {
-        expect(TRACKING_PARAM_PREFIXES, `AGENTS.md names ${name}`).toContain(name.slice(0, -1));
-      } else {
-        expect(TRACKING_PARAMS.has(name), `AGENTS.md names \`${name}\` but it is not stripped`).toBe(true);
-      }
-    }
+    // Compared BOTH ways. Asserting only that every documented param is
+    // stripped leaves the other direction open: an undocumented addition to
+    // TRACKING_PARAMS would pass while silently removing legitimate URL state.
+    // The doctrine is the spec, so the implementation must match it exactly —
+    // adding a param means editing AGENTS.md first.
+    const documentedPrefixes = documented.filter((n) => n.endsWith("*")).map((n) => n.slice(0, -1));
+    const documentedExact = documented.filter((n) => !n.endsWith("*"));
+
+    expect(
+      [...TRACKING_PARAMS].sort(),
+      "TRACKING_PARAMS and AGENTS.md's list have diverged — update the doctrine or the code, not just one",
+    ).toEqual(documentedExact.sort());
+
+    expect([...TRACKING_PARAM_PREFIXES].sort(), "prefix list has diverged from AGENTS.md").toEqual(
+      documentedPrefixes.sort(),
+    );
   });
 
   it.each([

--- a/functions/utils/__tests__/cleanLinks.test.js
+++ b/functions/utils/__tests__/cleanLinks.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { normalizeHttpUrl, sanitizeBandSocialLinks } from "../validation.js";
+// Imported from the module, not the facade: these describe HOW the doctrine is
+// implemented and are not part of the public surface 43 files consume. Adding
+// them to the facade would widen that surface — and correctly fail the guard in
+// validationPublicSurface.test.js.
+import { TRACKING_PARAMS, TRACKING_PARAM_PREFIXES } from "../validation/urls.js";
+
+/**
+ * AGENTS.md, under "Data doctrines (owner-set, non-negotiable)":
+ *
+ *   Clean links: strip tracking params (si, dlsi, nd, utm_*, from=) before
+ *   storing any URL.
+ *
+ * The doctrine was written down and not implemented — `?si=` survived on every
+ * stored URL, which is what Spotify's and YouTube's own share buttons append,
+ * so it failed on the DEFAULT paste rather than an edge case (#928).
+ *
+ * The first test reads the param list out of AGENTS.md itself. A test that
+ * hardcoded the same five names would pass while silently diverging from the
+ * doctrine it claims to enforce — the doctrine is the spec, so it is the
+ * fixture.
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+describe("clean-links doctrine is implemented, not just documented", () => {
+  it("strips exactly the params AGENTS.md names", () => {
+    const agents = readFileSync(join(REPO_ROOT, "AGENTS.md"), "utf-8");
+    const line = agents.split("\n").find((l) => l.includes("strip tracking params"));
+    expect(line, "AGENTS.md no longer states the clean-links doctrine — did it move?").toBeDefined();
+
+    // Backticked names on that line, minus the trailing `=` in `from=`.
+    const documented = [...line.matchAll(/`([a-z_*]+)=?`/g)].map((m) => m[1]);
+    expect(documented.length).toBeGreaterThanOrEqual(5);
+
+    for (const name of documented) {
+      if (name.endsWith("*")) {
+        expect(TRACKING_PARAM_PREFIXES, `AGENTS.md names ${name}`).toContain(name.slice(0, -1));
+      } else {
+        expect(TRACKING_PARAMS.has(name), `AGENTS.md names \`${name}\` but it is not stripped`).toBe(true);
+      }
+    }
+  });
+
+  it.each([
+    ["Spotify share link", "https://open.spotify.com/artist/abc?si=TRACK", "https://open.spotify.com/artist/abc"],
+    ["YouTube share link", "https://youtu.be/xyz?si=TRACK", "https://youtu.be/xyz"],
+    ["Bandcamp embed referrer", "https://band.bandcamp.com/?from=embed", "https://band.bandcamp.com/"],
+    ["utm_ campaign params", "https://example.com/a?utm_source=n&utm_medium=e", "https://example.com/a"],
+    ["dlsi", "https://example.com/a?dlsi=x", "https://example.com/a"],
+    ["nd", "https://example.com/a?nd=1", "https://example.com/a"],
+  ])("strips %s", (_label, input, expected) => {
+    expect(normalizeHttpUrl(input)).toBe(expected);
+  });
+
+  it("PRESERVES params that are not tracking", () => {
+    // The failure mode on the other side: over-stripping breaks a YouTube
+    // timestamp or a playlist id the artist deliberately shared.
+    expect(normalizeHttpUrl("https://youtu.be/xyz?t=120")).toBe("https://youtu.be/xyz?t=120");
+    expect(normalizeHttpUrl("https://example.com/a?list=PL1&v=2")).toBe("https://example.com/a?list=PL1&v=2");
+  });
+
+  it("keeps the path and hash intact while stripping the query", () => {
+    expect(normalizeHttpUrl("https://example.com/deep/path?si=x#section")).toBe(
+      "https://example.com/deep/path#section",
+    );
+  });
+
+  it("strips a tracking param mixed in with legitimate ones", () => {
+    expect(normalizeHttpUrl("https://youtu.be/xyz?si=TRACK&t=120")).toBe("https://youtu.be/xyz?t=120");
+  });
+
+  it("matches param names case-insensitively", () => {
+    expect(normalizeHttpUrl("https://example.com/a?SI=x&UTM_Source=y")).toBe("https://example.com/a");
+  });
+
+  it("applies to stored social links, which is the path that reaches D1", () => {
+    // normalizeHttpUrl being correct is not enough — the doctrine is about what
+    // gets STORED, so assert through the sanitizer the write path actually uses.
+    const stored = JSON.parse(
+      sanitizeBandSocialLinks(JSON.stringify({ spotify: "https://open.spotify.com/artist/abc?si=TRACK" })),
+    );
+    expect(stored.spotify).toBe("https://open.spotify.com/artist/abc");
+  });
+});

--- a/functions/utils/validation/schema.js
+++ b/functions/utils/validation/schema.js
@@ -6,7 +6,7 @@
 import { FIELD_LIMITS } from "./fieldLimits.js";
 import { sanitizeString } from "./strings.js";
 import { isValidEmail, validatePassword, VALID_ROLES } from "./identity.js";
-import { isValidURL } from "./urls.js";
+import { isValidURL, normalizeHttpUrl } from "./urls.js";
 import { isValidTime, validateDate } from "./datetime.js";
 import { validateId } from "./ids.js";
 import { POSTAL_CODE_REGEX, PHONE_REGEX } from "./contact.js";
@@ -105,7 +105,11 @@ export function validateEntity(data, schema) {
         errors[field] = `${rules.label || field} must be no more than ${rules.max} characters`;
         continue;
       }
-      sanitized[field] = trimmedUrl || null;
+      // Through the normaliser, not stored raw: this path previously kept
+      // tracking params that sanitizeBandSocialLinks strips, so the clean-links
+      // doctrine held for band links and failed silently for every generic URL
+      // field (ticket links, venue maps, event sites).
+      sanitized[field] = trimmedUrl ? normalizeHttpUrl(trimmedUrl) : null;
     } else if (rules.type === "time") {
       const timeResult = isValidTime(value);
       if (!timeResult.valid) {

--- a/functions/utils/validation/urls.js
+++ b/functions/utils/validation/urls.js
@@ -65,6 +65,42 @@ function sanitizeOptionalHandleOrUrl(value, maxLength, label) {
   return sanitizeOptionalHandle(text, maxLength, label);
 }
 
+/**
+ * Query params stripped from every stored URL.
+ *
+ * From AGENTS.md's clean-links doctrine, which names this exact list:
+ * `si`, `dlsi`, `nd`, `utm_*`, `from`. Exported so the guard test can assert
+ * the implementation against the doctrine rather than against a copy of it.
+ *
+ * `si` is what Spotify's and YouTube's own share buttons append, so this fires
+ * on the DEFAULT paste, not an edge case.
+ *
+ * Anything not listed is preserved deliberately — `?t=120` on a YouTube link is
+ * a timestamp the artist chose, not tracking.
+ */
+export const TRACKING_PARAMS = new Set(["si", "dlsi", "nd", "from"]);
+
+/** `utm_source`, `utm_medium`, and friends — matched by prefix, not enumerated. */
+export const TRACKING_PARAM_PREFIXES = ["utm_"];
+
+function isTrackingParam(name) {
+  const key = name.toLowerCase();
+  return TRACKING_PARAMS.has(key) || TRACKING_PARAM_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+/**
+ * Remove tracking params in place. Mutating the URL's own searchParams keeps
+ * every other part of the URL — path, hash, remaining query order — untouched.
+ */
+function stripTrackingParams(parsed) {
+  for (const name of [...parsed.searchParams.keys()]) {
+    if (isTrackingParam(name)) {
+      parsed.searchParams.delete(name);
+    }
+  }
+  return parsed;
+}
+
 export function normalizeHttpUrl(url) {
   if (!url || typeof url !== "string") {
     return null;
@@ -80,7 +116,7 @@ export function normalizeHttpUrl(url) {
     if (!ALLOWED_EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
       return null;
     }
-    return parsed.toString();
+    return stripTrackingParams(parsed).toString();
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

`AGENTS.md` lists this under **Data doctrines (owner-set, non-negotiable)**:

> **Clean links**: strip tracking params (`si`, `dlsi`, `nd`, `utm_*`, `from=`) before storing any URL.

It was written down and never implemented.

Closes #928

```
before:  https://open.spotify.com/artist/abc?si=TRACKER123
      →  https://open.spotify.com/artist/abc?si=TRACKER123

after:   →  https://open.spotify.com/artist/abc
```

`si` is what Spotify's and YouTube's **own share buttons** append — so the doctrine failed on the *default* paste, not an edge case.

## Both storage paths

`normalizeHttpUrl` now strips the listed params, covering everything through `sanitizeBandSocialLinks` / `sanitizeEventSocialLinks` / `sanitizeVenueInfo`.

**`schema.js`'s generic URL field was the second path**, and the reason a partial fix would have looked complete: it called `isValidURL()` then stored `trimmedUrl` **raw**, bypassing the normaliser. The doctrine would have held for band links and failed silently for ticket links, venue maps and event sites. Now routed through `normalizeHttpUrl`.

## Over-stripping is the other failure mode

Only the named params go:

| Input | Output |
|---|---|
| `youtu.be/xyz?si=TRACK&t=120` | `youtu.be/xyz?t=120` |
| `example.com/a?list=PL1&v=2` | unchanged |
| `example.com/deep/path?si=x#section` | `example.com/deep/path#section` |

`?t=120` is a timestamp the artist chose; losing it breaks the link as surely as keeping a tracker does. Matching is case-insensitive; `utm_` is matched by prefix, not enumerated.

## The doctrine is the fixture

The guard test **parses the param list out of `AGENTS.md`** and compares it to the implementation **in both directions**.

A test hardcoding the same five names would pass while diverging from the doctrine it claims to enforce. And checking only one direction leaves the other open — an undocumented addition to `TRACKING_PARAMS` would silently strip legitimate URL state. Adding a param now means editing `AGENTS.md` first.

`TRACKING_PARAMS` is exported from `urls.js` but deliberately **not** added to the facade — it describes *how* the doctrine is implemented, isn't part of the public surface 43 files consume, and widening that surface would correctly fail `validationPublicSurface.test.js`.

## Production impact — small, but not zero

Queried before writing the fix: **177 band profiles have `social_links`; 2 carry `?si=`.** Zero carry `utm_`, `from`, `dlsi` or `nd`.

Those 2 rows keep their tracker until re-saved. That's a one-line backfill — flagged for you rather than run from a PR, since it's a production write.

## Verification

- [x] Tests: **1,255** backend + 1,189 frontend, 0 failures
- [x] ESLint: 0 errors, 0 warnings · Format: clean · Build: green
- [x] `make gate`: exit 0
- [x] `make review` (CodeRabbit): its finding (one-directional check) is fixed here
- [x] Manual smoke: n/a — pure string transformation, asserted directly

**Mutation-verified in four directions:**

| Mutation | Result |
|---|---|
| Remove the strip call | 10 tests fail |
| Strip everything | both preservation tests fail |
| Drop `nd` from the list | doctrine test + `nd` case fail |
| Add undocumented `ref` | doctrine test fails |

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleaned tracking parameters from supported Spotify, YouTube, Bandcamp, campaign, and social links.
  * Preserved legitimate URL parameters, paths, and fragments during sanitization.
  * Applied URL normalization consistently before storing generic URL fields.
  * Added case-insensitive handling for tracking parameters and mixed tracking/legitimate query strings.

* **Tests**
  * Added coverage validating tracking-parameter removal and preservation of valid URL content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->