### PR TITLE
test(admin): pin EventFormModal's publish reroute and BandForm's conditional schedule

### DIFF
--- a/frontend/src/__tests__/missingTestGate.test.js
+++ b/frontend/src/__tests__/missingTestGate.test.js
@@ -41,13 +41,11 @@ const MAX_UNTESTED_LINES = 400
  * Do not add to this list to make a build pass. Adding an entry means shipping
  * a large untested file, which is the thing being prevented.
  */
-const MAX_ALLOWED = 7
+const MAX_ALLOWED = 5
 
 const ALLOWED = new Set([
   'App.jsx',
   'admin/AdminPanel.jsx',
-  'admin/components/BandForm.jsx',
-  'admin/components/EventFormModal.jsx',
   'admin/LineupTab.jsx',
   'admin/UserManagement.jsx',
   'admin/VenuesTab.jsx',

--- a/frontend/src/admin/components/__tests__/BandForm.test.jsx
+++ b/frontend/src/admin/components/__tests__/BandForm.test.jsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import BandForm from '../BandForm'
+
+vi.mock('../PhotoUpload', () => ({ default: () => <div data-testid="photo-upload" /> }))
+vi.mock('../RichTextEditor', () => ({ default: () => <div data-testid="rich-text-editor" /> }))
+
+const baseFormData = {
+  name: 'The Testers',
+  event_id: '',
+  venue_id: '',
+  start_time: '',
+  end_time: '',
+  duration: '',
+  performance_date: '',
+  notes: '',
+  origin_city: '',
+  origin_region: '',
+  genre: '',
+  photo_url: '',
+  photo_alt_text: '',
+  description: '',
+  website: '',
+  instagram: '',
+  bandcamp: '',
+  facebook: '',
+  youtube: '',
+  spotify: '',
+  apple_music: '',
+  linktree: '',
+  contact_email: '',
+  is_active: 1,
+}
+
+function renderForm(overrides = {}, props = {}) {
+  const onSubmit = vi.fn()
+  render(
+    <BandForm
+      events={[{ id: 12, name: 'Test Festival' }]}
+      venues={[{ id: 4, name: 'The Test Venue' }]}
+      formData={{ ...baseFormData, ...overrides }}
+      submitting={false}
+      mode="create"
+      onChange={vi.fn()}
+      onSubmit={onSubmit}
+      onCancel={vi.fn()}
+      {...props}
+    />
+  )
+  return onSubmit
+}
+
+function submittedFields(onSubmit) {
+  const form = onSubmit.mock.calls[0][0].target
+  return Object.fromEntries(new window.FormData(form).entries())
+}
+
+describe('BandForm', () => {
+  it('requires schedule controls when an event is selected, but not in global view', () => {
+    renderForm({ event_id: '12' })
+    expect(screen.getByLabelText(/Start Time/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Duration \(minutes\)/)).toBeInTheDocument()
+
+    cleanup()
+    renderForm({ event_id: '12' }, { globalView: true })
+    expect(screen.queryByLabelText(/Start Time/)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Duration \(minutes\)/)).not.toBeInTheDocument()
+  })
+
+  it('submits new profile fields while omitting unrendered schedule fields', () => {
+    const onSubmit = renderForm({}, { globalView: true })
+    fireEvent.submit(screen.getByRole('button', { name: 'Add Artist' }).closest('form'))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(submittedFields(onSubmit)).toMatchObject({
+      name: 'The Testers',
+      website: '',
+      instagram: '',
+      contact_email: '',
+      is_active: '1',
+    })
+    expect(submittedFields(onSubmit)).not.toHaveProperty('event_id')
+    expect(submittedFields(onSubmit)).not.toHaveProperty('start_time')
+    expect(submittedFields(onSubmit)).not.toHaveProperty('venue_id')
+  })
+
+  it('submits schedule fields for an edited performance, including empty values', () => {
+    const onSubmit = renderForm({ event_id: '12', venue_id: '' })
+    fireEvent.submit(screen.getByRole('button', { name: 'Create & Add Artist' }).closest('form'))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(submittedFields(onSubmit)).toMatchObject({
+      name: 'The Testers',
+      event_id: '12',
+      venue_id: '',
+      start_time: '',
+      end_time: '',
+      duration: '',
+    })
+  })
+
+  it('keeps the required validation attached to the artist name field', () => {
+    renderForm({ name: '' }, { globalView: true })
+    const nameInput = screen.getByLabelText('Artist Name *')
+
+    expect(nameInput).toBeRequired()
+  })
+})

--- a/frontend/src/admin/components/__tests__/EventFormModal.test.jsx
+++ b/frontend/src/admin/components/__tests__/EventFormModal.test.jsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import EventFormModal from '../EventFormModal'
+import { eventsApi } from '../../../utils/adminApi'
+import { publishWithLineupConfirm } from '../../utils/publishWithLineupConfirm'
+
+vi.mock('../../../utils/adminApi', () => ({
+  eventsApi: {
+    create: vi.fn(),
+    update: vi.fn(),
+    setPublishState: vi.fn(),
+    setRevealMode: vi.fn(),
+  },
+}))
+vi.mock('../../utils/publishWithLineupConfirm', () => ({ publishWithLineupConfirm: vi.fn() }))
+vi.mock('../PhotoUpload', () => ({ default: () => <div data-testid="photo-upload" /> }))
+
+const baseEvent = {
+  id: 37,
+  name: 'Long Weekend Band Crawl Vol. 18',
+  slug: 'lwbc18',
+  date: '2099-10-11',
+  end_date: null,
+  description: '',
+  city: 'Kitchener',
+  ticket_url: '',
+  poster_url: '',
+  social_links: null,
+  doors_json: null,
+  reveal_mode: 0,
+}
+
+function renderModal(event) {
+  const onClose = vi.fn()
+  const onSave = vi.fn()
+  render(<EventFormModal isOpen event={event} onClose={onClose} onSave={onSave} />)
+  return { onClose, onSave }
+}
+
+async function submitWithStatus(status) {
+  fireEvent.change(screen.getByLabelText('Status'), { target: { value: status } })
+  fireEvent.submit(screen.getByRole('button', { name: /update event/i }).closest('form'))
+  await waitFor(() => expect(eventsApi.update).toHaveBeenCalledTimes(1))
+}
+
+describe('EventFormModal publication routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    eventsApi.update.mockResolvedValue({ event: baseEvent })
+    eventsApi.create.mockResolvedValue({ event: baseEvent })
+    publishWithLineupConfirm.mockResolvedValue({ cancelled: false })
+  })
+
+  it('removes status from a draft-to-published update and calls the publish path', async () => {
+    renderModal({ ...baseEvent, status: 'draft' })
+    await submitWithStatus('published')
+
+    expect(eventsApi.update.mock.calls[0][1]).not.toHaveProperty('status')
+    expect(publishWithLineupConfirm).toHaveBeenCalledWith(eventsApi, {
+      id: baseEvent.id,
+      name: baseEvent.name,
+    })
+  })
+
+  it('keeps status in the payload when re-saving an already-published event', async () => {
+    renderModal({ ...baseEvent, status: 'published' })
+    await submitWithStatus('published')
+
+    expect(eventsApi.update.mock.calls[0][1]).toHaveProperty('status', 'published')
+    expect(publishWithLineupConfirm).not.toHaveBeenCalled()
+  })
+
+  it('removes status when editing an archived event', async () => {
+    renderModal({ ...baseEvent, status: 'archived' })
+    fireEvent.submit(screen.getByRole('button', { name: /update event/i }).closest('form'))
+    await waitFor(() => expect(eventsApi.update).toHaveBeenCalledTimes(1))
+
+    expect(eventsApi.update.mock.calls[0][1]).not.toHaveProperty('status')
+    expect(publishWithLineupConfirm).not.toHaveBeenCalled()
+  })
+
+  it('creates a draft without rerouting through publication', async () => {
+    render(<EventFormModal isOpen event={null} onClose={vi.fn()} onSave={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Event Name *'), { target: { value: 'New Festival' } })
+    fireEvent.change(screen.getByLabelText('Event Date *'), { target: { value: '2099-10-11' } })
+    fireEvent.submit(screen.getByRole('button', { name: /create event/i }).closest('form'))
+
+    await waitFor(() => expect(eventsApi.create).toHaveBeenCalledTimes(1))
+    expect(eventsApi.create.mock.calls[0][0]).toHaveProperty('status', 'draft')
+    expect(publishWithLineupConfirm).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #923

Both surfaces are tested by **behaviour**, not extraction — 268 of `BandForm`'s 684 lines are JSX and its non-render logic is three one-liners, so extracting would produce modules existing only for a test to point at while the part that breaks stayed uncovered.

## EventFormModal — the reroute is the point

#821: a draft → published transition must not send `status` through PATCH. It strips it and calls the publish route instead, because that's the only path checking for an empty lineup before an event goes public.

| case | `status` in payload | publish path |
|---|---|---|
| draft → published | **absent** | called |
| re-save already-published | **present** | not called |
| editing an archived event | absent (separate branch) | not called |
| create | n/a | not called |

**The second row is what makes this suite worth having.** "Fixing" the predicate to be unconditional would look like a tightening and would silently break routine editing of a live event's description or poster.

## The issue's premise about BandForm was wrong

#923 asked for tests on BandForm's *"submit payload shape — what actually reaches `bandsApi`"* and its validation error rendering. **Neither exists.** `BandForm` is fully controlled: it takes `formData`/`onChange`/`onSubmit` as props, does `<form onSubmit={onSubmit}>`, and has no error prop and no payload construction. The parent owns both.

So the tests assert what it actually owns — which controls render under `requireSchedule` (`false` in `globalView`, `Boolean(formData.event_id)` otherwise), which fields therefore reach a native submission, and that the artist-name field keeps its required validation.

## Mutations — verified here, independently of the delegate's own run

| mutation | result |
|---|---|
| drop `event?.status !== 'published'` from the transition | **1 RED** |
| stop stripping `status` on the transition | **1 RED** |
| flip `requireSchedule`'s `globalView` branch | **2 RED** |

Each confirmed applied (grepped) before its result was believed.

## Gate ratchet lowered, not gamed

Both files removed from #921's `ALLOWED` list; `MAX_ALLOWED` drops **7 → 5**. That gate fails if a listed file gains a test and the entry is left behind, so leaving them would not have been a safe no-op.

**Coverage rose, which was not a given** — mounting these two pulls ~1,480 previously-uncounted lines into the denominator:

```
statements +1.81%   branches +3.07%   functions +1.73%   lines +1.80%
```

Neither production component was modified (`git status` clean on both).

## Testing

- [x] `make gate` exits 0 — 1,299 backend + 1,230 frontend tests
- [x] Mutation table above, re-run here rather than taken on report

## Note on how this was built

Implemented by Otto (OpenCode, `gpt-5.6-luna`, $0.189); spec, review and mutation re-verification here. Otto correctly reported the BandForm contradiction rather than inventing a payload test to satisfy the brief.

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for band form scheduling, global views, artist profiles, validation, and submitted values.
  * Added event form coverage for publishing, draft updates, archived edits, and new draft events.
* **Chores**
  * Updated the test gate to reflect the expanded coverage and reduce the permitted outstanding test debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->