### PR TITLE
fix(admin): recompose origin when its components are cleared

### DIFF
--- a/functions/utils/__tests__/bandProfileOrigin.test.js
+++ b/functions/utils/__tests__/bandProfileOrigin.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { prepareBandProfileFields } from "../bandProfileFields.js";
+
+/**
+ * #954: clearing an artist's origin left the composite `origin` column stale.
+ * Sending origin_city:"" and origin_region:"" (no `origin`) nulled both
+ * component columns while the `origin = ?` update was skipped, so the admin UI
+ * re-displayed the value the user had just deleted.
+ *
+ * The happy path passes either way — only the CLEARING path distinguishes the
+ * fixed code from the broken code.
+ */
+const DB = () => ({
+  prepare: vi.fn(() => ({
+    bind: vi.fn(() => ({ first: vi.fn(async () => null) })),
+  })),
+});
+
+async function fieldsFor(body) {
+  const result = await prepareBandProfileFields(DB(), body, 7, undefined);
+  const { profileUpdates, profileParams } = result;
+  const map = new Map();
+  profileUpdates.forEach((clause, i) => map.set(clause.replace(" = ?", ""), profileParams[i]));
+  return map;
+}
+
+describe("band profile origin recomposition", () => {
+  it("clears the composite origin when both components are cleared", async () => {
+    const fields = await fieldsFor({ origin_city: "", origin_region: "" });
+
+    expect(fields.has("origin")).toBe(true);
+    expect(fields.get("origin")).toBeNull();
+    expect(fields.get("origin_city")).toBeNull();
+    expect(fields.get("origin_region")).toBeNull();
+  });
+
+  it("recomposes origin from a single supplied component", async () => {
+    const fields = await fieldsFor({ origin_city: "Kitchener" });
+
+    expect(fields.get("origin")).toBe("Kitchener");
+    expect(fields.get("origin_city")).toBe("Kitchener");
+  });
+
+  it("recomposes origin from both components", async () => {
+    const fields = await fieldsFor({ origin_city: "Kitchener", origin_region: "ON" });
+    expect(fields.get("origin")).toBe("Kitchener, ON");
+  });
+
+  it("still lets an explicit origin win", async () => {
+    const fields = await fieldsFor({ origin: "Waterloo, ON" });
+    expect(fields.get("origin")).toBe("Waterloo, ON");
+  });
+
+  it("touches none of the three columns when no origin field is supplied", async () => {
+    const fields = await fieldsFor({ name: "ALL" });
+
+    expect(fields.has("origin")).toBe(false);
+    expect(fields.has("origin_city")).toBe(false);
+    expect(fields.has("origin_region")).toBe(false);
+  });
+});

--- a/functions/utils/__tests__/bandProfileOrigin.test.js
+++ b/functions/utils/__tests__/bandProfileOrigin.test.js
@@ -10,14 +10,14 @@ import { prepareBandProfileFields } from "../bandProfileFields.js";
  * The happy path passes either way — only the CLEARING path distinguishes the
  * fixed code from the broken code.
  */
-const DB = () => ({
+const DB = (stored = null) => ({
   prepare: vi.fn(() => ({
-    bind: vi.fn(() => ({ first: vi.fn(async () => null) })),
+    bind: vi.fn(() => ({ first: vi.fn(async () => stored) })),
   })),
 });
 
-async function fieldsFor(body) {
-  const result = await prepareBandProfileFields(DB(), body, 7, undefined);
+async function fieldsFor(body, stored = null) {
+  const result = await prepareBandProfileFields(DB(stored), body, 7, undefined);
   const { profileUpdates, profileParams } = result;
   const map = new Map();
   profileUpdates.forEach((clause, i) => map.set(clause.replace(" = ?", ""), profileParams[i]));
@@ -32,6 +32,32 @@ describe("band profile origin recomposition", () => {
     expect(fields.get("origin")).toBeNull();
     expect(fields.get("origin_city")).toBeNull();
     expect(fields.get("origin_region")).toBeNull();
+  });
+
+  // A PARTIAL update must fall back to the STORED component, not to null.
+  // Clearing only the city while the row holds a region would otherwise write
+  // origin = NULL and leave origin_region = "ON" beside it — the composite
+  // disagreeing with the column it is composed from.
+  it("keeps the stored region when only the city is cleared", async () => {
+    const fields = await fieldsFor({ origin_city: "" }, { origin_city: "Kitchener", origin_region: "ON" });
+
+    expect(fields.get("origin_city")).toBeNull();
+    expect(fields.get("origin")).toBe("ON");
+    expect(fields.has("origin_region")).toBe(false);
+  });
+
+  it("keeps the stored city when only the region is cleared", async () => {
+    const fields = await fieldsFor({ origin_region: "" }, { origin_city: "Kitchener", origin_region: "ON" });
+
+    expect(fields.get("origin_region")).toBeNull();
+    expect(fields.get("origin")).toBe("Kitchener");
+    expect(fields.has("origin_city")).toBe(false);
+  });
+
+  it("recomposes with the stored region when a new city is supplied", async () => {
+    const fields = await fieldsFor({ origin_city: "Waterloo" }, { origin_city: "Kitchener", origin_region: "ON" });
+
+    expect(fields.get("origin")).toBe("Waterloo, ON");
   });
 
   it("recomposes origin from a single supplied component", async () => {

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -56,8 +56,18 @@ export async function prepareBandProfileFields(DB, body, bandProfileId, resolved
   const parsedOrigin = origin !== undefined ? parseOrigin(origin) : { city: null, region: null };
   const resolvedOriginCity = origin_city !== undefined ? origin_city : parsedOrigin.city;
   const resolvedOriginRegion = origin_region !== undefined ? origin_region : parsedOrigin.region;
+  // Recompose `origin` whenever a COMPONENT field is supplied, not only when the
+  // recomposition is non-empty. Clearing both components sends "" for each, the
+  // join is "", and a trailing `|| undefined` would make this read as "nothing
+  // supplied" — skipping the `origin = ?` update while origin_city and
+  // origin_region are set to NULL, so the composite column keeps the value the
+  // admin just deleted and the UI shows it again (#954).
   const computedOrigin =
-    origin !== undefined ? origin : [resolvedOriginCity, resolvedOriginRegion].filter(Boolean).join(", ") || undefined;
+    origin !== undefined
+      ? origin
+      : origin_city !== undefined || origin_region !== undefined
+        ? [resolvedOriginCity, resolvedOriginRegion].filter(Boolean).join(", ")
+        : undefined;
 
   if (origin !== undefined || origin_city !== undefined) {
     profileUpdates.push("origin_city = ?");

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -54,8 +54,24 @@ export async function prepareBandProfileFields(DB, body, bandProfileId, resolved
     profileParams.push(sanitizeString(genre) || null);
   }
   const parsedOrigin = origin !== undefined ? parseOrigin(origin) : { city: null, region: null };
-  const resolvedOriginCity = origin_city !== undefined ? origin_city : parsedOrigin.city;
-  const resolvedOriginRegion = origin_region !== undefined ? origin_region : parsedOrigin.region;
+
+  // A PARTIAL component update has to fall back to what is stored, not to null.
+  // Sending only { origin_city: "" } while the row holds origin_region "ON"
+  // would otherwise recompose origin from city alone — writing origin = NULL
+  // while leaving origin_region = "ON" untouched, so the composite disagrees
+  // with the column beside it. One read, and only on component updates.
+  let fallbackCity = parsedOrigin.city;
+  let fallbackRegion = parsedOrigin.region;
+  if (origin === undefined && (origin_city !== undefined || origin_region !== undefined)) {
+    const stored = await DB.prepare("SELECT origin_city, origin_region FROM band_profiles WHERE id = ?")
+      .bind(bandProfileId)
+      .first();
+    fallbackCity = stored?.origin_city ?? null;
+    fallbackRegion = stored?.origin_region ?? null;
+  }
+
+  const resolvedOriginCity = origin_city !== undefined ? origin_city : fallbackCity;
+  const resolvedOriginRegion = origin_region !== undefined ? origin_region : fallbackRegion;
   // Recompose `origin` whenever a COMPONENT field is supplied, not only when the
   // recomposition is non-empty. Clearing both components sends "" for each, the
   // join is "", and a trailing `|| undefined` would make this read as "nothing


### PR DESCRIPTION
Closes #954

## The bug

Clearing an artist's origin left the composite `origin` column stale. Send `origin_city: ""` and `origin_region: ""` with no `origin`:

| step | value |
|---|---|
| `resolvedOriginCity` / `Region` | `""` |
| `[..].filter(Boolean).join(", ")` | `""` |
| `"" \|\| undefined` | `undefined` |
| the `origin = ?` update | **skipped** |
| `origin_city` / `origin_region` | written as `NULL` |

Both components cleared, composite keeps its old value.

**It's visible, not silent.** The response path recomposes with `|| result.origin`, so the admin UI redisplays the origin the user just deleted — and reloading doesn't help, because the stale value is in the database.

## The fix, and the trap inside it

`origin` is now recomposed whenever a **component** field is supplied, rather than only when the recomposition is non-empty.

The trailing `|| undefined` had to go with it. Keeping it inside the new structure reintroduces the bug exactly — an empty join collapses back to "read as nothing supplied". That gets its own mutation:

| mutation | result |
|---|---|
| revert to the original expression | **1 RED** |
| keep the new shape but re-add `\|\| undefined` | **1 RED** |

## Tests assert the clearing path

The happy path passes either way, so it proves nothing here. The five cases: both components cleared, one component supplied, both supplied, an explicit `origin` winning, and no origin field touching none of the three columns.

## Sweep

One other site composes `origin` — `functions/api/admin/bands.js:497`. It's the find-or-create path ending in an `INSERT`, so there's no prior value to leave stale, and it composes with `|| null` rather than `|| undefined`. **Not the same bug.** One instance, no siblings on the write side.

## Testing

- [x] `make gate` exits 0 — 1,310 backend + 1,230 frontend tests
- [x] Mutation table above
- [x] Sibling sweep reported either way

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed band profile origin updates so clearing either origin component correctly updates the combined origin field.
  * Ensured direct origin values remain authoritative when provided.
  * Preserved existing origin information during partial or unrelated profile updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->