### PR TITLE
fix(admin): escape the embed iframe, and stop three copy buttons lying about success

### DIFF
--- a/frontend/src/admin/EventsTab.jsx
+++ b/frontend/src/admin/EventsTab.jsx
@@ -5,6 +5,7 @@ import EventFormModal from './components/EventFormModal'
 import HistoricalImportModal from './components/HistoricalImportModal'
 import EventStatusBadge from './components/EventStatusBadge'
 import EmbedCodeGenerator from './components/EmbedCodeGenerator'
+import { copyToClipboard } from '../utils/clipboard'
 import MetricsDashboard from './components/MetricsDashboard'
 import ArchivedEventBanner from './components/ArchivedEventBanner'
 import HelpPanel from './components/HelpPanel'
@@ -244,8 +245,8 @@ const EventRow = memo(function EventRow({
             </button>
             <button
               onClick={async () => {
-                await navigator.clipboard.writeText(ticketLink)
-                showToast('Ticket link copied!', 'success')
+                const ok = await copyToClipboard(ticketLink)
+                showToast(ok ? 'Ticket link copied!' : 'Could not copy the ticket link.', ok ? 'success' : 'error')
               }}
               className={`px-3 py-1 bg-amber-700 hover:bg-amber-800 text-white rounded text-xs font-medium transition-colors ${buttonFocusClass}`}
               title="Copy ticket link"

--- a/frontend/src/admin/components/EmbedCodeGenerator.jsx
+++ b/frontend/src/admin/components/EmbedCodeGenerator.jsx
@@ -1,17 +1,50 @@
+import { useState } from 'react'
+import PropTypes from 'prop-types'
+import { copyToClipboard } from '../../utils/clipboard'
+
+/**
+ * Escape a value for interpolation into a DOUBLE-QUOTED HTML attribute.
+ *
+ * The output of this component is copied by an admin and pasted into someone
+ * else's website, so an unescaped `"` in an event name does not misbehave here
+ * — it ships a broken or attribute-injecting tag to a third party. `&` must be
+ * replaced first, or it would double-escape the entities added after it.
+ */
+export function escapeHtmlAttribute(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
 export default function EmbedCodeGenerator({ event }) {
+  const [copyState, setCopyState] = useState('idle')
+
   const embedCode = `
 <iframe
-  src="https://settimes.ca/embed/${event.slug}"
+  src="https://settimes.ca/embed/${escapeHtmlAttribute(event.slug)}"
   width="100%"
   height="600"
   frameborder="0"
-  title="${event.name} Schedule"
+  title="${escapeHtmlAttribute(event.name)} Schedule"
 ></iframe>
   `.trim()
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(embedCode)
-    alert('Embed code copied!')
+  // copyToClipboard reports failure rather than throwing, and falls back to a
+  // hidden textarea + execCommand when the async API is unavailable (insecure
+  // context, denied permission). Reporting success unconditionally — as this
+  // did before — is worse than failing: the admin pastes whatever was already
+  // on their clipboard and never learns otherwise.
+  const handleCopy = async () => {
+    // copyToClipboard is written to report false rather than reject, but a
+    // handler whose only failure path depends on that promise is one refactor
+    // away from silently doing nothing. Treat a throw as a failed copy.
+    try {
+      setCopyState((await copyToClipboard(embedCode)) ? 'copied' : 'error')
+    } catch {
+      setCopyState('error')
+    }
   }
 
   return (
@@ -28,6 +61,13 @@ export default function EmbedCodeGenerator({ event }) {
         Copy Code
       </button>
 
+      <p aria-live="polite" className="mt-2 text-sm min-h-[1.25rem]">
+        {copyState === 'copied' && <span className="text-green-300">Embed code copied.</span>}
+        {copyState === 'error' && (
+          <span className="text-red-300">Could not copy automatically — select the code above and copy it.</span>
+        )}
+      </p>
+
       <div className="mt-4 p-3 bg-blue-900/30 border border-blue-600 rounded">
         <p className="text-blue-200 text-sm">
           <strong>Preview:</strong>{' '}
@@ -38,4 +78,11 @@ export default function EmbedCodeGenerator({ event }) {
       </div>
     </div>
   )
+}
+
+EmbedCodeGenerator.propTypes = {
+  event: PropTypes.shape({
+    slug: PropTypes.string,
+    name: PropTypes.string,
+  }).isRequired,
 }

--- a/frontend/src/admin/components/UserFormModal.jsx
+++ b/frontend/src/admin/components/UserFormModal.jsx
@@ -10,6 +10,7 @@
 import { useState, useEffect } from 'react'
 import { FIELD_LIMITS } from '../../utils/validation'
 import Modal from '../../components/ui/Modal'
+import { copyToClipboard } from '../../utils/clipboard'
 
 export default function UserFormModal({ isOpen, onClose, user, onSave, loading, inviteUrl }) {
   const isEditMode = Boolean(user)
@@ -23,6 +24,22 @@ export default function UserFormModal({ isOpen, onClose, user, onSave, loading, 
   })
 
   const [errors, setErrors] = useState({})
+  const [inviteCopy, setInviteCopy] = useState('idle')
+
+  // Was a bare fire-and-forget navigator.clipboard.writeText with no await, no
+  // catch and no feedback: an unhandled rejection, and an admin who believes an
+  // invite link is on their clipboard when it may not be. That link is the only
+  // way the new user can activate, so a silent miss is expensive.
+  const handleCopyInvite = async () => {
+    // copyToClipboard is written to report false rather than reject, but a
+    // handler whose only failure path depends on that promise is one refactor
+    // away from silently doing nothing. Treat a throw as a failed copy.
+    try {
+      setInviteCopy((await copyToClipboard(inviteUrl)) ? 'copied' : 'error')
+    } catch {
+      setInviteCopy('error')
+    }
+  }
 
   useEffect(() => {
     if (user) {
@@ -120,11 +137,15 @@ export default function UserFormModal({ isOpen, onClose, user, onSave, loading, 
         <div className="flex gap-3">
           <button
             type="button"
-            onClick={() => navigator.clipboard.writeText(inviteUrl)}
+            onClick={handleCopyInvite}
             className="flex-1 min-h-[44px] bg-accent-500 hover:bg-accent-600 text-bg-navy font-bold py-2 px-4 rounded-lg transition"
           >
             Copy Link
           </button>
+          <p aria-live="polite" className="sr-only">
+            {inviteCopy === 'copied' && 'Invite link copied.'}
+            {inviteCopy === 'error' && 'Could not copy the invite link.'}
+          </p>
           <button
             type="button"
             onClick={onClose}

--- a/frontend/src/admin/components/UserFormModal.jsx
+++ b/frontend/src/admin/components/UserFormModal.jsx
@@ -26,10 +26,9 @@ export default function UserFormModal({ isOpen, onClose, user, onSave, loading, 
   const [errors, setErrors] = useState({})
   const [inviteCopy, setInviteCopy] = useState('idle')
 
-  // Was a bare fire-and-forget navigator.clipboard.writeText with no await, no
-  // catch and no feedback: an unhandled rejection, and an admin who believes an
-  // invite link is on their clipboard when it may not be. That link is the only
-  // way the new user can activate, so a silent miss is expensive.
+  // This link is the only way the new user can activate their account, so a copy
+  // that quietly fails costs an onboarding round trip nobody knows to make. The
+  // result must reach the admin either way.
   const handleCopyInvite = async () => {
     // copyToClipboard is written to report false rather than reject, but a
     // handler whose only failure path depends on that promise is one refactor
@@ -142,10 +141,6 @@ export default function UserFormModal({ isOpen, onClose, user, onSave, loading, 
           >
             Copy Link
           </button>
-          <p aria-live="polite" className="sr-only">
-            {inviteCopy === 'copied' && 'Invite link copied.'}
-            {inviteCopy === 'error' && 'Could not copy the invite link.'}
-          </p>
           <button
             type="button"
             onClick={onClose}
@@ -154,6 +149,12 @@ export default function UserFormModal({ isOpen, onClose, user, onSave, loading, 
             Close
           </button>
         </div>
+        <p aria-live="polite" className="mt-2 text-sm min-h-[1.25rem]">
+          {inviteCopy === 'copied' && <span className="text-green-300">Invite link copied.</span>}
+          {inviteCopy === 'error' && (
+            <span className="text-red-300">Could not copy the invite link — select it above and copy manually.</span>
+          )}
+        </p>
       </Modal>
     )
   }

--- a/frontend/src/admin/components/UserFormModal.jsx
+++ b/frontend/src/admin/components/UserFormModal.jsx
@@ -26,6 +26,15 @@ export default function UserFormModal({ isOpen, onClose, user, onSave, loading, 
   const [errors, setErrors] = useState({})
   const [inviteCopy, setInviteCopy] = useState('idle')
 
+  // UserManagement renders this modal unconditionally and it early-returns on
+  // !isOpen, so closing hides it without unmounting and the copy result would
+  // survive into the NEXT invite. A stale "Invite link copied." is the same
+  // false success this component was just fixed to stop producing — the new
+  // link is not on the clipboard.
+  useEffect(() => {
+    setInviteCopy('idle')
+  }, [inviteUrl, isOpen])
+
   // This link is the only way the new user can activate their account, so a copy
   // that quietly fails costs an onboarding round trip nobody knows to make. The
   // result must reach the admin either way.

--- a/frontend/src/admin/components/UserFormModal.jsx
+++ b/frontend/src/admin/components/UserFormModal.jsx
@@ -7,7 +7,7 @@
 // - loading: boolean
 // - inviteUrl: string|null — when set, switches to invite-link copy view (email delivery failed)
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { FIELD_LIMITS } from '../../utils/validation'
 import Modal from '../../components/ui/Modal'
 import { copyToClipboard } from '../../utils/clipboard'
@@ -31,7 +31,15 @@ export default function UserFormModal({ isOpen, onClose, user, onSave, loading, 
   // survive into the NEXT invite. A stale "Invite link copied." is the same
   // false success this component was just fixed to stop producing — the new
   // link is not on the clipboard.
+  //
+  // Resetting the state is not sufficient on its own: copyToClipboard is async,
+  // so a copy still in flight when the invite changes would settle afterwards
+  // and write its result over the reset. The token makes a result apply only if
+  // the context it was started in is still current.
+  const copyAttemptRef = useRef(0)
+
   useEffect(() => {
+    copyAttemptRef.current += 1
     setInviteCopy('idle')
   }, [inviteUrl, isOpen])
 
@@ -39,14 +47,23 @@ export default function UserFormModal({ isOpen, onClose, user, onSave, loading, 
   // that quietly fails costs an onboarding round trip nobody knows to make. The
   // result must reach the admin either way.
   const handleCopyInvite = async () => {
+    const attempt = ++copyAttemptRef.current
+
     // copyToClipboard is written to report false rather than reject, but a
     // handler whose only failure path depends on that promise is one refactor
     // away from silently doing nothing. Treat a throw as a failed copy.
+    let copied
     try {
-      setInviteCopy((await copyToClipboard(inviteUrl)) ? 'copied' : 'error')
+      copied = await copyToClipboard(inviteUrl)
     } catch {
-      setInviteCopy('error')
+      copied = false
     }
+
+    // A newer invite (or a newer copy) superseded this one while it was in
+    // flight. Reporting now would attribute this result to the wrong link.
+    if (copyAttemptRef.current !== attempt) return
+
+    setInviteCopy(copied ? 'copied' : 'error')
   }
 
   useEffect(() => {

--- a/frontend/src/admin/components/__tests__/EmbedCodeGenerator.test.jsx
+++ b/frontend/src/admin/components/__tests__/EmbedCodeGenerator.test.jsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import EmbedCodeGenerator, { escapeHtmlAttribute } from '../EmbedCodeGenerator'
+import { copyToClipboard } from '../../../utils/clipboard'
+
+// Mock the shared helper rather than navigator.clipboard: the component's
+// contract is with copyToClipboard (which reports false instead of throwing and
+// has its own execCommand fallback). Mocking the browser API would test the
+// helper's internals through the component.
+vi.mock('../../../utils/clipboard', () => ({ copyToClipboard: vi.fn() }))
+
+const EVENT = { slug: 'lwbc18', name: 'Long Weekend Band Crawl Vol. 18' }
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('escapeHtmlAttribute', () => {
+  // & must be replaced first or the entities added afterwards get double-escaped.
+  it('escapes & before the entities that contain it', () => {
+    expect(escapeHtmlAttribute('Rock & "Roll"')).toBe('Rock &amp; &quot;Roll&quot;')
+  })
+
+  it.each([
+    ['"', '&quot;'],
+    ['<', '&lt;'],
+    ['>', '&gt;'],
+    ['&', '&amp;'],
+  ])('escapes %s', (raw, escaped) => {
+    expect(escapeHtmlAttribute(raw)).toBe(escaped)
+  })
+
+  it('renders null and undefined as empty rather than the literal words', () => {
+    expect(escapeHtmlAttribute(null)).toBe('')
+    expect(escapeHtmlAttribute(undefined)).toBe('')
+  })
+})
+
+describe('EmbedCodeGenerator', () => {
+  // The generated code is pasted onto someone ELSE's site, so a quote in the
+  // event name must not be able to close the title attribute and open another.
+  it('does not let an event name inject an attribute into the generated iframe', () => {
+    render(<EmbedCodeGenerator event={{ slug: 'x', name: 'evil" onload="alert(1)' }} />)
+
+    const code = screen.getByText(/<iframe/).textContent
+    expect(code).not.toContain('onload="alert(1)')
+    expect(code).toContain('&quot;')
+    expect(code.match(/title="/g)).toHaveLength(1)
+  })
+
+  it('escapes the slug in the generated src as well', () => {
+    render(<EmbedCodeGenerator event={{ slug: 'a"b', name: 'n' }} />)
+    expect(screen.getByText(/<iframe/).textContent).toContain('embed/a&quot;b')
+  })
+
+  it('reports success when the clipboard write resolves', async () => {
+    copyToClipboard.mockResolvedValue(true)
+    render(<EmbedCodeGenerator event={EVENT} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /copy code/i }))
+
+    expect(await screen.findByText(/copied/i)).toBeInTheDocument()
+  })
+
+  // The load-bearing case: before this fix the success message fired whether or
+  // not the write worked, so the admin pasted whatever was already on their
+  // clipboard. A rejected write must never read as success.
+  it('does NOT claim success when the clipboard write rejects', async () => {
+    copyToClipboard.mockResolvedValue(false)
+    render(<EmbedCodeGenerator event={EVENT} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /copy code/i }))
+
+    expect(await screen.findByText(/could not copy/i)).toBeInTheDocument()
+    expect(screen.queryByText(/copied\./i)).not.toBeInTheDocument()
+  })
+
+  // copyToClipboard also returns false when it rejects internally; the component
+  // must treat that identically to an explicit false.
+  it('does NOT claim success when the copy helper rejects', async () => {
+    copyToClipboard.mockRejectedValue(new Error('denied'))
+    render(<EmbedCodeGenerator event={EVENT} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /copy code/i }))
+
+    expect(await screen.findByText(/could not copy/i)).toBeInTheDocument()
+    expect(screen.queryByText(/copied\./i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/admin/components/__tests__/EmbedCodeGenerator.test.jsx
+++ b/frontend/src/admin/components/__tests__/EmbedCodeGenerator.test.jsx
@@ -75,8 +75,10 @@ describe('EmbedCodeGenerator', () => {
     expect(screen.queryByText(/copied\./i)).not.toBeInTheDocument()
   })
 
-  // copyToClipboard also returns false when it rejects internally; the component
-  // must treat that identically to an explicit false.
+  // copyToClipboard is not expected to reject: it catches a Clipboard API
+  // rejection and then tries the textarea fallback, which can still return true.
+  // This covers an UNEXPECTED rejection escaping it, which is distinct from its
+  // normal false result — the component must treat both as a failed copy.
   it('does NOT claim success when the copy helper rejects', async () => {
     copyToClipboard.mockRejectedValue(new Error('denied'))
     render(<EmbedCodeGenerator event={EVENT} />)

--- a/frontend/src/admin/components/__tests__/UserFormModal.copy.test.jsx
+++ b/frontend/src/admin/components/__tests__/UserFormModal.copy.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import UserFormModal from '../UserFormModal'
 import { copyToClipboard } from '../../../utils/clipboard'
@@ -79,6 +79,32 @@ describe('UserFormModal invite-link copy', () => {
 
     rerender(<UserFormModal {...props} isOpen={false} />)
     rerender(<UserFormModal {...props} isOpen={true} />)
+
+    expect(screen.queryByText(/invite link copied/i)).not.toBeInTheDocument()
+  })
+
+  // The reset effect alone does not close this: copyToClipboard is async, so a
+  // copy still in flight when the invite changes settles AFTERWARDS and would
+  // write its result over the reset — attributing the old link's success to the
+  // new one. The attempt token is what makes a superseded result inert.
+  it('ignores an in-flight copy that settles after the invite changed', async () => {
+    let settle
+    copyToClipboard.mockReturnValue(
+      new Promise(resolve => {
+        settle = resolve
+      })
+    )
+
+    const { rerender } = render(<UserFormModal {...props} />)
+    clickCopy()
+
+    // The invite changes while the copy is still pending.
+    rerender(<UserFormModal {...props} inviteUrl="https://settimes.ca/admin/signup?code=newer" />)
+
+    // Now the OLD copy succeeds.
+    await act(async () => {
+      settle(true)
+    })
 
     expect(screen.queryByText(/invite link copied/i)).not.toBeInTheDocument()
   })

--- a/frontend/src/admin/components/__tests__/UserFormModal.copy.test.jsx
+++ b/frontend/src/admin/components/__tests__/UserFormModal.copy.test.jsx
@@ -57,6 +57,32 @@ describe('UserFormModal invite-link copy', () => {
     expect(status).toHaveAttribute('aria-live', 'polite')
   })
 
+  // The parent renders this modal unconditionally, so closing it does not
+  // unmount and state persists. Without a reset the previous invite's result is
+  // still on screen when the next one opens.
+  it('clears the previous result when a new invite arrives', async () => {
+    copyToClipboard.mockResolvedValue(true)
+    const { rerender } = render(<UserFormModal {...props} />)
+    clickCopy()
+    expect(await screen.findByText(/invite link copied/i)).toBeInTheDocument()
+
+    rerender(<UserFormModal {...props} inviteUrl="https://settimes.ca/admin/signup?code=different" />)
+
+    expect(screen.queryByText(/invite link copied/i)).not.toBeInTheDocument()
+  })
+
+  it('clears the previous result when the modal is closed and reopened', async () => {
+    copyToClipboard.mockResolvedValue(true)
+    const { rerender } = render(<UserFormModal {...props} />)
+    clickCopy()
+    expect(await screen.findByText(/invite link copied/i)).toBeInTheDocument()
+
+    rerender(<UserFormModal {...props} isOpen={false} />)
+    rerender(<UserFormModal {...props} isOpen={true} />)
+
+    expect(screen.queryByText(/invite link copied/i)).not.toBeInTheDocument()
+  })
+
   it('announces failure when the helper rejects outright', async () => {
     copyToClipboard.mockRejectedValue(new Error('denied'))
     render(<UserFormModal {...props} />)

--- a/frontend/src/admin/components/__tests__/UserFormModal.copy.test.jsx
+++ b/frontend/src/admin/components/__tests__/UserFormModal.copy.test.jsx
@@ -42,6 +42,21 @@ describe('UserFormModal invite-link copy', () => {
     expect(await screen.findByText(/could not copy/i)).toBeInTheDocument()
   })
 
+  // The failure message was sr-only once, so a SIGHTED admin got no feedback at
+  // all — the exact silence this fix exists to remove. getByText finds sr-only
+  // nodes and Tailwind's sr-only (1px + clip) still reads as visible to jsdom,
+  // so neither queries nor toBeVisible catch a regression here. Asserting the
+  // class is absent is the only check that goes red if it is re-hidden.
+  it('shows the failure to sighted users, not only to screen readers', async () => {
+    copyToClipboard.mockResolvedValue(false)
+    render(<UserFormModal {...props} />)
+    clickCopy()
+
+    const status = (await screen.findByText(/could not copy/i)).closest('p')
+    expect(status).not.toHaveClass('sr-only')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+  })
+
   it('announces failure when the helper rejects outright', async () => {
     copyToClipboard.mockRejectedValue(new Error('denied'))
     render(<UserFormModal {...props} />)

--- a/frontend/src/admin/components/__tests__/UserFormModal.copy.test.jsx
+++ b/frontend/src/admin/components/__tests__/UserFormModal.copy.test.jsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import UserFormModal from '../UserFormModal'
+import { copyToClipboard } from '../../../utils/clipboard'
+
+vi.mock('../../../utils/clipboard', () => ({ copyToClipboard: vi.fn() }))
+
+const props = {
+  isOpen: true,
+  onClose: vi.fn(),
+  user: null,
+  onSave: vi.fn(),
+  loading: false,
+  inviteUrl: 'https://settimes.ca/admin/signup?code=abc123',
+}
+
+const clickCopy = () => fireEvent.click(screen.getByRole('button', { name: /copy link/i }))
+
+describe('UserFormModal invite-link copy', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('copies through the shared helper rather than the raw clipboard API', () => {
+    render(<UserFormModal {...props} />)
+    clickCopy()
+    expect(copyToClipboard).toHaveBeenCalledWith(props.inviteUrl)
+  })
+
+  it('announces success when the copy works', async () => {
+    copyToClipboard.mockResolvedValue(true)
+    render(<UserFormModal {...props} />)
+    clickCopy()
+    expect(await screen.findByText(/invite link copied/i)).toBeInTheDocument()
+  })
+
+  // The invite link is the only way a new user can activate, so an admin who
+  // believes it is on the clipboard when it is not sends nothing and never finds
+  // out. Before this fix the click was fire-and-forget with no feedback at all.
+  it('announces failure instead of staying silent when the copy fails', async () => {
+    copyToClipboard.mockResolvedValue(false)
+    render(<UserFormModal {...props} />)
+    clickCopy()
+    expect(await screen.findByText(/could not copy/i)).toBeInTheDocument()
+  })
+
+  it('announces failure when the helper rejects outright', async () => {
+    copyToClipboard.mockRejectedValue(new Error('denied'))
+    render(<UserFormModal {...props} />)
+    clickCopy()
+    expect(await screen.findByText(/could not copy/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #945

## 1. Unescaped interpolation into a generated HTML attribute

```js
title="${event.name} Schedule"   // no escaping
```

| `event.name` | generated |
|---|---|
| `x" onload="alert(1)` | `title="x" onload="alert(1) Schedule"` |

**It never executed in our admin** — the string renders as text inside a `<pre>`. The damage landed in the code an admin copies onto **their own site**, which is the component's entire purpose. `event.slug` is escaped too; slugs are constrained, but the constraint lives elsewhere.

`&` is replaced before the entities containing it, or the escaping double-encodes itself.

## 2. The copy button reported success unconditionally

```js
navigator.clipboard.writeText(embedCode)   // not awaited, no catch
alert('Embed code copied!')                // fired either way
```

Unhandled rejection, plus an admin told it worked when it may not have — they paste whatever was already on the clipboard and never find out.

## The sweep found two more, and a helper I should have used

`frontend/src/utils/clipboard.js` already exports `copyToClipboard`, which returns `false` instead of throwing **and** falls back to a hidden textarea when the async API is unavailable. Three public components use it; **zero admin ones did**. The hand-rolled version I first wrote was strictly worse — it reports failure where the helper succeeds. Replaced.

| site | before | |
|---|---|---|
| `EmbedCodeGenerator` | claimed success unconditionally | **fixed** |
| `EventsTab:247` | awaited, no catch; toast said "Ticket link copied!" regardless | **fixed** |
| `UserFormModal:123` | fire-and-forget — no await, no catch, no feedback at all | **fixed** |
| `EventsTab:541` | correct (own inline fallback) | left alone |
| `MfaSettingsModal:101` | correct | left alone |

`UserFormModal` is the worst: that invite link is the only way a new user can activate, so a silent miss sends nothing and nobody learns why.

**Batched deliberately** — same class, same shared helper. Three PRs would have conflicted with each other for no review benefit.

## A hole the tests found in the fix itself

My first version was `setState((await copyToClipboard(x)) ? … : …)` with no `try/catch`. `copyToClipboard` is written never to reject — but a handler whose only failure path depends on that is one refactor from silently doing nothing. The rejection test caught it; both handlers now treat a throw as a failed copy.

## Mutations — each confirmed applied before its result was believed

| mutation | result |
|---|---|
| drop title escaping | **1 RED** |
| claim success on a `false` result | **1 RED** |
| revert UserFormModal to fire-and-forget | **3 RED** |
| remove the reject guard from both handlers | **2 RED** |

The fourth first reported *"no tests"* because a crude edit broke the parse — that proves nothing, so it was redone as a syntactically valid removal.

## Testing

- [x] `make gate` exits 0 — 1,299 backend + 1,204 frontend tests
- [x] 15 new tests across two files
- [x] Mutation table above, all four verified

**Not covered:** `EventsTab:247`. Mounting `EventsTab` (1,000+ lines, in the large-file allowlist) to test a toast branch would tank the coverage denominator — a documented trap in this repo. Verified by inspection plus the shared helper's own tests.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clear success and error feedback when copying event tickets, invite links, and embed code.
  - Added accessible status messages for clipboard actions.
  - Improved embed code safety by escaping event details before displaying them.

- **Bug Fixes**
  - Clipboard failures are now handled gracefully instead of incorrectly reporting success or showing unreliable alerts.
  - Prevented outdated invite-copy feedback from appearing after a newer invite or copy attempt.

- **Tests**
  - Added coverage for clipboard outcomes, accessibility feedback, asynchronous invite updates, and embed-code escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->