### PR TITLE
chore(validation): split the value:null sites by what they actually mean

### DIFF
--- a/functions/utils/__tests__/valueNullPolicy.test.js
+++ b/functions/utils/__tests__/valueNullPolicy.test.js
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { validatePerformanceDate, validateDoorsJson } from "../validation/datetime.js";
+
+const validationDir = join(dirname(dirname(fileURLToPath(import.meta.url))), "validation");
+
+/**
+ * `.github/instructions/nodejs-javascript-vitest.instructions.md` prefers
+ * `undefined` over `null` for optional values, and #917 asked for a sweep. The
+ * sweep found two different cases wearing the same shape:
+ *
+ *   valid: false  -> `.value` is never read; callers branch on `.valid` and
+ *                    return the error. A value key there is noise.
+ *   valid: true   -> the value is legitimately ABSENT and is bound straight into
+ *                    D1 (bands.js binds it as performance_date, events.js as
+ *                    doors_json). D1's .bind() REJECTS undefined, so null is
+ *                    correct and required.
+ *
+ * A blanket sed would have broken the second case. These pin the split so a
+ * future "consistency" pass cannot quietly flip it.
+ */
+describe("validation result value policy", () => {
+  it("returns null - never undefined - when a valid result has no value", () => {
+    const noDate = validatePerformanceDate(null, { date: "2026-10-11", end_date: null });
+    expect(noDate.valid).toBe(true);
+    expect(noDate.value).toBeNull();
+    expect(Object.hasOwn(noDate, "value")).toBe(true);
+
+    const noDoors = validateDoorsJson(null, { date: "2026-10-11", end_date: null });
+    expect(noDoors.valid).toBe(true);
+    expect(noDoors.value).toBeNull();
+    expect(Object.hasOwn(noDoors, "value")).toBe(true);
+  });
+
+  it("omits value entirely on a rejection", () => {
+    const bad = validatePerformanceDate("not-a-date", { date: "2026-10-11", end_date: null });
+    expect(bad.valid).toBe(false);
+    expect(Object.hasOwn(bad, "value")).toBe(false);
+  });
+
+  // Source scan: a runtime test only reaches the paths it exercises, and these
+  // modules have many rejection branches.
+  it("no rejection anywhere in validation/ carries a value key", () => {
+    const offenders = [];
+    for (const file of ["datetime.js", "ids.js", "strings.js", "urls.js", "contact.js", "identity.js", "schema.js"]) {
+      let source;
+      try {
+        source = readFileSync(join(validationDir, file), "utf8");
+      } catch {
+        continue;
+      }
+      source.split("\n").forEach((line, i) => {
+        if (line.includes("valid: false") && line.includes("value:")) {
+          offenders.push(`${file}:${i + 1}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/functions/utils/__tests__/valueNullPolicy.test.js
+++ b/functions/utils/__tests__/valueNullPolicy.test.js
@@ -52,12 +52,11 @@ describe("validation result value policy", () => {
     const offenders = [];
 
     for (const file of ["datetime.js", "ids.js", "strings.js", "urls.js", "contact.js", "identity.js", "schema.js"]) {
-      let source;
-      try {
-        source = readFileSync(join(validationDir, file), "utf8");
-      } catch {
-        continue;
-      }
+      // Fail closed. Swallowing a read error would let this guard quietly stop
+      // checking a module that was renamed, moved or deleted — a scan that
+      // silently covers less than it claims is worse than no scan, because the
+      // green tick still says the policy holds.
+      const source = readFileSync(join(validationDir, file), "utf8");
 
       for (const match of source.matchAll(/return\s*\{[\s\S]*?\};/g)) {
         const literal = match[0];

--- a/functions/utils/__tests__/valueNullPolicy.test.js
+++ b/functions/utils/__tests__/valueNullPolicy.test.js
@@ -40,10 +40,17 @@ describe("validation result value policy", () => {
     expect(Object.hasOwn(bad, "value")).toBe(false);
   });
 
-  // Source scan: a runtime test only reaches the paths it exercises, and these
-  // modules have many rejection branches.
+  // Source scan, because a runtime test only reaches the paths it exercises and
+  // these modules have many rejection branches.
+  //
+  // Matches whole `return { ... };` literals rather than physical lines. A
+  // line-based scan misses the shape that actually occurs in these files —
+  // rejections are routinely formatted across several lines, so `valid: false`
+  // and `value:` land on different lines and a per-line check reports nothing
+  // while the policy is violated.
   it("no rejection anywhere in validation/ carries a value key", () => {
     const offenders = [];
+
     for (const file of ["datetime.js", "ids.js", "strings.js", "urls.js", "contact.js", "identity.js", "schema.js"]) {
       let source;
       try {
@@ -51,12 +58,16 @@ describe("validation result value policy", () => {
       } catch {
         continue;
       }
-      source.split("\n").forEach((line, i) => {
-        if (line.includes("valid: false") && line.includes("value:")) {
-          offenders.push(`${file}:${i + 1}`);
-        }
-      });
+
+      for (const match of source.matchAll(/return\s*\{[\s\S]*?\};/g)) {
+        const literal = match[0];
+        if (!/valid:\s*false/.test(literal)) continue;
+        if (!/\bvalue\s*:/.test(literal)) continue;
+        const line = source.slice(0, match.index).split("\n").length;
+        offenders.push(`${file}:${line}`);
+      }
     }
+
     expect(offenders).toEqual([]);
   });
 });

--- a/functions/utils/validation/datetime.js
+++ b/functions/utils/validation/datetime.js
@@ -222,16 +222,21 @@ export function validateDate(dateString) {
  */
 export function validatePerformanceDate(performanceDate, event) {
   if (performanceDate === undefined || performanceDate === null || performanceDate === "") {
+    // `null`, NOT `undefined`. This is a VALID result whose value is legitimately
+    // absent, and callers bind it straight into D1 — bands.js binds it as
+    // performance_date, events.js as doors_json. D1's .bind() rejects undefined
+    // outright, so the guideline's "prefer undefined for optional values" does
+    // not apply here: this null IS the value written to a nullable column.
     return { valid: true, error: undefined, value: null };
   }
 
   if (typeof performanceDate !== "string") {
-    return { valid: false, error: "performance_date must be a YYYY-MM-DD string", value: null };
+    return { valid: false, error: "performance_date must be a YYYY-MM-DD string" };
   }
 
   const dateCheck = validateDate(performanceDate);
   if (!dateCheck.valid) {
-    return { valid: false, error: dateCheck.error, value: null };
+    return { valid: false, error: dateCheck.error };
   }
 
   const minDate = event?.date || null;
@@ -241,7 +246,6 @@ export function validatePerformanceDate(performanceDate, event) {
     return {
       valid: false,
       error: `performance_date must be between ${minDate || "the event start"} and ${maxDate || "the event end"}`,
-      value: null,
     };
   }
 
@@ -265,6 +269,11 @@ export function validatePerformanceDate(performanceDate, event) {
  */
 export function validateDoorsJson(doorsJson, event) {
   if (doorsJson === undefined || doorsJson === null || doorsJson === "") {
+    // `null`, NOT `undefined`. This is a VALID result whose value is legitimately
+    // absent, and callers bind it straight into D1 — bands.js binds it as
+    // performance_date, events.js as doors_json. D1's .bind() rejects undefined
+    // outright, so the guideline's "prefer undefined for optional values" does
+    // not apply here: this null IS the value written to a nullable column.
     return { valid: true, error: undefined, value: null };
   }
 
@@ -274,26 +283,30 @@ export function validateDoorsJson(doorsJson, event) {
       return {
         valid: false,
         error: `Doors times must be no more than ${FIELD_LIMITS.eventDoorsJson.max} characters`,
-        value: null,
       };
     }
     try {
       parsed = JSON.parse(doorsJson);
     } catch {
-      return { valid: false, error: "Doors times must be valid JSON", value: null };
+      return { valid: false, error: "Doors times must be valid JSON" };
     }
   } else if (typeof doorsJson === "object") {
     parsed = doorsJson;
   } else {
-    return { valid: false, error: "Doors times must be a JSON object", value: null };
+    return { valid: false, error: "Doors times must be a JSON object" };
   }
 
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return { valid: false, error: "Doors times must be a JSON object", value: null };
+    return { valid: false, error: "Doors times must be a JSON object" };
   }
 
   const entries = Object.entries(parsed);
   if (entries.length === 0) {
+    // `null`, NOT `undefined`. This is a VALID result whose value is legitimately
+    // absent, and callers bind it straight into D1 — bands.js binds it as
+    // performance_date, events.js as doors_json. D1's .bind() rejects undefined
+    // outright, so the guideline's "prefer undefined for optional values" does
+    // not apply here: this null IS the value written to a nullable column.
     return { valid: true, error: undefined, value: null };
   }
 
@@ -303,19 +316,18 @@ export function validateDoorsJson(doorsJson, event) {
   for (const [dateKey, timeValue] of entries) {
     const dateCheck = validateDate(dateKey);
     if (!dateCheck.valid) {
-      return { valid: false, error: `Doors times key "${dateKey}" must be a valid YYYY-MM-DD date`, value: null };
+      return { valid: false, error: `Doors times key "${dateKey}" must be a valid YYYY-MM-DD date` };
     }
 
     if (!minDate || dateKey < minDate || dateKey > maxDate) {
       return {
         valid: false,
         error: `Doors times date "${dateKey}" must be between ${minDate || "the event start"} and ${maxDate || "the event end"}`,
-        value: null,
       };
     }
 
     if (typeof timeValue !== "string" || !DOORS_TIME_REGEX.test(timeValue)) {
-      return { valid: false, error: `Doors time for "${dateKey}" must be in 24-hour HH:MM format`, value: null };
+      return { valid: false, error: `Doors time for "${dateKey}" must be in 24-hour HH:MM format` };
     }
   }
 
@@ -324,7 +336,6 @@ export function validateDoorsJson(doorsJson, event) {
     return {
       valid: false,
       error: `Doors times must be no more than ${FIELD_LIMITS.eventDoorsJson.max} characters`,
-      value: null,
     };
   }
 

--- a/functions/utils/validation/ids.js
+++ b/functions/utils/validation/ids.js
@@ -8,12 +8,12 @@
  */
 export function validateId(id) {
   if (id === undefined || id === null || id === "") {
-    return { valid: false, value: null, error: "ID is required" };
+    return { valid: false, error: "ID is required" };
   }
 
   const numId = Number(id);
   if (!Number.isInteger(numId) || numId < 1) {
-    return { valid: false, value: null, error: "ID must be a positive integer" };
+    return { valid: false, error: "ID must be a positive integer" };
   }
 
   return { valid: true, value: numId, error: undefined };


### PR DESCRIPTION
Closes #917

#917 asked for a sweep toward the guideline's *"prefer `undefined` for optional values."* The sweep found **two different cases wearing the same shape**, and only one should change.

## 13 rejections — the `value` key is noise

On `valid: false` the caller never reads `.value`; every consumer branches on `.valid` and returns the error. Those returns now omit the key entirely, which reads as `undefined` without asserting a value that doesn't exist.

## 3 valid results — `null` is required, not a style slip

`validatePerformanceDate` and `validateDoorsJson` return `{ valid: true, value: null }` when the input is legitimately absent, and callers bind that **straight into D1**:

```
functions/api/admin/bands.js:578    .bind(..., resolvedPerformanceDate, ...)
functions/api/admin/events.js:283   .bind(..., sanitizedDoorsJson, ...)
```

**D1's `.bind()` rejects `undefined`.** So that null is the value written to a nullable column, not an unset optional — the guideline doesn't apply to it. Each of the three now says so in a comment, because the next person running a consistency pass will otherwise "fix" it.

**This is exactly why #917 said not to blanket-sed the value half.** A single sed would have been green in tests and broken two production write paths.

## Guard

`functions/utils/__tests__/valueNullPolicy.test.js` pins both halves:

- valid results still return `null` **and still carry the key**
- rejections carry no `value` key
- a source scan covers the rejection branches no runtime test reaches

| mutation | result |
|---|---|
| flip a `valid: true` null to `undefined` | **1 RED** |
| re-add a `value` key to a rejection | **1 RED** |

## Testing

- [x] `make gate` exits 0 — 1,302 backend + 1,230 frontend tests
- [x] Traced both `valid: true` consumers to their `.bind()` call sites before deciding
- [x] Mutation table above

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Validation failures no longer include an incorrect `value: null` field.
  - Validation results now clearly distinguish invalid inputs from valid inputs with no value.
  - Valid results continue returning `null` when no value is available and retain values when provided.
  - Existing validation rules and error handling remain unchanged.

- **Tests**
  - Expanded coverage to verify validation result value behaviour across supported validators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->