### PR TITLE
fix(admin): merge the website link inside the UPDATE, not around it

### DIFF
--- a/functions/utils/__tests__/bandProfileSocialLinksReadFailure.test.js
+++ b/functions/utils/__tests__/bandProfileSocialLinksReadFailure.test.js
@@ -14,11 +14,11 @@ function readSocialLinks(rawDb, profileId) {
   return rawDb.prepare("SELECT social_links FROM band_profiles WHERE id = ?").get(profileId).social_links;
 }
 
-async function runUrlUpdateOutcome(DB, profileId) {
+async function runUrlUpdateOutcome(DB, profileId, url = "https://example.com") {
   let result;
   let error;
   try {
-    result = await prepareBandProfileFields(DB, { url: "https://example.com" }, profileId, undefined);
+    result = await prepareBandProfileFields(DB, { url }, profileId, undefined);
     if (result.profileStatement) {
       result.profileStatement.run();
     }
@@ -33,7 +33,7 @@ async function runUrlUpdate(DB, profileId) {
 }
 
 describe("band profile social-links URL updates", () => {
-  it("surfaces a failed social-links read without wiping existing links", async () => {
+  it("does not read social links during a website update", async () => {
     const profile = createProfile({
       instagram: "https://instagram.com/test-band",
       bandcamp: "https://test-band.bandcamp.com",
@@ -50,14 +50,15 @@ describe("band profile social-links URL updates", () => {
 
     const error = await runUrlUpdate(failingDB, profile.id);
 
-    expect(error).toHaveProperty("message", "simulated transient D1 failure");
-    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toEqual({
+    expect(error).toBeUndefined();
+    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toMatchObject({
       instagram: "https://instagram.com/test-band",
       bandcamp: "https://test-band.bandcamp.com",
+      website: "https://example.com/",
     });
   });
 
-  it("surfaces a rejected social-links read without wiping existing links", async () => {
+  it("does not depend on a social-links read promise during a website update", async () => {
     const profile = createProfile({
       instagram: "https://instagram.com/test-band",
       bandcamp: "https://test-band.bandcamp.com",
@@ -79,14 +80,15 @@ describe("band profile social-links URL updates", () => {
 
     const error = await runUrlUpdate(failingDB, profile.id);
 
-    expect(error).toHaveProperty("message", "simulated rejected D1 failure");
-    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toEqual({
+    expect(error).toBeUndefined();
+    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toMatchObject({
       instagram: "https://instagram.com/test-band",
       bandcamp: "https://test-band.bandcamp.com",
+      website: "https://example.com/",
     });
   });
 
-  it("surfaces a missing profile without preparing a replacement social-links blob", async () => {
+  it("lets an UPDATE matching a missing profile do nothing", async () => {
     const profile = createProfile({
       instagram: "https://instagram.com/test-band",
       bandcamp: "https://test-band.bandcamp.com",
@@ -105,8 +107,9 @@ describe("band profile social-links URL updates", () => {
 
     const error = await runUrlUpdate(trackingDB, profile.id);
 
-    expect(error).toHaveProperty("message", "Band profile not found");
-    expect(updatePrepared).toBe(false);
+    expect(error).toBeUndefined();
+    expect(updatePrepared).toBe(true);
+    expect(profile.rawDb.prepare("SELECT * FROM band_profiles WHERE id = ?").get(profile.id)).toBeUndefined();
   });
 
   it("recovers from malformed stored JSON and updates the website", async () => {
@@ -118,6 +121,20 @@ describe("band profile social-links URL updates", () => {
     expect(error).toBeUndefined();
     expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toMatchObject({
       website: "https://example.com/",
+    });
+  });
+
+  it("returns a validation error for an unsafe incoming website URL", async () => {
+    const profile = createProfile({ instagram: "https://instagram.com/test-band" });
+
+    const outcome = await runUrlUpdateOutcome(profile.DB, profile.id, "ftp://example.com");
+
+    expect(outcome).toMatchObject({
+      threw: false,
+      error: { message: "Website URL must start with http:// or https://" },
+    });
+    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toEqual({
+      instagram: "https://instagram.com/test-band",
     });
   });
 
@@ -138,20 +155,33 @@ describe("band profile social-links URL updates", () => {
   });
 
   it.each([
-    ["an unsafe scheme", '{"bandcamp":"ftp://x.com"}', "Bandcamp URL must start with http:// or https://"],
-    [
-      "an overlong URL",
-      `{"bandcamp":"https://x.com/${"a".repeat(501)}"}`,
-      "Bandcamp URL must be no more than 500 characters",
-    ],
-  ])("surfaces stored-data sanitisation failure for %s as a server fault", async (_caseName, storedValue, message) => {
+    ["an unsafe scheme", '{"bandcamp":"ftp://x.com"}'],
+    ["an overlong URL", `{"bandcamp":"https://x.com/${"a".repeat(501)}"}`],
+  ])("does not revalidate unrelated stored data: %s", async (_caseName, storedValue) => {
     const profile = createProfile({ instagram: "https://instagram.com/test-band" });
     profile.rawDb.prepare("UPDATE band_profiles SET social_links = ? WHERE id = ?").run(storedValue, profile.id);
 
     const outcome = await runUrlUpdateOutcome(profile.DB, profile.id);
 
-    expect(outcome).toMatchObject({ threw: true, error: { message } });
-    expect(readSocialLinks(profile.rawDb, profile.id)).toBe(storedValue);
+    expect(outcome).toMatchObject({ threw: false, error: undefined });
+    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toMatchObject({
+      bandcamp: JSON.parse(storedValue).bandcamp,
+      website: "https://example.com/",
+    });
+  });
+
+  it("preserves the SQL NULL all-empty collapse when clearing the only link", async () => {
+    const profile = createProfile({ website: "https://old.example.com" });
+
+    const error = await runUrlUpdate(profile.DB, profile.id);
+
+    expect(error).toBeUndefined();
+    expect(readSocialLinks(profile.rawDb, profile.id)).toBe('{"website":"https://example.com/"}');
+
+    const clearStatement = (await prepareBandProfileFields(profile.DB, { url: "" }, profile.id, undefined))
+      .profileStatement;
+    clearStatement.run();
+    expect(readSocialLinks(profile.rawDb, profile.id)).toBeNull();
   });
 
   it("merges the website with existing social links", async () => {
@@ -166,7 +196,30 @@ describe("band profile social-links URL updates", () => {
     expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toMatchObject({
       website: "https://example.com/",
       instagram: "https://instagram.com/test-band",
-      bandcamp: "https://test-band.bandcamp.com/",
+      bandcamp: "https://test-band.bandcamp.com",
+    });
+  });
+
+  it("preserves an interleaved wholesale social-links update", async () => {
+    const profile = createProfile({ instagram: "https://instagram.com/test-band" });
+    const urlUpdate = prepareBandProfileFields(profile.DB, { url: "https://example.com" }, profile.id, undefined);
+    const linksUpdate = prepareBandProfileFields(
+      profile.DB,
+      { social_links: { instagram: "https://instagram.com/new-band" } },
+      profile.id,
+      undefined,
+    );
+    const [{ profileStatement: urlStatement }, { profileStatement: linksStatement }] = await Promise.all([
+      urlUpdate,
+      linksUpdate,
+    ]);
+
+    linksStatement.run();
+    urlStatement.run();
+
+    expect(JSON.parse(readSocialLinks(profile.rawDb, profile.id))).toMatchObject({
+      website: "https://example.com/",
+      instagram: "https://instagram.com/new-band",
     });
   });
 });

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -1,4 +1,5 @@
 import { FIELD_LIMITS, sanitizeBandSocialLinks, sanitizeOptionalHttpUrl, sanitizeString } from "./validation.js";
+import { BAND_LINK_FIELD_KEYS } from "./bandLinkFields.js";
 import { normalizeBandName } from "./bandName.js";
 import { parseOrigin } from "./parseOrigin.js";
 
@@ -18,6 +19,14 @@ export async function findVenue(DB, venueId) {
     .bind(venueId)
     .first();
 }
+
+// Derived from the canonical registry, never hand-listed. These keys are module
+// constants, not caller input, so interpolating them is safe — and it is the
+// only way the SQL below cannot drift: a ninth platform missing from this
+// filter would make a profile whose sole link is that platform collapse to
+// NULL, wiping it. That is #963's bug class expressed in SQL, where the
+// runtime guard on sanitizeBandSocialLinks cannot see it.
+const CANONICAL_LINK_KEY_SQL = BAND_LINK_FIELD_KEYS.map((key) => `'${key}'`).join(", ");
 
 export async function prepareBandProfileFields(DB, body, bandProfileId, resolvedPhotoUrl) {
   const {
@@ -140,31 +149,39 @@ export async function prepareBandProfileFields(DB, body, bandProfileId, resolved
       return { error };
     }
   } else if (url !== undefined) {
-    shouldUpdateSocialLinks = true;
-    let existingLinks;
-    const profile = await DB.prepare("SELECT social_links FROM band_profiles WHERE id = ?").bind(bandProfileId).first();
-    if (!profile) {
-      throw new Error("Band profile not found");
-    }
-    // Only the parse belongs inside this try. Resetting to {} is the right
-    // recovery for corrupt stored data and the wrong one for anything else,
-    // because shouldUpdateSocialLinks is already set — so whatever reaches this
-    // catch gets written over the row. Widening it to cover the read above is
-    // what discarded every other platform link on a single failed SELECT (#962).
     try {
-      existingLinks = JSON.parse(profile.social_links || "{}");
-      if (!existingLinks || typeof existingLinks !== "object" || Array.isArray(existingLinks)) {
-        existingLinks = {};
-      }
-    } catch {
-      existingLinks = {};
-    }
-    try {
-      existingLinks.website = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");
+      const sanitizedUrl = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");
+      profileUpdates.push(
+        `social_links = (
+          WITH merged(value) AS (
+            SELECT json_set(
+              CASE
+                WHEN json_valid(social_links) AND json_type(social_links) = 'object' THEN social_links
+                ELSE '{}'
+              END,
+              '$.website', ?
+            )
+          )
+          SELECT CASE
+            WHEN EXISTS (
+              SELECT 1 FROM json_each(merged.value)
+              WHERE key IN (${CANONICAL_LINK_KEY_SQL})
+                AND value IS NOT NULL
+                AND value <> ''
+            ) THEN merged.value
+            ELSE NULL
+          END
+          FROM merged
+        )`,
+      );
+      profileParams.push(sanitizedUrl);
     } catch (error) {
       return { error };
     }
-    newSocialLinks = sanitizeBandSocialLinks(existingLinks);
+
+    // The SQL merge deliberately does not revalidate unrelated stored links.
+    // Validation belongs on the way in; revalidating legacy data here can wedge
+    // an otherwise unrelated website edit.
   }
 
   if (shouldUpdateSocialLinks) {

--- a/functions/utils/bandProfileFields.js
+++ b/functions/utils/bandProfileFields.js
@@ -152,11 +152,18 @@ export async function prepareBandProfileFields(DB, body, bandProfileId, resolved
     try {
       const sanitizedUrl = sanitizeOptionalHttpUrl(url, FIELD_LIMITS.bandUrl.max, "Website URL");
       profileUpdates.push(
+        // Nested rather than `json_valid(...) AND json_type(...)`: SQLite does
+        // short-circuit that AND for a column reference, but the same
+        // expression over bound parameters evaluates both operands and
+        // json_type raises "malformed JSON" on unparseable input. Nesting
+        // costs two lines and does not depend on an ordering guarantee this
+        // write path should not rest on.
         `social_links = (
           WITH merged(value) AS (
             SELECT json_set(
               CASE
-                WHEN json_valid(social_links) AND json_type(social_links) = 'object' THEN social_links
+                WHEN json_valid(social_links) THEN
+                  CASE WHEN json_type(social_links) = 'object' THEN social_links ELSE '{}' END
                 ELSE '{}'
               END,
               '$.website', ?


### PR DESCRIPTION
## Summary

Closes the last half of #962. The `url`-only path read the stored blob, merged one key in JS, and wrote the whole blob back — so two overlapping edits on the same profile both read the same snapshot and the later write discarded the earlier one **wholesale**, every platform key at once rather than a single column.

The merge now happens inside the UPDATE via `json_set`, so no JS-side read participates and there is no window. The incoming url is still sanitised and still returns a 400 on bad input.

Verified — the interleaving test fails against the previous implementation:

```
- Expected instagram: "https://instagram.com/new-band"
+ Received instagram: "https://instagram.com/test-band"
```

## Five behaviours that had to survive the move

Moving a JS merge into SQL silently inherits everything the surrounding code was guaranteeing. Each was enumerated before the change, not discovered after:

| behaviour | why a naive `json_set` breaks it |
|---|---|
| malformed stored JSON recovered to `{}` | `json_set` **raises** on invalid JSON — guarded with `json_valid` |
| a non-object stored value coerced to `{}` | `"null"`, `"42"`, `"[]"` are *valid* JSON, so `json_valid` alone misses them — `json_type` is checked too |
| clearing the only link collapsed the column to SQL NULL | a plain merge leaves an object of empty values — reproduced with `json_each` |
| every write normalised the row to all eight keys | a merge preserves the row's shape, so read paths were swept first to confirm they tolerate partial blobs |
| tests describing the now-removed read | re-derived rather than deleted: a missing row is a zero-row UPDATE, and both callers already establish existence before this runs |

## Deliberate behaviour change

Stored links are **no longer revalidated** during an unrelated website edit. That revalidation is exactly what wedged an edit behind a legacy bad value (documented in the previous PR). Validation belongs on the way in, so legacy values now persist rather than blocking unrelated work.

## Two findings from review, both acted on

**The SQL hardcoded all eight platform keys — a fourth copy of the registry.** That is #963's bug class expressed in SQL, and invisible to the guard merged in #965, which inspects the *sanitiser's output keys* and cannot see a key list inside a SQL string. A ninth platform absent from that filter would make a profile whose sole link is that platform collapse to NULL — wiping it. The list is now derived from `BAND_LINK_FIELD_KEYS`, so drift is structurally impossible.

**CodeRabbit flagged `json_valid(...) AND json_type(...)` as unsafe if SQLite evaluates both operands.** Probed both ways: against a **column reference** it does short-circuit and returns the fallback, so the flat form was not broken — but the identical expression over **bound parameters** evaluates both operands and `json_type` raises `malformed JSON`. Not a guarantee this write path should rest on for two lines, so the CASE is nested.

## Test plan

- [x] the race is closed — interleaved `url` and `social_links` updates, proven to fail against the old implementation
- [x] malformed stored JSON still recovers
- [x] all four non-object stored values (`null`, `42`, `"hello"`, `[]`) still coerce
- [x] clearing the only link still collapses to SQL NULL
- [x] bad incoming url still rejected as a 400
- [x] missing row is a no-op UPDATE, not a crash
- [x] read paths swept for partial-blob tolerance before accepting the shape change
- [x] `make gate` exit code **0** — 1349 backend, 1230 frontend
- [x] `make review` — one Major, resolved above

## Risk

Moderate for the session — this is SQL on a write path, not a test change. Mitigated by covering each inherited behaviour explicitly and by the mutation showing eight tests fail against the old implementation. Note most of those eight are *specification* tests for the new design; only the interleaving one proves the race.

Closes #962

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Website updates now preserve existing social links instead of unintentionally removing them.
  - Updates remain reliable when profile data is missing, malformed, or incomplete.
  - Unsafe website URLs are rejected during updates.
  - Profiles with no social links continue to behave correctly without displaying empty or invalid links.
  - Concurrent social-link updates are better preserved when a website is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->