### PR TITLE
fix(admin): batch the bulk band delete with its audit row

### DIFF
--- a/functions/api/admin/bands/bulk.js
+++ b/functions/api/admin/bands/bulk.js
@@ -483,7 +483,7 @@ export async function onRequestPatch(context) {
   }
 
   try {
-    let result;
+    let statements;
     let rowsAffected = 0;
 
     if (action === "move_venue") {
@@ -515,12 +515,9 @@ export async function onRequestPatch(context) {
       }
 
       // Build batch update statements (ATOMIC - all or nothing)
-      const statements = validatedBandIds.map((id) =>
+      statements = validatedBandIds.map((id) =>
         env.DB.prepare("UPDATE performances SET venue_id = ? WHERE id = ?").bind(venue_id, id),
       );
-
-      result = await env.DB.batch(statements);
-      rowsAffected = result.reduce((total, res) => total + (res.meta?.changes ?? 0), 0);
     } else if (action === "change_time") {
       const { start_time } = params;
 
@@ -557,7 +554,7 @@ export async function onRequestPatch(context) {
         .bind(...validatedBandIds)
         .all();
 
-      const statements = currentPerfs.map((perf) => {
+      statements = currentPerfs.map((perf) => {
         const newEnd =
           perf.start_time && perf.end_time ? computeNewEndTime(perf.start_time, perf.end_time, start_time) : null;
         return env.DB.prepare("UPDATE performances SET start_time = ?, end_time = ? WHERE id = ?").bind(
@@ -566,32 +563,31 @@ export async function onRequestPatch(context) {
           perf.id,
         );
       });
-
-      result = await env.DB.batch(statements);
-      rowsAffected = result.reduce((total, res) => total + (res.meta?.changes ?? 0), 0);
     } else if (action === "delete") {
       const placeholders = validatedBandIds.map(() => "?").join(",");
-      result = await env.DB.prepare(`DELETE FROM performances WHERE id IN (${placeholders})`)
-        .bind(...validatedBandIds)
-        .run();
-      rowsAffected = result.meta?.changes ?? 0;
+      statements = [env.DB.prepare(`DELETE FROM performances WHERE id IN (${placeholders})`).bind(...validatedBandIds)];
     }
 
-    // Audit log the bulk operation
-    await auditLog(
-      env,
-      user.userId,
-      `band.bulk_${action}`,
-      "band",
-      null,
-      {
-        action,
-        bandIds: validatedBandIds,
-        bandCount: validatedBandIds.length,
-        params,
-      },
-      ipAddress,
+    const dataStatementCount = statements.length;
+    statements.push(
+      auditLogStatement(
+        env,
+        user.userId,
+        `band.bulk_${action}`,
+        "band",
+        null,
+        {
+          action,
+          bandIds: validatedBandIds,
+          bandCount: validatedBandIds.length,
+          params,
+        },
+        ipAddress,
+      ),
     );
+
+    const result = await env.DB.batch(statements);
+    rowsAffected = result.slice(0, dataStatementCount).reduce((total, res) => total + (res.meta?.changes ?? 0), 0);
 
     return new Response(
       JSON.stringify({

--- a/functions/utils/__tests__/auditAtomicity.test.js
+++ b/functions/utils/__tests__/auditAtomicity.test.js
@@ -3,6 +3,8 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { auditLogStatement } from "../auditLogStatement.js";
+import { onRequestPatch } from "../../api/admin/bands/bulk.js";
+import { createTestEnv, insertBand, insertEvent, insertVenue } from "../../api/test-utils.js";
 
 // __tests__ -> utils -> functions -> repo root (four levels, not three: the
 // first dirname strips the filename itself).
@@ -76,12 +78,12 @@ describe("auditLogStatement", () => {
 function batchPayloads(source) {
   const payloads = [];
 
-  const balancedFrom = (openIndex) => {
+  const balancedFrom = (openIndex, open = "[", close = "]") => {
     let depth = 0;
     for (let i = openIndex; i < source.length; i += 1) {
       const c = source[i];
-      if (c === "[") depth += 1;
-      else if (c === "]") {
+      if (c === open) depth += 1;
+      else if (c === close) {
         depth -= 1;
         if (depth === 0) return source.slice(openIndex, i + 1);
       }
@@ -95,9 +97,21 @@ function batchPayloads(source) {
       payloads.push(balancedFrom(match.index + match[0].lastIndexOf("[")));
       continue;
     }
-    // Variable form: find the array literal assigned to that identifier.
+    // Variable form: the payload is what actually lands in the array — its
+    // literal contents PLUS anything pushed onto it before the batch call.
+    // A raw text slice from the declaration to the batch is not equivalent and
+    // was a live bypass: it also swallows statements executed on their own in
+    // that window, so a sequential `.run()` delete written after the
+    // declaration read as batched. Verified by mutation, 2026-08-25.
     const decl = source.indexOf(`${token} = [`);
-    if (decl !== -1) payloads.push(balancedFrom(source.indexOf("[", decl)));
+    if (decl === -1) continue;
+    let payload = balancedFrom(source.indexOf("[", decl));
+    const pushToken = `${token}.push(`;
+    for (let at = source.indexOf(pushToken, decl); at !== -1 && at < match.index;) {
+      payload += balancedFrom(at + pushToken.length - 1, "(", ")");
+      at = source.indexOf(pushToken, at + pushToken.length);
+    }
+    payloads.push(payload);
   }
 
   return payloads;
@@ -140,6 +154,28 @@ describe("the batch scanner", () => {
     );
     expect(ok, "a delete-only batch with a separate audit must not pass").toBe(false);
   });
+
+  const passes = (src) =>
+    batchPayloads(src).some(
+      (p) => p.includes("venue.deleted") && p.includes("auditLogStatement") && /DELETE FROM/i.test(p),
+    );
+
+  it("accepts the variable form with the audit pushed on after the literal", () => {
+    const src = `let stmts;\nstmts = [DB.prepare("DELETE FROM venues WHERE id = ?").bind(id)];\nstmts.push(${AUDIT});\nawait DB.batch(stmts);`;
+    expect(passes(src)).toBe(true);
+  });
+
+  // The second bypass, found by mutation. Both symbols are present AND a batch
+  // exists, but the delete runs on its own between the declaration and the
+  // batch — so only the audit is ever batched.
+  it("REJECTS a delete executed separately after the array is declared", () => {
+    const src = `let stmts;\nstmts = [];\nawait DB.prepare("DELETE FROM venues WHERE id = ?").bind(id).run();\nstmts.push(${AUDIT});\nawait DB.batch(stmts);`;
+
+    expect(src).toContain("auditLogStatement");
+    expect(src).toContain("DB.batch(");
+
+    expect(passes(src), "a separately-executed delete must not read as batched").toBe(false);
+  });
 });
 
 describe("destructive admin handlers batch their audit row", () => {
@@ -152,6 +188,7 @@ describe("destructive admin handlers batch their audit row", () => {
     ["functions/api/admin/bands/[id].js", "band.deleted", /DELETE\s+FROM\s+performances\b/i],
     ["functions/api/admin/bands/bulk.js", "band_profile.deleted", /DELETE\s+FROM\s+band_profiles\b/i],
     ["functions/api/admin/bands/bulk.js", "band.deleted", /DELETE\s+FROM\s+performances\b/i],
+    ["functions/api/admin/bands/bulk.js", "band.bulk_${action}", /DELETE\s+FROM\s+performances\b/i],
     ["functions/api/admin/events/[id].js", "event.deleted", /DELETE\s+FROM\s+events\b/i],
     ["functions/api/admin/users/[id].js", "user.deleted", /DELETE\s+FROM\s+users\b/i],
     ["functions/api/admin/venues/[id].js", "venue.deleted", /DELETE\s+FROM\s+venues\b/i],
@@ -165,5 +202,108 @@ describe("destructive admin handlers batch their audit row", () => {
     );
 
     expect(together, `${file}: "${action}" is not in the same DB.batch(...) as ${deletePattern}`).toBe(true);
+  });
+});
+
+function patchRequest(env, body) {
+  return onRequestPatch({
+    request: new Request("https://example.test/api/admin/bands/bulk", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+    data: { user: { userId: 1, email: "admin@test", role: "editor" } },
+  });
+}
+
+function useTransactionalBatch(env, rawDb) {
+  const batch = vi.fn(async (statements) => rawDb.transaction(() => statements.map((statement) => statement.run()))());
+  env.DB.batch = batch;
+  return batch;
+}
+
+function makePerformanceFixture() {
+  const { env, rawDb } = createTestEnv({ role: "editor" });
+  const event = insertEvent(rawDb, { name: "Atomic Event", slug: "atomic-event" });
+  const venue = insertVenue(rawDb, { name: "Atomic Venue" });
+  const performance = insertBand(rawDb, {
+    name: "Atomic Band",
+    event_id: event.id,
+    venue_id: venue.id,
+    start_time: "18:00",
+    end_time: "19:00",
+  });
+  return { env, rawDb, event, venue, performance };
+}
+
+describe("bulk PATCH audit atomicity", () => {
+  it("rolls back the audit row when the DELETE fails", async () => {
+    const { env, rawDb, performance } = makePerformanceFixture();
+    rawDb.exec(`
+      CREATE TRIGGER fail_bulk_delete
+      BEFORE DELETE ON performances
+      BEGIN
+        SELECT RAISE(ABORT, 'forced bulk delete failure');
+      END
+    `);
+    const batch = useTransactionalBatch(env, rawDb);
+
+    const response = await patchRequest(env, { band_ids: [performance.id], action: "delete" });
+
+    expect(response.status).toBe(500);
+    expect(batch).toHaveBeenCalledOnce();
+    expect(rawDb.prepare("SELECT id FROM performances WHERE id = ?").get(performance.id)).toBeTruthy();
+    expect(rawDb.prepare("SELECT COUNT(*) AS count FROM audit_log WHERE action = 'band.bulk_delete'").get().count).toBe(
+      0,
+    );
+  });
+
+  it("rolls back the DELETE when the audit INSERT fails", async () => {
+    const { env, rawDb, performance } = makePerformanceFixture();
+    rawDb.exec(`
+      CREATE TRIGGER fail_bulk_audit
+      BEFORE INSERT ON audit_log
+      BEGIN
+        SELECT RAISE(ABORT, 'forced bulk audit failure');
+      END
+    `);
+    useTransactionalBatch(env, rawDb);
+
+    const response = await patchRequest(env, { band_ids: [performance.id], action: "delete" });
+
+    expect(response.status).toBe(500);
+    expect(rawDb.prepare("SELECT id FROM performances WHERE id = ?").get(performance.id)).toBeTruthy();
+  });
+
+  it("reports only deleted performances in updated", async () => {
+    const { env, rawDb, event, venue, performance } = makePerformanceFixture();
+    const second = insertBand(rawDb, {
+      name: "Second Atomic Band",
+      event_id: event.id,
+      venue_id: venue.id,
+      start_time: "20:00",
+      end_time: "21:00",
+    });
+    useTransactionalBatch(env, rawDb);
+
+    const response = await patchRequest(env, { band_ids: [performance.id, second.id], action: "delete" });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).updated).toBe(2);
+  });
+
+  it("reports only updated performances in updated", async () => {
+    const { env, rawDb, performance } = makePerformanceFixture();
+    useTransactionalBatch(env, rawDb);
+
+    const response = await patchRequest(env, {
+      band_ids: [performance.id],
+      action: "change_time",
+      start_time: "20:00",
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).updated).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

The bulk band PATCH handler ran its destructive branch on its own, then wrote a shared audit row in a second round-trip. Either half could fail alone:

| failure | result |
|---|---|
| the bulk removal fails | `band.bulk_delete` is recorded for something that never happened |
| the audit insert fails | swallowed — an arbitrary number of sets vanish with **no record of who did it** |

The second matters more here than at the single-row sites #955 fixed: the audit `details` carry `bandIds` and `bandCount`, so losing that row loses the only record of *which* sets were removed.

All three action branches (`move_venue`, `change_time`, `delete`) now build a `statements` array and converge on one atomic `DB.batch()` that includes the audit statement.

## The regression this refactor risked

`rowsAffected` is returned to the admin UI as `updated`. The audit statement contributes its own `meta.changes` of 1, so appending it to the batch would have made **every** bulk operation over-report by exactly 1. The count is now taken from a slice of the result covering only the data statements.

Proven by mutation — removing the slice reports `3` instead of `2` on a two-row delete, and `2` instead of `1` on an update.

## Scanner hardening (found during review, not delegated)

The shared source scanner in `auditAtomicity.test.js` had its variable-form branch take a raw text slice from the array declaration to the batch call. That window swallows anything written inside it, so a **sequential delete placed after the declaration read as batched**.

This was not theoretical. The bypass shape was constructed and confirmed to pass the scan while being genuinely non-atomic — the exact defect the test exists to catch. The scanner now collects the array literal plus what is `push`ed onto it, and two new self-tests pin both the accepted and the rejected shape.

That makes three rounds this guard has been tightened after reporting success it had not earned. Worth noting for whoever touches it next.

## Test plan

- [x] the bulk removal fails -> **no** `band.bulk_delete` audit row (real SQLite `RAISE(ABORT)` trigger, real transaction)
- [x] the audit insert fails -> the performances are **not** removed
- [x] `updated` is correct after the change, on the delete branch **and** an update branch
- [x] every test proven by mutation — reverted to the sequential form and confirmed red
- [x] the hardened scanner catches the bypass that previously passed
- [x] `make gate` exits 0 — **1333** backend, **1230** frontend, 0 lint errors
- [x] `make review` (CodeRabbit) — no findings

## Risk

Low. Behaviour is unchanged on the success path; the failure path becomes atomic instead of split-brain. One latent coupling worth knowing: `let statements` is uninitialized, so an action with no branch would now throw rather than silently return `200 updated: 0` with an audit row written for nothing. Safe today — `allowedActions` is exactly the three branches — and the loud failure is the better of the two.

## Documentation

None needed.

Closes #958

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk venue moves, time changes, and deletions now complete atomically, preventing partial updates.
  * Audit records are saved together with related bulk changes and correctly exclude audit entries from update counts.
  * Improved rollback behaviour when a bulk operation fails.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->