### PR TITLE
fix(admin): recompose origin inside the UPDATE, not around it

### DIFF
--- a/functions/utils/__tests__/bandProfileOrigin.test.js
+++ b/functions/utils/__tests__/bandProfileOrigin.test.js
@@ -1,87 +1,143 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import { createTestEnv } from "../../api/test-utils.js";
 import { prepareBandProfileFields } from "../bandProfileFields.js";
 
-/**
- * #954: clearing an artist's origin left the composite `origin` column stale.
- * Sending origin_city:"" and origin_region:"" (no `origin`) nulled both
- * component columns while the `origin = ?` update was skipped, so the admin UI
- * re-displayed the value the user had just deleted.
- *
- * The happy path passes either way — only the CLEARING path distinguishes the
- * fixed code from the broken code.
- */
-const DB = (stored = null) => ({
-  prepare: vi.fn(() => ({
-    bind: vi.fn(() => ({ first: vi.fn(async () => stored) })),
-  })),
-});
+function createProfile({ origin_city = null, origin_region = null, origin = null } = {}) {
+  const { env, rawDb } = createTestEnv();
+  const result = rawDb
+    .prepare(
+      "INSERT INTO band_profiles (name, name_normalized, origin, origin_city, origin_region) VALUES (?, ?, ?, ?, ?)",
+    )
+    .run("Test Band", "test-band", origin, origin_city, origin_region);
+  return { DB: env.DB, rawDb, id: result.lastInsertRowid };
+}
 
-async function fieldsFor(body, stored = null) {
-  const result = await prepareBandProfileFields(DB(stored), body, 7, undefined);
-  const { profileUpdates, profileParams } = result;
-  const map = new Map();
-  profileUpdates.forEach((clause, i) => map.set(clause.replace(" = ?", ""), profileParams[i]));
-  return map;
+async function applyUpdate(DB, body, profileId) {
+  const { profileStatement } = await prepareBandProfileFields(DB, body, profileId, undefined);
+  expect(profileStatement).toBeDefined();
+  profileStatement.run();
+}
+
+function readOrigin(rawDb, profileId) {
+  return rawDb.prepare("SELECT origin, origin_city, origin_region FROM band_profiles WHERE id = ?").get(profileId);
 }
 
 describe("band profile origin recomposition", () => {
-  it("clears the composite origin when both components are cleared", async () => {
-    const fields = await fieldsFor({ origin_city: "", origin_region: "" });
+  it("recomposes a city-only update with the stored region", async () => {
+    const profile = createProfile({ origin_city: "Kitchener", origin_region: "ON" });
 
-    expect(fields.has("origin")).toBe(true);
-    expect(fields.get("origin")).toBeNull();
-    expect(fields.get("origin_city")).toBeNull();
-    expect(fields.get("origin_region")).toBeNull();
+    await applyUpdate(profile.DB, { origin_city: "Waterloo" }, profile.id);
+
+    expect(readOrigin(profile.rawDb, profile.id)).toEqual({
+      origin: "Waterloo, ON",
+      origin_city: "Waterloo",
+      origin_region: "ON",
+    });
   });
 
-  // A PARTIAL update must fall back to the STORED component, not to null.
-  // Clearing only the city while the row holds a region would otherwise write
-  // origin = NULL and leave origin_region = "ON" beside it — the composite
-  // disagreeing with the column it is composed from.
-  it("keeps the stored region when only the city is cleared", async () => {
-    const fields = await fieldsFor({ origin_city: "" }, { origin_city: "Kitchener", origin_region: "ON" });
+  it("recomposes a region-only update with the stored city", async () => {
+    const profile = createProfile({ origin_city: "Kitchener", origin_region: "ON" });
 
-    expect(fields.get("origin_city")).toBeNull();
-    expect(fields.get("origin")).toBe("ON");
-    expect(fields.has("origin_region")).toBe(false);
+    await applyUpdate(profile.DB, { origin_region: "QC" }, profile.id);
+
+    expect(readOrigin(profile.rawDb, profile.id)).toEqual({
+      origin: "Kitchener, QC",
+      origin_city: "Kitchener",
+      origin_region: "QC",
+    });
   });
 
-  it("keeps the stored city when only the region is cleared", async () => {
-    const fields = await fieldsFor({ origin_region: "" }, { origin_city: "Kitchener", origin_region: "ON" });
+  it("keeps the surviving region when the city is cleared", async () => {
+    const profile = createProfile({ origin_city: "Kitchener", origin_region: "ON" });
 
-    expect(fields.get("origin_region")).toBeNull();
-    expect(fields.get("origin")).toBe("Kitchener");
-    expect(fields.has("origin_city")).toBe(false);
+    await applyUpdate(profile.DB, { origin_city: "" }, profile.id);
+
+    expect(readOrigin(profile.rawDb, profile.id)).toEqual({
+      origin: "ON",
+      origin_city: null,
+      origin_region: "ON",
+    });
   });
 
-  it("recomposes with the stored region when a new city is supplied", async () => {
-    const fields = await fieldsFor({ origin_city: "Waterloo" }, { origin_city: "Kitchener", origin_region: "ON" });
+  it("keeps the surviving city when the region is cleared", async () => {
+    const profile = createProfile({ origin_city: "Kitchener", origin_region: "ON" });
 
-    expect(fields.get("origin")).toBe("Waterloo, ON");
+    await applyUpdate(profile.DB, { origin_region: "" }, profile.id);
+
+    expect(readOrigin(profile.rawDb, profile.id)).toEqual({
+      origin: "Kitchener",
+      origin_city: "Kitchener",
+      origin_region: null,
+    });
   });
 
-  it("recomposes origin from a single supplied component", async () => {
-    const fields = await fieldsFor({ origin_city: "Kitchener" });
+  it("clears all three columns when both components are cleared", async () => {
+    const profile = createProfile({ origin: "Kitchener, ON", origin_city: "Kitchener", origin_region: "ON" });
 
-    expect(fields.get("origin")).toBe("Kitchener");
-    expect(fields.get("origin_city")).toBe("Kitchener");
+    await applyUpdate(profile.DB, { origin_city: "", origin_region: "" }, profile.id);
+
+    expect(readOrigin(profile.rawDb, profile.id)).toEqual({
+      origin: null,
+      origin_city: null,
+      origin_region: null,
+    });
   });
 
-  it("recomposes origin from both components", async () => {
-    const fields = await fieldsFor({ origin_city: "Kitchener", origin_region: "ON" });
-    expect(fields.get("origin")).toBe("Kitchener, ON");
+  it("lets an explicit origin win over component fields", async () => {
+    const profile = createProfile({ origin_city: "Kitchener", origin_region: "ON" });
+
+    await applyUpdate(profile.DB, { origin: "Waterloo, ON", origin_city: "Waterloo", origin_region: "ON" }, profile.id);
+
+    expect(readOrigin(profile.rawDb, profile.id)).toEqual({
+      origin: "Waterloo, ON",
+      origin_city: "Waterloo",
+      origin_region: "ON",
+    });
   });
 
-  it("still lets an explicit origin win", async () => {
-    const fields = await fieldsFor({ origin: "Waterloo, ON" });
-    expect(fields.get("origin")).toBe("Waterloo, ON");
+  // Both components supplied is the JS path, deliberately left in place because
+  // it reads nothing and so has no race. It still needs cover: the SQL branch
+  // above does not run for it.
+  it("recomposes origin when both components are supplied together", async () => {
+    const profile = createProfile({ origin: "Kitchener, ON", origin_city: "Kitchener", origin_region: "ON" });
+
+    await applyUpdate(profile.DB, { origin_city: "Guelph", origin_region: "QC" }, profile.id);
+
+    expect(readOrigin(profile.rawDb, profile.id)).toEqual({
+      origin: "Guelph, QC",
+      origin_city: "Guelph",
+      origin_region: "QC",
+    });
   });
 
-  it("touches none of the three columns when no origin field is supplied", async () => {
-    const fields = await fieldsFor({ name: "ALL" });
+  it("keeps the composite consistent when partial updates interleave", async () => {
+    const profile = createProfile({ origin_city: "Kitchener", origin_region: "ON" });
+    const cityUpdate = prepareBandProfileFields(profile.DB, { origin_city: "Waterloo" }, profile.id, undefined);
+    const regionUpdate = prepareBandProfileFields(profile.DB, { origin_region: "QC" }, profile.id, undefined);
+    const [{ profileStatement: cityStatement }, { profileStatement: regionStatement }] = await Promise.all([
+      cityUpdate,
+      regionUpdate,
+    ]);
 
-    expect(fields.has("origin")).toBe(false);
-    expect(fields.has("origin_city")).toBe(false);
-    expect(fields.has("origin_region")).toBe(false);
+    cityStatement.run();
+    regionStatement.run();
+
+    expect(readOrigin(profile.rawDb, profile.id)).toEqual({
+      origin: "Waterloo, QC",
+      origin_city: "Waterloo",
+      origin_region: "QC",
+    });
+  });
+
+  it("does not touch origin columns when no origin field is supplied", async () => {
+    const profile = createProfile({ origin: "Kitchener, ON", origin_city: "Kitchener", origin_region: "ON" });
+
+    await applyUpdate(profile.DB, { name: "ALL" }, profile.id);
+
+    expect(readOrigin(profile.rawDb, profile.id)).toEqual({
+      origin: "Kitchener, ON",
+      origin_city: "Kitchener",
+      origin_region: "ON",
+    });
   });
 });

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -55,47 +55,51 @@ export async function prepareBandProfileFields(DB, body, bandProfileId, resolved
   }
   const parsedOrigin = origin !== undefined ? parseOrigin(origin) : { city: null, region: null };
 
-  // A PARTIAL component update has to fall back to what is stored, not to null.
-  // Sending only { origin_city: "" } while the row holds origin_region "ON"
-  // would otherwise recompose origin from city alone — writing origin = NULL
-  // while leaving origin_region = "ON" untouched, so the composite disagrees
-  // with the column beside it. One read, and only on component updates.
-  let fallbackCity = parsedOrigin.city;
-  let fallbackRegion = parsedOrigin.region;
-  if (origin === undefined && (origin_city !== undefined || origin_region !== undefined)) {
-    const stored = await DB.prepare("SELECT origin_city, origin_region FROM band_profiles WHERE id = ?")
-      .bind(bandProfileId)
-      .first();
-    fallbackCity = stored?.origin_city ?? null;
-    fallbackRegion = stored?.origin_region ?? null;
-  }
-
-  const resolvedOriginCity = origin_city !== undefined ? origin_city : fallbackCity;
-  const resolvedOriginRegion = origin_region !== undefined ? origin_region : fallbackRegion;
+  const isPartialOriginUpdate = origin === undefined && (origin_city !== undefined) !== (origin_region !== undefined);
+  const resolvedOriginCity = origin_city !== undefined ? origin_city : parsedOrigin.city;
+  const resolvedOriginRegion = origin_region !== undefined ? origin_region : parsedOrigin.region;
   // Recompose `origin` whenever a COMPONENT field is supplied, not only when the
   // recomposition is non-empty. Clearing both components sends "" for each, the
   // join is "", and a trailing `|| undefined` would make this read as "nothing
   // supplied" — skipping the `origin = ?` update while origin_city and
   // origin_region are set to NULL, so the composite column keeps the value the
   // admin just deleted and the UI shows it again (#954).
-  const computedOrigin =
-    origin !== undefined
-      ? origin
-      : origin_city !== undefined || origin_region !== undefined
-        ? [resolvedOriginCity, resolvedOriginRegion].filter(Boolean).join(", ")
-        : undefined;
+  if (isPartialOriginUpdate) {
+    if (origin_city !== undefined) {
+      profileUpdates.push("origin_city = ?");
+      profileParams.push(origin_city || null);
+      profileUpdates.push(
+        "origin = NULLIF(TRIM(COALESCE(?, '') || CASE WHEN COALESCE(?, '') <> '' AND COALESCE(origin_region, '') <> '' THEN ', ' ELSE '' END || COALESCE(origin_region, '')), '')",
+      );
+      profileParams.push(origin_city, origin_city);
+    } else {
+      profileUpdates.push("origin_region = ?");
+      profileParams.push(origin_region || null);
+      profileUpdates.push(
+        "origin = NULLIF(TRIM(COALESCE(origin_city, '') || CASE WHEN COALESCE(origin_city, '') <> '' AND COALESCE(?, '') <> '' THEN ', ' ELSE '' END || COALESCE(?, '')), '')",
+      );
+      profileParams.push(origin_region, origin_region);
+    }
+  } else {
+    const computedOrigin =
+      origin !== undefined
+        ? origin
+        : origin_city !== undefined || origin_region !== undefined
+          ? [resolvedOriginCity, resolvedOriginRegion].filter(Boolean).join(", ")
+          : undefined;
 
-  if (origin !== undefined || origin_city !== undefined) {
-    profileUpdates.push("origin_city = ?");
-    profileParams.push(resolvedOriginCity || null);
-  }
-  if (origin !== undefined || origin_region !== undefined) {
-    profileUpdates.push("origin_region = ?");
-    profileParams.push(resolvedOriginRegion || null);
-  }
-  if (computedOrigin !== undefined) {
-    profileUpdates.push("origin = ?");
-    profileParams.push(computedOrigin || null);
+    if (origin !== undefined || origin_city !== undefined) {
+      profileUpdates.push("origin_city = ?");
+      profileParams.push(resolvedOriginCity || null);
+    }
+    if (origin !== undefined || origin_region !== undefined) {
+      profileUpdates.push("origin_region = ?");
+      profileParams.push(resolvedOriginRegion || null);
+    }
+    if (computedOrigin !== undefined) {
+      profileUpdates.push("origin = ?");
+      profileParams.push(computedOrigin || null);
+    }
   }
   if (contact_email !== undefined) {
     profileUpdates.push("contact_email = ?");

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -55,6 +55,17 @@ export async function prepareBandProfileFields(DB, body, bandProfileId, resolved
   }
   const parsedOrigin = origin !== undefined ? parseOrigin(origin) : { city: null, region: null };
 
+  // Precedence when a request carries BOTH `origin` and a component: the
+  // component wins for its own column, and `origin` wins for the composite.
+  // That looks backwards until you see what the admin UI sends — it always
+  // posts all three, deriving `origin` from the components
+  // ([city, region].filter(Boolean).join(", ")). Deriving the columns back out
+  // of `origin` instead loses data: a region-only profile posts
+  // { origin: "ON", origin_city: "", origin_region: "ON" }, and parseOrigin("ON")
+  // yields city "ON" with a null region — flipping the region into the city
+  // column. The components are authoritative because they are the source the
+  // composite was built from. Flagged as an inconsistency by review twice now;
+  // it is deliberate.
   const isPartialOriginUpdate = origin === undefined && (origin_city !== undefined) !== (origin_region !== undefined);
   const resolvedOriginCity = origin_city !== undefined ? origin_city : parsedOrigin.city;
   const resolvedOriginRegion = origin_region !== undefined ? origin_region : parsedOrigin.region;


### PR DESCRIPTION
## Summary

A partial component update (`origin_city` **or** `origin_region`, not both) read the stored pair, recomposed the composite `origin` in JS, and wrote it later through `DB.batch`. The read and the write were not one operation, so two overlapping partial updates on the same profile both read the same pair and each wrote only its own component:

```
A: { origin_city: "Waterloo" }   reads (Kitchener, ON) -> origin "Waterloo, ON"
B: { origin_region: "QC" }       reads (Kitchener, ON) -> origin "Kitchener, QC"

B lands last:  origin_city = Waterloo   origin_region = QC   origin = "Kitchener, QC"
```

The one-component paths now compose `origin` **inside the UPDATE**, reading the untouched component from its own column. SQLite evaluates SET right-hand sides against pre-update row values, and that component is not being written on those paths, so the value it reads is the one that will still be there afterwards. No JS-side read participates, so there is no window.

Updates supplying **both** components, or an explicit `origin`, keep the JS path deliberately — they read nothing and were never racy.

## The test that matters

The file moves from a mocked `DB` to a real sqlite handle, because the race cannot be expressed against a mock. The interleaving test starts both updates before either statement runs, reproducing read/read/write/write.

Verified against the previous implementation — **it alone fails**:

```
AssertionError: expected { origin: 'Kitchener, QC', …(2) }
                to deeply equal { origin: 'Waterloo, QC', …(2) }
```

The other 8 cases pass on **both** implementations. They are regression cover, not proof, and the issue said so up front.

Also restores coverage for the both-components-supplied path, which the rewritten suite dropped. That is precisely the JS branch left in place, so it is the code the new SQL tests do not reach.

## A review finding deliberately not applied

CodeRabbit flagged the mixed precedence (a component wins for its own column; `origin` wins for the composite) and proposed deriving both component columns from `parseOrigin(origin)`.

**That would corrupt data on the real payload.** `RosterTab.jsx:283` builds `origin` *from* the components (`[city, region].filter(Boolean).join(", ")`) and posts all three. A region-only profile therefore sends `{ origin: "ON", origin_city: "", origin_region: "ON" }` — and `parseOrigin("ON")` yields `{ city: "ON", region: null }`, flipping the region into the city column and dropping it.

The components are authoritative because they are the source the composite was built from. The reasoning is now a comment in the file, since this is the second time review has read it as a bug.

## Test plan

- [x] city-only update with a stored region -> recomposed correctly
- [x] region-only update with a stored city -> same
- [x] clearing one component while the other is stored -> composite matches the survivor
- [x] both cleared -> all three NULL
- [x] explicit `origin` still wins
- [x] both components supplied together (restored coverage)
- [x] **the race is closed** — interleaved partial updates, proven to fail against the old implementation
- [x] `make gate` exits 0 — **1327** backend, **1230** frontend, 0 lint errors
- [x] `make review` (CodeRabbit) — one finding, addressed above with reasoning

## Risk

Low. The success path is unchanged; the concurrent path stops producing an inconsistent row. The SQL composition mirrors the JS format exactly (same separator, same trim, empty becomes NULL), verified by the per-field cases passing against both implementations.

## Documentation

None needed beyond the in-file comment.

Closes #959

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved band profile origin updates when only one origin component is changed.
  - Preserved existing origin components during partial updates.
  - Correctly handled clearing components, explicit origins, simultaneous updates, and interleaved changes.
  - Prevented unrelated profile updates from altering origin information.

- **Tests**
  - Added database-backed coverage for origin recomposition and partial update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->