### PR TITLE
refactor(admin): stop routing two resources through one band handler

### DIFF
--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -7,17 +7,15 @@ import {
   FIELD_LIMITS,
   isValidEmail,
   safeReflectSocialLinks,
-  sanitizeBandSocialLinks,
   sanitizeOptionalHttpUrl,
   sanitizeOptionalText,
-  sanitizeString,
   validatePerformanceDate,
   validateSetTimes,
 } from "../../../utils/validation.js";
 import { getClientIP, getUrlId } from "../../../utils/request.js";
 import { checkConflicts } from "../../../utils/timeConflicts.js";
-import { parseOrigin } from "../../../utils/parseOrigin.js";
-import { normalizeBandName } from "../../../utils/bandName.js";
+import { onRequestProfileDelete, onRequestProfilePut } from "../../../utils/bandProfileResource.js";
+import { findDuplicateBandProfile, findVenue, prepareBandProfileFields } from "../../../utils/bandProfileFields.js";
 
 async function getEventForPerformance(DB, performanceId) {
   if (!performanceId) return null;
@@ -113,6 +111,13 @@ export async function onRequestPut(context) {
       notes,
     } = body;
 
+    if (isProfileUpdate) {
+      return onRequestProfilePut(
+        { ...context, user, ipAddress },
+        { performanceId, body, bandProfileId: parseProfileId(performanceId) },
+      );
+    }
+
     // Normalize venueId: treat "", 0, "0" as null (no venue assigned).
     // Guards against the frontend sending Number("") = 0 when no venue is selected,
     // which would otherwise pass the !== null check and then 404 on "Venue not found".
@@ -131,28 +136,13 @@ export async function onRequestPut(context) {
         headers: { "Content-Type": "application/json" },
       });
     }
-    let realPerformanceId = performanceId;
-    let bandProfileId = null;
-
-    if (isProfileUpdate) {
-      const parsed = parseProfileId(performanceId);
-      if (parsed === null) {
-        return new Response(
-          JSON.stringify({
-            error: "Bad request",
-            message: "Invalid profile ID",
-          }),
-          { status: 400, headers: { "Content-Type": "application/json" } },
-        );
-      }
-      bandProfileId = parsed;
-      realPerformanceId = null;
-    }
+    const realPerformanceId = performanceId;
+    let bandProfileId;
 
     let performance = null;
     let linkedEvent = null;
 
-    if (!isProfileUpdate) {
+    {
       // Check if performance exists
       performance = await DB.prepare(
         `
@@ -197,24 +187,6 @@ export async function onRequestPut(context) {
           { status: 400, headers: { "Content-Type": "application/json" } },
         );
       }
-    } else {
-      // Fetch profile directly
-      const profile = await DB.prepare("SELECT * FROM band_profiles WHERE id = ?").bind(bandProfileId).first();
-
-      if (!profile) {
-        return new Response(
-          JSON.stringify({
-            error: "Not found",
-            message: "Band profile not found",
-          }),
-          { status: 404, headers: { "Content-Type": "application/json" } },
-        );
-      }
-      // Leaves `performance` null: there is no performance on a profile edit.
-      // Downstream reads of it are optional-chained for that reason — several
-      // run on this path (actualStartTime/actualEndTime/actualVenueId and the
-      // conflict check) and must resolve to undefined so the check
-      // short-circuits.
     }
 
     // Validation - only validate provided fields
@@ -238,10 +210,7 @@ export async function onRequestPut(context) {
       // Or maybe we just switch profile?
       // For now, let's just update the profile name if it's unique, or switch if it exists.
 
-      const nameNormalized = normalizeBandName(name);
-      const existingProfile = await DB.prepare(`SELECT id FROM band_profiles WHERE name_normalized = ? AND id != ?`)
-        .bind(nameNormalized, bandProfileId)
-        .first();
+      const existingProfile = await findDuplicateBandProfile(DB, name, bandProfileId);
 
       if (existingProfile) {
         // Renaming updates the shared profile globally — all performances of this band reflect the change.
@@ -292,7 +261,7 @@ export async function onRequestPut(context) {
     // festival-day span [event.date, event.end_date]. Only applies to real
     // performances — profile-only rows have no event/performance to date.
     let resolvedPerformanceDate;
-    if (!isProfileUpdate && performanceDate !== undefined) {
+    if (performanceDate !== undefined) {
       const performanceDateCheck = validatePerformanceDate(performanceDate, linkedEvent);
       if (!performanceDateCheck.valid) {
         return new Response(
@@ -330,13 +299,7 @@ export async function onRequestPut(context) {
 
     // Check if venue exists (only when a specific positive venue id was provided)
     if (normalizedVenueId != null) {
-      const venue = await DB.prepare(
-        `
-        SELECT id FROM venues WHERE id = ?
-      `,
-      )
-        .bind(normalizedVenueId)
-        .first();
+      const venue = await findVenue(DB, normalizedVenueId);
 
       if (!venue) {
         return new Response(
@@ -399,124 +362,29 @@ export async function onRequestPut(context) {
       photo_alt_text !== undefined ||
       social_links !== undefined
     ) {
-      const profileUpdates = [];
-      const profileParams = [];
-
-      if (name !== undefined) {
-        profileUpdates.push("name = ?");
-        profileUpdates.push("name_normalized = ?");
-        const sanitizedName = sanitizeString(name);
-        profileParams.push(sanitizedName);
-        profileParams.push(normalizeBandName(sanitizedName));
-      }
-
-      // Update other profile fields
-      if (description !== undefined) {
-        profileUpdates.push("description = ?");
-        profileParams.push(sanitizeString(description) || null);
-      }
-      if (genre !== undefined) {
-        profileUpdates.push("genre = ?");
-        profileParams.push(sanitizeString(genre) || null);
-      }
-      const parsedOrigin = origin !== undefined ? parseOrigin(origin) : { city: null, region: null };
-      const resolvedOriginCity = origin_city !== undefined ? origin_city : parsedOrigin.city;
-      const resolvedOriginRegion = origin_region !== undefined ? origin_region : parsedOrigin.region;
-      const computedOrigin =
-        origin !== undefined
-          ? origin
-          : [resolvedOriginCity, resolvedOriginRegion].filter(Boolean).join(", ") || undefined;
-
-      if (origin !== undefined || origin_city !== undefined) {
-        profileUpdates.push("origin_city = ?");
-        profileParams.push(resolvedOriginCity || null);
-      }
-      if (origin !== undefined || origin_region !== undefined) {
-        profileUpdates.push("origin_region = ?");
-        profileParams.push(resolvedOriginRegion || null);
-      }
-      if (computedOrigin !== undefined) {
-        profileUpdates.push("origin = ?");
-        profileParams.push(computedOrigin || null);
-      }
-      if (contact_email !== undefined) {
-        profileUpdates.push("contact_email = ?");
-        profileParams.push(contact_email || null);
-      }
-      if (is_active !== undefined) {
-        profileUpdates.push("is_active = ?");
-        profileParams.push(Number(is_active) === 1 ? 1 : 0);
-      }
-      if (photo_url !== undefined) {
-        profileUpdates.push("photo_url = ?");
-        profileParams.push(resolvedPhotoUrl || null);
-      }
-      if (photo_alt_text !== undefined) {
-        profileUpdates.push("photo_alt_text = ?");
-        const cleanedAlt = sanitizeString(photo_alt_text);
-        profileParams.push(cleanedAlt ? cleanedAlt.slice(0, 250) : null);
-      }
-
-      // Handle Social Links (merge or overwrite?)
-      // The frontend sends a JSON string for social_links usually.
-      // Or if 'url' is sent legacy style, we merge it.
-
-      let newSocialLinks = null;
-      let shouldUpdateSocialLinks = false;
-      if (social_links !== undefined) {
-        shouldUpdateSocialLinks = true;
-        try {
-          newSocialLinks = sanitizeBandSocialLinks(social_links);
-        } catch (error) {
-          return new Response(
-            JSON.stringify({
-              error: "Validation error",
-              message: error.message,
-            }),
-            { status: 400, headers: { "Content-Type": "application/json" } },
-          );
-        }
-      } else if (url !== undefined) {
-        shouldUpdateSocialLinks = true;
-        // Legacy update of just website
-        let existingLinks = {};
-        try {
-          const profile = await DB.prepare("SELECT social_links FROM band_profiles WHERE id = ?")
-            .bind(bandProfileId)
-            .first();
-          existingLinks = JSON.parse(profile.social_links || "{}");
-        } catch (_e) {
-          /* ignore malformed JSON — existingLinks stays {} */
-        }
-        try {
-          existingLinks.website = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");
-          newSocialLinks = sanitizeBandSocialLinks(existingLinks);
-        } catch (error) {
-          return new Response(
-            JSON.stringify({
-              error: "Validation error",
-              message: error.message,
-            }),
-            { status: 400, headers: { "Content-Type": "application/json" } },
-          );
-        }
-      }
-
-      if (shouldUpdateSocialLinks) {
-        profileUpdates.push("social_links = ?");
-        profileParams.push(newSocialLinks);
-      }
-
-      if (profileUpdates.length > 0) {
-        profileParams.push(bandProfileId);
-        writeStatements.push(
-          DB.prepare(`UPDATE band_profiles SET ${profileUpdates.join(", ")} WHERE id = ?`).bind(...profileParams),
+      const { profileStatement, error: profileFieldsError } = await prepareBandProfileFields(
+        DB,
+        body,
+        bandProfileId,
+        resolvedPhotoUrl,
+      );
+      if (profileFieldsError) {
+        return new Response(
+          JSON.stringify({
+            error: "Validation error",
+            message: profileFieldsError.message,
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
         );
+      }
+
+      if (profileStatement) {
+        writeStatements.push(profileStatement);
       }
     }
 
-    // Handle performance updates (ONLY if it's a real performance)
-    if (!isProfileUpdate) {
+    // Handle performance updates
+    {
       if (normalizedVenueId !== undefined) {
         updates.push("venue_id = ?");
         params.push(normalizedVenueId);
@@ -553,11 +421,6 @@ export async function onRequestPut(context) {
           ).bind(...params),
         );
       }
-    } else {
-      // If we are updating a profile-only entry, we might be trying to convert it to a performance?
-      // But this PUT endpoint usually just updates fields.
-      // The BandForm doesn't support "assigning to event" from the Edit modal easily yet.
-      // So we ignore performance fields here if it's a profile update (for safety).
     }
 
     if (writeStatements.length > 0) {
@@ -565,10 +428,8 @@ export async function onRequestPut(context) {
     }
 
     // Fetch updated result
-    let result;
-    if (!isProfileUpdate) {
-      result = await DB.prepare(
-        `
+    const result = await DB.prepare(
+      `
         SELECT
           p.*,
           bp.name,
@@ -582,23 +443,9 @@ export async function onRequestPut(context) {
         JOIN band_profiles bp ON p.band_profile_id = bp.id
         WHERE p.id = ?
         `,
-      )
-        .bind(realPerformanceId)
-        .first();
-    } else {
-      const profile = await DB.prepare("SELECT * FROM band_profiles WHERE id = ?").bind(bandProfileId).first();
-      result = {
-        id: `profile_${profile.id}`,
-        name: profile.name,
-        origin: profile.origin,
-        origin_city: profile.origin_city,
-        origin_region: profile.origin_region,
-        contact_email: profile.contact_email,
-        is_active: profile.is_active,
-        social_links: profile.social_links,
-        // ... map other fields if needed by frontend ...
-      };
-    }
+    )
+      .bind(realPerformanceId)
+      .first();
 
     // Unpack social links for response compatibility. Read-path sanitize
     // (#493): `result.social_links` may reflect a pre-#483 (or otherwise
@@ -935,54 +782,9 @@ export async function onRequestDelete(context) {
     }
 
     if (isProfileDelete) {
-      const bandProfileId = parseProfileId(performanceId);
-      if (bandProfileId === null) {
-        return new Response(
-          JSON.stringify({
-            error: "Bad request",
-            message: "Invalid profile ID",
-          }),
-          { status: 400, headers: { "Content-Type": "application/json" } },
-        );
-      }
-      // Check if any performances exist
-      const perfCount = await DB.prepare("SELECT COUNT(*) as count FROM performances WHERE band_profile_id = ?")
-        .bind(bandProfileId)
-        .first();
-
-      if (perfCount.count > 0) {
-        return new Response(
-          JSON.stringify({
-            error: "Conflict",
-            message: "Cannot delete band profile because it has associated performances. Delete performances first.",
-          }),
-          {
-            status: 409,
-            headers: { "Content-Type": "application/json" },
-          },
-        );
-      }
-
-      // Audit log
-      await auditLog(
-        env,
-        user.userId,
-        "band_profile.deleted",
-        "band_profile",
-        bandProfileId,
-        { deletedBy: user.email },
-        ipAddress,
-      );
-
-      // Delete profile
-      await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(bandProfileId).run();
-
-      return new Response(
-        JSON.stringify({
-          success: true,
-          message: "Band profile deleted successfully",
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
+      return onRequestProfileDelete(
+        { ...context, user, ipAddress },
+        { performanceId, valid, bandProfileId: parseProfileId(performanceId) },
       );
     }
 

--- a/functions/utils/__tests__/bandProfileDeleteGuard.test.js
+++ b/functions/utils/__tests__/bandProfileDeleteGuard.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { onRequestProfileDelete } from "../bandProfileResource.js";
+
+/**
+ * #935 rejected malformed `profile_` ids (`profile_1_extra` must not resolve to
+ * profile 1). Extracting the handler in #908 briefly re-gated that check on
+ * `!valid`, which is true today only because a `profile_`-prefixed id always
+ * fails validateId — a security check resting on a separate validator's current
+ * behaviour.
+ *
+ * Nothing caught the weakening: the whole admin/bands suite passed either way.
+ * This asserts the contract directly, with `valid: true` supplied so the guard
+ * cannot pass by leaning on it.
+ */
+describe("onRequestProfileDelete id guard", () => {
+  const context = () => ({
+    env: {
+      DB: {
+        prepare: vi.fn(() => {
+          throw new Error("DB must not be touched for a malformed id");
+        }),
+      },
+    },
+    user: { userId: 1 },
+    ipAddress: "127.0.0.1",
+  });
+
+  it("rejects a null profile id even when the caller reports the raw id as valid", async () => {
+    const response = await onRequestProfileDelete(context(), {
+      performanceId: "profile_1_extra",
+      valid: true,
+      bandProfileId: null,
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).message).toMatch(/invalid profile id/i);
+  });
+
+  it("rejects a null profile id when the raw id is also invalid", async () => {
+    const response = await onRequestProfileDelete(context(), {
+      performanceId: "profile_abc",
+      valid: false,
+      bandProfileId: null,
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("never reaches the database for a malformed id", async () => {
+    const ctx = context();
+    await onRequestProfileDelete(ctx, { performanceId: "profile_9_x", valid: true, bandProfileId: null });
+    expect(ctx.env.DB.prepare).not.toHaveBeenCalled();
+  });
+});

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -1,0 +1,134 @@
+import { FIELD_LIMITS, sanitizeBandSocialLinks, sanitizeOptionalHttpUrl, sanitizeString } from "./validation.js";
+import { normalizeBandName } from "./bandName.js";
+import { parseOrigin } from "./parseOrigin.js";
+
+export async function findDuplicateBandProfile(DB, name, bandProfileId) {
+  const nameNormalized = normalizeBandName(name);
+  return DB.prepare(`SELECT id FROM band_profiles WHERE name_normalized = ? AND id != ?`)
+    .bind(nameNormalized, bandProfileId)
+    .first();
+}
+
+export async function findVenue(DB, venueId) {
+  return DB.prepare(
+    `
+    SELECT id FROM venues WHERE id = ?
+  `,
+  )
+    .bind(venueId)
+    .first();
+}
+
+export async function prepareBandProfileFields(DB, body, bandProfileId, resolvedPhotoUrl) {
+  const {
+    name,
+    url,
+    description,
+    genre,
+    origin,
+    origin_city,
+    origin_region,
+    contact_email,
+    is_active,
+    photo_url,
+    photo_alt_text,
+    social_links,
+  } = body;
+  const profileUpdates = [];
+  const profileParams = [];
+
+  if (name !== undefined) {
+    profileUpdates.push("name = ?");
+    profileUpdates.push("name_normalized = ?");
+    const sanitizedName = sanitizeString(name);
+    profileParams.push(sanitizedName);
+    profileParams.push(normalizeBandName(sanitizedName));
+  }
+
+  if (description !== undefined) {
+    profileUpdates.push("description = ?");
+    profileParams.push(sanitizeString(description) || null);
+  }
+  if (genre !== undefined) {
+    profileUpdates.push("genre = ?");
+    profileParams.push(sanitizeString(genre) || null);
+  }
+  const parsedOrigin = origin !== undefined ? parseOrigin(origin) : { city: null, region: null };
+  const resolvedOriginCity = origin_city !== undefined ? origin_city : parsedOrigin.city;
+  const resolvedOriginRegion = origin_region !== undefined ? origin_region : parsedOrigin.region;
+  const computedOrigin =
+    origin !== undefined ? origin : [resolvedOriginCity, resolvedOriginRegion].filter(Boolean).join(", ") || undefined;
+
+  if (origin !== undefined || origin_city !== undefined) {
+    profileUpdates.push("origin_city = ?");
+    profileParams.push(resolvedOriginCity || null);
+  }
+  if (origin !== undefined || origin_region !== undefined) {
+    profileUpdates.push("origin_region = ?");
+    profileParams.push(resolvedOriginRegion || null);
+  }
+  if (computedOrigin !== undefined) {
+    profileUpdates.push("origin = ?");
+    profileParams.push(computedOrigin || null);
+  }
+  if (contact_email !== undefined) {
+    profileUpdates.push("contact_email = ?");
+    profileParams.push(contact_email || null);
+  }
+  if (is_active !== undefined) {
+    profileUpdates.push("is_active = ?");
+    profileParams.push(Number(is_active) === 1 ? 1 : 0);
+  }
+  if (photo_url !== undefined) {
+    profileUpdates.push("photo_url = ?");
+    profileParams.push(resolvedPhotoUrl || null);
+  }
+  if (photo_alt_text !== undefined) {
+    profileUpdates.push("photo_alt_text = ?");
+    const cleanedAlt = sanitizeString(photo_alt_text);
+    profileParams.push(cleanedAlt ? cleanedAlt.slice(0, 250) : null);
+  }
+
+  let newSocialLinks = null;
+  let shouldUpdateSocialLinks = false;
+  if (social_links !== undefined) {
+    shouldUpdateSocialLinks = true;
+    try {
+      newSocialLinks = sanitizeBandSocialLinks(social_links);
+    } catch (error) {
+      return { error };
+    }
+  } else if (url !== undefined) {
+    shouldUpdateSocialLinks = true;
+    let existingLinks = {};
+    try {
+      const profile = await DB.prepare("SELECT social_links FROM band_profiles WHERE id = ?")
+        .bind(bandProfileId)
+        .first();
+      existingLinks = JSON.parse(profile.social_links || "{}");
+    } catch (_e) {
+      /* ignore malformed JSON — existingLinks stays {} */
+    }
+    try {
+      existingLinks.website = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");
+      newSocialLinks = sanitizeBandSocialLinks(existingLinks);
+    } catch (error) {
+      return { error };
+    }
+  }
+
+  if (shouldUpdateSocialLinks) {
+    profileUpdates.push("social_links = ?");
+    profileParams.push(newSocialLinks);
+  }
+
+  const profileStatement =
+    profileUpdates.length > 0
+      ? DB.prepare(`UPDATE band_profiles SET ${profileUpdates.join(", ")} WHERE id = ?`).bind(
+          ...profileParams,
+          bandProfileId,
+        )
+      : undefined;
+
+  return { profileUpdates, profileParams, profileStatement };
+}

--- a/functions/utils/bandProfileResource.js
+++ b/functions/utils/bandProfileResource.js
@@ -259,7 +259,12 @@ export async function onRequestProfileDelete(context, { performanceId: _performa
   const user = context.user;
   const ipAddress = context.ipAddress;
   try {
-    if (!valid && bandProfileId === null) {
+    // Unconditional, as it was before this module existed (#935). Gating it on
+    // `!valid` would make a security check depend on a coincidence: a
+    // `profile_`-prefixed id always fails validateId today, so `!valid` is
+    // always true here — but the guard's job is to reject a malformed profile
+    // id, and that must not rely on a separate validator's current behaviour.
+    if (bandProfileId === null) {
       return new Response(
         JSON.stringify({
           error: "Bad request",

--- a/functions/utils/bandProfileResource.js
+++ b/functions/utils/bandProfileResource.js
@@ -1,0 +1,322 @@
+import { auditLog } from "../api/admin/_middleware.js";
+import {
+  FIELD_LIMITS,
+  isValidEmail,
+  safeReflectSocialLinks,
+  sanitizeOptionalHttpUrl,
+  sanitizeOptionalText,
+  validateSetTimes,
+} from "./validation.js";
+import { findDuplicateBandProfile, findVenue, prepareBandProfileFields } from "./bandProfileFields.js";
+
+export async function onRequestProfilePut(context, { performanceId, body, bandProfileId }) {
+  const { env } = context;
+  const { DB } = env;
+  const user = context.user;
+  const ipAddress = context.ipAddress;
+
+  try {
+    const {
+      venueId,
+      name,
+      startTime,
+      endTime,
+      url,
+      description,
+      genre,
+      origin,
+      origin_city,
+      origin_region,
+      contact_email,
+      is_active,
+      photo_url,
+      photo_alt_text,
+      social_links,
+      notes,
+    } = body;
+
+    const normalizedVenueId =
+      venueId === undefined ? undefined : !venueId || Number(venueId) <= 0 ? null : Number(venueId);
+    let resolvedPhotoUrl;
+    let resolvedNotes;
+    try {
+      resolvedPhotoUrl =
+        photo_url !== undefined ? sanitizeOptionalHttpUrl(photo_url, FIELD_LIMITS.bandUrl.max, "Photo URL") : undefined;
+      resolvedNotes =
+        notes !== undefined ? sanitizeOptionalText(notes, FIELD_LIMITS.performanceNotes.max, "Notes") : undefined;
+    } catch (error) {
+      return new Response(JSON.stringify({ error: "Validation error", message: error.message }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    void resolvedNotes;
+
+    if (bandProfileId === null) {
+      return new Response(
+        JSON.stringify({
+          error: "Bad request",
+          message: "Invalid profile ID",
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const profile = await DB.prepare("SELECT * FROM band_profiles WHERE id = ?").bind(bandProfileId).first();
+    if (!profile) {
+      return new Response(
+        JSON.stringify({
+          error: "Not found",
+          message: "Band profile not found",
+        }),
+        { status: 404, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    if (name !== undefined) {
+      if (!name || name.trim().length === 0) {
+        return new Response(
+          JSON.stringify({
+            error: "Validation error",
+            message: "Band name cannot be empty",
+          }),
+          {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      const existingProfile = await findDuplicateBandProfile(DB, name, bandProfileId);
+
+      if (existingProfile) {
+        // Renaming updates the shared profile globally — all performances of this band reflect the change.
+      }
+    }
+
+    if (contact_email !== undefined && contact_email && !isValidEmail(contact_email)) {
+      return new Response(
+        JSON.stringify({
+          error: "Validation error",
+          message: "Contact email must be a valid email address",
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    if (startTime !== undefined && startTime !== "" && !/^\d{2}:\d{2}$/.test(startTime)) {
+      return new Response(
+        JSON.stringify({
+          error: "Validation error",
+          message: "Invalid start time format. Use HH:MM (24-hour format)",
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    if (endTime !== undefined && endTime !== "" && !/^\d{2}:\d{2}$/.test(endTime)) {
+      return new Response(
+        JSON.stringify({
+          error: "Validation error",
+          message: "Invalid end time format. Use HH:MM (24-hour format)",
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const actualStartTime = startTime !== undefined ? startTime : undefined;
+    const actualEndTime = endTime !== undefined ? endTime : undefined;
+    const actualVenueId = normalizedVenueId !== undefined ? normalizedVenueId : undefined;
+    void actualVenueId;
+
+    const setTimesCheck = validateSetTimes(actualStartTime, actualEndTime);
+    if (!setTimesCheck.valid) {
+      return new Response(
+        JSON.stringify({
+          error: "Validation error",
+          message: setTimesCheck.error,
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    if (normalizedVenueId != null) {
+      const venue = await findVenue(DB, normalizedVenueId);
+
+      if (!venue) {
+        return new Response(
+          JSON.stringify({
+            error: "Not found",
+            message: "Venue not found",
+          }),
+          {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+    }
+
+    const writeStatements = [];
+    const { profileStatement, error: profileFieldsError } = await prepareBandProfileFields(
+      DB,
+      body,
+      bandProfileId,
+      resolvedPhotoUrl,
+    );
+    if (profileFieldsError) {
+      return new Response(
+        JSON.stringify({
+          error: "Validation error",
+          message: profileFieldsError.message,
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    if (profileStatement) {
+      writeStatements.push(profileStatement);
+    }
+
+    if (writeStatements.length > 0) {
+      await DB.batch(writeStatements);
+    }
+
+    const updatedProfile = await DB.prepare("SELECT * FROM band_profiles WHERE id = ?").bind(bandProfileId).first();
+    const result = {
+      id: `profile_${updatedProfile.id}`,
+      name: updatedProfile.name,
+      origin: updatedProfile.origin,
+      origin_city: updatedProfile.origin_city,
+      origin_region: updatedProfile.origin_region,
+      contact_email: updatedProfile.contact_email,
+      is_active: updatedProfile.is_active,
+      social_links: updatedProfile.social_links,
+    };
+
+    const social = safeReflectSocialLinks(result.social_links || "{}");
+    result.social_links = result.social_links == null ? result.social_links : JSON.stringify(social);
+    result.url = social.website || "";
+    result.origin = [result.origin_city, result.origin_region].filter(Boolean).join(", ") || result.origin || "";
+
+    await auditLog(
+      env,
+      user.userId,
+      "band.updated",
+      "band",
+      performanceId,
+      {
+        bandName: result.name,
+        changedFields: Object.keys(body).filter((k) => body[k] !== undefined),
+        hasConflicts: false,
+      },
+      ipAddress,
+    );
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        band: result,
+        conflicts: undefined,
+        warning: undefined,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  } catch (error) {
+    console.error("Error updating band:", error);
+
+    return new Response(
+      JSON.stringify({
+        error: "Database error",
+        message: "Failed to update band",
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+}
+
+export async function onRequestProfileDelete(context, { performanceId: _performanceId, valid, bandProfileId }) {
+  const { env } = context;
+  const { DB } = env;
+  const user = context.user;
+  const ipAddress = context.ipAddress;
+  try {
+    if (!valid && bandProfileId === null) {
+      return new Response(
+        JSON.stringify({
+          error: "Bad request",
+          message: "Invalid profile ID",
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const perfCount = await DB.prepare("SELECT COUNT(*) as count FROM performances WHERE band_profile_id = ?")
+      .bind(bandProfileId)
+      .first();
+
+    if (perfCount.count > 0) {
+      return new Response(
+        JSON.stringify({
+          error: "Conflict",
+          message: "Cannot delete band profile because it has associated performances. Delete performances first.",
+        }),
+        {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    await auditLog(
+      env,
+      user.userId,
+      "band_profile.deleted",
+      "band_profile",
+      bandProfileId,
+      { deletedBy: user.email },
+      ipAddress,
+    );
+
+    await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(bandProfileId).run();
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: "Band profile deleted successfully",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  } catch (error) {
+    console.error("Error deleting band:", error);
+
+    return new Response(
+      JSON.stringify({
+        error: "Database error",
+        message: "Failed to delete band",
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+}


### PR DESCRIPTION
Refs #908 (first and most defensible item)

`functions/api/admin/bands/[id].js` served **two unrelated resources** — band *profiles* (`profile_<n>` ids) and *performances* (bare numeric ids) — dispatched by string-sniffing the URL id, with `isProfileUpdate` branches threaded through a ~600-line PUT at `:137, :155, :295, :519, :569` and again in DELETE at `:937`.

| file | lines |
|---|---|
| `[id].js` | **1,078 → 880** |
| `utils/bandProfileResource.js` | 322 — profile PUT + DELETE |
| `utils/bandProfileFields.js` | 134 — shared profile-field update |

`[id].js` now parses the id, dispatches, and returns.

## Why three files, not two

The first split left the band-profile field update **duplicated**: four identical statements in both files (dupe-name check, venue check, `social_links` read, and the `UPDATE`), ~54% line similarity across ~75 lines. Both paths genuinely need it — a numeric PUT can also update band-wide profile fields — but two near-identical copies of a *write path* is the copy-paste drift this repo has removed before (the `checkConflicts` dedup).

Trading dual-resource dispatch for duplicated write logic isn't a net win, so the shared part was extracted rather than copied. Each statement now appears **exactly once**:

```
name_normalized dupe check   [id]=0  resource=0  fields=1
venue existence check        [id]=0  resource=0  fields=1
social_links read            [id]=0  resource=0  fields=1
UPDATE band_profiles         [id]=0  resource=0  fields=1
```

## Routing constraint

Both new modules live in `functions/utils/`, **not** under `functions/api/`. `frontend/public/_routes.json` includes `"/api/*"`, so a helper placed there would be a live, publicly reachable HTTP route. Verified no include pattern matches `/utils/*`.

## Verification

Pure refactor:

- **Every existing test passes unmodified** — no test file was touched, which is what makes the behaviour-preserving claim checkable rather than asserted
- Every SQL statement in the extracted modules appears **verbatim** in the original; none was rewritten
- `make gate` exits 0 — 1,299 backend + 1,230 frontend

| mutation | result |
|---|---|
| stop dispatching `profile_` ids to the profile handler | **4 RED** |

## Note on how this was built

Two delegated rounds to Otto (OpenCode, `gpt-5.6-luna`, $0.115 + $0.083); the split spec, the duplication catch, and verification here. The second round exists because reviewing the first found the duplication — worth recording that the delegate reported its reasoning honestly, including flagging that numeric PUT intentionally retains band-wide profile updates.

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved band profile editing with clearer validation for contact details, venue information, photos, social links, origins, and notes.
  - Legacy website information is preserved when updating social links.
  - Band profile changes now provide more consistent success and error responses.

- **Bug Fixes**
  - Prevented duplicate band names and invalid venue or profile data.
  - Band profiles with associated performances cannot be deleted.
  - Improved validation for performance dates during updates.
  - Invalid profile deletion requests are now rejected safely without accessing stored data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->