### PR TITLE
fix(admin): batch the audit row with the delete it records

### DIFF
--- a/functions/api/admin/_middleware.js
+++ b/functions/api/admin/_middleware.js
@@ -7,6 +7,9 @@ import { getClientIP } from "../../utils/request.js";
 import { initializeLucia, SESSION_CONFIG } from "../../utils/auth.js";
 import { fromSqliteDateTime } from "../../utils/authAttempts.js";
 import { createRequestLogger, logger } from "../../utils/logger.js";
+import { auditLogStatement } from "../../utils/auditLogStatement.js";
+
+export { auditLogStatement } from "../../utils/auditLogStatement.js";
 
 function normalizeUser(user) {
   if (!user) return null;
@@ -205,21 +208,7 @@ export async function checkPermission(context, requiredRole) {
 // Audit log function - logs all admin actions
 export async function auditLog(env, userId, action, resourceType, resourceId, details, ipAddress, log = null) {
   try {
-    await env.DB.prepare(
-      `
-      INSERT INTO audit_log (user_id, action, resource_type, resource_id, details, ip_address)
-      VALUES (?, ?, ?, ?, ?, ?)
-    `,
-    )
-      .bind(
-        userId,
-        action,
-        resourceType || null,
-        resourceId || null,
-        details ? JSON.stringify(details) : null,
-        ipAddress || "unknown",
-      )
-      .run();
+    await auditLogStatement(env, userId, action, resourceType, resourceId, details, ipAddress).run();
   } catch (error) {
     // Never throws: audit logging must not fail the request it records.
     //

--- a/functions/api/admin/bands/[id].js
+++ b/functions/api/admin/bands/[id].js
@@ -3,6 +3,7 @@
 // DELETE /api/admin/bands/{id} - Delete band
 
 import { checkPermission, auditLog } from "../_middleware.js";
+import { auditLogStatement } from "../../../utils/auditLogStatement.js";
 import {
   FIELD_LIMITS,
   isValidEmail,
@@ -827,31 +828,28 @@ export async function onRequestDelete(context) {
       );
     }
 
-    // Audit log before deletion
-    await auditLog(
-      env,
-      user.userId,
-      "band.deleted",
-      "band",
-      performanceId,
-      {
-        bandName: performance.name,
-        eventId: performance.event_id,
-        venueId: performance.venue_id,
-        startTime: performance.start_time,
-        endTime: performance.end_time,
-      },
-      ipAddress,
-    );
-
-    // Delete performance
-    await DB.prepare(
-      `
-      DELETE FROM performances WHERE id = ?
-    `,
-    )
-      .bind(performanceId)
-      .run();
+    await DB.batch([
+      DB.prepare(
+        `
+        DELETE FROM performances WHERE id = ?
+      `,
+      ).bind(performanceId),
+      auditLogStatement(
+        env,
+        user.userId,
+        "band.deleted",
+        "band",
+        performanceId,
+        {
+          bandName: performance.name,
+          eventId: performance.event_id,
+          venueId: performance.venue_id,
+          startTime: performance.start_time,
+          endTime: performance.end_time,
+        },
+        ipAddress,
+      ),
+    ]);
 
     return new Response(
       JSON.stringify({

--- a/functions/api/admin/bands/bulk.js
+++ b/functions/api/admin/bands/bulk.js
@@ -1,4 +1,5 @@
 import { auditLog, checkPermission } from "../_middleware.js";
+import { auditLogStatement } from "../../../utils/auditLogStatement.js";
 import { getClientIP } from "../../../utils/request.js";
 import { computeNewEndTime, detectBulkConflicts } from "../../../utils/timeConflicts.js";
 import { isValidTime, validateIdArray, validateSetTimes } from "../../../utils/validation.js";
@@ -157,30 +158,34 @@ export async function onRequestDelete(context) {
             continue;
           }
 
-          await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(profileId).run();
-          await auditLog(
-            env,
-            user.userId,
-            "band_profile.deleted",
-            "band_profile",
-            profileId,
-            { deletedBy: user.email, bulk: true },
-            ipAddress,
-          );
+          await DB.batch([
+            DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(profileId),
+            auditLogStatement(
+              env,
+              user.userId,
+              "band_profile.deleted",
+              "band_profile",
+              profileId,
+              { deletedBy: user.email, bulk: true },
+              ipAddress,
+            ),
+          ]);
           deletedCount++;
         } else {
           const performance = performanceMap.get(Number(id));
           if (performance) {
-            await DB.prepare("DELETE FROM performances WHERE id = ?").bind(id).run();
-            await auditLog(
-              env,
-              user.userId,
-              "band.deleted",
-              "band",
-              id,
-              { bandName: performance.name, bulk: true },
-              ipAddress,
-            );
+            await DB.batch([
+              DB.prepare("DELETE FROM performances WHERE id = ?").bind(id),
+              auditLogStatement(
+                env,
+                user.userId,
+                "band.deleted",
+                "band",
+                id,
+                { bandName: performance.name, bulk: true },
+                ipAddress,
+              ),
+            ]);
             deletedCount++;
           }
         }

--- a/functions/api/admin/events/[id].js
+++ b/functions/api/admin/events/[id].js
@@ -5,6 +5,7 @@
 // DELETE /api/admin/events/{id} - Delete event
 
 import { checkPermission, auditLog } from "../_middleware.js";
+import { auditLogStatement } from "../../../utils/auditLogStatement.js";
 import {
   FIELD_LIMITS,
   isValidURL,
@@ -776,22 +777,21 @@ export async function onRequestDelete(context) {
       );
     }
 
-    // Delete the event (performance records are removed automatically via ON DELETE CASCADE)
-    await DB.prepare("DELETE FROM events WHERE id = ?").bind(eventIdNum).run();
-
-    // Audit log
-    await auditLog(
-      env,
-      currentUser.userId,
-      "event.deleted",
-      "event",
-      eventIdNum,
-      {
-        name: event.name,
-        performanceCount: performanceCount.count,
-      },
-      ipAddress,
-    );
+    await DB.batch([
+      DB.prepare("DELETE FROM events WHERE id = ?").bind(eventIdNum),
+      auditLogStatement(
+        env,
+        currentUser.userId,
+        "event.deleted",
+        "event",
+        eventIdNum,
+        {
+          name: event.name,
+          performanceCount: performanceCount.count,
+        },
+        ipAddress,
+      ),
+    ]);
 
     return new Response(
       JSON.stringify({

--- a/functions/api/admin/users/[id].js
+++ b/functions/api/admin/users/[id].js
@@ -3,6 +3,7 @@
 // DELETE /api/admin/users/:id - Delete user (soft delete)
 
 import { checkPermission, auditLog } from "../_middleware.js";
+import { auditLogStatement } from "../../../utils/auditLogStatement.js";
 import { getClientIP } from "../../../utils/request.js";
 import { validateId } from "../../../utils/validation.js";
 
@@ -389,23 +390,21 @@ export async function onRequestDelete(context) {
 
       // Delete the user - this will trigger ON DELETE CASCADE for sessions/tokens
       DB.prepare("DELETE FROM users WHERE id = ?").bind(userId),
+      auditLogStatement(
+        env,
+        currentUser.userId,
+        "user.deleted",
+        "user",
+        userId,
+        {
+          email: user.email,
+          role: user.role,
+        },
+        ipAddress,
+      ),
     ];
 
     await DB.batch(cleanupStmts);
-
-    // Audit log
-    await auditLog(
-      env,
-      currentUser.userId,
-      "user.deleted",
-      "user",
-      userId,
-      {
-        email: user.email,
-        role: user.role,
-      },
-      ipAddress,
-    );
 
     return new Response(
       JSON.stringify({

--- a/functions/api/admin/venues/[id].js
+++ b/functions/api/admin/venues/[id].js
@@ -3,6 +3,7 @@
 // DELETE /api/admin/venues/{id} - Delete venue
 
 import { checkPermission, auditLog } from "../_middleware.js";
+import { auditLogStatement } from "../../../utils/auditLogStatement.js";
 import {
   FIELD_LIMITS,
   isValidEmail,
@@ -372,28 +373,25 @@ export async function onRequestDelete(context) {
       );
     }
 
-    // Audit log before deletion
-    await auditLog(
-      env,
-      user.userId,
-      "venue.deleted",
-      "venue",
-      venueId,
-      {
-        venueName: venue.name,
-        address: venue.address,
-      },
-      ipAddress,
-    );
-
-    // Delete venue
-    await DB.prepare(
-      `
-      DELETE FROM venues WHERE id = ?
-    `,
-    )
-      .bind(venueId)
-      .run();
+    await DB.batch([
+      DB.prepare(
+        `
+        DELETE FROM venues WHERE id = ?
+      `,
+      ).bind(venueId),
+      auditLogStatement(
+        env,
+        user.userId,
+        "venue.deleted",
+        "venue",
+        venueId,
+        {
+          venueName: venue.name,
+          address: venue.address,
+        },
+        ipAddress,
+      ),
+    ]);
 
     return new Response(
       JSON.stringify({

--- a/functions/utils/__tests__/auditAtomicity.test.js
+++ b/functions/utils/__tests__/auditAtomicity.test.js
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { auditLogStatement } from "../auditLogStatement.js";
+
+// __tests__ -> utils -> functions -> repo root (four levels, not three: the
+// first dirname strips the filename itself).
+const repoRoot = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+
+/**
+ * #955: a destructive admin action and its audit row were two independent
+ * statements, so they could disagree in both directions — a failed DELETE left
+ * an audit row claiming the deletion happened, and a failed audit INSERT was
+ * swallowed while the row was deleted unlogged. The second is worse: for a
+ * destructive action, who deleted what is exactly what the trail exists for.
+ *
+ * `auditLog` still deliberately never throws for its other callers, whose work
+ * may have external side effects (an email sent, a digest flushed) that a
+ * rollback cannot undo. Only the DB-only destructive paths are batched.
+ */
+describe("auditLogStatement", () => {
+  it("returns a prepared statement instead of executing one", () => {
+    const run = vi.fn();
+    const bind = vi.fn(() => ({ run }));
+    const env = { DB: { prepare: vi.fn(() => ({ bind })) } };
+
+    const stmt = auditLogStatement(env, 1, "venue.deleted", "venue", 9, { a: 1 }, "1.2.3.4");
+
+    expect(env.DB.prepare).toHaveBeenCalledOnce();
+    expect(run).not.toHaveBeenCalled();
+    expect(stmt).toBeDefined();
+  });
+
+  it("serialises details and defaults the ip, matching auditLog's bindings", () => {
+    const bind = vi.fn(() => ({ run: vi.fn() }));
+    const env = { DB: { prepare: vi.fn(() => ({ bind })) } };
+
+    auditLogStatement(env, 1, "venue.deleted", "venue", 9, { venueName: "Blue Room" }, undefined);
+
+    expect(bind).toHaveBeenCalledWith(
+      1,
+      "venue.deleted",
+      "venue",
+      9,
+      JSON.stringify({ venueName: "Blue Room" }),
+      "unknown",
+    );
+  });
+
+  it("passes null details through as null rather than the string 'null'", () => {
+    const bind = vi.fn(() => ({ run: vi.fn() }));
+    const env = { DB: { prepare: vi.fn(() => ({ bind })) } };
+
+    auditLogStatement(env, 1, "venue.deleted", "venue", 9, null, "1.2.3.4");
+
+    expect(bind.mock.calls[0][4]).toBeNull();
+  });
+});
+
+/**
+ * Source scan. The runtime tests above cover the statement builder; this covers
+ * the property that matters at each call site — that the destructive path uses
+ * the STATEMENT form (which can only reach D1 inside a batch) rather than the
+ * fire-and-forget `auditLog`, which executes on its own and swallows failures.
+ *
+ * Deliberately not asserting the shape of the batch call: two of these build a
+ * statement array in a variable and pass it (`DB.batch(cleanupStmts)`), so a
+ * regex for the inline `DB.batch([...])` form reports a false negative. It did,
+ * on users/[id].js, before this was rewritten.
+ */
+describe("destructive admin handlers audit via a batched statement", () => {
+  const sites = [
+    ["functions/utils/bandProfileResource.js", "band_profile.deleted"],
+    ["functions/api/admin/bands/[id].js", "band.deleted"],
+    ["functions/api/admin/events/[id].js", "event.deleted"],
+    ["functions/api/admin/users/[id].js", "user.deleted"],
+    ["functions/api/admin/venues/[id].js", "venue.deleted"],
+  ];
+
+  it.each(sites)("%s audits %s as a statement, not a bare call", (file, action) => {
+    const source = readFileSync(join(repoRoot, file), "utf8");
+
+    expect(source, `${file} should import auditLogStatement`).toContain("auditLogStatement");
+    expect(source, `${file} should batch its writes`).toContain("DB.batch(");
+
+    // The executing form must not be used for this action: a bare auditLog runs
+    // on its own and cannot roll back with the delete.
+    const bare = new RegExp(`auditLog\\([^)]*?${action.replace(".", "\\.")}`, "s");
+    expect(
+      bare.test(source.replace(/auditLogStatement\(/g, "STATEMENT(")),
+      `${file}: "${action}" still uses the bare auditLog`,
+    ).toBe(false);
+  });
+});

--- a/functions/utils/__tests__/auditAtomicity.test.js
+++ b/functions/utils/__tests__/auditAtomicity.test.js
@@ -59,37 +59,107 @@ describe("auditLogStatement", () => {
 });
 
 /**
- * Source scan. The runtime tests above cover the statement builder; this covers
- * the property that matters at each call site — that the destructive path uses
- * the STATEMENT form (which can only reach D1 inside a batch) rather than the
- * fire-and-forget `auditLog`, which executes on its own and swallows failures.
+ * Source scan. The runtime tests above cover the statement builder; this proves
+ * the property that matters at each call site: the audit statement and its
+ * DELETE are entries in the SAME `DB.batch(...)` call.
  *
- * Deliberately not asserting the shape of the batch call: two of these build a
- * statement array in a variable and pass it (`DB.batch(cleanupStmts)`), so a
- * regex for the inline `DB.batch([...])` form reports a false negative. It did,
- * on users/[id].js, before this was rewritten.
+ * Checking for `auditLogStatement` and `DB.batch` independently is not enough —
+ * `auditLogStatement(...).run()` after a delete-only batch would satisfy that
+ * while restoring the split exactly. So the batch payload is extracted and both
+ * markers must appear inside it.
+ *
+ * Two shapes exist and both must be handled: an inline `DB.batch([...])`, and a
+ * statement array built in a variable and passed as `DB.batch(cleanupStmts)`.
+ * An inline-only regex reports a false negative on the latter — it did, on
+ * users/[id].js.
  */
-describe("destructive admin handlers audit via a batched statement", () => {
+function batchPayloads(source) {
+  const payloads = [];
+
+  const balancedFrom = (openIndex) => {
+    let depth = 0;
+    for (let i = openIndex; i < source.length; i += 1) {
+      const c = source[i];
+      if (c === "[") depth += 1;
+      else if (c === "]") {
+        depth -= 1;
+        if (depth === 0) return source.slice(openIndex, i + 1);
+      }
+    }
+    return "";
+  };
+
+  for (const match of source.matchAll(/DB\.batch\(\s*(\[|[A-Za-z_$][\w$]*)/g)) {
+    const token = match[1];
+    if (token === "[") {
+      payloads.push(balancedFrom(match.index + match[0].lastIndexOf("[")));
+      continue;
+    }
+    // Variable form: find the array literal assigned to that identifier.
+    const decl = source.indexOf(`${token} = [`);
+    if (decl !== -1) payloads.push(balancedFrom(source.indexOf("[", decl)));
+  }
+
+  return payloads;
+}
+
+/**
+ * The scanner is itself guard code, so it is exercised against sources it must
+ * REJECT as well as ones it must accept. Synthetic strings rather than mutating
+ * a real handler: the bypass shape is what matters, not which file wears it.
+ */
+describe("the batch scanner", () => {
+  const AUDIT = 'auditLogStatement(env, 1, "venue.deleted", "venue", id, {}, ip)';
+
+  it("accepts an inline batch holding both statements", () => {
+    const src = `await DB.batch([DB.prepare("DELETE FROM venues WHERE id = ?").bind(id), ${AUDIT}]);`;
+    const ok = batchPayloads(src).some(
+      (p) => p.includes("venue.deleted") && p.includes("auditLogStatement") && /DELETE FROM/i.test(p),
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("accepts the variable form, which an inline-only regex misses", () => {
+    const src = `const stmts = [DB.prepare("DELETE FROM venues WHERE id = ?").bind(id), ${AUDIT}];\nawait DB.batch(stmts);`;
+    const ok = batchPayloads(src).some(
+      (p) => p.includes("venue.deleted") && p.includes("auditLogStatement") && /DELETE FROM/i.test(p),
+    );
+    expect(ok).toBe(true);
+  });
+
+  // The bypass: both symbols are present in the file, but the audit runs on its
+  // own after a delete-only batch — the split this whole change removes.
+  it("REJECTS a delete-only batch with the audit executed separately", () => {
+    const src = `await DB.batch([DB.prepare("DELETE FROM venues WHERE id = ?").bind(id)]);\nawait ${AUDIT}.run();`;
+
+    expect(src).toContain("auditLogStatement");
+    expect(src).toContain("DB.batch(");
+
+    const ok = batchPayloads(src).some(
+      (p) => p.includes("venue.deleted") && p.includes("auditLogStatement") && /DELETE FROM/i.test(p),
+    );
+    expect(ok, "a delete-only batch with a separate audit must not pass").toBe(false);
+  });
+});
+
+describe("destructive admin handlers batch their audit row", () => {
   const sites = [
     ["functions/utils/bandProfileResource.js", "band_profile.deleted"],
     ["functions/api/admin/bands/[id].js", "band.deleted"],
+    ["functions/api/admin/bands/bulk.js", "band_profile.deleted"],
+    ["functions/api/admin/bands/bulk.js", "band.deleted"],
     ["functions/api/admin/events/[id].js", "event.deleted"],
     ["functions/api/admin/users/[id].js", "user.deleted"],
     ["functions/api/admin/venues/[id].js", "venue.deleted"],
   ];
 
-  it.each(sites)("%s audits %s as a statement, not a bare call", (file, action) => {
+  it.each(sites)("%s puts %s in the same batch as its DELETE", (file, action) => {
     const source = readFileSync(join(repoRoot, file), "utf8");
 
-    expect(source, `${file} should import auditLogStatement`).toContain("auditLogStatement");
-    expect(source, `${file} should batch its writes`).toContain("DB.batch(");
+    const together = batchPayloads(source).some(
+      (payload) => payload.includes(action) && payload.includes("auditLogStatement") && /DELETE FROM/i.test(payload),
+    );
 
-    // The executing form must not be used for this action: a bare auditLog runs
-    // on its own and cannot roll back with the delete.
-    const bare = new RegExp(`auditLog\\([^)]*?${action.replace(".", "\\.")}`, "s");
-    expect(
-      bare.test(source.replace(/auditLogStatement\(/g, "STATEMENT(")),
-      `${file}: "${action}" still uses the bare auditLog`,
-    ).toBe(false);
+    expect(together, `${file}: "${action}" is not in the same DB.batch(...) as its DELETE`).toBe(true);
   });
 });

--- a/functions/utils/__tests__/auditAtomicity.test.js
+++ b/functions/utils/__tests__/auditAtomicity.test.js
@@ -143,23 +143,27 @@ describe("the batch scanner", () => {
 });
 
 describe("destructive admin handlers batch their audit row", () => {
+  // The table is named per site rather than checking for a generic DELETE: these
+  // handlers delete from several tables, so a generic check can be satisfied by
+  // the WRONG one. `bands/[id].js` also issues DELETE FROM band_announce_queue,
+  // which would let "band.deleted" pass with its performances delete removed.
   const sites = [
-    ["functions/utils/bandProfileResource.js", "band_profile.deleted"],
-    ["functions/api/admin/bands/[id].js", "band.deleted"],
-    ["functions/api/admin/bands/bulk.js", "band_profile.deleted"],
-    ["functions/api/admin/bands/bulk.js", "band.deleted"],
-    ["functions/api/admin/events/[id].js", "event.deleted"],
-    ["functions/api/admin/users/[id].js", "user.deleted"],
-    ["functions/api/admin/venues/[id].js", "venue.deleted"],
+    ["functions/utils/bandProfileResource.js", "band_profile.deleted", /DELETE\s+FROM\s+band_profiles\b/i],
+    ["functions/api/admin/bands/[id].js", "band.deleted", /DELETE\s+FROM\s+performances\b/i],
+    ["functions/api/admin/bands/bulk.js", "band_profile.deleted", /DELETE\s+FROM\s+band_profiles\b/i],
+    ["functions/api/admin/bands/bulk.js", "band.deleted", /DELETE\s+FROM\s+performances\b/i],
+    ["functions/api/admin/events/[id].js", "event.deleted", /DELETE\s+FROM\s+events\b/i],
+    ["functions/api/admin/users/[id].js", "user.deleted", /DELETE\s+FROM\s+users\b/i],
+    ["functions/api/admin/venues/[id].js", "venue.deleted", /DELETE\s+FROM\s+venues\b/i],
   ];
 
-  it.each(sites)("%s puts %s in the same batch as its DELETE", (file, action) => {
+  it.each(sites)("%s puts %s in the same batch as its own DELETE", (file, action, deletePattern) => {
     const source = readFileSync(join(repoRoot, file), "utf8");
 
     const together = batchPayloads(source).some(
-      (payload) => payload.includes(action) && payload.includes("auditLogStatement") && /DELETE FROM/i.test(payload),
+      (payload) => payload.includes(action) && payload.includes("auditLogStatement") && deletePattern.test(payload),
     );
 
-    expect(together, `${file}: "${action}" is not in the same DB.batch(...) as its DELETE`).toBe(true);
+    expect(together, `${file}: "${action}" is not in the same DB.batch(...) as ${deletePattern}`).toBe(true);
   });
 });

--- a/functions/utils/auditLogStatement.js
+++ b/functions/utils/auditLogStatement.js
@@ -1,0 +1,15 @@
+export function auditLogStatement(env, userId, action, resourceType, resourceId, details, ipAddress) {
+  return env.DB.prepare(
+    `
+    INSERT INTO audit_log (user_id, action, resource_type, resource_id, details, ip_address)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `,
+  ).bind(
+    userId,
+    action,
+    resourceType || null,
+    resourceId || null,
+    details ? JSON.stringify(details) : null,
+    ipAddress || "unknown",
+  );
+}

--- a/functions/utils/bandProfileResource.js
+++ b/functions/utils/bandProfileResource.js
@@ -1,4 +1,5 @@
 import { auditLog } from "../api/admin/_middleware.js";
+import { auditLogStatement } from "./auditLogStatement.js";
 import {
   FIELD_LIMITS,
   isValidEmail,
@@ -291,17 +292,18 @@ export async function onRequestProfileDelete(context, { performanceId: _performa
       );
     }
 
-    await auditLog(
-      env,
-      user.userId,
-      "band_profile.deleted",
-      "band_profile",
-      bandProfileId,
-      { deletedBy: user.email },
-      ipAddress,
-    );
-
-    await DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(bandProfileId).run();
+    await DB.batch([
+      DB.prepare("DELETE FROM band_profiles WHERE id = ?").bind(bandProfileId),
+      auditLogStatement(
+        env,
+        user.userId,
+        "band_profile.deleted",
+        "band_profile",
+        bandProfileId,
+        { deletedBy: user.email },
+        ipAddress,
+      ),
+    ]);
 
     return new Response(
       JSON.stringify({


### PR DESCRIPTION
Closes #955

## The bug

A destructive admin action and its audit row were two independent statements, so they could disagree in both directions:

| failure | result |
|---|---|
| the DELETE fails | an audit row records a deletion that never happened |
| the audit INSERT fails | **swallowed** — the row is deleted unlogged |

The second is worse. For a destructive action, *who deleted what* is exactly what an audit trail exists to preserve, and it failed silently.

## Why the fix is narrower than the issue's framing

`auditLog` **deliberately never throws**, and its own comment says why:

> audit logging must not fail the request it records … an email sent, a digest flushed — and invite a retry of it.

That reasoning is **correct** for actions with external side effects a rollback can't undo. It's wrong only for destructive, database-only actions. So `auditLog`'s behaviour is unchanged for its other **31** callers; a statement-returning variant was added beside it, and `auditLog` now uses it internally so the two can't drift.

Seven destructive sites batched: `band_profile.deleted` ×2, `band.deleted` ×2, `event.deleted`, `user.deleted`, `venue.deleted`. `invite_code.revoked` was checked and left alone — it deactivates via `UPDATE`, not a delete.

## Two corrections to the delegated implementation

1. **`auditLogStatement.js` was placed under `functions/api/admin/`**, which `_routes.json` matches via `/api/*` — a shared helper in the route tree. It exports no request handler so it was inert rather than exposed, but it's moved to `functions/utils/`. Verified no include pattern matches `/utils/*`.
2. **The delegation mutation-verified its work and then deleted its tests**, so the fix arrived unguarded. Permanent tests added.

## And a false negative in my own guard

My first source scan matched only the inline `DB.batch([...])` form and failed on `users/[id].js`, which builds a statement array and passes it as `DB.batch(cleanupStmts)`. **The code was right; my test was wrong.** It now asserts the property that matters — the destructive path uses the *statement* form rather than the executing one — and documents why it doesn't assert the batch's shape.

| mutation | result |
|---|---|
| revert the venue delete to the sequential form | **1 RED** |

## Testing

- [x] `make gate` exits 0 — 1,313 backend + 1,230 frontend tests
- [x] **No existing test modified**
- [x] 8 new tests: statement builder bindings (including `null` details and the `"unknown"` ip default) plus the per-site scan

## Note

Implemented by Otto (OpenCode, `gpt-5.6-luna`, $0.139); sweep, corrections and verification here. Otto also flagged an eighth site (`bulk.js:576`) as outside the requested scope rather than silently changing it — worth a follow-up look.

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of administrative deletions for bands, profiles, events, users, and venues.
  - Deletion actions and their audit records are now processed together, helping prevent incomplete or inconsistent activity histories.
  - Audit entries now handle missing details and IP addresses more consistently.

- **Tests**
  - Added coverage to verify audit-record creation, data handling, and atomic deletion behaviour.
  - Added checks confirming destructive actions and their audit records are processed as one operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->