### PR TITLE
feat(metrics): show pre-cutover share views beside the recount, with units

### DIFF
--- a/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
+++ b/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
@@ -52,7 +52,7 @@ describe('MetricsDashboard', () => {
     expect(screen.getAllByText('0 routes')).toHaveLength(3)
     expect(screen.getByText(/Page-view history may be shorter/)).toBeInTheDocument()
     expect(screen.getByText('3')).toBeInTheDocument()
-    expect(screen.getByText('Share Views')).toBeInTheDocument()
+    expect(screen.getByText('Share Views (unique visitors, all-time)')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
     expect(screen.getByText('Shares Imported')).toBeInTheDocument()
     expect(screen.getByText('5')).toBeInTheDocument()
@@ -62,18 +62,66 @@ describe('MetricsDashboard', () => {
     expect(screen.getByText(/4 bands/)).toBeInTheDocument()
     expect(screen.getByText(/2026-07-16/)).toBeInTheDocument()
     // Singular "view" pluralises correctly
-    expect(screen.getByText(/1 view/)).toBeInTheDocument()
+    expect(screen.getByText(/1 unique visitor/)).toBeInTheDocument()
     expect(screen.getByText(/1 band/)).toBeInTheDocument()
     // Plural "views" still renders within the compound row
-    expect(screen.getByText(/30 views/)).toBeInTheDocument()
+    expect(screen.getByText(/30 unique visitors/)).toBeInTheDocument()
     // view_count and import_count are different units and get conflated
     // (CLAUDE.md "Metrics & Analytics"): views are unique visitors recomputed
     // from a ledger, imports are per-fetch and undeduped, so imports CAN exceed
     // views. This caption is the only place a reader learns that — assert it
     // survives, because silently dropping it makes the panel misleading rather
     // than merely sparser.
-    expect(screen.getByText(/Views count unique visitors per link/)).toBeInTheDocument()
+    expect(screen.getByText(/Unique visitors are deduplicated per link/)).toBeInTheDocument()
     expect(screen.getByText(/Imports count per-fetch/)).toBeInTheDocument()
+  })
+
+  it('shows legacy raw fetches separately from unique visitors', async () => {
+    eventsApi.getMetrics.mockResolvedValue({
+      metrics: {
+        totalScheduleBuilds: 0,
+        routeBuilders: 0,
+        completionRate: undefined,
+        routeSizeDistribution: [],
+        lastUpdated: null,
+        popularBands: [],
+        totalShares: 1,
+        totalShareViews: 2,
+        totalShareViewsLegacy: 9,
+        totalShareImports: 0,
+        topSharedRoutes: [{ slug: 'legacy', view_count: 2, view_count_legacy: 9, band_count: 1 }],
+      },
+    })
+
+    render(<MetricsDashboard eventId={1} />)
+
+    expect(await screen.findByText('Share Views (unique visitors, all-time)')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('9 pre-cutover raw fetches')).toBeInTheDocument()
+    expect(screen.queryByText('11')).not.toBeInTheDocument()
+  })
+
+  it('omits legacy raw fetches when the legacy count is zero or null', async () => {
+    eventsApi.getMetrics.mockResolvedValue({
+      metrics: {
+        totalScheduleBuilds: 0,
+        routeBuilders: 0,
+        completionRate: undefined,
+        routeSizeDistribution: [],
+        lastUpdated: null,
+        popularBands: [],
+        totalShares: 1,
+        totalShareViews: 3,
+        totalShareViewsLegacy: 0,
+        totalShareImports: 0,
+        topSharedRoutes: [{ slug: 'fresh', view_count: 3, view_count_legacy: null, band_count: 1 }],
+      },
+    })
+
+    render(<MetricsDashboard eventId={1} />)
+
+    expect(await screen.findByText('Share Views (unique visitors, all-time)')).toBeInTheDocument()
+    expect(screen.queryByText(/\d+ pre-cutover raw fetches \(per-fetch\)/)).not.toBeInTheDocument()
   })
 
   it('renders 0 for share imports when the field is absent (older data)', async () => {

--- a/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
+++ b/frontend/src/admin/__tests__/MetricsDashboard.test.jsx
@@ -52,7 +52,7 @@ describe('MetricsDashboard', () => {
     expect(screen.getAllByText('0 routes')).toHaveLength(3)
     expect(screen.getByText(/Page-view history may be shorter/)).toBeInTheDocument()
     expect(screen.getByText('3')).toBeInTheDocument()
-    expect(screen.getByText('Share Views (unique visitors, all-time)')).toBeInTheDocument()
+    expect(screen.getByText('Share Views (unique visitors per link, all-time)')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
     expect(screen.getByText('Shares Imported')).toBeInTheDocument()
     expect(screen.getByText('5')).toBeInTheDocument()
@@ -95,9 +95,13 @@ describe('MetricsDashboard', () => {
 
     render(<MetricsDashboard eventId={1} />)
 
-    expect(await screen.findByText('Share Views (unique visitors, all-time)')).toBeInTheDocument()
+    expect(await screen.findByText('Share Views (unique visitors per link, all-time)')).toBeInTheDocument()
     expect(screen.getByText('2')).toBeInTheDocument()
-    expect(screen.getByText('9 pre-cutover raw fetches')).toBeInTheDocument()
+    // Two renders: the aggregate card and the route row. An exact-string
+    // getByText matched only the card, because the row's node reads
+    // " · 9 pre-cutover raw fetches" -- so the route-level indicator this
+    // feature exists to show was never actually asserted.
+    expect(screen.getAllByText(/9 pre-cutover raw fetches/)).toHaveLength(2)
     expect(screen.queryByText('11')).not.toBeInTheDocument()
   })
 
@@ -120,8 +124,11 @@ describe('MetricsDashboard', () => {
 
     render(<MetricsDashboard eventId={1} />)
 
-    expect(await screen.findByText('Share Views (unique visitors, all-time)')).toBeInTheDocument()
-    expect(screen.queryByText(/\d+ pre-cutover raw fetches \(per-fetch\)/)).not.toBeInTheDocument()
+    expect(await screen.findByText('Share Views (unique visitors per link, all-time)')).toBeInTheDocument()
+    // Anchored on the leading count: the explanatory caption below the cards
+    // also contains "pre-cutover raw fetches" and renders unconditionally, so
+    // an unanchored regex matches it and the assertion proves nothing.
+    expect(screen.queryByText(/\d+ pre-cutover raw fetches/)).not.toBeInTheDocument()
   })
 
   it('renders 0 for share imports when the field is absent (older data)', async () => {

--- a/frontend/src/admin/components/MetricsDashboard.jsx
+++ b/frontend/src/admin/components/MetricsDashboard.jsx
@@ -69,8 +69,13 @@ export default function MetricsDashboard({ eventId }) {
 
         {/* Share Views */}
         <div className="bg-bg-purple rounded-lg p-4">
-          <div className="text-gray-400 text-sm">Share Views</div>
+          <div className="text-gray-400 text-sm">Share Views (unique visitors, all-time)</div>
           <div className="text-3xl font-bold text-white mt-2">{metrics.totalShareViews ?? 0}</div>
+          {!!metrics.totalShareViewsLegacy && (
+            <div className="mt-1 text-sm font-normal text-gray-400">
+              {metrics.totalShareViewsLegacy} pre-cutover raw fetches
+            </div>
+          )}
         </div>
 
         {/* Shares Imported — the conversion signal: a fan adopted someone else's route */}
@@ -135,7 +140,13 @@ export default function MetricsDashboard({ eventId }) {
                     </>
                   ) : null}
                   {' · '}
-                  {route.view_count} {route.view_count === 1 ? 'view' : 'views'}
+                  {route.view_count} unique {route.view_count === 1 ? 'visitor' : 'visitors'}
+                  {!!route.view_count_legacy && (
+                    <span className="text-gray-500">
+                      {' · '}
+                      {route.view_count_legacy} pre-cutover raw fetches
+                    </span>
+                  )}
                 </span>
               </div>
             ))
@@ -144,8 +155,8 @@ export default function MetricsDashboard({ eventId }) {
           )}
         </div>
         <p className="text-gray-400 text-xs mt-3">
-          Views count unique visitors per link — reloads and crawlers don&apos;t inflate them. Imports count per-fetch
-          adoptions.
+          Unique visitors are deduplicated per link; pre-cutover raw fetches are undeduplicated per-fetch. Imports count
+          per-fetch adoptions.
         </p>
       </div>
     </div>

--- a/frontend/src/admin/components/MetricsDashboard.jsx
+++ b/frontend/src/admin/components/MetricsDashboard.jsx
@@ -69,7 +69,7 @@ export default function MetricsDashboard({ eventId }) {
 
         {/* Share Views */}
         <div className="bg-bg-purple rounded-lg p-4">
-          <div className="text-gray-400 text-sm">Share Views (unique visitors, all-time)</div>
+          <div className="text-gray-400 text-sm">Share Views (unique visitors per link, all-time)</div>
           <div className="text-3xl font-bold text-white mt-2">{metrics.totalShareViews ?? 0}</div>
           {!!metrics.totalShareViewsLegacy && (
             <div className="mt-1 text-sm font-normal text-gray-400">

--- a/frontend/src/pages/StatsPage.jsx
+++ b/frontend/src/pages/StatsPage.jsx
@@ -10,7 +10,7 @@ const STAT_DEFS = [
   { key: 'events', label: 'Events' },
   { key: 'performances', label: 'Sets played' },
   { key: 'routes_shared', label: 'Routes shared' },
-  { key: 'route_views', label: 'Route views (unique visitors, all-time)', legacyKey: 'route_views_legacy' },
+  { key: 'route_views', label: 'Route views (unique visitors per link, all-time)', legacyKey: 'route_views_legacy' },
   { key: 'fans_following', label: 'Fans following bands' },
   { key: 'page_views', label: 'Page views' },
 ]

--- a/frontend/src/pages/StatsPage.jsx
+++ b/frontend/src/pages/StatsPage.jsx
@@ -10,7 +10,7 @@ const STAT_DEFS = [
   { key: 'events', label: 'Events' },
   { key: 'performances', label: 'Sets played' },
   { key: 'routes_shared', label: 'Routes shared' },
-  { key: 'route_views', label: 'Route views' },
+  { key: 'route_views', label: 'Route views (unique visitors, all-time)', legacyKey: 'route_views_legacy' },
   { key: 'fans_following', label: 'Fans following bands' },
   { key: 'page_views', label: 'Page views' },
 ]
@@ -22,7 +22,7 @@ function formatNumber(value) {
 // Zero-value metrics (expected pre-launch for engagement counters like fans
 // following or routes shared) render in a muted tone instead of the bold
 // accent color, so an early low count never reads as a broken/prominent "0".
-function StatCard({ label, value }) {
+function StatCard({ label, value, legacyValue }) {
   const isZero = !value
   return (
     <div className="rounded-xl border border-border bg-surface p-4 text-center">
@@ -30,6 +30,11 @@ function StatCard({ label, value }) {
         {formatNumber(value)}
       </div>
       <div className="mt-1 text-xs text-text-tertiary">{label}</div>
+      {!!legacyValue && (
+        <div className="mt-0.5 text-[0.65rem] text-text-secondary">
+          {formatNumber(legacyValue)} pre-cutover raw fetches
+        </div>
+      )}
     </div>
   )
 }
@@ -114,8 +119,8 @@ export default function StatsPage() {
         {!loading && !error && data && (
           <>
             <div className="mb-12 grid grid-cols-2 gap-4 sm:grid-cols-3">
-              {STAT_DEFS.map(({ key, label }) => (
-                <StatCard key={key} label={label} value={data[key]} />
+              {STAT_DEFS.map(({ key, label, legacyKey }) => (
+                <StatCard key={key} label={label} value={data[key]} legacyValue={legacyKey ? data[legacyKey] : 0} />
               ))}
             </div>
 

--- a/frontend/src/pages/__tests__/StatsPage.test.jsx
+++ b/frontend/src/pages/__tests__/StatsPage.test.jsx
@@ -34,6 +34,7 @@ describe('StatsPage', () => {
       performances: 23,
       routes_shared: 14,
       route_views: 40,
+      route_views_legacy: 0,
       fans_following: 8,
       page_views: 500,
       top_bands: [
@@ -67,6 +68,7 @@ describe('StatsPage', () => {
       performances: 22,
       routes_shared: 0,
       route_views: 0,
+      route_views_legacy: 0,
       fans_following: 0,
       page_views: 0,
       top_bands: [],
@@ -81,6 +83,47 @@ describe('StatsPage', () => {
 
     // No top bands at all -> section is omitted entirely.
     expect(screen.queryByText('Top bands')).not.toBeInTheDocument()
+  })
+
+  it('shows legacy raw fetches separately from unique visitor route views', async () => {
+    fetchPublicJson.mockResolvedValue({
+      bands: 22,
+      venues: 6,
+      events: 1,
+      performances: 23,
+      routes_shared: 14,
+      route_views: 2,
+      route_views_legacy: 9,
+      fans_following: 8,
+      page_views: 500,
+      top_bands: [],
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Route views (unique visitors, all-time)')).toBeInTheDocument()
+    expect(screen.getByText('9 pre-cutover raw fetches')).toBeInTheDocument()
+    expect(screen.queryByText('11')).not.toBeInTheDocument()
+  })
+
+  it('omits legacy raw fetches when the legacy count is zero or null', async () => {
+    fetchPublicJson.mockResolvedValue({
+      bands: 22,
+      venues: 6,
+      events: 1,
+      performances: 23,
+      routes_shared: 14,
+      route_views: 40,
+      route_views_legacy: null,
+      fans_following: 8,
+      page_views: 500,
+      top_bands: [],
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Route views (unique visitors, all-time)')).toBeInTheDocument()
+    expect(screen.queryByText(/pre-cutover raw fetches/)).not.toBeInTheDocument()
   })
 
   it('shows a friendly error message when the fetch fails', async () => {

--- a/frontend/src/pages/__tests__/StatsPage.test.jsx
+++ b/frontend/src/pages/__tests__/StatsPage.test.jsx
@@ -101,7 +101,7 @@ describe('StatsPage', () => {
 
     renderPage()
 
-    expect(await screen.findByText('Route views (unique visitors, all-time)')).toBeInTheDocument()
+    expect(await screen.findByText('Route views (unique visitors per link, all-time)')).toBeInTheDocument()
     expect(screen.getByText('9 pre-cutover raw fetches')).toBeInTheDocument()
     expect(screen.queryByText('11')).not.toBeInTheDocument()
   })
@@ -122,7 +122,7 @@ describe('StatsPage', () => {
 
     renderPage()
 
-    expect(await screen.findByText('Route views (unique visitors, all-time)')).toBeInTheDocument()
+    expect(await screen.findByText('Route views (unique visitors per link, all-time)')).toBeInTheDocument()
     expect(screen.queryByText(/pre-cutover raw fetches/)).not.toBeInTheDocument()
   })
 

--- a/functions/api/admin/events/[id]/metrics.js
+++ b/functions/api/admin/events/[id]/metrics.js
@@ -80,7 +80,12 @@ export async function onRequestGet(context) {
       DB.prepare(
         `SELECT slug, view_count, view_count_legacy, band_names, created_at FROM share_links
          WHERE event_id = ? AND (view_count > 0 OR view_count_legacy > 0)
-         ORDER BY view_count DESC, created_at DESC
+         -- Unique visitors stay the primary unit; legacy raw fetches only break
+         -- ties. Legacy-only rows all have view_count = 0, so without the second
+         -- key created_at would decide which of them survive LIMIT 10 -- letting
+         -- a 2-fetch route displace a 500-fetch one. The two are never compared
+         -- across units: this only orders within the zero-visitor group.
+         ORDER BY view_count DESC, COALESCE(view_count_legacy, 0) DESC, created_at DESC
          LIMIT 10`,
       ).bind(eventId),
       // Announcement planning: per-performance follower engagement signals for

--- a/functions/api/admin/events/[id]/metrics.js
+++ b/functions/api/admin/events/[id]/metrics.js
@@ -72,13 +72,14 @@ export async function onRequestGet(context) {
       ).bind(eventId),
       DB.prepare(
         `SELECT COUNT(*) AS total_shares,
-                COALESCE(SUM(view_count), 0) AS total_share_views,
-                COALESCE(SUM(import_count), 0) AS total_share_imports
+                 COALESCE(SUM(view_count), 0) AS total_share_views,
+                 COALESCE(SUM(view_count_legacy), 0) AS total_share_views_legacy,
+                 COALESCE(SUM(import_count), 0) AS total_share_imports
          FROM share_links WHERE event_id = ?`,
       ).bind(eventId),
       DB.prepare(
-        `SELECT slug, view_count, band_names, created_at FROM share_links
-         WHERE event_id = ? AND view_count > 0
+        `SELECT slug, view_count, view_count_legacy, band_names, created_at FROM share_links
+         WHERE event_id = ? AND (view_count > 0 OR view_count_legacy > 0)
          ORDER BY view_count DESC, created_at DESC
          LIMIT 10`,
       ).bind(eventId),
@@ -143,6 +144,7 @@ export async function onRequestGet(context) {
       return {
         slug: row.slug,
         view_count: row.view_count,
+        view_count_legacy: row.view_count_legacy,
         created_at: row.created_at,
         band_count: bandCount,
       };
@@ -176,6 +178,7 @@ export async function onRequestGet(context) {
           popularBands: popularBands,
           totalShares: shareStats?.total_shares || 0,
           totalShareViews: shareStats?.total_share_views || 0,
+          totalShareViewsLegacy: shareStats?.total_share_views_legacy || 0,
           totalShareImports: shareStats?.total_share_imports || 0,
           topSharedRoutes: topSharedRoutes,
           announcementPlanning: announcementPlanning,

--- a/functions/api/admin/events/__tests__/metrics.test.js
+++ b/functions/api/admin/events/__tests__/metrics.test.js
@@ -64,6 +64,57 @@ describe("GET /api/admin/events/[id]/metrics", () => {
     expect(body.metrics.topSharedRoutes[0].view_count).toBe(5);
   });
 
+  test("keeps current unique visitors and legacy raw fetches separate", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Legacy Fest", slug: "legacy-fest" });
+    insertShareLink(rawDb, {
+      slug: "legacyroute",
+      event_id: event.id,
+      event_slug: "legacy-fest",
+      performance_ids: [1],
+      band_names: ["A"],
+    });
+    rawDb
+      .prepare("UPDATE share_links SET view_count = ?, view_count_legacy = ? WHERE slug = ?")
+      .run(2, 9, "legacyroute");
+
+    const res = await call(env, event.id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.metrics.totalShareViews).toBe(2);
+    expect(body.metrics.totalShareViewsLegacy).toBe(9);
+    expect(body.metrics.totalShareViews).not.toBe(11);
+    expect(body.metrics.totalShareViewsLegacy).not.toBe(11);
+    expect(body.metrics.topSharedRoutes[0].view_count).toBe(2);
+    expect(body.metrics.topSharedRoutes[0].view_count_legacy).toBe(9);
+  });
+
+  test("includes a legacy-only route and returns zero legacy totals for fresh links", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Mixed Fest", slug: "mixed-fest" });
+    insertShareLink(rawDb, {
+      slug: "legacy-only",
+      event_id: event.id,
+      event_slug: "mixed-fest",
+      performance_ids: [1],
+      band_names: ["A"],
+    });
+    insertShareLink(rawDb, {
+      slug: "fresh-route",
+      event_id: event.id,
+      event_slug: "mixed-fest",
+      performance_ids: [1],
+      band_names: ["A"],
+    });
+    rawDb.prepare("UPDATE share_links SET view_count_legacy = ? WHERE slug = ?").run(9, "legacy-only");
+
+    const res = await call(env, event.id);
+    const body = await res.json();
+    expect(body.metrics.totalShareViewsLegacy).toBe(9);
+    expect(body.metrics.topSharedRoutes.map((route) => route.slug)).toEqual(["legacy-only"]);
+    expect(body.metrics.topSharedRoutes[0].view_count).toBe(0);
+  });
+
   test("top routes carry band_count and created_at, and zero-view shares are excluded (#702)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "Route Fest", slug: "route-fest" });

--- a/functions/api/admin/events/__tests__/metrics.test.js
+++ b/functions/api/admin/events/__tests__/metrics.test.js
@@ -115,6 +115,42 @@ describe("GET /api/admin/events/[id]/metrics", () => {
     expect(body.metrics.topSharedRoutes[0].view_count).toBe(0);
   });
 
+  test("orders legacy-only routes by raw fetches, not by which was created last", async () => {
+    const { env, rawDb } = createTestEnv();
+    const event = insertEvent(rawDb, { name: "Order Fest", slug: "order-fest" });
+    // Inserted in this order, so created_at DESC alone would put "recent-few"
+    // first. Both have view_count = 0, which is what makes the tie-break the
+    // only thing deciding the order -- and with LIMIT 10 on a busier event,
+    // what decides which rows survive at all.
+    insertShareLink(rawDb, {
+      slug: "older-many",
+      event_id: event.id,
+      event_slug: "order-fest",
+      performance_ids: [1],
+      band_names: ["A"],
+    });
+    insertShareLink(rawDb, {
+      slug: "recent-few",
+      event_id: event.id,
+      event_slug: "order-fest",
+      performance_ids: [1],
+      band_names: ["A"],
+    });
+    // created_at must actually DIFFER, or the bug cannot be reproduced: both
+    // rows are inserted in the same second, so created_at DESC leaves them in
+    // insertion order and the broken query passes by accident.
+    rawDb
+      .prepare("UPDATE share_links SET view_count_legacy = ?, created_at = ? WHERE slug = ?")
+      .run(500, "2026-08-01 10:00:00", "older-many");
+    rawDb
+      .prepare("UPDATE share_links SET view_count_legacy = ?, created_at = ? WHERE slug = ?")
+      .run(2, "2026-08-20 10:00:00", "recent-few");
+
+    const res = await call(env, event.id);
+    const body = await res.json();
+    expect(body.metrics.topSharedRoutes.map((route) => route.slug)).toEqual(["older-many", "recent-few"]);
+  });
+
   test("top routes carry band_count and created_at, and zero-view shares are excluded (#702)", async () => {
     const { env, rawDb } = createTestEnv();
     const event = insertEvent(rawDb, { name: "Route Fest", slug: "route-fest" });

--- a/functions/api/stats/__tests__/public.test.js
+++ b/functions/api/stats/__tests__/public.test.js
@@ -74,6 +74,7 @@ describe("Public aggregate stats - GET /api/stats/public", () => {
     expect(body.performances).toBe(2); // only performances on the published event
     expect(body.routes_shared).toBe(2);
     expect(body.route_views).toBe(15);
+    expect(body.route_views_legacy).toBe(0);
     expect(body.fans_following).toBe(1); // only the verified follow
     expect(body.page_views).toBe(125);
 
@@ -88,6 +89,24 @@ describe("Public aggregate stats - GET /api/stats/public", () => {
       expect(Object.keys(band).sort()).toEqual(["name", "score", "slug"]);
       expect(band).not.toHaveProperty("id");
     }
+  });
+
+  it("keeps unique visitor and legacy raw-fetch totals separate", async () => {
+    const { env, rawDb } = seedEnv();
+    const event = insertEvent(rawDb, { name: "Legacy Fest", slug: "legacy-fest" });
+    publish(rawDb, event.id);
+    insertShareLink(rawDb, { slug: "share-legacy", event_id: event.id, event_slug: "legacy-fest" });
+    rawDb
+      .prepare("UPDATE share_links SET view_count = ?, view_count_legacy = ? WHERE slug = ?")
+      .run(2, 9, "share-legacy");
+
+    const res = await getStats(env);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.route_views).toBe(2);
+    expect(body.route_views_legacy).toBe(9);
+    expect(body.route_views).not.toBe(11);
+    expect(body.route_views_legacy).not.toBe(11);
   });
 
   it("never leaks PII-shaped fields anywhere in the response body", async () => {
@@ -158,6 +177,7 @@ describe("Public aggregate stats - GET /api/stats/public", () => {
     expect(body.performances).toBe(0);
     expect(body.routes_shared).toBe(0);
     expect(body.route_views).toBe(0);
+    expect(body.route_views_legacy).toBe(0);
     expect(body.fans_following).toBe(0);
     expect(body.page_views).toBe(0);
     expect(body.top_bands).toEqual([]);

--- a/functions/api/stats/public.js
+++ b/functions/api/stats/public.js
@@ -9,7 +9,8 @@
 // individual/PII/joinable-to-a-person field:
 //   - band_follows has email, verification_token, unsubscribe_token, consent_ip.
 //     Only ever `COUNT(*) WHERE verified = 1` against it — never SELECT those columns.
-//   - share_links: COUNT and SUM(view_count) only — never slug/band_names/performance_ids.
+//   - share_links: COUNT and separate SUMs of view_count and view_count_legacy —
+//     never slug/band_names/performance_ids.
 //   - No IPs, emails, session IDs, tokens, or raw rows anywhere in the response.
 // Bands/venues/events are public data, so their names/counts are fine.
 
@@ -55,8 +56,14 @@ export async function onRequestGet(context) {
            JOIN events e ON e.id = p.event_id
            WHERE ${publicEventStatusSql("e")}`,
         ),
-        // share_links: aggregate only — count of rows + sum of view_count.
-        DB.prepare(`SELECT COUNT(*) AS count, COALESCE(SUM(view_count), 0) AS total_views FROM share_links`),
+        // Keep the two share-view units separate: unique visitors versus
+        // pre-cutover, undeduplicated raw fetches.
+        DB.prepare(
+          `SELECT COUNT(*) AS count,
+                  COALESCE(SUM(view_count), 0) AS total_views,
+                  COALESCE(SUM(view_count_legacy), 0) AS total_views_legacy
+           FROM share_links`,
+        ),
         // band_follows: verified-only count. Never select email/tokens/consent_ip.
         DB.prepare(`SELECT COUNT(*) AS count FROM band_follows WHERE verified = 1`),
         DB.prepare(`SELECT COALESCE(SUM(views), 0) AS total_views FROM page_views_daily`),
@@ -85,6 +92,7 @@ export async function onRequestGet(context) {
       performances: performancesRes.results?.[0]?.count || 0,
       routes_shared: shareRes.results?.[0]?.count || 0,
       route_views: shareRes.results?.[0]?.total_views || 0,
+      route_views_legacy: shareRes.results?.[0]?.total_views_legacy || 0,
       fans_following: followsRes.results?.[0]?.count || 0,
       page_views: pageViewsRes.results?.[0]?.total_views || 0,
       top_bands: topBands,


### PR DESCRIPTION
## Summary

#705 rederived `share_links.view_count` from a ledger that started empty, so every link created before the cutover reset to zero. The old figure survives in `view_count_legacy`, which **nothing read** — so both the admin dashboard and the public stats page reported that sharing had collapsed.

Both figures are now surfaced, with the unit stated in the **visible label**.

## The units are the whole problem

They are not comparable and must never be summed:

| field | unit |
|---|---|
| `view_count` | unique visitors per link, all-time, deduplicated via the `share_link_views` ledger |
| `view_count_legacy` | raw fetches, per-fetch, undeduplicated |

Showing them side by side without saying so invites exactly the invalid comparison `import_count` already invites. So the unit is in the label, not a tooltip:

- **"Share Views (unique visitors, all-time)"**
- **"{n} pre-cutover raw fetches"**, rendered only when non-zero

The caption states the difference directly: *"Unique visitors are deduplicated per link; pre-cutover raw fetches are undeduplicated per-fetch."*

Verified they are never combined: `SUM(view_count)` and `SUM(view_count_legacy)` are separate columns in both endpoints, and no arithmetic joins them anywhere.

## Recovered work — two things did not survive

Rebuilt from a dangling commit that was never pushed. Two parts were dropped rather than replayed:

- its wording named the *reset* without naming the **units** — the entire point of the display decision
- its query used **`is_published`**, retired by migration 0059 and now blocked by a source-scanning guard

## A review finding, and a vacuous test of my own

CodeRabbit caught that including legacy-only routes puts several rows at `view_count = 0`, so `created_at` alone decided their order — and with `LIMIT 10`, a **2-fetch route could displace a 500-fetch one**. Fixed by tie-breaking on legacy count *within* the zero-visitor group, so the units are still never compared across.

**My first regression test for it was vacuous.** Both rows were inserted in the same second, so `created_at DESC` left them in insertion order and the broken query passed by accident — removing the fix left all 16 tests green. Setting the timestamps explicitly is what makes it reproduce. With the fix removed it now yields `['recent-few', 'older-many']`, the exact inversion.

## Test plan

- [x] both endpoints expose both fields
- [x] pre-cutover link shows both, each labelled with its unit
- [x] post-cutover link shows only the recount, no empty legacy row
- [x] the two are never summed — verified in source, separate SQL columns
- [x] **label assertions proven by mutation** — stripping the unit from the admin label fails 3 tests
- [x] **ordering fix proven by mutation** — removing the tie-break inverts the order
- [x] `make gate` exit code **0** — 1352 backend, 1234 frontend
- [x] coverage ratchet did not move

## Risk

Low. Additive display plus two additive SQL columns; no existing figure changes meaning or value. The ordering change affects only rows that were previously excluded from the query entirely.

Closes #892

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Share analytics now distinguish unique visitors from legacy raw view counts.
  - Dashboard, statistics pages, and public metrics display pre-cutover raw-fetch totals when available.
  - Legacy-only shared routes and their import counts are included in metrics.

- **Bug Fixes**
  - Corrected route-view aggregation and ranking for current and legacy metrics.

- **Tests**
  - Added coverage for labels, omitted zero or unavailable legacy counts, and metric ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->