### PR TITLE
test(frontend): scope a longer wait to EventTimeline's deferred renders

### DIFF
--- a/frontend/src/components/__tests__/EventTimeline.cancelled.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.cancelled.test.jsx
@@ -4,6 +4,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import EventTimeline from '../EventTimeline'
 
+// EventTimeline expands details inside a React transition
+// (`useTransition` in EventTimeline.jsx, ~line 48). React deliberately
+// DEPRIORITISES transition work, so these waits are the ones that lose the CPU
+// first when the full suite contends — the same tests pass 26/26 on an idle
+// host in 1.5s. That deferral is the component's design, not a slow render to
+// optimise away, which is why the fix is a scoped timeout rather than smaller
+// fixtures. Scoped deliberately: raising the global default would hide a real
+// regression anywhere else in the suite (#868).
+const DETAILS_RENDER_TIMEOUT = 5000
+
 function jsonResponse(data) {
   return {
     ok: true,
@@ -174,9 +184,12 @@ describe('EventTimeline expanded details render cancellation on every band-list 
     expect(await screen.findByText('Cancel Coverage Fest')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /view details/i }))
 
-    await waitFor(() => {
-      expect(screen.queryByText(/loading performers and venues/i)).not.toBeInTheDocument()
-    })
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/loading performers and venues/i)).not.toBeInTheDocument()
+      },
+      { timeout: DETAILS_RENDER_TIMEOUT }
+    )
   }
 
   it('strikes through a cancelled performer with a Cancelled pill in the "All Performers" grid, leaving a scheduled one untouched', async () => {
@@ -184,14 +197,22 @@ describe('EventTimeline expanded details render cancellation on every band-list 
 
     // Card is a Link -- accessible name is its full text content, so a regex
     // anchored on the band name is enough to find the one card.
-    const cancelledCard = await screen.findByRole('link', { name: /Pulled Openers/i })
+    const cancelledCard = await screen.findByRole(
+      'link',
+      { name: /Pulled Openers/i },
+      { timeout: DETAILS_RENDER_TIMEOUT }
+    )
     // Structural, not just text-presence: the NAME must be inside a real <s>
     // element. A CSS-only line-through (no <s>) would render identical
     // visible text but is invisible to a screen reader.
     expect(cancelledCard.querySelector('s')).toHaveTextContent('Pulled Openers')
     expect(cancelledCard).toHaveTextContent('Cancelled')
 
-    const scheduledCard = await screen.findByRole('link', { name: /Playing Headliner/i })
+    const scheduledCard = await screen.findByRole(
+      'link',
+      { name: /Playing Headliner/i },
+      { timeout: DETAILS_RENDER_TIMEOUT }
+    )
     expect(scheduledCard.querySelector('s')).toBeNull()
     expect(scheduledCard).not.toHaveTextContent('Cancelled')
   })
@@ -202,7 +223,11 @@ describe('EventTimeline expanded details render cancellation on every band-list 
     // GenreDiscovery renders a <button> per act -- the cancelled tile's
     // aria-label states its status rather than an Add/Remove instruction,
     // since tapping it must do nothing.
-    const cancelledTile = await screen.findByRole('button', { name: /Pulled Openers/i })
+    const cancelledTile = await screen.findByRole(
+      'button',
+      { name: /Pulled Openers/i },
+      { timeout: DETAILS_RENDER_TIMEOUT }
+    )
     expect(cancelledTile).toBeDisabled()
     expect(cancelledTile.querySelector('s')).toHaveTextContent('Pulled Openers')
     expect(cancelledTile).toHaveTextContent('Cancelled')
@@ -211,7 +236,11 @@ describe('EventTimeline expanded details render cancellation on every band-list 
     // clickable and still flips its own Add/Remove aria-label, proving the
     // suppression is scoped to is_cancelled rather than a global regression
     // that freezes every tile.
-    const scheduledTile = await screen.findByRole('button', { name: /Add Playing Headliner to my schedule/i })
+    const scheduledTile = await screen.findByRole(
+      'button',
+      { name: /Add Playing Headliner to my schedule/i },
+      { timeout: DETAILS_RENDER_TIMEOUT }
+    )
     expect(scheduledTile).not.toBeDisabled()
     fireEvent.click(scheduledTile)
     expect(screen.getByRole('button', { name: /Remove Playing Headliner from my schedule/i })).toBeInTheDocument()

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -6,6 +6,16 @@ import EventTimeline from '../EventTimeline'
 import { POSTER_IMAGE_HOST } from '../../utils/posterImage'
 import { formatPerformanceDayLabel } from '../../utils/timeFormat'
 
+// EventTimeline expands details inside a React transition
+// (`useTransition` in EventTimeline.jsx, ~line 48). React deliberately
+// DEPRIORITISES transition work, so these waits are the ones that lose the CPU
+// first when the full suite contends — the same tests pass 26/26 on an idle
+// host in 1.5s. That deferral is the component's design, not a slow render to
+// optimise away, which is why the fix is a scoped timeout rather than smaller
+// fixtures. Scoped deliberately: raising the global default would hide a real
+// regression anywhere else in the suite (#868).
+const DETAILS_RENDER_TIMEOUT = 5000
+
 function jsonResponse(data) {
   return {
     ok: true,
@@ -91,8 +101,8 @@ describe('EventTimeline', () => {
     )
 
     // Band One now appears in both the genre discovery wall and the All Performers grid
-    expect((await screen.findAllByText('Band One'))[0]).toBeInTheDocument()
-    expect(await screen.findByText('Stage A')).toBeInTheDocument()
+    expect((await screen.findAllByText('Band One', {}, { timeout: DETAILS_RENDER_TIMEOUT }))[0]).toBeInTheDocument()
+    expect(await screen.findByText('Stage A', {}, { timeout: DETAILS_RENDER_TIMEOUT })).toBeInTheDocument()
     await waitFor(() => {
       expect(screen.queryByText(/loading performers and venues/i)).not.toBeInTheDocument()
     })
@@ -210,7 +220,11 @@ describe('EventTimeline duplicate performer chips (#605)', () => {
 
     // GenreDiscovery wall: one photo-tile button per ACT — the two-set band
     // must be deduped to a single tile, not one per performance.
-    const genreTiles = await screen.findAllByRole('button', { name: /Two Set Band/i })
+    const genreTiles = await screen.findAllByRole(
+      'button',
+      { name: /Two Set Band/i },
+      { timeout: DETAILS_RENDER_TIMEOUT }
+    )
     expect(genreTiles).toHaveLength(1)
     expect(screen.getAllByRole('button', { name: /Solo Band/i })).toHaveLength(1)
 
@@ -384,8 +398,8 @@ describe('EventTimeline performance day labels (#743)', () => {
       event_end_date: '2026-08-09',
     })
 
-    expect(await screen.findByText(day1Label)).toBeInTheDocument()
-    expect(await screen.findByText(day3Label)).toBeInTheDocument()
+    expect(await screen.findByText(day1Label, {}, { timeout: DETAILS_RENDER_TIMEOUT })).toBeInTheDocument()
+    expect(await screen.findByText(day3Label, {}, { timeout: DETAILS_RENDER_TIMEOUT })).toBeInTheDocument()
   })
 
   it('shows no day label at all for a single-day event', async () => {
@@ -464,7 +478,7 @@ describe('EventTimeline performance day labels (#743)', () => {
       expect(screen.queryByText(/loading performers and venues/i)).not.toBeInTheDocument()
     })
     // Appears in both the GenreDiscovery wall and the All Performers grid.
-    expect((await screen.findAllByText('Only Band'))[0]).toBeInTheDocument()
+    expect((await screen.findAllByText('Only Band', {}, { timeout: DETAILS_RENDER_TIMEOUT }))[0]).toBeInTheDocument()
 
     // A single-day event must not show a redundant date on every set (#540/#541).
     const soleDayLabel = formatPerformanceDayLabel({
@@ -958,7 +972,7 @@ describe('EventTimeline Venues grid directions (#754)', () => {
 
     expect(await screen.findByText('Test Event')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /view details/i }))
-    expect(await screen.findByText('The Mill')).toBeInTheDocument()
+    expect(await screen.findByText('The Mill', {}, { timeout: DETAILS_RENDER_TIMEOUT })).toBeInTheDocument()
 
     const link = screen.getByRole('link', { name: 'Directions to The Mill' })
     expect(link).toBeInTheDocument()
@@ -982,7 +996,7 @@ describe('EventTimeline Venues grid directions (#754)', () => {
 
     expect(await screen.findByText('Test Event')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /view details/i }))
-    expect(await screen.findByText('Roost')).toBeInTheDocument()
+    expect(await screen.findByText('Roost', {}, { timeout: DETAILS_RENDER_TIMEOUT })).toBeInTheDocument()
 
     expect(screen.queryByRole('link', { name: /directions to roost/i })).not.toBeInTheDocument()
 


### PR DESCRIPTION
## Summary

`EventTimeline.test.jsx` and `EventTimeline.cancelled.test.jsx` fail intermittently in the **full** frontend suite while passing reliably in isolation. Every failure is a `waitFor` timeout on real rendered content — `Band One`, `/Two Set Band/i`, `/Pulled Openers/i`.

**The cause is not a slow render.** `EventTimeline` expands details inside a React transition — `useTransition` at `EventTimeline.jsx:48`, with five `startTransition` call sites. React deliberately **deprioritises** transition work, so those waits are the first to lose the CPU when the suite contends for it.

Measured:

| condition | result |
|---|---|
| both files, idle host | **26 passed in 1.51s** |
| `EventTimeline.test.jsx`, contended host (#868) | **20.3s**, intermittent failures at 1.9–3.5s |

## Why a timeout, when "raise the timeout" is usually the wrong answer

The issue says not to reach for it reflexively, and that is right — it would make the symptom vanish while leaving a 20-second file at 20 seconds.

But the measurement points somewhere specific: the deferral is **the component's design**, not a cost to optimise away. Smaller fixtures, a split file, or a cheaper mount would not change how React schedules transition work. A scoped timeout is the fix that matches the cause.

Two constraints held:

- **Scoped, never global.** Only the waits that observe transition output are affected. Raising the default would hide a real regression anywhere else in the suite.
- **No assertion weakened.** Every check still asserts what it did — the structural `<s>` element check (a CSS-only line-through would be invisible to a screen reader), the aria-labels, the disabled tile, the Add/Remove flip.

The constant carries a comment naming `useTransition` and the file it lives in, so the next reader can verify the reasoning with one grep rather than taking it on faith.

## Test plan

- [x] baseline measured on an idle host: 26 passed, 1.51s
- [x] root cause verified in source, not inferred — `useTransition` + 5 `startTransition` sites
- [x] assertions unchanged; only wait budgets touched
- [x] global `waitFor` default untouched
- [x] `make gate` exit code **0**
- [x] `make review` (CodeRabbit) — no findings

## Risk

Low. Test-only. The failure mode this addresses is a local-developer annoyance today — it has not been seen failing in CI — but a shared runner under load is exactly the condition that produced it, and a test that fails only under load is the least debuggable kind.

## Honest limitation

The fix cannot be *proven* on an idle host, because the flake does not reproduce there. What is verified is the root cause in source and that the assertions are unchanged; that a 5s budget is sufficient under contention is a judgement, not a measurement.

Closes #868

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the reliability of EventTimeline cancellation and detail-rendering tests by allowing asynchronous transitions and content to complete within a scoped timeout.
  * Preserved existing assertions and cancellation behaviour without changing application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->