### PR TITLE
fix(validation): reject calendar dates that do not exist

### DIFF
--- a/functions/utils/__tests__/calendarDates.test.js
+++ b/functions/utils/__tests__/calendarDates.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { isValidISODate, validateDate } from "../validation.js";
+
+/**
+ * `new Date('2025-02-29')` does not fail — it rolls over to March 1 and reports
+ * itself valid. So a format check plus a parse check accepted dates that do not
+ * exist (#929): the value was stored as typed while meaning a different day, and
+ * could never match a real event date under this repo's lexicographic
+ * YYYY-MM-DD comparisons.
+ *
+ * The two validators disagreed about it, which is the more interesting half:
+ * validateDate rejected 2025-02-29 correctly while isValidISODate accepted it.
+ * They now share isRealCalendarDate, so they cannot drift apart again.
+ */
+
+describe("impossible calendar dates are rejected", () => {
+  it.each([
+    ["Feb 29 in a non-leap year", "2025-02-29"],
+    ["Feb 30 in a leap year", "2024-02-30"],
+    ["April 31", "2025-04-31"],
+    ["June 31", "2025-06-31"],
+    ["September 31", "2025-09-31"],
+    ["November 31", "2025-11-31"],
+    ["day zero", "2025-06-00"],
+    ["month zero", "2025-00-15"],
+    ["month 13", "2025-13-01"],
+  ])("rejects %s", (_label, date) => {
+    expect(isValidISODate(date)).toBe(false);
+    expect(validateDate(date).valid).toBe(false);
+  });
+
+  it.each([
+    ["Feb 29 in a leap year", "2024-02-29"],
+    ["Feb 29 in a 400-year leap year", "2000-02-29"],
+    ["Feb 28 in a non-leap year", "2025-02-28"],
+    ["a 31-day month", "2025-07-31"],
+    ["a 30-day month", "2025-04-30"],
+    ["the target event date", "2026-10-11"],
+  ])("accepts %s", (_label, date) => {
+    expect(isValidISODate(date)).toBe(true);
+  });
+
+  it("rejects a century year that is NOT a leap year", () => {
+    // 1900 is divisible by 4 but not a leap year — the case a hand-written
+    // `year % 4 === 0` rule gets wrong.
+    expect(isValidISODate("1900-02-29")).toBe(false);
+  });
+
+  it("keeps validateDate's year range as its own concern", () => {
+    // isValidISODate answers "does this date exist?"; validateDate adds the
+    // business rule that events fall between 2020 and 2100. Collapsing the two
+    // would silently apply that range everywhere.
+    expect(isValidISODate("2019-06-15")).toBe(true);
+    expect(validateDate("2019-06-15").valid).toBe(false);
+  });
+
+  it("applies calendar validity to the DATETIME form too", () => {
+    // ISO_DATE_REGEX accepts a full timestamp, so the calendar check must read
+    // only the leading YYYY-MM-DD — splitting the whole string on "-" yields
+    // NaN for the day and would reject every timestamp.
+    expect(isValidISODate("2025-11-18T14:00:00Z")).toBe(true);
+    expect(isValidISODate("2025-11-18T14:00:00.123Z")).toBe(true);
+    expect(isValidISODate("2025-11-18T14:00:00+00:00")).toBe(true);
+    expect(isValidISODate("2024-02-29T00:00:00Z")).toBe(true);
+    expect(isValidISODate("2025-02-29T14:00:00Z")).toBe(false);
+  });
+
+  it("still rejects malformed input rather than throwing", () => {
+    for (const bad of ["", null, undefined, "not-a-date", "2025-6-15", "20250615", 20250615]) {
+      expect(isValidISODate(bad)).toBe(false);
+    }
+  });
+});

--- a/functions/utils/__tests__/calendarDates.test.js
+++ b/functions/utils/__tests__/calendarDates.test.js
@@ -74,6 +74,20 @@ describe("impossible calendar dates are rejected", () => {
     expect(isValidISODate("2025-02-29T14:00:00Z")).toBe(false);
   });
 
+  it.each([
+    ["hour 99", "2025-11-18T99:99:99Z"],
+    ["minute 60", "2025-11-18T14:60:00Z"],
+    ["hour 25", "2025-11-18T25:00:00Z"],
+    ["offset +99:99", "2025-11-18T14:00:00+99:99"],
+  ])("rejects an impossible TIME: %s", (_label, value) => {
+    // Regression guard. ISO_DATE_REGEX matches the \d{2}:\d{2} shape, so these
+    // satisfy the pattern and only the parse refuses them. An earlier version of
+    // the calendar fix REPLACED the parse rather than adding to it, which fixed
+    // impossible dates and let impossible times through — one bug traded for
+    // another. Both checks are load-bearing and neither subsumes the other.
+    expect(isValidISODate(value)).toBe(false);
+  });
+
   it("still rejects malformed input rather than throwing", () => {
     for (const bad of ["", null, undefined, "not-a-date", "2025-6-15", "20250615", 20250615]) {
       expect(isValidISODate(bad)).toBe(false);

--- a/functions/utils/__tests__/calendarDates.test.js
+++ b/functions/utils/__tests__/calendarDates.test.js
@@ -40,6 +40,15 @@ describe("impossible calendar dates are rejected", () => {
     expect(isValidISODate(date)).toBe(true);
   });
 
+  it("handles ISO years 0000-0099 without Date remapping them to 1900-1999", () => {
+    // `new Date(year, month, 0)` maps year 0 to 1900, which is NOT a leap year
+    // while year 0 IS (divisible by 400) — so 0000-02-29 was wrongly rejected.
+    // setFullYear sets the literal year instead.
+    expect(isValidISODate("0000-02-29")).toBe(true);
+    expect(isValidISODate("0099-02-29")).toBe(false);
+    expect(isValidISODate("0004-02-29")).toBe(true);
+  });
+
   it("rejects a century year that is NOT a leap year", () => {
     // 1900 is divisible by 4 but not a leap year — the case a hand-written
     // `year % 4 === 0` rule gets wrong.

--- a/functions/utils/validation/datetime.js
+++ b/functions/utils/validation/datetime.js
@@ -47,8 +47,12 @@ export function isRealCalendarDate(year, month, day) {
   if (month < 1 || month > 12) {
     return false;
   }
-  const daysInMonth = new Date(year, month, 0).getDate();
-  return day >= 1 && day <= daysInMonth;
+  // setFullYear rather than the Date constructor: `new Date(year, ...)` remaps
+  // years 0-99 to 1900-1999, so year 0 was evaluated as 1900 — which is not a
+  // leap year, while year 0 is (divisible by 400). That rejected 0000-02-29.
+  const probe = new Date(0);
+  probe.setFullYear(year, month, 0);
+  return day >= 1 && day <= probe.getDate();
 }
 
 export function isValidISODate(dateString) {
@@ -175,10 +179,11 @@ export function validateDate(dateString) {
   // disagree about which dates exist; the specific day count is recomputed here
   // only to name it in the error message.
   if (!isRealCalendarDate(year, month, day)) {
-    const daysInMonth = new Date(year, month, 0).getDate();
+    const probe = new Date(0);
+    probe.setFullYear(year, month, 0);
     return {
       valid: false,
-      error: `Day must be between 01 and ${daysInMonth} for this month`,
+      error: `Day must be between 01 and ${probe.getDate()} for this month`,
       date: null,
     };
   }

--- a/functions/utils/validation/datetime.js
+++ b/functions/utils/validation/datetime.js
@@ -65,13 +65,23 @@ export function isValidISODate(dateString) {
     return false;
   }
 
-  // Format alone is not enough: new Date('2025-02-29') rolls over to March 1
-  // rather than failing, so a parse check accepts dates that do not exist.
+  // BOTH checks are required, and they catch different things.
   //
-  // Only the leading YYYY-MM-DD is examined. ISO_DATE_REGEX also accepts a full
-  // datetime, and splitting the whole string on "-" yields NaN for the day of
-  // "2025-11-18T14:00:00Z" — which would reject every timestamp this function
-  // has always accepted.
+  // The parse rejects an impossible TIME: ISO_DATE_REGEX matches \d{2}:\d{2}
+  // shapes, so "2025-11-18T99:99:99Z" and "T14:60:00" satisfy the pattern and
+  // only Date.parse refuses them.
+  //
+  // The calendar check rejects an impossible DATE, which the parse does not:
+  // new Date('2025-02-29') rolls over to March 1 and reports itself valid.
+  //
+  // Replacing one with the other trades one bug for the other — an earlier
+  // version of this fix dropped the parse and let T99:99:99 through.
+  if (isNaN(new Date(dateString).getTime())) {
+    return false;
+  }
+
+  // Only the leading YYYY-MM-DD is examined: splitting the whole string on "-"
+  // yields NaN for the day of a full datetime.
   const [year, month, day] = dateString.slice(0, 10).split("-").map(Number);
   return isRealCalendarDate(year, month, day);
 }

--- a/functions/utils/validation/datetime.js
+++ b/functions/utils/validation/datetime.js
@@ -21,6 +21,36 @@ const DOORS_TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
  * @param {string} dateString - Date string to validate
  * @returns {boolean} True if valid ISO date format
  */
+/**
+ * True when a YYYY-MM-DD string names a date that actually exists.
+ *
+ * The trap this exists for: `new Date('2025-02-29')` does not fail, it rolls
+ * over to March 1 and reports itself valid. So a format check plus a parse
+ * check accepts 2025-02-29 and 2025-04-31 — the value is then stored as typed
+ * while meaning a different day, and never matches a real event date under this
+ * repo's lexicographic YYYY-MM-DD comparisons.
+ *
+ * `new Date(year, month, 0).getDate()` gives the last day of `month` (month is
+ * 1-based here because day 0 rolls back from the following month), which is
+ * leap-year correct without a hand-written February rule.
+ *
+ * Shared so `isValidISODate` and `validateDate` cannot disagree about which
+ * dates exist — they did: validateDate rejected 2025-02-29 while isValidISODate
+ * accepted it.
+ *
+ * @param {number} year
+ * @param {number} month - 1-12
+ * @param {number} day
+ * @returns {boolean}
+ */
+export function isRealCalendarDate(year, month, day) {
+  if (month < 1 || month > 12) {
+    return false;
+  }
+  const daysInMonth = new Date(year, month, 0).getDate();
+  return day >= 1 && day <= daysInMonth;
+}
+
 export function isValidISODate(dateString) {
   if (!dateString || typeof dateString !== "string") {
     return false;
@@ -31,9 +61,15 @@ export function isValidISODate(dateString) {
     return false;
   }
 
-  // Then verify it's a valid date that can be parsed
-  const date = new Date(dateString);
-  return !isNaN(date.getTime());
+  // Format alone is not enough: new Date('2025-02-29') rolls over to March 1
+  // rather than failing, so a parse check accepts dates that do not exist.
+  //
+  // Only the leading YYYY-MM-DD is examined. ISO_DATE_REGEX also accepts a full
+  // datetime, and splitting the whole string on "-" yields NaN for the day of
+  // "2025-11-18T14:00:00Z" — which would reject every timestamp this function
+  // has always accepted.
+  const [year, month, day] = dateString.slice(0, 10).split("-").map(Number);
+  return isRealCalendarDate(year, month, day);
 }
 
 /**
@@ -135,9 +171,11 @@ export function validateDate(dateString) {
     return { valid: false, error: "Month must be between 01 and 12", date: null };
   }
 
-  // Check day (accounting for month lengths and leap years)
-  const daysInMonth = new Date(year, month, 0).getDate();
-  if (day < 1 || day > daysInMonth) {
+  // Check day. Shares isRealCalendarDate with isValidISODate so the two cannot
+  // disagree about which dates exist; the specific day count is recomputed here
+  // only to name it in the error message.
+  if (!isRealCalendarDate(year, month, day)) {
+    const daysInMonth = new Date(year, month, 0).getDate();
     return {
       valid: false,
       error: `Day must be between 01 and ${daysInMonth} for this month`,


### PR DESCRIPTION
## Summary

`new Date('2025-02-29')` doesn't fail — it rolls over to March 1 and reports itself valid. So a format check plus a parse check accepted dates that don't exist.

Closes #929

```
before:  isValidISODate('2025-02-29') -> true    2025 is not a leap year
         isValidISODate('2025-04-31') -> true    April has 30 days
```

The value was stored as typed while meaning a different day, and could never match a real event date under this repo's lexicographic `YYYY-MM-DD` comparisons. Silent: nothing rejected it, nothing downstream looked wrong enough to investigate.

## The sweep found the more interesting half

**`validateDate` — the validator actually used on the write paths — already rejected these correctly.** So the two validators disagreed about which dates exist, and **the broken one has zero callers**: nothing outside the facade imports `isValidISODate` at all.

Rather than fix one and leave the duplicate, the day-count check is extracted as `isRealCalendarDate` and both use it. They can't drift again.

`validateDate` keeps its own 2020–2100 range — that's a business rule about when events happen, not a fact about which dates exist. Collapsing them would silently apply that range everywhere.

## Two bugs I introduced, both caught

Worth recording, because neither was in the original issue:

1. **`split("-")` broke the datetime form.** `ISO_DATE_REGEX` also accepts `2025-11-18T14:00:00Z`, where splitting the whole string yields `NaN` for the day — that would have rejected every timestamp the function has always accepted. **An existing test caught it.** Now only the leading `YYYY-MM-DD` is read.

2. **`new Date(year, month, 0)` remaps years 0–99 to 1900–1999.** Caught on review. Year 0 became 1900 — not a leap year, while year 0 *is* (divisible by 400) — so `0000-02-29` was wrongly rejected. Now `setFullYear`.

## Verification

- [x] Tests: **1,263** backend + 1,189 frontend, 0 failures
- [x] ESLint: 0 errors, 0 warnings · Format: clean · Build: green
- [x] `make gate`: exit 0
- [x] `make review` (CodeRabbit): its finding is fix #2 above
- [x] Manual smoke: n/a — pure predicate, asserted directly

**Mutation-verified three ways:**

| Mutation | Result |
|---|---|
| Revert to the parse check | 7 tests fail |
| Naive `year % 4` leap rule | `1900-02-29` case fails |
| Revert to the `Date` constructor | `0000-02-29` case fails |

That second one is why the day count is *computed* rather than tabulated — 1900 is divisible by 4 and is not a leap year.

## Note for follow-up

`isValidISODate` has **no callers**. Deleting it is arguably better than fixing it — an unused validator that's subtly wrong is a trap for whoever picks it by name over `validateDate`. Not done here because it's on the facade and removal is a deliberate surface change; happy to file it.

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date validation to reject impossible calendar dates, including invalid leap-year and month-end dates.
  - Correctly handles years from 0000–0099 and preserves existing date-range validation.
  - Improved validation for ISO datetime values and malformed date inputs without unexpected errors.

- **Tests**
  - Added comprehensive coverage for calendar-date validation, leap years, century rules, and datetime formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->