### PR TITLE
ci(lighthouse): pass with a warning when #878 aborts the retry too

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -287,7 +287,30 @@ jobs:
           echo "  retrying Lighthouse once..." >&2
           code=0
           run_lighthouse || code=$?
-          if [ "$code" -eq 0 ]; then echo "+ passed on retry after a #878 abort" >&2; fi
+          if [ "$code" -eq 0 ]; then echo "+ passed on retry after a #878 abort" >&2; exit 0; fi
+
+          # The retry ALSO failed. Ask the same discriminator again: if the server
+          # is gone a second time, this is #878 twice over, not a score
+          # regression -- the assertions never got to run against a live server.
+          # Warn and pass rather than spend a human triage on a failure whose
+          # cause is already known and is not in this PR.
+          #
+          # Observed 2026-08-25/26 on #961 and #964: wrangler died, the restart
+          # succeeded in ~4s, and the retry hit CHROME_INTERSTITIAL_ERROR again.
+          # Two of three PRs that day, both green on a manual re-run, and the job
+          # is not a required check -- so its only effect was a red X that had to
+          # be read to be dismissed. That is signal erosion: a check that is
+          # usually-wrong trains you to wave past the time it is right.
+          #
+          # A real regression still fails, because it leaves the server HEALTHY
+          # and takes the branch above. Do not replace this with
+          # continue-on-error -- that would swallow score regressions too.
+          if server_gone; then
+              echo "::warning title=Lighthouse skipped::Lighthouse aborted twice with wrangler gone (#878). Scores were never measured against a live server, so this is not a score regression. See #925." >&2
+              exit 0
+          fi
+
+          echo "x Lighthouse failed on retry with the server up -- a real failure." >&2
           exit "$code"
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}


### PR DESCRIPTION
## Summary

Lighthouse CI has been going red for a cause that is already diagnosed and is never in the PR.

The job **already** distinguishes the two failure shapes — a score regression leaves the server healthy; the upstream wrangler abort (#878) leaves no listener and no process. It used that discriminator to decide whether to *retry*, then exited with the failure code regardless of what the retry hit.

So when the abort reproduced on the retry, the job failed anyway. Observed 2026-08-25/26 on #961 and #964 — **two of three PRs that day**, both green on a manual re-run.

Now the same discriminator runs once more after the retry:

- **server gone a second time** → the assertions never ran against a live server, so there is nothing to regress. Emit a `::warning::` and pass.
- **server healthy** → a real failure. Still exits non-zero.

## Why not `continue-on-error`

That would swallow genuine score regressions along with the known-false ones. The whole point is that this job *can* already tell them apart — the fix uses that, rather than giving up the gate.

## Verified by simulation, not by reading

None of this executes on a green build, so a passing CI run says nothing about whether it works. The step's shell was extracted from the workflow with its three externals (`run_lighthouse`, `server_gone`, `restart_wrangler`) stubbed, leaving the **decision logic byte-for-byte unchanged**, and every branch exercised:

| scenario | exit | warning |
|---|---|---|
| passes first try | 0 | — |
| fails, **server healthy** — real regression | **1** | — |
| fails + gone, retry fails + gone — #878 twice | **0** | ✓ |
| fails + gone, retry fails, **server healthy** | **1** | — |
| fails + gone, retry passes | 0 | — |

Rows 2 and 4 are the ones that matter: they prove this is not a blanket swallow.

Worth noting the harness caught its own bug first — the initial stub regexes silently failed to match (YAML block scalars strip the common indent), so the *real* `server_gone` ran and two rows reported the wrong exit. A harness that doesn't stub what it claims to stub produces confident, wrong results.

## Test plan

- [x] YAML parses and the `Run Lighthouse CI` step still resolves
- [x] all five decision branches simulated, exits `0/1/0/1/0`
- [x] warning emitted **only** on the double-abort branch
- [x] a real regression (server healthy) still fails — both before and after the retry
- [x] `make gate` exit code **0**

## Follow-up worth considering

The simulation above was ad-hoc. `functions/__tests__/wranglerDevCommand.test.js` is precedent for asserting on this workflow's shell from the test suite, and turning this harness into a committed test would make the five branches a permanent guard rather than something re-derived by hand. Not in this PR to keep the diff to the fix.

## Risk

Low, and bounded in the safe direction: the change can only turn a *failure* into a pass, and only on the branch where the server is provably gone — a state in which no score was ever measured.

Closes #925

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lighthouse test retry handling.
  * Successful retries now complete normally.
  * Added clearer handling for server interruptions, including warnings when the server stops unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->