### PR TITLE
fix(admin): make the dual-table PUT atomic via DB.batch

### DIFF
--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -362,6 +362,7 @@ export async function onRequestPut(context) {
     // Build dynamic update query based on provided fields
     const updates = [];
     const params = [];
+    const writeStatements = [];
 
     // Handle profile updates (name, url, and other profile fields)
     if (
@@ -488,9 +489,9 @@ export async function onRequestPut(context) {
 
       if (profileUpdates.length > 0) {
         profileParams.push(performance.band_profile_id);
-        await DB.prepare(`UPDATE band_profiles SET ${profileUpdates.join(", ")} WHERE id = ?`)
-          .bind(...profileParams)
-          .run();
+        writeStatements.push(
+          DB.prepare(`UPDATE band_profiles SET ${profileUpdates.join(", ")} WHERE id = ?`).bind(...profileParams),
+        );
       }
     }
 
@@ -522,22 +523,25 @@ export async function onRequestPut(context) {
         // Add performance ID as final parameter
         params.push(realPerformanceId);
 
-        // Update performance
-        await DB.prepare(
-          `
+        writeStatements.push(
+          DB.prepare(
+            `
             UPDATE performances
             SET ${updates.join(", ")}
             WHERE id = ?
             `,
-        )
-          .bind(...params)
-          .run();
+          ).bind(...params),
+        );
       }
     } else {
       // If we are updating a profile-only entry, we might be trying to convert it to a performance?
       // But this PUT endpoint usually just updates fields.
       // The BandForm doesn't support "assigning to event" from the Edit modal easily yet.
       // So we ignore performance fields here if it's a profile update (for safety).
+    }
+
+    if (writeStatements.length > 0) {
+      await DB.batch(writeStatements);
     }
 
     // Fetch updated result

--- a/functions/api/admin/bands/__tests__/putAtomicity.test.js
+++ b/functions/api/admin/bands/__tests__/putAtomicity.test.js
@@ -1,0 +1,58 @@
+import { expect, it, vi } from "vitest";
+
+vi.mock("../../_middleware.js", () => ({
+  checkPermission: async () => ({ error: false, user: { userId: 1, role: "editor" }, userId: 1 }),
+  auditLog: vi.fn(async () => {}),
+}));
+
+import { onRequestPut } from "../[id].js";
+import { createTestEnv, insertBand, insertEvent, insertVenue } from "../../../test-utils.js";
+
+function put(env, id, body) {
+  return onRequestPut({
+    request: new Request(`https://example.test/api/admin/bands/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+    data: { user: { role: "editor", id: 2 } },
+  });
+}
+
+it("rolls back the profile update when the performance update fails", async () => {
+  const { env, rawDb } = createTestEnv({ role: "editor" });
+  const event = insertEvent(rawDb, { name: "Atomicity Fest", slug: "put-atomicity" });
+  const venue = insertVenue(rawDb, { name: "Atomicity Hall" });
+  const performance = insertBand(rawDb, {
+    name: "Atomicity Band",
+    genre: "rock",
+    event_id: event.id,
+    venue_id: venue.id,
+    start_time: "20:00",
+    end_time: "21:00",
+  });
+
+  rawDb.exec(`
+    CREATE TRIGGER fail_atomicity_performance_update
+    BEFORE UPDATE OF notes ON performances
+    BEGIN
+      SELECT RAISE(ABORT, 'forced performance update failure');
+    END
+  `);
+
+  // The shared test helper mirrors D1's API but does not provide rollback.
+  // Use SQLite's transaction here so this test exercises the production guarantee.
+  env.DB.batch = async (statements) => rawDb.transaction(() => statements.map((statement) => statement.run()))();
+
+  const response = await put(env, performance.id, {
+    genre: "metal",
+    notes: "This update must fail",
+  });
+
+  expect(response.status).toBe(500);
+  expect(rawDb.prepare("SELECT genre FROM band_profiles WHERE id = ?").get(performance.band_profile_id)).toEqual({
+    genre: "rock",
+  });
+  expect(rawDb.prepare("SELECT notes FROM performances WHERE id = ?").get(performance.id)).toEqual({ notes: null });
+});


### PR DESCRIPTION
## Summary

`onRequestPut` can update **two tables in one request** and did so with two independent awaited writes. If the second failed, the request returned an error **after the first had already committed** — the caller saw a failure and the band's profile had changed anyway.

Closes #934

## It contradicted a documented invariant

From `CLAUDE.md`:

> D1 has no BEGIN/COMMIT. Multi-statement mutations must use `env.DB.batch([...])` (atomic) or an explicit compensating-delete rollback.

Neither was used.

## The fix

Both statements are assembled **after** all validation and conflict detection, then executed in one `DB.batch()`.

The ordering is the non-trivial part: the profile write previously ran *before* conflict detection could reject the performance write, so the batch had to move **down** rather than validation moving up. A profile-only edit produces a one-statement batch and never touches `performances`; when there's nothing to write, `batch` isn't called.

## Delegated to OpenCode — the first this session

**Cost: $0.107.** That's the point of Otto: a separate subscription, spending none of the orchestrator's context. Three earlier delegations this session went to in-context Sonnet agents at 140k–190k tokens each, which was the wrong call.

**Verified independently before commit**, not taken on its report:

| Check | Result |
|---|---|
| Batch placement | line 544, after conflict detection at 351 |
| Profile-only path | guarded by `writeStatements.length > 0` |
| `make gate` | exit 0 |
| Mutation: batch → sequential `.run()` | `putAtomicity.test.js` **fails**, as claimed |

## The test earns its place

It forces the second write to fail with a real SQLite `RAISE(ABORT)` trigger rather than a stubbed throw, then asserts the profile row is unchanged. Against the old structure the profile persisted as `"metal"` despite a 500 — a green suite alone would never have shown that.

## Merge conflict resolution

Conflicted with #935 (both touched `[id].js`). Resolved by taking **both**: `bandProfileId` from `main` (#935's fabricated-object removal) with the batched write form from this branch. Verified after: 1,294 backend tests, and the 15 dispatch + atomicity tests pass together.

## Verification

- [x] Tests: **1,294** backend + 1,189 frontend, 0 failures
- [x] ESLint 0 · Format clean · Build green · `make gate` exit 0
- [x] Manual smoke: n/a — atomicity is asserted directly by a test that fails against the old structure

**Out of scope, confirmed not affected:** `PATCH` writes only `performances`; `DELETE` handles profile-only and performance deletion separately.

---
Built by Otto (OpenCode) · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Band profile and performance updates are now applied atomically, preventing partial changes when an update fails.

* **Tests**
  * Added coverage to verify that failed band updates leave existing profile and performance data unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->