### PR TITLE
chore(opencode): stop defaulting delegations to the premium glm-5.2

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "opencode-go/glm-5.2",
+  "model": "opencode-go/gpt-5.6-luna",
   "mcp": {
     "cloudflare-bindings": {
       "type": "remote",


### PR DESCRIPTION
## What

One line in `opencode.json`: `model` moves from `opencode-go/glm-5.2` to `opencode-go/gpt-5.6-luna`.

## Why

`glm-5.2` is the premium tier. On a flat-rate-but-usage-capped plan that is a **throughput limit, not an invoice** — an expensive model buys fewer delegations per window.

CLAUDE.md already says to always pass `--model` explicitly. The config default is what makes forgetting cheap to do and expensive to have done: any run relying on it silently took the premium tier.

`gpt-5.6-luna` is the one model measured on real work in this repo — the "make the dual-table PUT atomic, write an atomicity test, verify it by mutation" delegation shipped as #936 reported **$0.107**.

`small_model` (`opencode-go/deepseek-v4-flash`) is unchanged.

## Not claimed

- This is **not** a benchmark. Comparing models needs the same brief on the same repo state, run once per model. That has not been done, and CLAUDE.md says to treat unmeasured models as unmeasured.
- **Data residency for the `opencode-go` provider has not been verified from vendor docs.** The residency constraint governs model choice here; this PR changes the cost tier only. If residency rules out `gpt-5.6-luna`, say so and I'll re-point it.

## Testing

- [x] `make gate` exits 0 (1,294 backend + 1,189 frontend tests)
- [x] `node -e` confirms the config parses and resolves to the new default
- [x] Verified `opencode.json` already failed `prettier --check` on `main` — pre-existing, and outside the gate's prettier scope (`functions/`, `scripts/`, `e2e/`), so not touched here

## Risk

Near zero. Config-only; no source file changes. Reverting is a one-line edit.

Refs #679

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the default AI model used by the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->