### PR TITLE
fix(admin): stop a failed social-links read from wiping every artist link

### DIFF
--- a/functions/utils/__tests__/bandProfileSocialLinksReadFailure.test.js
+++ b/functions/utils/__tests__/bandProfileSocialLinksReadFailure.test.js
@@ -121,11 +121,11 @@ describe("band profile social-links URL updates", () => {
     });
   });
 
-  it.each([
-    ["null", null],
-    ["42", 42],
-    ['"hello"', "hello"],
-  ])("recovers from a non-object stored JSON value: %s", async (storedValue) => {
+  // Each row is the raw JSON TEXT stored in the column, not a JS value: the
+  // callback takes one parameter, so it.each binds the first element. "[]" is
+  // the only case that reaches the Array.isArray clause -- an array parses as a
+  // truthy typeof "object" and passes every other check in the guard.
+  it.each(["null", "42", '"hello"', "[]"])("recovers from a non-object stored JSON value: %s", async (storedValue) => {
     const profile = createProfile({ instagram: "https://instagram.com/test-band" });
     profile.rawDb.prepare("UPDATE band_profiles SET social_links = ? WHERE id = ?").run(storedValue, profile.id);
 

--- a/functions/utils/__tests__/bandProfileSocialLinksReadFailure.test.js
+++ b/functions/utils/__tests__/bandProfileSocialLinksReadFailure.test.js
@@ -14,7 +14,7 @@ function readSocialLinks(rawDb, profileId) {
   return rawDb.prepare("SELECT social_links FROM band_profiles WHERE id = ?").get(profileId).social_links;
 }
 
-async function runUrlUpdate(DB, profileId) {
+async function runUrlUpdateOutcome(DB, profileId) {
   let result;
   let error;
   try {
@@ -25,7 +25,11 @@ async function runUrlUpdate(DB, profileId) {
   } catch (caughtError) {
     error = caughtError;
   }
-  return error;
+  return { error: error || result?.error, threw: Boolean(error) };
+}
+
+async function runUrlUpdate(DB, profileId) {
+  return (await runUrlUpdateOutcome(DB, profileId)).error;
 }
 
 describe("band profile social-links URL updates", () => {
@@ -53,17 +57,56 @@ describe("band profile social-links URL updates", () => {
     });
   });
 
+  it("surfaces a rejected social-links read without wiping existing links", async () => {
+    const profile = createProfile({
+      instagram: "https://instagram.com/test-band",
+      bandcamp: "https://test-band.bandcamp.com",
+    });
+    const failingDB = {
+      ...profile.DB,
+      prepare(sql) {
+        if (!sql.startsWith("SELECT social_links")) {
+          return profile.DB.prepare(sql);
+        }
+        return {
+          bind(...params) {
+            const statement = profile.DB.prepare(sql).bind(...params);
+            return { ...statement, first: () => Promise.reject(new Error("simulated rejected D1 failure")) };
+          },
+        };
+      },
+    };
+
+    const error = await runUrlUpdate(failingDB, profile.id);
+
+    expect(error).toHaveProperty("message", "simulated rejected D1 failure");
+    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toEqual({
+      instagram: "https://instagram.com/test-band",
+      bandcamp: "https://test-band.bandcamp.com",
+    });
+  });
+
   it("surfaces a missing profile without preparing a replacement social-links blob", async () => {
     const profile = createProfile({
       instagram: "https://instagram.com/test-band",
       bandcamp: "https://test-band.bandcamp.com",
     });
     profile.rawDb.prepare("DELETE FROM band_profiles WHERE id = ?").run(profile.id);
+    let updatePrepared = false;
+    const trackingDB = {
+      ...profile.DB,
+      prepare(sql) {
+        if (sql.startsWith("UPDATE band_profiles")) {
+          updatePrepared = true;
+        }
+        return profile.DB.prepare(sql);
+      },
+    };
 
-    const error = await runUrlUpdate(profile.DB, profile.id);
+    const error = await runUrlUpdate(trackingDB, profile.id);
 
     expect(error).toHaveProperty("message", "Band profile not found");
-    expect(profile.rawDb.prepare("SELECT id FROM band_profiles WHERE id = ?").get(profile.id)).toBeUndefined();
+    expect(updatePrepared).toBe(false);
   });
 
   it("recovers from malformed stored JSON and updates the website", async () => {
@@ -76,6 +119,39 @@ describe("band profile social-links URL updates", () => {
     expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toMatchObject({
       website: "https://example.com/",
     });
+  });
+
+  it.each([
+    ["null", null],
+    ["42", 42],
+    ['"hello"', "hello"],
+  ])("recovers from a non-object stored JSON value: %s", async (storedValue) => {
+    const profile = createProfile({ instagram: "https://instagram.com/test-band" });
+    profile.rawDb.prepare("UPDATE band_profiles SET social_links = ? WHERE id = ?").run(storedValue, profile.id);
+
+    const error = await runUrlUpdate(profile.DB, profile.id);
+
+    expect(error).toBeUndefined();
+    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toMatchObject({
+      website: "https://example.com/",
+    });
+  });
+
+  it.each([
+    ["an unsafe scheme", '{"bandcamp":"ftp://x.com"}', "Bandcamp URL must start with http:// or https://"],
+    [
+      "an overlong URL",
+      `{"bandcamp":"https://x.com/${"a".repeat(501)}"}`,
+      "Bandcamp URL must be no more than 500 characters",
+    ],
+  ])("surfaces stored-data sanitisation failure for %s as a server fault", async (_caseName, storedValue, message) => {
+    const profile = createProfile({ instagram: "https://instagram.com/test-band" });
+    profile.rawDb.prepare("UPDATE band_profiles SET social_links = ? WHERE id = ?").run(storedValue, profile.id);
+
+    const outcome = await runUrlUpdateOutcome(profile.DB, profile.id);
+
+    expect(outcome).toMatchObject({ threw: true, error: { message } });
+    expect(readSocialLinks(profile.rawDb, profile.id)).toBe(storedValue);
   });
 
   it("merges the website with existing social links", async () => {

--- a/functions/utils/__tests__/bandProfileSocialLinksReadFailure.test.js
+++ b/functions/utils/__tests__/bandProfileSocialLinksReadFailure.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { createTestEnv } from "../../api/test-utils.js";
+import { prepareBandProfileFields } from "../bandProfileFields.js";
+
+function createProfile(socialLinks) {
+  const { env, rawDb } = createTestEnv();
+  const result = rawDb
+    .prepare("INSERT INTO band_profiles (name, name_normalized, social_links) VALUES (?, ?, ?)")
+    .run("Test Band", "test-band", JSON.stringify(socialLinks));
+  return { DB: env.DB, rawDb, id: result.lastInsertRowid };
+}
+
+function readSocialLinks(rawDb, profileId) {
+  return rawDb.prepare("SELECT social_links FROM band_profiles WHERE id = ?").get(profileId).social_links;
+}
+
+async function runUrlUpdate(DB, profileId) {
+  let result;
+  let error;
+  try {
+    result = await prepareBandProfileFields(DB, { url: "https://example.com" }, profileId, undefined);
+    if (result.profileStatement) {
+      result.profileStatement.run();
+    }
+  } catch (caughtError) {
+    error = caughtError;
+  }
+  return error;
+}
+
+describe("band profile social-links URL updates", () => {
+  it("surfaces a failed social-links read without wiping existing links", async () => {
+    const profile = createProfile({
+      instagram: "https://instagram.com/test-band",
+      bandcamp: "https://test-band.bandcamp.com",
+    });
+    const failingDB = {
+      ...profile.DB,
+      prepare(sql) {
+        if (sql.startsWith("SELECT social_links")) {
+          throw new Error("simulated transient D1 failure");
+        }
+        return profile.DB.prepare(sql);
+      },
+    };
+
+    const error = await runUrlUpdate(failingDB, profile.id);
+
+    expect(error).toHaveProperty("message", "simulated transient D1 failure");
+    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toEqual({
+      instagram: "https://instagram.com/test-band",
+      bandcamp: "https://test-band.bandcamp.com",
+    });
+  });
+
+  it("surfaces a missing profile without preparing a replacement social-links blob", async () => {
+    const profile = createProfile({
+      instagram: "https://instagram.com/test-band",
+      bandcamp: "https://test-band.bandcamp.com",
+    });
+    profile.rawDb.prepare("DELETE FROM band_profiles WHERE id = ?").run(profile.id);
+
+    const error = await runUrlUpdate(profile.DB, profile.id);
+
+    expect(error).toHaveProperty("message", "Band profile not found");
+    expect(profile.rawDb.prepare("SELECT id FROM band_profiles WHERE id = ?").get(profile.id)).toBeUndefined();
+  });
+
+  it("recovers from malformed stored JSON and updates the website", async () => {
+    const profile = createProfile({ instagram: "https://instagram.com/test-band" });
+    profile.rawDb.prepare("UPDATE band_profiles SET social_links = ? WHERE id = ?").run("{bad", profile.id);
+
+    const error = await runUrlUpdate(profile.DB, profile.id);
+
+    expect(error).toBeUndefined();
+    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toMatchObject({
+      website: "https://example.com/",
+    });
+  });
+
+  it("merges the website with existing social links", async () => {
+    const profile = createProfile({
+      instagram: "https://instagram.com/test-band",
+      bandcamp: "https://test-band.bandcamp.com",
+    });
+
+    const error = await runUrlUpdate(profile.DB, profile.id);
+
+    expect(error).toBeUndefined();
+    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toMatchObject({
+      website: "https://example.com/",
+      instagram: "https://instagram.com/test-band",
+      bandcamp: "https://test-band.bandcamp.com/",
+    });
+  });
+});

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -142,10 +142,11 @@ export async function prepareBandProfileFields(DB, body, bandProfileId, resolved
   } else if (url !== undefined) {
     shouldUpdateSocialLinks = true;
     let existingLinks = {};
+    const profile = await DB.prepare("SELECT social_links FROM band_profiles WHERE id = ?").bind(bandProfileId).first();
+    if (!profile) {
+      throw new Error("Band profile not found");
+    }
     try {
-      const profile = await DB.prepare("SELECT social_links FROM band_profiles WHERE id = ?")
-        .bind(bandProfileId)
-        .first();
       existingLinks = JSON.parse(profile.social_links || "{}");
     } catch (_e) {
       /* ignore malformed JSON — existingLinks stays {} */

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -141,7 +141,7 @@ export async function prepareBandProfileFields(DB, body, bandProfileId, resolved
     }
   } else if (url !== undefined) {
     shouldUpdateSocialLinks = true;
-    let existingLinks = {};
+    let existingLinks;
     const profile = await DB.prepare("SELECT social_links FROM band_profiles WHERE id = ?").bind(bandProfileId).first();
     if (!profile) {
       throw new Error("Band profile not found");

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -146,13 +146,18 @@ export async function prepareBandProfileFields(DB, body, bandProfileId, resolved
     if (!profile) {
       throw new Error("Band profile not found");
     }
+    // Only the parse belongs inside this try. Resetting to {} is the right
+    // recovery for corrupt stored data and the wrong one for anything else,
+    // because shouldUpdateSocialLinks is already set — so whatever reaches this
+    // catch gets written over the row. Widening it to cover the read above is
+    // what discarded every other platform link on a single failed SELECT (#962).
     try {
       existingLinks = JSON.parse(profile.social_links || "{}");
       if (!existingLinks || typeof existingLinks !== "object" || Array.isArray(existingLinks)) {
         existingLinks = {};
       }
-    } catch (_e) {
-      /* ignore malformed JSON — existingLinks stays {} */
+    } catch {
+      existingLinks = {};
     }
     try {
       existingLinks.website = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -148,15 +148,18 @@ export async function prepareBandProfileFields(DB, body, bandProfileId, resolved
     }
     try {
       existingLinks = JSON.parse(profile.social_links || "{}");
+      if (!existingLinks || typeof existingLinks !== "object" || Array.isArray(existingLinks)) {
+        existingLinks = {};
+      }
     } catch (_e) {
       /* ignore malformed JSON — existingLinks stays {} */
     }
     try {
       existingLinks.website = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");
-      newSocialLinks = sanitizeBandSocialLinks(existingLinks);
     } catch (error) {
       return { error };
     }
+    newSocialLinks = sanitizeBandSocialLinks(existingLinks);
   }
 
   if (shouldUpdateSocialLinks) {


### PR DESCRIPTION
## Summary

A transient database read could silently destroy an artist's links.

The `url`-only branch of the social-links handling wrapped **both** a D1 read and a `JSON.parse` in one `try`, whose `catch` reset the merge base to `{}`. Correct recovery for malformed JSON; catastrophic for a failed read — `shouldUpdateSocialLinks` was already `true`, so execution continued and wrote a blob containing only the website, discarding every other platform link.

**Reproduced before fixing.** On the original code, a simulated read failure left the row as:

```json
{"website":"https://example.com/","instagram":null,"bandcamp":null,...}
```

No concurrency required. One blip.

## Three defects, one root cause

Each is a `try` spanning two operations with **different error semantics**, and a `catch` written for only one of them.

**1. The read.** SELECT moved outside the `try`; a missing row throws explicitly; only `JSON.parse` remains inside. Both callers already wrap this in a try returning 500, so a read fault now surfaces instead of rewriting the row.

Throwing rather than returning the sibling `{ error }` shape is deliberate: callers render that shape as a **400 validation error**, which would report a database fault as the admin's input being wrong.

**2. The same defect five lines below — found by a silent-failure review, not by me.** One `try` wrapped `sanitizeOptionalHttpUrl(url)` (the caller's input) *and* `sanitizeBandSocialLinks(existingLinks)` (data read from D1), returning the 400 shape for both. A legacy row with a bad stored link therefore made an **unrelated** website edit fail and blamed the admin:

| stored | admin edits | before |
|---|---|---|
| `{"bandcamp":"ftp://x.com"}` | website only | 400 "Bandcamp URL must start with http:// or https://" |
| `{"bandcamp":"https://x.com/<501 chars>"}` | website only | 400 "Bandcamp URL must be no more than 500 characters" |

Both are **wedge states** — the edit can never save, and the endpoint that would repair the stored value is the one refusing. Such rows are documented as existing in `functions/utils/validation/urls.js`.

Now separated: the caller's url keeps its genuine 400; a stored-data failure throws and surfaces as a server fault with the specific message logged. *Recovering by dropping the bad stored link was rejected* — that discards data silently, which is the class this change exists to remove.

**3. A parse that succeeds without yielding an object.** `JSON.parse` can return `null`, a number, a string or an array, none of which the `{}` recovery catches, so a corrupt row surfaced a raw V8 `TypeError` as a 400. Mirrors the existing check in `safeReflectSocialLinks` rather than inventing a second shape.

## Test plan

- [x] read fails -> other links **survive**, caller learns it failed
- [x] read rejects (a real transient D1 fault is a rejected promise, not a sync throw — the original test only covered the latter)
- [x] row missing -> throws, and **no update statement is prepared**
- [x] malformed JSON still recovers to `{}` (unchanged, deliberate)
- [x] non-object parse results: `null`, `42`, `"hello"`, `[]`
- [x] stored-data sanitisation failure surfaces as a server fault, row untouched
- [x] normal merge preserves existing links
- [x] **every test proven by mutation**, each fixed clause broken independently
- [x] `make gate` exits 0 — **1345** backend, **1230** frontend, 0 lint errors
- [x] `make review` — one Minor, addressed below

## On the review finding

CodeRabbit read the `it.each` table as `[label, value]` pairs. It is neither: the callback takes one parameter, so `it.each` binds the **first** element and the second column was never used. The existing cases were correct.

It did land on a real gap for the wrong reason — an array parses as a truthy `typeof "object"`, so `Array.isArray` is the only clause catching it, and it had no test. Added, and the misleading second column removed. Proven by mutation: dropping *only* that clause fails *only* the new case.

## Scope

Two things found during this work are deliberately **not** here:

- the read-modify-write **race** in the same branch — needs a `json_set` merge, genuinely different work; #962 stays open for it
- **#963** — `sanitizeBandSocialLinks` hand-enumerates the eight platform keys and is a third unguarded copy of the link registry

## Risk

Low. Failures that previously destroyed data or misattributed blame now surface. The one behaviour change an admin could notice: a legacy row with a bad stored link now returns 500 rather than a misleading 400. It failed before and fails now — the difference is that it no longer blames the operator, and the specific cause is logged.

Partially addresses #962

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved band profile website URL updates when profiles are missing or existing social-link data is invalid.
  - Preserved existing social links when adding or updating a website URL.
  - Added more reliable URL normalisation and clearer error handling for unsuccessful updates.
  - Prevented malformed or incorrectly formatted saved social-link data from disrupting profile updates.
  - Improved recovery when social-link information cannot be read or processed successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->