### PR TITLE
refactor(admin): mount the two form modals only while open

### DIFF
--- a/frontend/src/admin/EventsTab.jsx
+++ b/frontend/src/admin/EventsTab.jsx
@@ -974,7 +974,7 @@ export default function EventsTab({
         </div>
 
         {/* Modals */}
-        {!readOnly && (
+        {!readOnly && showModal && (
           <EventFormModal
             isOpen={showModal}
             onClose={() => {
@@ -1117,7 +1117,7 @@ export default function EventsTab({
       )}
 
       {/* Event Form Modal */}
-      {!readOnly && (
+      {!readOnly && showModal && (
         <EventFormModal
           isOpen={showModal}
           onClose={() => {

--- a/frontend/src/admin/UserManagement.jsx
+++ b/frontend/src/admin/UserManagement.jsx
@@ -436,19 +436,23 @@ export default function UserManagement({ showToast }) {
         </div>
       </div>
 
-      {/* User Form Modal */}
-      <UserFormModal
-        isOpen={showUserModal}
-        onClose={() => {
-          setShowUserModal(false)
-          setEditingUser(null)
-          setPendingInviteUrl(null)
-        }}
-        user={editingUser}
-        onSave={handleSaveUser}
-        loading={actionLoading}
-        inviteUrl={pendingInviteUrl}
-      />
+      {/* User Form Modal — mounted only while open, so closing DISCARDS its state
+          rather than leaving a hidden instance whose every field needs a manual
+          reset. The Password Reset Modal below has always done this. */}
+      {showUserModal && (
+        <UserFormModal
+          isOpen={showUserModal}
+          onClose={() => {
+            setShowUserModal(false)
+            setEditingUser(null)
+            setPendingInviteUrl(null)
+          }}
+          user={editingUser}
+          onSave={handleSaveUser}
+          loading={actionLoading}
+          inviteUrl={pendingInviteUrl}
+        />
+      )}
 
       {/* Password Reset Modal */}
       {showResetModal && (


### PR DESCRIPTION
Refs #948

## Change

Three render sites now gate on the open flag, so closing a modal unmounts it:

| site | before |
|---|---|
| `UserManagement:440` | `<UserFormModal isOpen={showUserModal} …>` |
| `EventsTab:978` | `{!readOnly && <EventFormModal isOpen={showModal} …>}` |
| `EventsTab:1121` | same |

Both modals early-return on `!isOpen`, so closing previously **hid them without unmounting** and all their state survived into the next open. Correctness was opt-in — a state variable was right only if someone remembered to reset it. `UserManagement` already used the correct pattern three lines below, for the Password Reset Modal.

## The issue's premise was wrong, and the tests proved it

#948 predicted `UserFormModal`'s reset effect and attempt token would become dead weight. Deleting them turned **3 of 8 tests red**:

```
× clears the previous result when a new invite arrives
× clears the previous result when the modal is closed and reopened
× ignores an in-flight copy that settles after the invite changed
```

Two reasons, second one decisive:

1. Those tests render the component **directly**, so they never exercise the parent's mounting.
2. **`inviteUrl` changes while the modal stays mounted.** `UserManagement:76` sets `pendingInviteUrl` and deliberately keeps the modal open to switch to the URL-copy view. Unmounting on close doesn't touch that path, so both guards are still load-bearing.

**The guards are kept.** Deleting working guards to satisfy a refactor's premise would have reintroduced the exact bug three review rounds on #947 just removed. Correction posted on #948.

## What this is worth, then

Smaller than the issue claimed, still real:

- **`EventFormModal` never resets `loading`.** Safe today only because `setLoading(false)` sits in a `finally` plus two early returns — a *different mechanism* from the reset effect covering its other four state variables. Unmounting removes the asymmetry rather than depending on that `finally` staying.
- Form data, validation errors and slug-edited state are discarded by React rather than a `setTimeout`-wrapped effect.
- New state on either modal is correct by default instead of needing to be remembered.

## Testing

- [x] `make gate` exits 0 — 1,299 backend + 1,208 frontend tests
- [x] Empirically tested the deletion the issue proposed, and reverted it on the evidence

**Not verified:** the animation tradeoff. `Modal.jsx` uses `animate-fade-in`/`animate-scale-in`, which read as entry-only, so unmounting should cost nothing visually — but that is read-not-run, and jsdom can't show it. Worth a browser check before merge.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed event and user form modals appearing when they were not explicitly opened.
  - Closing a user form modal now reliably clears its related editing and invitation details.
  - Read-only access continues to prevent unauthorized event form display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->