### PR TITLE
feat(live): offer nearby alternatives when a saved set is cancelled

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -868,6 +868,7 @@ function App() {
           >
             <MySchedule
               bands={myBands}
+              allBands={bands}
               onToggleBand={toggleBand}
               onClearSchedule={clearSchedule}
               showPast={showPast}

--- a/frontend/src/components/MySchedule.jsx
+++ b/frontend/src/components/MySchedule.jsx
@@ -24,7 +24,8 @@ import { HIGHLIGHTED_BANDS, getHighlightMessage } from '../config/highlights.jsx
 import { copyToClipboard } from '../utils/clipboard'
 import { dayNumberMapFromDays, formatFestivalDate, orderedFestivalDays } from '../utils/festivalDays'
 import { prepareBands } from '../utils/bandUtils'
-import { formatTimeRange } from '../utils/timeFormat'
+import { suggestGapFillers } from '../utils/gapSuggestions'
+import { formatTime, formatTimeRange } from '../utils/timeFormat'
 import { useFestivalDayFilter } from '../hooks/useFestivalDayFilter'
 import BandCard from './BandCard'
 import LockInLineupPanel from './LockInLineupPanel'
@@ -88,8 +89,45 @@ function ForkCard({ band1, band2, onToggleBand }) {
   )
 }
 
+function GapSuggestions({ cancelledBand, myBands, allBands, onToggleBand }) {
+  const suggestions = suggestGapFillers({ cancelledBand, myBands, allBands })
+  if (suggestions.length === 0) return null
+
+  // role="group" is load-bearing: aria-label on a generic div is not reliably
+  // exposed, so without a role the label never reaches assistive tech. Grouping
+  // also keeps these announced as belonging to the cancelled set above them
+  // rather than as loose buttons adrift in the schedule list.
+  return (
+    <div
+      role="group"
+      className="rounded-lg border border-info-500/40 bg-info-500/10 p-3 sm:p-4"
+      aria-label={`Suggestions after ${cancelledBand.name} was cancelled`}
+    >
+      <p className="text-sm font-semibold text-text-primary">Try filling this gap:</p>
+      <ul className="mt-2 space-y-2">
+        {suggestions.map(({ band, walkMinutes }) => (
+          <li key={band.id}>
+            <button
+              type="button"
+              onClick={() => onToggleBand(band.id)}
+              className="flex min-h-[44px] w-full items-center justify-between gap-3 rounded-md border border-border bg-surface px-3 py-2 text-left text-sm text-text-primary transition-colors hover:bg-surface-hover focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-500"
+            >
+              <span>
+                Try {band.name} at {band.venue}, starting at {formatTime(band.startTime)}
+                {walkMinutes !== null && `, ${walkMinutes} min walk`}
+              </span>
+              <span className="shrink-0 text-xs font-semibold text-accent-400">Add</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
 function MySchedule({
   bands,
+  allBands = bands,
   onToggleBand,
   onClearSchedule,
   showPast,
@@ -738,6 +776,14 @@ function MySchedule({
                       </div>
                     )
                   })()}
+                  {band.is_cancelled && (
+                    <GapSuggestions
+                      cancelledBand={band}
+                      myBands={bands}
+                      allBands={allBands}
+                      onToggleBand={onToggleBand}
+                    />
+                  )}
                 </div>
               </div>
             </Fragment>

--- a/frontend/src/test/MySchedule.test.jsx
+++ b/frontend/src/test/MySchedule.test.jsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import '@testing-library/jest-dom'
 import MySchedule from '../components/MySchedule'
+import * as gapSuggestions from '../utils/gapSuggestions'
 
 const makeMs = (timeStr, date = '2026-05-17') => new Date(`${date}T${timeStr}:00`).getTime()
 
@@ -302,5 +303,65 @@ describe('MySchedule — genre chip on the route-list card', () => {
     const chip = screen.getByText('Punk')
     expect(chip.className).toMatch(/bg-bg-navy\/15/)
     expect(chip.className).toMatch(/text-bg-navy/)
+  })
+})
+
+describe('MySchedule — cancelled set gap suggestions', () => {
+  const cancelledBand = { ...makeBand(1, 'Cancelled Act', 'Room 47', '20:00', '22:00'), is_cancelled: 1 }
+  const candidateBand = makeBand(2, 'Replacement Act', 'Princess Cafe', '21:00', '21:30')
+  const bands = [cancelledBand]
+  const allBands = [cancelledBand, candidateBand]
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('suggests an artist, venue, and start time for a cancelled saved set', () => {
+    renderSchedule({ bands, allBands })
+
+    expect(
+      screen.getByRole('button', { name: /Try Replacement Act at Princess Cafe, starting at 9:00 PM/i })
+    ).toBeInTheDocument()
+  })
+
+  it('renders nothing when the engine returns no suggestions', () => {
+    vi.spyOn(gapSuggestions, 'suggestGapFillers').mockReturnValue([])
+
+    renderSchedule({ bands, allBands })
+
+    expect(screen.queryByText('Try filling this gap:')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Try Replacement Act at Princess Cafe/i)).not.toBeInTheDocument()
+  })
+
+  it('omits distance text when the walk time is unknown', () => {
+    renderSchedule({ bands, allBands })
+
+    const suggestion = screen.getByRole('button', { name: /Try Replacement Act/i })
+    expect(suggestion).toHaveTextContent('Try Replacement Act at Princess Cafe, starting at 9:00 PM')
+    expect(suggestion).not.toHaveTextContent(/walk|null/i)
+  })
+
+  it('does not suggest alternatives for a non-cancelled saved set', () => {
+    const savedBand = makeBand(1, 'Saved Act', 'Room 47', '20:00', '22:00')
+    vi.spyOn(gapSuggestions, 'suggestGapFillers').mockReturnValue([
+      { band: candidateBand, walkMinutes: null, startsAtMs: candidateBand.startMs },
+    ])
+
+    renderSchedule({ bands: [savedBand], allBands: [savedBand, candidateBand] })
+
+    expect(screen.queryByText(/Try Replacement Act/i)).not.toBeInTheDocument()
+  })
+
+  it('adds a suggestion only through onToggleBand', () => {
+    const onToggleBand = vi.fn()
+    const selectedBands = [...bands]
+
+    renderSchedule({ bands: selectedBands, allBands, onToggleBand })
+    fireEvent.click(screen.getByRole('button', { name: /Try Replacement Act/i }))
+
+    expect(onToggleBand).toHaveBeenCalledWith(candidateBand.id)
+    expect(onToggleBand).toHaveBeenCalledTimes(1)
+    expect(selectedBands).toEqual(bands)
+    expect(selectedBands).not.toContain(candidateBand)
   })
 })


### PR DESCRIPTION
## Summary

A fan whose locked-in lineup loses a set sees it struck through — accurate, but it leaves a hole in their night with no help filling it. This offers what else is playing in that window, nearest first.

> Try Replacement Act at Princess Cafe, starting at 9:00 PM, 2 min walk

## Most of this already existed

**The suggestion engine shipped in #877 and was imported by nothing but its own test.** So this is the wiring and the UI, not the algorithm — `suggestGapFillers` is untouched.

Worth flagging, because the issue predicted the opposite: *"This is not a rendering change."* True when filed; #877 changed it. The engine already handles every constraint the issue lists — excludes cancelled candidates and sets the fan already holds, rejects anything overlapping their other sets, orders by walking time with a deterministic tiebreak, and returns `[]` rather than guessing.

The plumbing is one prop. `App.jsx` already holds the full lineup through `prepareBands`, so the bands carry the `startMs`/`endMs` offsets encoding the after-midnight convention. No new fetch, no lifted state.

## The three constraints, each mutation-tested

| constraint | how it holds |
|---|---|
| **Advisory only — never auto-modify a saved lineup** | choosing a suggestion goes through the existing `onToggleBand`; nothing here writes |
| **Degrade to silence rather than a bad nudge** | an empty result renders *nothing* — no container, no "no suggestions" line |
| **No distance claim without data** | `walkMinutes === null` omits distance entirely rather than printing it |

The silence case is the one most likely to be written carelessly, so it is asserted against the absence of something present in the positive case. Removing the guard fails it — verified, not assumed.

Note **zero minutes is a real answer, not missing data**: Blue Room is inside Revive Karaoke, and The Mill shares a building with Paddy's Underground. A zero-walk suggestion is the best one available.

## Two things checked rather than trusted

**Field names verified against the live `/api/schedule` response**, not the test fixtures — `venue`, `startTime`, `venue_lat`, `venue_lng` are what production returns. A fixture carrying the wrong shape would pass every test here and render nothing for a real fan.

**`role="group"` is load-bearing.** The original markup put `aria-label` on a bare `<div>`, where it is not reliably exposed — without a role the label never reaches assistive tech. This is read on a phone, in a dark venue, mid-crawl.

## Test plan

- [x] a cancelled saved set with valid alternatives renders suggestions naming artist, venue and time
- [x] **renders nothing when the engine returns `[]`** — proven by mutation
- [x] `walkMinutes === null` renders no distance text and never the word "null"
- [x] a non-cancelled saved set renders no suggestions
- [x] choosing a suggestion calls `onToggleBand` and mutates nothing itself
- [x] theme tokens throughout — no `text-white`/`bg-white`, so it reads on both light themes
- [x] 44px touch target and a visible focus ring
- [x] `make gate` exit code **0** — 1353 backend, 1239 frontend
- [x] coverage ratchet did not move
- [x] `make review` (CodeRabbit) — no findings

## Risk

Low, and additive: it renders only beneath a cancelled set in a fan's own list, and only when the engine finds something. Every existing path is unchanged.

Closes #735

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added replacement-band suggestions beneath cancelled performances in My Schedule.
  * Suggestions account for schedule gaps and available walking time.
  * Selecting a suggested band adds or removes it from the schedule.

* **Bug Fixes**
  * Improved handling of empty suggestions, unknown walking times, and non-cancelled performances.
  * Preserved existing selected-band data when choosing suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->