### PR TITLE
refactor(admin): delete the fabricated performance object on the profile path

### DIFF
--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -188,13 +188,15 @@ export async function onRequestPut(context) {
           { status: 404, headers: { "Content-Type": "application/json" } },
         );
       }
-      // Mock performance object with profile data for downstream logic
-      performance = {
-        band_profile_id: bandProfileId,
-        name: profile.name,
-        social_links: profile.social_links,
-        // other fields null
-      };
+      // Deliberately leaves `performance` null. This used to assign a
+      // fabricated performance-shaped object here so shared downstream code
+      // would run — but its `name` and `social_links` were never read, and its
+      // only live field duplicated `bandProfileId`, which is already set above.
+      // The remaining reads are optional-chained, because several of them DO
+      // run on this path — computing actualStartTime/actualEndTime/actualVenueId
+      // and the conflict check. On a profile edit there is no performance, so
+      // those resolve to undefined and the conflict check short-circuits, which
+      // is what the mock's null fields were simulating all along.
     }
 
     // Validation - only validate provided fields
@@ -220,7 +222,7 @@ export async function onRequestPut(context) {
 
       const nameNormalized = normalizeBandName(name);
       const existingProfile = await DB.prepare(`SELECT id FROM band_profiles WHERE name_normalized = ? AND id != ?`)
-        .bind(nameNormalized, performance.band_profile_id)
+        .bind(nameNormalized, bandProfileId)
         .first();
 
       if (existingProfile) {
@@ -287,9 +289,9 @@ export async function onRequestPut(context) {
     }
 
     // Determine actual times to use (provided or existing)
-    const actualStartTime = startTime !== undefined ? startTime : performance.start_time;
-    const actualEndTime = endTime !== undefined ? endTime : performance.end_time;
-    const actualVenueId = normalizedVenueId !== undefined ? normalizedVenueId : performance.venue_id;
+    const actualStartTime = startTime !== undefined ? startTime : performance?.start_time;
+    const actualEndTime = endTime !== undefined ? endTime : performance?.end_time;
+    const actualVenueId = normalizedVenueId !== undefined ? normalizedVenueId : performance?.venue_id;
 
     // Validate times (allow sets that cross midnight; prevent zero-length sets).
     // Checked against the MERGED values, not the body: a PATCH that touches only
@@ -334,16 +336,16 @@ export async function onRequestPut(context) {
 
     // Check for conflicts only if we have all required scheduling fields
     let conflicts = [];
-    if (actualVenueId && actualStartTime && actualEndTime && performance.event_id) {
+    if (actualVenueId && actualStartTime && actualEndTime && performance?.event_id) {
       conflicts = await checkConflicts(DB, {
-        eventId: performance.event_id,
+        eventId: performance?.event_id,
         venueId: actualVenueId,
         startTime: actualStartTime,
         endTime: actualEndTime,
         excludePerformanceId: performanceId,
         // The performance's festival day after this update: the newly supplied
         // day if it's being changed, otherwise the day it already had.
-        performanceDate: performanceDate !== undefined ? resolvedPerformanceDate : performance.performance_date,
+        performanceDate: performanceDate !== undefined ? resolvedPerformanceDate : performance?.performance_date,
         eventDate: linkedEvent.date,
       });
     }
@@ -461,7 +463,7 @@ export async function onRequestPut(context) {
         let existingLinks = {};
         try {
           const profile = await DB.prepare("SELECT social_links FROM band_profiles WHERE id = ?")
-            .bind(performance.band_profile_id)
+            .bind(bandProfileId)
             .first();
           existingLinks = JSON.parse(profile.social_links || "{}");
         } catch (_e) {
@@ -487,7 +489,7 @@ export async function onRequestPut(context) {
       }
 
       if (profileUpdates.length > 0) {
-        profileParams.push(performance.band_profile_id);
+        profileParams.push(bandProfileId);
         await DB.prepare(`UPDATE band_profiles SET ${profileUpdates.join(", ")} WHERE id = ?`)
           .bind(...profileParams)
           .run();

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -113,7 +113,11 @@ export async function onRequestPut(context) {
     let bandProfileId = null;
 
     if (isProfileUpdate) {
-      const parsed = Number(performanceId.toString().split("_")[1]);
+      // Anchored, matching the WHOLE id. `split("_")[1]` read only the second
+      // segment, so "profile_1_extra" resolved to profile 1 and would have
+      // edited it — a malformed identifier silently targeting a real record.
+      const match = /^profile_([1-9]\d*)$/.exec(performanceId.toString());
+      const parsed = match ? Number(match[1]) : NaN;
       if (!Number.isInteger(parsed) || parsed <= 0) {
         return new Response(
           JSON.stringify({

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -36,21 +36,17 @@ async function getEventForPerformance(DB, performanceId) {
 
 // PUT - Update band
 /**
- * Parse a `profile_<n>` id, or return null if it is not one.
+ * Parse a `profile_<n>` id, or return null if it is not one (#935).
  *
- * Anchored on the WHOLE string. `split("_")[1]` read only the second segment,
- * so "profile_1_extra" resolved to profile 1 — a malformed identifier silently
- * addressing a real record. On the DELETE path that meant deleting it.
+ * Anchored on the WHOLE string: an unanchored parse lets "profile_1_extra"
+ * resolve to profile 1, addressing a real record under a malformed id — on the
+ * DELETE path, deleting it.
  *
- * isSafeInteger, not isInteger: Number("9007199254740993") silently becomes
- * ...992, so past 2^53 an id resolves to a DIFFERENT record while still looking
- * like a valid integer.
+ * isSafeInteger, not isInteger: past 2^53 Number() aliases a value onto a
+ * different integer, so the id would resolve to a different record while still
+ * looking valid.
  *
- * One implementation because there are two call sites (PUT and DELETE) and they
- * had already drifted — PUT was fixed first and DELETE kept the unsafe parse.
- *
- * @param {unknown} rawId
- * @returns {number|null}
+ * Shared by PUT and DELETE; both must use it.
  */
 function parseProfileId(rawId) {
   const match = /^profile_([1-9]\d*)$/.exec(String(rawId ?? ""));
@@ -214,15 +210,11 @@ export async function onRequestPut(context) {
           { status: 404, headers: { "Content-Type": "application/json" } },
         );
       }
-      // Deliberately leaves `performance` null. This used to assign a
-      // fabricated performance-shaped object here so shared downstream code
-      // would run — but its `name` and `social_links` were never read, and its
-      // only live field duplicated `bandProfileId`, which is already set above.
-      // The remaining reads are optional-chained, because several of them DO
-      // run on this path — computing actualStartTime/actualEndTime/actualVenueId
-      // and the conflict check. On a profile edit there is no performance, so
-      // those resolve to undefined and the conflict check short-circuits, which
-      // is what the mock's null fields were simulating all along.
+      // Leaves `performance` null: there is no performance on a profile edit.
+      // Downstream reads of it are optional-chained for that reason — several
+      // run on this path (actualStartTime/actualEndTime/actualVenueId and the
+      // conflict check) and must resolve to undefined so the check
+      // short-circuits.
     }
 
     // Validation - only validate provided fields

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -35,6 +35,32 @@ async function getEventForPerformance(DB, performanceId) {
 }
 
 // PUT - Update band
+/**
+ * Parse a `profile_<n>` id, or return null if it is not one.
+ *
+ * Anchored on the WHOLE string. `split("_")[1]` read only the second segment,
+ * so "profile_1_extra" resolved to profile 1 — a malformed identifier silently
+ * addressing a real record. On the DELETE path that meant deleting it.
+ *
+ * isSafeInteger, not isInteger: Number("9007199254740993") silently becomes
+ * ...992, so past 2^53 an id resolves to a DIFFERENT record while still looking
+ * like a valid integer.
+ *
+ * One implementation because there are two call sites (PUT and DELETE) and they
+ * had already drifted — PUT was fixed first and DELETE kept the unsafe parse.
+ *
+ * @param {unknown} rawId
+ * @returns {number|null}
+ */
+function parseProfileId(rawId) {
+  const match = /^profile_([1-9]\d*)$/.exec(String(rawId ?? ""));
+  if (!match) {
+    return null;
+  }
+  const parsed = Number(match[1]);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
 export async function onRequestPut(context) {
   const { request, env } = context;
   const { DB } = env;
@@ -113,12 +139,8 @@ export async function onRequestPut(context) {
     let bandProfileId = null;
 
     if (isProfileUpdate) {
-      // Anchored, matching the WHOLE id. `split("_")[1]` read only the second
-      // segment, so "profile_1_extra" resolved to profile 1 and would have
-      // edited it — a malformed identifier silently targeting a real record.
-      const match = /^profile_([1-9]\d*)$/.exec(performanceId.toString());
-      const parsed = match ? Number(match[1]) : NaN;
-      if (!Number.isInteger(parsed) || parsed <= 0) {
+      const parsed = parseProfileId(performanceId);
+      if (parsed === null) {
         return new Response(
           JSON.stringify({
             error: "Bad request",
@@ -917,8 +939,8 @@ export async function onRequestDelete(context) {
     }
 
     if (isProfileDelete) {
-      const bandProfileId = Number(performanceId.toString().split("_")[1]);
-      if (!Number.isInteger(bandProfileId) || bandProfileId <= 0) {
+      const bandProfileId = parseProfileId(performanceId);
+      if (bandProfileId === null) {
         return new Response(
           JSON.stringify({
             error: "Bad request",

--- a/functions/api/admin/bands/__tests__/putDispatch.test.js
+++ b/functions/api/admin/bands/__tests__/putDispatch.test.js
@@ -127,7 +127,10 @@ describe("PUT /api/admin/bands/:id — profile_ vs numeric dispatch", () => {
 
   it("rejects a malformed profile_ id rather than treating it as a performance", async () => {
     const { env } = seed();
-    for (const bad of ["profile_abc", "profile_0", "profile_-1", "profile_"]) {
+    // "profile_1_extra" is the one that mattered: the old parser read only the
+    // second underscore-delimited segment, so it resolved to profile 1 and would
+    // have edited a real record under a malformed id.
+    for (const bad of ["profile_abc", "profile_0", "profile_-1", "profile_", "profile_1_extra", "profile_01"]) {
       const res = await put(env, bad, { genre: "punk" });
       expect(res.status, `expected 400 for ${bad}`).toBe(400);
     }

--- a/functions/api/admin/bands/__tests__/putDispatch.test.js
+++ b/functions/api/admin/bands/__tests__/putDispatch.test.js
@@ -161,10 +161,8 @@ describe("PUT /api/admin/bands/:id — profile_ vs numeric dispatch", () => {
 });
 
 describe("DELETE /api/admin/bands/:id — the same parser, the same trap", () => {
-  // PUT and DELETE parse `profile_<n>` independently and had DRIFTED: PUT was
-  // fixed first while DELETE kept `split("_")[1]`. On this path the consequence
-  // is worse than a wrong edit — "profile_1_extra" resolved to profile 1 and
-  // would have DELETED it. Both now share parseProfileId.
+  // DELETE shares PUT's profile-id parser, and must: an unanchored parse here
+  // resolves "profile_1_extra" to profile 1 and deletes it (#935).
   function del(env, id) {
     return onRequestDelete({
       request: new Request(`https://example.test/api/admin/bands/${id}`, { method: "DELETE" }),

--- a/functions/api/admin/bands/__tests__/putDispatch.test.js
+++ b/functions/api/admin/bands/__tests__/putDispatch.test.js
@@ -5,7 +5,7 @@ vi.mock("../../_middleware.js", () => ({
   auditLog: vi.fn(async () => {}),
 }));
 
-import { onRequestPut } from "../[id].js";
+import { onRequestDelete, onRequestPut } from "../[id].js";
 import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils.js";
 
 /**
@@ -130,7 +130,15 @@ describe("PUT /api/admin/bands/:id — profile_ vs numeric dispatch", () => {
     // "profile_1_extra" is the one that mattered: the old parser read only the
     // second underscore-delimited segment, so it resolved to profile 1 and would
     // have edited a real record under a malformed id.
-    for (const bad of ["profile_abc", "profile_0", "profile_-1", "profile_", "profile_1_extra", "profile_01"]) {
+    for (const bad of [
+      "profile_abc",
+      "profile_0",
+      "profile_-1",
+      "profile_",
+      "profile_1_extra",
+      "profile_01",
+      "profile_9007199254740993",
+    ]) {
       const res = await put(env, bad, { genre: "punk" });
       expect(res.status, `expected 400 for ${bad}`).toBe(400);
     }
@@ -149,5 +157,39 @@ describe("PUT /api/admin/bands/:id — profile_ vs numeric dispatch", () => {
     const { env } = seed();
     const res = await put(env, 99999, { startTime: "22:00" });
     expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/admin/bands/:id — the same parser, the same trap", () => {
+  // PUT and DELETE parse `profile_<n>` independently and had DRIFTED: PUT was
+  // fixed first while DELETE kept `split("_")[1]`. On this path the consequence
+  // is worse than a wrong edit — "profile_1_extra" resolved to profile 1 and
+  // would have DELETED it. Both now share parseProfileId.
+  function del(env, id) {
+    return onRequestDelete({
+      request: new Request(`https://example.test/api/admin/bands/${id}`, { method: "DELETE" }),
+      env,
+      data: { user: { role: "admin", id: 1 } },
+    });
+  }
+
+  it.each([
+    ["extra segment", "profile_1_extra"],
+    ["leading zero", "profile_01"],
+    ["past 2^53", "profile_9007199254740993"],
+    ["non-numeric", "profile_abc"],
+    ["zero", "profile_0"],
+    ["empty", "profile_"],
+  ])("rejects %s rather than resolving it to a real profile", async (_label, bad) => {
+    const { env, rawDb, perf } = seed();
+    const before = rawDb.prepare("SELECT COUNT(*) AS n FROM band_profiles").get().n;
+
+    const res = await del(env, bad);
+    expect(res.status).toBe(400);
+
+    // The assertion that matters: nothing was deleted.
+    const after = rawDb.prepare("SELECT COUNT(*) AS n FROM band_profiles").get().n;
+    expect(after).toBe(before);
+    expect(rawDb.prepare("SELECT id FROM band_profiles WHERE id = ?").get(perf.band_profile_id)).toBeDefined();
   });
 });

--- a/functions/api/admin/bands/__tests__/putDispatch.test.js
+++ b/functions/api/admin/bands/__tests__/putDispatch.test.js
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../_middleware.js", () => ({
+  checkPermission: async () => ({ error: false, user: { userId: 1, role: "editor" }, userId: 1 }),
+  auditLog: vi.fn(async () => {}),
+}));
+
+import { onRequestPut } from "../[id].js";
+import { createTestEnv, insertEvent, insertVenue, insertBand } from "../../../test-utils.js";
+
+/**
+ * Pins `PUT /api/admin/bands/:id`'s dual-resource dispatch before the handler is
+ * split (#908).
+ *
+ * That one route serves two unrelated resources, chosen by string-sniffing the
+ * id: `profile_<n>` edits a band PROFILE (band-wide fields), a bare number edits
+ * a PERFORMANCE (one set at one event). RosterTab sends the first form,
+ * LineupTab the second.
+ *
+ * Nothing tested the profile branch. Every existing test used a numeric id, so
+ * the entire reason the dispatch exists was uncovered — and it is the half a
+ * split is most likely to break, because the two paths share one 600-line
+ * function and a set of variables that are only meaningful on one side
+ * (`performance` stays null throughout the profile path).
+ *
+ * These assert the ROUTING and the isolation between the two, not the field
+ * validation each path performs — that is covered by bands.test.js.
+ */
+
+function put(env, id, body) {
+  return onRequestPut({
+    request: new Request(`https://example.test/api/admin/bands/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+    data: { user: { role: "editor", id: 2 } },
+  });
+}
+
+function seed() {
+  const { env, rawDb } = createTestEnv({ role: "editor" });
+  const event = insertEvent(rawDb, { name: "Fest", slug: "fest-put-dispatch" });
+  const venue = insertVenue(rawDb, { name: "Hall" });
+  const perf = insertBand(rawDb, {
+    name: "Dispatch Band",
+    event_id: event.id,
+    venue_id: venue.id,
+    start_time: "20:00",
+    end_time: "21:00",
+  });
+  return { env, rawDb, event, venue, perf };
+}
+
+describe("PUT /api/admin/bands/:id — profile_ vs numeric dispatch", () => {
+  it("a profile_ id updates band-profile fields", async () => {
+    const { env, rawDb, perf } = seed();
+    const res = await put(env, `profile_${perf.band_profile_id}`, {
+      genre: "punk",
+      origin_city: "Waterloo",
+      is_active: 0,
+    });
+
+    expect(res.status).toBe(200);
+    const row = rawDb
+      .prepare("SELECT genre, origin_city, is_active FROM band_profiles WHERE id = ?")
+      .get(perf.band_profile_id);
+    expect(row).toEqual({ genre: "punk", origin_city: "Waterloo", is_active: 0 });
+  });
+
+  it("a profile_ id returns the profile shape, with the prefixed id echoed back", async () => {
+    // RosterTab keys rows off this id, so the `profile_` prefix must survive the
+    // round trip — a split that returned the bare number would break the grid.
+    const { env, perf } = seed();
+    const res = await put(env, `profile_${perf.band_profile_id}`, { genre: "ska" });
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.band.id).toBe(`profile_${perf.band_profile_id}`);
+  });
+
+  it("a profile_ id IGNORES performance fields sent alongside it", async () => {
+    // The isolation that matters: these are different resources sharing a route.
+    //
+    // Sending the performance fields is the whole point. A version of this test
+    // that posted only `genre` passed even with the performance-update block
+    // forced to run for profile ids — because with no set-time fields in the
+    // body there was nothing for it to write. It proved nothing.
+    const { env, rawDb, perf } = seed();
+    const res = await put(env, `profile_${perf.band_profile_id}`, {
+      genre: "punk",
+      startTime: "01:00",
+      endTime: "02:00",
+      notes: "should not land",
+    });
+
+    expect(res.status).toBe(200);
+    const row = rawDb.prepare("SELECT start_time, end_time, notes FROM performances WHERE id = ?").get(perf.id);
+    expect(row.start_time).toBe("20:00");
+    expect(row.end_time).toBe("21:00");
+    expect(row.notes).not.toBe("should not land");
+
+    // ...while the profile field it WAS allowed to change did land.
+    const profile = rawDb.prepare("SELECT genre FROM band_profiles WHERE id = ?").get(perf.band_profile_id);
+    expect(profile.genre).toBe("punk");
+  });
+
+  it("a numeric id updates the performance row", async () => {
+    const { env, rawDb, perf } = seed();
+    const res = await put(env, perf.id, { startTime: "22:00", endTime: "23:00" });
+
+    expect(res.status).toBe(200);
+    const row = rawDb.prepare("SELECT start_time, end_time FROM performances WHERE id = ?").get(perf.id);
+    expect(row).toEqual({ start_time: "22:00", end_time: "23:00" });
+  });
+
+  it("a numeric id can still edit band-profile fields — they are band-wide", async () => {
+    // Deliberately NOT symmetric with the isolation test above. Editing a set
+    // may also edit the band's profile; editing a profile may not edit a set.
+    const { env, rawDb, perf } = seed();
+    await put(env, perf.id, { genre: "metal" });
+
+    const row = rawDb.prepare("SELECT genre FROM band_profiles WHERE id = ?").get(perf.band_profile_id);
+    expect(row.genre).toBe("metal");
+  });
+
+  it("rejects a malformed profile_ id rather than treating it as a performance", async () => {
+    const { env } = seed();
+    for (const bad of ["profile_abc", "profile_0", "profile_-1", "profile_"]) {
+      const res = await put(env, bad, { genre: "punk" });
+      expect(res.status, `expected 400 for ${bad}`).toBe(400);
+    }
+  });
+
+  it("404s a profile_ id for a profile that does not exist", async () => {
+    // Exactly 404, not ">= 400". The loose form also accepted a 500, so the test
+    // passed if the handler CRASHED on a missing profile — and 400 would mean it
+    // had mistaken a well-formed id for a malformed one.
+    const { env } = seed();
+    const res = await put(env, "profile_99999", { genre: "punk" });
+    expect(res.status).toBe(404);
+  });
+
+  it("404s a numeric id for a performance that does not exist", async () => {
+    const { env } = seed();
+    const res = await put(env, 99999, { startTime: "22:00" });
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

#908 **step 1**, following the corrected diagnosis on that issue.

`PUT /api/admin/bands/:id` serves two resources. On the profile path it assigned a **fake performance-shaped object** so shared downstream code would run:

```js
// Mock performance object with profile data for downstream logic
performance = { band_profile_id, name, social_links, /* other fields null */ };
```

That's why the 600-line handler resists splitting: everything downstream is written against `performance`, and one path lies to it about what it's holding.

Refs #908

## Most of the mock was dead weight

`name` and `social_links` were **never read** anywhere in the handler. Its only live field duplicated `bandProfileId`, which is already assigned on both paths before first use. Those three reads now use the variable, and `performance` stays `null` on the profile path — the honest value, since there is no performance there.

## The pin caught this going wrong

Removing the mock **broke the profile path**, and all **176 other band tests still passed**. Only the dispatch pin from #933 caught it:

```
TypeError: Cannot read properties of null (reading 'start_time')  at [id].js:290
```

I had written a comment claiming the remaining reads were *"all inside `!isProfileUpdate` blocks or guarded"*. **That was wrong** — six of them run on both paths: the `actualStartTime`/`actualEndTime`/`actualVenueId` computation and the conflict check. They're optional-chained now, so on a profile edit they resolve to `undefined` and the conflict check short-circuits — exactly what the mock's null fields were simulating.

Worth stating plainly: I asserted that from reading, shipped it into a comment, and it took a test to disprove it. **This was only safe because the pin existed first.**

## Also fixed on review — a real hole

```js
"profile_1_extra".split("_")[1]  →  "1"
```

A malformed identifier resolved to profile 1 and would have edited it. The parse is now anchored on the whole string (`/^profile_([1-9]\d*)$/`), which also closes `profile_01` addressing the same record as `profile_1`. Mutation-verified.

## Declined, and filed instead

- **#934 (p2)** — the handler writes `band_profiles` and `performances` non-atomically, contradicting the documented "D1 has no BEGIN/COMMIT, use `env.DB.batch`" invariant. Pre-existing; restructuring the write ordering is a behaviour change that deserves its own diff.
- **Scheduling fields are still validated on profile updates**, even though they're ignored. Real inconsistency, but changing it converts a 400 into a silent accept — a behaviour change, not a refactor. Better as its own decision.

## Verification

- [x] Tests: **1,287** backend + 1,189 frontend, 0 failures
- [x] ESLint 0 · Format clean · Build green · `make gate` exit 0
- [x] `make review` (CodeRabbit): 3 findings — 1 fixed here, 2 filed/declined with reasons
- [x] Manual smoke: not browser-verified; the profile path is now covered by the 8-test dispatch pin that previously had zero coverage

**Note:** `putDispatch.test.js` is carried here from #933 so this branch has its own net. The file is identical and collapses on merge.

## What this unblocks

Downstream code no longer requires a performance-shaped object on both paths — the precondition for extracting the band-profile update block (step 2) and, if still worthwhile, splitting the handler (step 3).

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid or unsafe profile identifiers are rejected safely during updates and deletions.
  - Profile-only updates no longer affect performance details.
  - Valid profile and performance updates continue to be dispatched correctly.
- **Tests**
  - Expanded coverage for profile and performance updates, malformed identifiers, field isolation, and missing resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->