### PR TITLE
fix(ci): take the E2E admin password from the environment, not argv

### DIFF
--- a/.github/actions/e2e-env/action.yml
+++ b/.github/actions/e2e-env/action.yml
@@ -271,7 +271,7 @@ runs:
                   exit 1
               fi
               echo "Creating E2E admin user..."
-              SEED_SQL=$(node scripts/seed-e2e-admin.mjs --email "$E2E_ADMIN_EMAIL" --password "$E2E_ADMIN_PASSWORD")
+              SEED_SQL=$(E2E_ADMIN_PASSWORD="$E2E_ADMIN_PASSWORD" node scripts/seed-e2e-admin.mjs --email "$E2E_ADMIN_EMAIL")
               ./frontend/node_modules/.bin/wrangler d1 execute settimes-production-db --local --persist-to .wrangler/state --command="$SEED_SQL"
               echo "✓ E2E admin user created: $E2E_ADMIN_EMAIL"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ npm run pages:dev
 The admin panel is at `http://localhost:8788/admin`. Create a first admin user with:
 
 ```bash
-node scripts/seed-e2e-admin.mjs --email you@example.com --password yourpassword \
+E2E_ADMIN_PASSWORD="$YOUR_CHOSEN_PASSWORD" node scripts/seed-e2e-admin.mjs --email you@example.com \
   | xargs -I{} npx wrangler d1 execute settimes-production-db --local --command="{}"
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ E2E_STATE := .wrangler/e2e-state
 E2E_PID := .wrangler/e2e-state/wrangler.pid
 E2E_ADMIN_EMAIL ?= e2e-admin@test.local
 E2E_ADMIN_PASSWORD ?= e2e-test-password-Xk9
+# Exported, never interpolated: make echoes recipe text, so a $(VAR) in a
+# recipe prints the secret to the terminal and into CI logs. Exporting puts
+# the value in the child environment instead, where $$VAR reads it at run
+# time and the recipe text never contains it. Verify with `make -n e2e-setup`.
+export E2E_ADMIN_EMAIL
+export E2E_ADMIN_PASSWORD
 
 .PHONY: help install build dev format format-check lint test test-backend test-frontend \
 	gate review review-wip validate-openapi schema-check e2e e2e-setup e2e-serve e2e-run e2e-clean
@@ -87,7 +93,7 @@ e2e-setup: build ## Init + seed an isolated local D1 for E2E (safe to re-run)
 	rm -rf $(E2E_STATE)
 	$(WRANGLER) d1 execute settimes-production-db --local --persist-to $(E2E_STATE) --file=database/setup-complete.sql
 	$(WRANGLER) d1 execute settimes-production-db --local --persist-to $(E2E_STATE) --file=database/seed-test-data.sql
-	SEED_SQL=$$(node scripts/seed-e2e-admin.mjs --email "$(E2E_ADMIN_EMAIL)" --password "$(E2E_ADMIN_PASSWORD)"); \
+	SEED_SQL=$$(node scripts/seed-e2e-admin.mjs --email "$$E2E_ADMIN_EMAIL"); \
 	$(WRANGLER) d1 execute settimes-production-db --local --persist-to $(E2E_STATE) --command="$$SEED_SQL"
 
 e2e-serve: ## Start wrangler for E2E in the background (writes pidfile); retries boot once, never test failures (mirrors e2e-env action.yml, #625)
@@ -111,14 +117,14 @@ e2e-serve: ## Start wrangler for E2E in the background (writes pidfile); retries
 	echo "wrangler failed to start after 2 attempts"; exit 1
 
 e2e-run: ## Run Playwright (server must be up; credentials required even for --list)
-	ADMIN_EMAIL="$(E2E_ADMIN_EMAIL)" ADMIN_PASSWORD="$(E2E_ADMIN_PASSWORD)" npx playwright test $(SPEC) --reporter=list
+	ADMIN_EMAIL="$$E2E_ADMIN_EMAIL" ADMIN_PASSWORD="$$E2E_ADMIN_PASSWORD" npx playwright test $(SPEC) --reporter=list
 
 e2e-clean: ## Kill the E2E server by pidfile and remove isolated state
 	-[ -f $(E2E_PID) ] && kill $$(cat $(E2E_PID)) 2>/dev/null || true
 	rm -rf $(E2E_STATE)
 
 e2e: e2e-setup e2e-serve ## Full local E2E: setup, serve, run, always clean up
-	ADMIN_EMAIL="$(E2E_ADMIN_EMAIL)" ADMIN_PASSWORD="$(E2E_ADMIN_PASSWORD)" npx playwright test $(SPEC) --reporter=list; \
+	ADMIN_EMAIL="$$E2E_ADMIN_EMAIL" ADMIN_PASSWORD="$$E2E_ADMIN_PASSWORD" npx playwright test $(SPEC) --reporter=list; \
 	status=$$?; \
 	$(MAKE) e2e-clean; \
 	exit $$status

--- a/scripts/__tests__/seed-e2e-admin.test.js
+++ b/scripts/__tests__/seed-e2e-admin.test.js
@@ -1,0 +1,70 @@
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const scriptsDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
+const scriptPath = join(scriptsDirectory, "seed-e2e-admin.mjs");
+
+const runScript = (args, password) => {
+  const env = { ...process.env };
+  if (password === undefined) {
+    delete env.E2E_ADMIN_PASSWORD;
+  } else {
+    env.E2E_ADMIN_PASSWORD = password;
+  }
+
+  return execFileSync(process.execPath, [scriptPath, ...args], {
+    env,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+};
+
+describe("seed-e2e-admin", () => {
+  it("fails when E2E_ADMIN_PASSWORD is missing", () => {
+    expect(() => runScript(["--email", "admin@example.com"], undefined)).toThrowError(
+      expect.objectContaining({
+        status: 1,
+        stderr: expect.stringContaining("E2E_ADMIN_PASSWORD"),
+      }),
+    );
+  });
+
+  // The security property this script exists to hold (#867) is not "env is
+  // required" but "argv is refused" — those are independent. A script reading
+  // env-first-then-argv satisfies the first and violates the second, and the
+  // missing-password test above stays green the whole time. This is the only
+  // assertion that goes red if an argv fallback is ever reintroduced.
+  it("refuses a password passed on argv, even though that used to be the interface", () => {
+    expect(() =>
+      runScript(["--email", "admin@example.com", "--password", "placeholder-argv-value"], undefined),
+    ).toThrowError(
+      expect.objectContaining({
+        status: 1,
+        stderr: expect.stringContaining("E2E_ADMIN_PASSWORD"),
+      }),
+    );
+  });
+
+  // The dangerous case is not argv-alone (that already fails for lack of a
+  // password) but argv ALONGSIDE a valid environment password: there the script
+  // has everything it needs and would happily succeed with the secret sitting in
+  // the process list. This is the assertion that makes the refusal load-bearing.
+  it.each([["--password", "placeholder-argv-value"], ["--password=placeholder-argv-value"]])(
+    "refuses %s even when E2E_ADMIN_PASSWORD is set",
+    (...argvPassword) => {
+      expect(() =>
+        runScript(["--email", "admin@example.com", ...argvPassword], "placeholder-not-a-real-password"),
+      ).toThrowError(expect.objectContaining({ status: 1 }));
+    },
+  );
+
+  it("emits the admin INSERT SQL when the password is supplied through the environment", () => {
+    const output = runScript(["--email", "admin@example.com"], "placeholder-test-password");
+
+    expect(output).toContain("INSERT OR REPLACE INTO users");
+    expect(output).toContain("'admin@example.com'");
+    expect(output).toContain("'admin'");
+  });
+});

--- a/scripts/seed-e2e-admin.mjs
+++ b/scripts/seed-e2e-admin.mjs
@@ -2,15 +2,34 @@ import { hashPassword } from "../functions/utils/crypto.js";
 
 const args = process.argv.slice(2);
 const emailIdx = args.indexOf("--email");
-const passwordIdx = args.indexOf("--password");
+const password = process.env.E2E_ADMIN_PASSWORD;
 
-if (emailIdx === -1 || passwordIdx === -1 || !args[emailIdx + 1] || !args[passwordIdx + 1]) {
-  console.error("Usage: node scripts/seed-e2e-admin.mjs --email <email> --password <password>");
+// Refuse argv even when the environment ALSO carries the password. Removing the
+// old flag parsing is not enough on its own: an unparsed argument is still an
+// argument, so a caller that keeps passing it leaks the secret into the process
+// list while the script quietly succeeds off the environment. Failing loudly is
+// what turns a stale caller into a build error instead of a silent regression.
+//
+// Both spellings are refused, including the joined "flag=value" form, which
+// arrives as a single argv entry. The flag names live in the check below rather
+// than in this comment on purpose: a secret scanner reads a flag followed by a
+// bare word as a credential assignment and flags the prose (it did, on this
+// exact comment). Keep the literals in code, keep the explanation flag-free.
+const hasArgvPassword = args.some((arg) => arg === "--password" || arg.startsWith("--password="));
+
+if (hasArgvPassword) {
+  console.error(
+    "Refusing --password: it would expose the secret in the process list. Pass E2E_ADMIN_PASSWORD in the environment instead.",
+  );
+  process.exit(1);
+}
+
+if (emailIdx === -1 || !args[emailIdx + 1] || !password) {
+  console.error("Usage: E2E_ADMIN_PASSWORD=<password> node scripts/seed-e2e-admin.mjs --email <email>");
   process.exit(1);
 }
 
 const email = args[emailIdx + 1];
-const password = args[passwordIdx + 1];
 
 // Escape single quotes for SQLite
 const esc = (v) => v.replace(/'/g, "''");


### PR DESCRIPTION
Closes #867

## Problem

`scripts/seed-e2e-admin.mjs` read `--password` off `process.argv`, putting a credential in the process argument list — readable by anything that can run `ps` or read `/proc/PID/cmdline` for the life of the run.

Low severity as it stands (ephemeral single-tenant runner, CI-only credential), but the fix is small and the docs were teaching the insecure form to contributors.

## Change

The password now comes from `E2E_ADMIN_PASSWORD`. `--email` is not sensitive and is untouched.

**The argv parsing is removed, not demoted to a fallback.** An env-first-then-argv read would pass every "is the env var required?" test while leaving the secret exactly where it started.

## Three call sites, not one

The issue says there is one caller. The sweep found three:

| File | What it was |
|---|---|
| `.github/actions/e2e-env/action.yml:274` | the CI seed step |
| `Makefile:90` | `make e2e-setup` |
| `CONTRIBUTING.md:33` | docs — the one that *teaches* the bad form |

`git grep seed-e2e-admin` confirms no fourth, and zero `--password` invocations remain.

## The test asserts two independent properties

```js
it("fails when E2E_ADMIN_PASSWORD is missing", …)
it("refuses a password passed on argv, even though that used to be the interface", …)
```

Only the second is the security property, and it is the one that was missing from the first draft. They are independent — a script reading env-first-then-argv satisfies (1) and violates (2).

**Verified by mutation, both directions:**

| Mutation | Test 1 | Test 2 |
|---|---|---|
| drop the `!password` guard | **RED** | green |
| re-add an argv `--password` fallback | green | **RED** |

Neither test subsumes the other, so neither can be dropped. The script runs as a child process rather than being imported, because the behaviour under test is `process.exit` and a non-zero status.

## Testing

- [x] `make gate` exits 0 — 1,297 backend + 1,189 frontend tests
- [x] Mutation table above reproduced locally, each mutation confirmed to have actually applied before believing its result
- [x] `git grep` confirms no surviving argv `--password` call site

## Note on how this was built

Implemented by Otto (OpenCode, `gpt-5.6-luna`, $0.086), reviewed and gate-run here. The delegated version had both the script change and a working test; the argv-refusal assertion was missing and was added after mutation testing showed an argv fallback could be reintroduced with the suite still green.

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved end-to-end administrator setup by accepting passwords through a secure environment variable instead of command-line arguments.
  - Passwords supplied through command-line options are now rejected to help prevent accidental exposure.

- **Bug Fixes**
  - Updated password validation and usage guidance for the secure input method.
  - Email-based configuration and successful administrator setup remain supported.

- **Tests**
  - Added coverage for missing, invalid, and securely supplied passwords, including successful setup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->