### PR TITLE
feat(admin): API key storage and verification foundation (#744 part 1)

### DIFF
--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -514,14 +514,21 @@ CREATE TABLE IF NOT EXISTS api_keys (
   key_prefix TEXT NOT NULL,
   key_hash TEXT NOT NULL UNIQUE,
   role TEXT NOT NULL CHECK(role IN ('viewer','editor','admin')),
-  created_by INTEGER NOT NULL REFERENCES users(id),
+  -- RESTRICT, not CASCADE: deleting the row would destroy the attribution an
+  -- incident needs. Deleting a user who still holds keys must fail loudly so
+  -- the revoke step cannot be silently skipped. Part 2 adds that step to the
+  -- user-delete path; until an endpoint exists no key can be created, so
+  -- nothing can hit this yet.
+  created_by INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  expires_at TEXT NOT NULL,
+  -- SEC-F1 made unstorable rather than merely handled. A T-separated value
+  -- ('2026-01-01T00:00:00Z') is what turned a string comparison into a
+  -- production expiry bypass; this makes the shape illegal at the layer it
+  -- would have to originate from. Write with toSqliteDateTime().
+  expires_at TEXT NOT NULL CHECK(expires_at LIKE '____-__-__ __:__:__'),
   last_used_at TEXT,
   revoked_at TEXT
 );
-
-CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys (key_hash);
 
 CREATE INDEX IF NOT EXISTS idx_api_keys_created_by ON api_keys (created_by);
 

--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -508,6 +508,23 @@ CREATE INDEX IF NOT EXISTS idx_share_link_views_slug ON share_link_views(slug);
 
 CREATE INDEX IF NOT EXISTS idx_events_status_date ON events (status, date);
 
+CREATE TABLE IF NOT EXISTS api_keys (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  key_prefix TEXT NOT NULL,
+  key_hash TEXT NOT NULL UNIQUE,
+  role TEXT NOT NULL CHECK(role IN ('viewer','editor','admin')),
+  created_by INTEGER NOT NULL REFERENCES users(id),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT NOT NULL,
+  last_used_at TEXT,
+  revoked_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys (key_hash);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_created_by ON api_keys (created_by);
+
 -- ============================================
 -- TEST ACCOUNTS (passwords set by scripts/setup-local-db.sh)
 -- ============================================

--- a/functions/utils/__tests__/apiKeys.test.js
+++ b/functions/utils/__tests__/apiKeys.test.js
@@ -1,0 +1,132 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createDBEnv, createTestDB } from "../../api/test-utils.js";
+import { generateApiKey, hashApiKey, verifyApiKey } from "../apiKeys.js";
+
+describe("apiKeys", () => {
+  let rawDb;
+  let DB;
+
+  beforeEach(() => {
+    rawDb = createTestDB();
+    DB = createDBEnv(rawDb);
+  });
+
+  async function insertKey({ expiresAt, revokedAt = null } = {}) {
+    const generated = await generateApiKey(expiresAt ?? new Date(Date.now() + 60_000));
+    rawDb
+      .prepare(
+        "INSERT INTO api_keys (name, key_prefix, key_hash, role, created_by, expires_at, revoked_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .run("Test key", generated.keyPrefix, generated.keyHash, "viewer", 1, generated.expiresAt, revokedAt);
+    return generated;
+  }
+
+  it("generates 256 bits of base64url entropy with the st_ prefix", async () => {
+    const first = await generateApiKey();
+    const second = await generateApiKey();
+
+    expect(first.plaintext).toMatch(/^st_[A-Za-z0-9_-]{43}$/);
+    expect(first.plaintext.slice(3)).toHaveLength(43);
+    expect(first.plaintext).not.toBe(second.plaintext);
+    expect(first.keyPrefix).toBe(first.plaintext.slice(0, 8));
+    expect(first.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it("returns plaintext only from generation and stores a separate hash", async () => {
+    const generated = await generateApiKey();
+    const hash = await hashApiKey(generated.plaintext);
+
+    expect(hash).not.toBe(generated.plaintext);
+    expect(hash).not.toContain(generated.plaintext);
+    expect(hash).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(generated.keyHash).toBe(hash);
+  });
+
+  it("verifies a valid, unexpired, unrevoked key", async () => {
+    const generated = await insertKey();
+
+    await expect(verifyApiKey(DB, generated.plaintext)).resolves.toMatchObject({ role: "viewer" });
+  });
+
+  it("rejects a revoked key", async () => {
+    const generated = await insertKey({ revokedAt: "2026-08-26 12:00:00" });
+
+    await expect(verifyApiKey(DB, generated.plaintext)).resolves.toBeUndefined();
+  });
+
+  it("rejects an expired key", async () => {
+    const generated = await insertKey({ expiresAt: new Date(Date.now() - 60_000) });
+
+    await expect(verifyApiKey(DB, generated.plaintext)).resolves.toBeUndefined();
+  });
+
+  // The original test here stored a key that was ALREADY expired and then
+  // rewrote its separator -- which passes whether or not the T form is handled,
+  // because a past date is rejected either way. Verified by mutation: breaking
+  // the T branch of fromSqliteDateTime left all seven tests green.
+  //
+  // The direction that actually distinguishes the implementations is a FUTURE
+  // expiry stored with a T. If the parser mishandles it the value becomes an
+  // Invalid Date, the key is rejected, and a live integration dies for no
+  // stated reason.
+  it("accepts a still-valid key whose expires_at carries the legacy T separator", async () => {
+    const generated = await insertKey({ expiresAt: new Date(Date.now() + 3_600_000) });
+    rawDb
+      .prepare("UPDATE api_keys SET expires_at = REPLACE(expires_at, ' ', 'T') || 'Z' WHERE key_hash = ?")
+      .run(generated.keyHash);
+
+    await expect(verifyApiKey(DB, generated.plaintext)).resolves.toBeDefined();
+  });
+
+  it("rejects an expired key whose expires_at carries the legacy T separator", async () => {
+    const generated = await insertKey({ expiresAt: new Date(Date.now() - 60_000) });
+    rawDb
+      .prepare("UPDATE api_keys SET expires_at = REPLACE(expires_at, ' ', 'T') || 'Z' WHERE key_hash = ?")
+      .run(generated.keyHash);
+
+    await expect(verifyApiKey(DB, generated.plaintext)).resolves.toBeUndefined();
+  });
+
+  // SEC-F1 itself is structurally impossible here, and this is what keeps it
+  // that way. The production invite-code bypass needed the comparison to happen
+  // in SQL, where `expires_at > datetime('now')` is a STRING compare and "T"
+  // (0x54) sorts after " " (0x20) -- so an expired value read as far-future.
+  // This module parses in JS and compares timestamps instead, which cannot
+  // exhibit that. Moving the check into the query to save a round-trip would
+  // silently reintroduce the bypass, so the query is asserted not to mention
+  // expiry at all.
+  it("never filters expiry in SQL, where the T separator becomes a bypass", () => {
+    const source = readFileSync(new URL("../apiKeys.js", import.meta.url), "utf8");
+    // Matches double-quoted, single-quoted and template-literal SQL. The
+    // length assertion below is what stops this going vacuous: if the query is
+    // reshaped into a form this does not match, the guard fails loudly instead
+    // of silently inspecting nothing.
+    const sqlStrings = source.match(/(["'`])(?:(?!\1)[\s\S])*\bFROM\s+api_keys\b(?:(?!\1)[\s\S])*\1/gi) || [];
+
+    expect(sqlStrings.length, "expected at least one api_keys query to inspect").toBeGreaterThan(0);
+    for (const sql of sqlStrings) {
+      // Selecting expires_at is fine and necessary -- the JS check needs the
+      // value. What must never appear is a COMPARISON on it, or any use of
+      // SQLite's datetime(), because that is where the string ordering bites.
+      expect(sql, `expiry must not be compared in SQL: ${sql}`).not.toMatch(/expires_at\s*(<|>|<=|>=|=|BETWEEN)/i);
+      expect(sql, `SQLite datetime() must not gate expiry: ${sql}`).not.toMatch(/datetime\s*\(/i);
+    }
+  });
+
+  // The endpoints in the next part return what this resolves to. If the hash
+  // rides along in that object it will eventually be serialised into a response.
+  it("never returns the key hash to its caller", async () => {
+    const generated = await insertKey();
+
+    const row = await verifyApiKey(DB, generated.plaintext);
+
+    expect(row).toBeDefined();
+    expect(row).not.toHaveProperty("key_hash");
+    expect(JSON.stringify(row)).not.toContain(generated.keyHash);
+  });
+
+  it("rejects a key that does not exist without throwing", async () => {
+    await expect(verifyApiKey(DB, "st_not-a-real-key")).resolves.toBeUndefined();
+  });
+});

--- a/functions/utils/__tests__/apiKeys.test.js
+++ b/functions/utils/__tests__/apiKeys.test.js
@@ -1,6 +1,9 @@
-import { readFileSync } from "node:fs";
-import { beforeEach, describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDBEnv, createTestDB } from "../../api/test-utils.js";
+import { toSqliteDateTime } from "../authAttempts.js";
 import { generateApiKey, hashApiKey, verifyApiKey } from "../apiKeys.js";
 
 describe("apiKeys", () => {
@@ -12,13 +15,22 @@ describe("apiKeys", () => {
     DB = createDBEnv(rawDb);
   });
 
-  async function insertKey({ expiresAt, revokedAt = null } = {}) {
-    const generated = await generateApiKey(expiresAt ?? new Date(Date.now() + 60_000));
+  // generateApiKey refuses a past expiry, which is correct -- creation must not
+  // mint an already-dead key. A STORED key can still be expired, because time
+  // passes, so that state is produced by ageing the row rather than by asking
+  // the generator for something it should refuse.
+  async function insertKey({ expiredBy = null, revokedAt = null, role = "viewer" } = {}) {
+    const generated = await generateApiKey(new Date(Date.now() + 3_600_000));
     rawDb
       .prepare(
         "INSERT INTO api_keys (name, key_prefix, key_hash, role, created_by, expires_at, revoked_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
       )
-      .run("Test key", generated.keyPrefix, generated.keyHash, "viewer", 1, generated.expiresAt, revokedAt);
+      .run(`Test key ${role}`, generated.keyPrefix, generated.keyHash, role, 1, generated.expiresAt, revokedAt);
+
+    if (expiredBy !== null) {
+      const past = toSqliteDateTime(new Date(Date.now() - expiredBy));
+      rawDb.prepare("UPDATE api_keys SET expires_at = ? WHERE key_hash = ?").run(past, generated.keyHash);
+    }
     return generated;
   }
 
@@ -31,6 +43,66 @@ describe("apiKeys", () => {
     expect(first.plaintext).not.toBe(second.plaintext);
     expect(first.keyPrefix).toBe(first.plaintext.slice(0, 8));
     expect(first.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  // The shape assertions above are satisfied by a COUNTER -- verified: swapping
+  // getRandomValues for a monotonic byte counter left the whole suite green.
+  // That matters more here than a usual vacuous test, because hashing with a
+  // fast SHA-256 rather than PBKDF2 is justified ONLY by the key carrying 256
+  // bits of unpredictable entropy. It is the premise the design rests on and
+  // the one property shape checks cannot observe, so it is asserted directly.
+  it("draws its key material from getRandomValues, 32 bytes at a time", async () => {
+    const source = readFileSync(new URL("../apiKeys.js", import.meta.url), "utf8");
+    expect(source).toMatch(/crypto\.getRandomValues\(new Uint8Array\(KEY_BYTES\)\)/);
+    expect(source).toMatch(/KEY_BYTES\s*=\s*32\b/);
+    expect(source, "Math.random is not a CSPRNG").not.toMatch(/Math\.random/);
+
+    const spy = vi.spyOn(crypto, "getRandomValues");
+    const generated = await generateApiKey();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const requested = spy.mock.calls[0][0];
+    expect(requested).toBeInstanceOf(Uint8Array);
+    expect(requested.byteLength).toBe(32);
+    // The bytes the CSPRNG produced must be the bytes that reach the key --
+    // a counter passes every check above but fails this one.
+    const emitted = spy.mock.results[0].value;
+    const encoded = btoa(String.fromCharCode(...emitted))
+      .replaceAll("+", "-")
+      .replaceAll("/", "_")
+      .replace(/=+$/, "");
+    expect(generated.plaintext).toBe(`st_${encoded}`);
+    spy.mockRestore();
+  });
+
+  it("refuses to mint a key that is already dead, unbounded, or nonsense", async () => {
+    await expect(generateApiKey(new Date(Date.now() - 1000))).rejects.toThrow(/future/i);
+    await expect(generateApiKey(new Date(Date.now() + 400 * 24 * 60 * 60 * 1000))).rejects.toThrow(/maximum/i);
+    await expect(generateApiKey(new Date("nonsense"))).rejects.toThrow(/valid Date/i);
+    await expect(generateApiKey("2027-01-01")).rejects.toThrow(/valid Date/i);
+  });
+
+  it("rejects anything that is not a plausible key, without throwing", async () => {
+    for (const bad of [null, undefined, "", {}, 42, "ghp_someoneelsestoken"]) {
+      await expect(verifyApiKey(DB, bad)).resolves.toBeUndefined();
+    }
+  });
+
+  it("reads the role from the matched row, not from a fixed value", async () => {
+    const viewer = await insertKey({ role: "viewer" });
+    const admin = await insertKey({ role: "admin" });
+
+    await expect(verifyApiKey(DB, viewer.plaintext)).resolves.toMatchObject({ role: "viewer" });
+    await expect(verifyApiKey(DB, admin.plaintext)).resolves.toMatchObject({ role: "admin" });
+  });
+
+  // Known-answer vector, the same discipline the TOTP helper uses with its RFC
+  // 6238 cases: a silent switch to SHA-1 or SHA-512 would still produce a
+  // plausible base64url string and pass every structural check.
+  it("hashes with SHA-256 and no salt, pinned by a known answer", async () => {
+    await expect(hashApiKey("st_test_placeholder_not_a_real_key")).resolves.toBe(
+      "F-a1MhRIhoPkoh4e8TgtxJtbMPtnX5J4FbM4pFWxkho",
+    );
   });
 
   it("returns plaintext only from generation and stores a separate hash", async () => {
@@ -56,36 +128,31 @@ describe("apiKeys", () => {
   });
 
   it("rejects an expired key", async () => {
-    const generated = await insertKey({ expiresAt: new Date(Date.now() - 60_000) });
+    const generated = await insertKey({ expiredBy: 60_000 });
 
     await expect(verifyApiKey(DB, generated.plaintext)).resolves.toBeUndefined();
   });
 
-  // The original test here stored a key that was ALREADY expired and then
-  // rewrote its separator -- which passes whether or not the T form is handled,
-  // because a past date is rejected either way. Verified by mutation: breaking
-  // the T branch of fromSqliteDateTime left all seven tests green.
-  //
-  // The direction that actually distinguishes the implementations is a FUTURE
-  // expiry stored with a T. If the parser mishandles it the value becomes an
-  // Invalid Date, the key is rejected, and a live integration dies for no
-  // stated reason.
-  it("accepts a still-valid key whose expires_at carries the legacy T separator", async () => {
-    const generated = await insertKey({ expiresAt: new Date(Date.now() + 3_600_000) });
-    rawDb
-      .prepare("UPDATE api_keys SET expires_at = REPLACE(expires_at, ' ', 'T') || 'Z' WHERE key_hash = ?")
-      .run(generated.keyHash);
+  // SEC-F1 is now unstorable rather than merely handled. The earlier tests here
+  // aged a row and rewrote its separator to prove the parser failed closed; the
+  // CHECK constraint added to migration 0060 makes that value illegal at the
+  // point it would have to be written, which is the stronger guarantee. So the
+  // assertion moved down a layer: the schema refuses the shape outright.
+  it("refuses to store a T-separated expires_at at all", async () => {
+    const generated = await insertKey();
 
+    expect(() =>
+      rawDb
+        .prepare("UPDATE api_keys SET expires_at = REPLACE(expires_at, ' ', 'T') || 'Z' WHERE key_hash = ?")
+        .run(generated.keyHash),
+    ).toThrow(/CHECK constraint failed/i);
+
+    expect(() =>
+      rawDb.prepare("UPDATE api_keys SET expires_at = 'banana' WHERE key_hash = ?").run(generated.keyHash),
+    ).toThrow(/CHECK constraint failed/i);
+
+    // The key still verifies: the rejected writes changed nothing.
     await expect(verifyApiKey(DB, generated.plaintext)).resolves.toBeDefined();
-  });
-
-  it("rejects an expired key whose expires_at carries the legacy T separator", async () => {
-    const generated = await insertKey({ expiresAt: new Date(Date.now() - 60_000) });
-    rawDb
-      .prepare("UPDATE api_keys SET expires_at = REPLACE(expires_at, ' ', 'T') || 'Z' WHERE key_hash = ?")
-      .run(generated.keyHash);
-
-    await expect(verifyApiKey(DB, generated.plaintext)).resolves.toBeUndefined();
   });
 
   // SEC-F1 itself is structurally impossible here, and this is what keeps it
@@ -97,12 +164,30 @@ describe("apiKeys", () => {
   // silently reintroduce the bypass, so the query is asserted not to mention
   // expiry at all.
   it("never filters expiry in SQL, where the T separator becomes a bypass", () => {
-    const source = readFileSync(new URL("../apiKeys.js", import.meta.url), "utf8");
-    // Matches double-quoted, single-quoted and template-literal SQL. The
-    // length assertion below is what stops this going vacuous: if the query is
-    // reshaped into a form this does not match, the guard fails loudly instead
-    // of silently inspecting nothing.
-    const sqlStrings = source.match(/(["'`])(?:(?!\1)[\s\S])*\bFROM\s+api_keys\b(?:(?!\1)[\s\S])*\1/gi) || [];
+    // Scans every file under functions/, not just this module: part 2's list
+    // endpoint is where "show only active keys" is most tempting, and it will
+    // live in a file this guard would otherwise never open.
+    //
+    // Per file, never concatenated: joining them let an apostrophe in one
+    // file's prose ("PBKDF2's") open a quoted run that swallowed SQL from
+    // another. Comments are stripped for the same reason -- prose is not code.
+    const root = fileURLToPath(new URL("../..", import.meta.url));
+    const files = [];
+    const walk = (dir) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith(".js") && !full.includes("__tests__")) files.push(full);
+      }
+    };
+    walk(root);
+
+    const sqlStrings = [];
+    for (const file of files) {
+      const code = readFileSync(file, "utf8").replace(/^\s*\/\/.*$/gm, "");
+      if (!/\bapi_keys\b/.test(code)) continue;
+      sqlStrings.push(...(code.match(/(["'`])(?:(?!\1)[\s\S])*\bFROM\s+api_keys\b(?:(?!\1)[\s\S])*\1/gi) || []));
+    }
 
     expect(sqlStrings.length, "expected at least one api_keys query to inspect").toBeGreaterThan(0);
     for (const sql of sqlStrings) {

--- a/functions/utils/__tests__/apiKeys.test.js
+++ b/functions/utils/__tests__/apiKeys.test.js
@@ -80,6 +80,9 @@ describe("apiKeys", () => {
     await expect(generateApiKey(new Date(Date.now() + 400 * 24 * 60 * 60 * 1000))).rejects.toThrow(/maximum/i);
     await expect(generateApiKey(new Date("nonsense"))).rejects.toThrow(/valid Date/i);
     await expect(generateApiKey("2027-01-01")).rejects.toThrow(/valid Date/i);
+    // Sub-second expiry: passes the "in the future" check, then truncates to
+    // the current second on the way to storage -- a key born already dead.
+    await expect(generateApiKey(new Date(Date.now() + 200))).rejects.toThrow(/once stored/i);
   });
 
   it("rejects anything that is not a plausible key, without throwing", async () => {

--- a/functions/utils/__tests__/apiKeys.test.js
+++ b/functions/utils/__tests__/apiKeys.test.js
@@ -77,7 +77,10 @@ describe("apiKeys", () => {
 
   it("refuses to mint a key that is already dead, unbounded, or nonsense", async () => {
     await expect(generateApiKey(new Date(Date.now() - 1000))).rejects.toThrow(/future/i);
-    await expect(generateApiKey(new Date(Date.now() + 400 * 24 * 60 * 60 * 1000))).rejects.toThrow(/maximum/i);
+    // Just inside and just outside the 180-day ceiling, so the bound itself is
+    // pinned rather than merely "some large number is refused".
+    await expect(generateApiKey(new Date(Date.now() + 179 * 24 * 60 * 60 * 1000))).resolves.toBeDefined();
+    await expect(generateApiKey(new Date(Date.now() + 181 * 24 * 60 * 60 * 1000))).rejects.toThrow(/maximum/i);
     await expect(generateApiKey(new Date("nonsense"))).rejects.toThrow(/valid Date/i);
     await expect(generateApiKey("2027-01-01")).rejects.toThrow(/valid Date/i);
     // Sub-second expiry: passes the "in the future" check, then truncates to

--- a/functions/utils/apiKeys.js
+++ b/functions/utils/apiKeys.js
@@ -52,6 +52,17 @@ export async function generateApiKey(expiresAt = new Date(Date.now() + DEFAULT_L
     throw new Error("expiresAt exceeds the maximum key lifetime");
   }
 
+  // Validate what gets STORED, not what was handed in. toSqliteDateTime drops
+  // sub-second precision, so an expiry a few hundred milliseconds out passes
+  // the future check above and then serialises to the current second -- a key
+  // born already dead. Round-tripping through the stored form is the only
+  // check that sees what verification will later see.
+  const sqliteExpiresAt = toSqliteDateTime(expiresAt);
+  const storedExpiresAt = fromSqliteDateTime(sqliteExpiresAt);
+  if (!storedExpiresAt || storedExpiresAt.getTime() <= Date.now()) {
+    throw new Error("expiresAt must still be in the future once stored");
+  }
+
   const randomBytes = crypto.getRandomValues(new Uint8Array(KEY_BYTES));
   const plaintext = `${API_KEY_PREFIX}${encodeBase64Url(randomBytes)}`;
 
@@ -59,7 +70,7 @@ export async function generateApiKey(expiresAt = new Date(Date.now() + DEFAULT_L
     plaintext,
     keyPrefix: plaintext.slice(0, DISPLAY_PREFIX_LENGTH),
     keyHash: await digestApiKey(plaintext),
-    expiresAt: toSqliteDateTime(expiresAt),
+    expiresAt: sqliteExpiresAt,
   };
 }
 

--- a/functions/utils/apiKeys.js
+++ b/functions/utils/apiKeys.js
@@ -21,7 +21,13 @@ const DISPLAY_PREFIX_LENGTH = 8;
 // bypasses CSRF, MFA and the cookie boundary, so a default set here is what
 // every endpoint built on this inherits.
 const DEFAULT_LIFETIME_MS = 90 * 24 * 60 * 60 * 1000;
-const MAX_LIFETIME_MS = 365 * 24 * 60 * 60 * 1000;
+// The ceiling is a policy, not an inherited default -- 365 was simply the old
+// default and picking it as the maximum decided nothing. #744 asks for forced
+// rotation, and this credential bypasses CSRF, MFA and the cookie boundary, so
+// the escape hatch is half a year rather than a full one. Anything longer
+// should be a conscious product decision made when a real consumer needs it,
+// not a limit nobody chose.
+const MAX_LIFETIME_MS = 180 * 24 * 60 * 60 * 1000;
 
 function encodeBase64Url(bytes) {
   return btoa(String.fromCharCode(...bytes))

--- a/functions/utils/apiKeys.js
+++ b/functions/utils/apiKeys.js
@@ -1,0 +1,73 @@
+// API key utilities use a different hash strategy from password utilities.
+// PBKDF2's 600,000 iterations cost about 105 ms per verification here, while
+// a plain SHA-256 digest costs about 0.161 ms. API keys are verified on every
+// request, so paying that cost forever would consume Workers CPU for no
+// security benefit: this key contains 256 bits from getRandomValues and cannot
+// be brute-forced at any practical hash speed. PBKDF2 remains mandatory for
+// human-chosen passwords; fast hashing is appropriate for this high-entropy
+// secret.
+
+import { fromSqliteDateTime, toSqliteDateTime } from "./authAttempts.js";
+
+const API_KEY_PREFIX = "st_";
+const KEY_BYTES = 32;
+const DISPLAY_PREFIX_LENGTH = 8;
+const DEFAULT_LIFETIME_MS = 365 * 24 * 60 * 60 * 1000;
+
+function encodeBase64Url(bytes) {
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+async function digestApiKey(plaintext) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(plaintext));
+  return encodeBase64Url(new Uint8Array(digest));
+}
+
+export async function generateApiKey(expiresAt = new Date(Date.now() + DEFAULT_LIFETIME_MS)) {
+  const randomBytes = crypto.getRandomValues(new Uint8Array(KEY_BYTES));
+  const plaintext = `${API_KEY_PREFIX}${encodeBase64Url(randomBytes)}`;
+
+  return {
+    plaintext,
+    keyPrefix: plaintext.slice(0, DISPLAY_PREFIX_LENGTH),
+    keyHash: await digestApiKey(plaintext),
+    expiresAt: toSqliteDateTime(expiresAt),
+  };
+}
+
+export async function hashApiKey(plaintext) {
+  return digestApiKey(plaintext);
+}
+
+export async function verifyApiKey(DB, presentedKey) {
+  if (typeof presentedKey !== "string" || !presentedKey.startsWith(API_KEY_PREFIX)) {
+    return undefined;
+  }
+
+  const presentedHash = await digestApiKey(presentedKey);
+  // Columns are listed rather than SELECT *, and key_hash is deliberately NOT
+  // among them: this row is what the endpoints built on top of this will hand
+  // back, and a credential hash reaching a response body is how hashes leak.
+  // The hash equality check lives in the WHERE clause -- an exact comparison
+  // performed by SQLite -- so re-comparing the column in JS would prove nothing
+  // that the lookup has not already established.
+  const row = await DB.prepare(
+    `SELECT id, name, key_prefix, role, created_by, created_at, expires_at, last_used_at, revoked_at
+     FROM api_keys WHERE key_hash = ?`,
+  )
+    .bind(presentedHash)
+    .first();
+  if (!row) {
+    return undefined;
+  }
+
+  const expiresAt = fromSqliteDateTime(row.expires_at);
+  if (row.revoked_at !== null || !expiresAt || expiresAt.getTime() <= Date.now()) {
+    return undefined;
+  }
+
+  return row;
+}

--- a/functions/utils/apiKeys.js
+++ b/functions/utils/apiKeys.js
@@ -6,13 +6,22 @@
 // be brute-forced at any practical hash speed. PBKDF2 remains mandatory for
 // human-chosen passwords; fast hashing is appropriate for this high-entropy
 // secret.
+//
+// The digest is deterministic and UNSALTED by design: verification looks a key
+// up with WHERE key_hash = ?, so a per-row salt would make that lookup
+// impossible. That is safe here for the same reason the fast hash is -- there
+// is no dictionary to precompute against a 256-bit random space.
 
 import { fromSqliteDateTime, toSqliteDateTime } from "./authAttempts.js";
 
 const API_KEY_PREFIX = "st_";
 const KEY_BYTES = 32;
 const DISPLAY_PREFIX_LENGTH = 8;
-const DEFAULT_LIFETIME_MS = 365 * 24 * 60 * 60 * 1000;
+// #744 calls for a short default and forced rotation. A bearer credential
+// bypasses CSRF, MFA and the cookie boundary, so a default set here is what
+// every endpoint built on this inherits.
+const DEFAULT_LIFETIME_MS = 90 * 24 * 60 * 60 * 1000;
+const MAX_LIFETIME_MS = 365 * 24 * 60 * 60 * 1000;
 
 function encodeBase64Url(bytes) {
   return btoa(String.fromCharCode(...bytes))
@@ -27,6 +36,22 @@ async function digestApiKey(plaintext) {
 }
 
 export async function generateApiKey(expiresAt = new Date(Date.now() + DEFAULT_LIFETIME_MS)) {
+  // Rejected rather than clamped: silently shortening a lifetime the caller
+  // asked for produces a key that stops working at a time nobody recorded.
+  // toSqliteDateTime also slices at 19 chars, so an out-of-range Date would
+  // store a truncated value that verifies as valid forever -- this closes
+  // that path too.
+  const requested = expiresAt instanceof Date ? expiresAt.getTime() : Number.NaN;
+  if (!Number.isFinite(requested)) {
+    throw new Error("expiresAt must be a valid Date");
+  }
+  if (requested <= Date.now()) {
+    throw new Error("expiresAt must be in the future");
+  }
+  if (requested - Date.now() > MAX_LIFETIME_MS) {
+    throw new Error("expiresAt exceeds the maximum key lifetime");
+  }
+
   const randomBytes = crypto.getRandomValues(new Uint8Array(KEY_BYTES));
   const plaintext = `${API_KEY_PREFIX}${encodeBase64Url(randomBytes)}`;
 

--- a/migrations/0060_create_api_keys.sql
+++ b/migrations/0060_create_api_keys.sql
@@ -1,0 +1,18 @@
+-- Migration: 0060_create_api_keys.sql
+-- Stores high-entropy machine-to-machine credentials for the admin API.
+
+CREATE TABLE api_keys (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  key_prefix TEXT NOT NULL,
+  key_hash TEXT NOT NULL UNIQUE,
+  role TEXT NOT NULL CHECK(role IN ('viewer','editor','admin')),
+  created_by INTEGER NOT NULL REFERENCES users(id),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT NOT NULL,
+  last_used_at TEXT,
+  revoked_at TEXT
+);
+
+CREATE INDEX idx_api_keys_key_hash ON api_keys (key_hash);
+CREATE INDEX idx_api_keys_created_by ON api_keys (created_by);

--- a/migrations/0060_create_api_keys.sql
+++ b/migrations/0060_create_api_keys.sql
@@ -7,12 +7,20 @@ CREATE TABLE api_keys (
   key_prefix TEXT NOT NULL,
   key_hash TEXT NOT NULL UNIQUE,
   role TEXT NOT NULL CHECK(role IN ('viewer','editor','admin')),
-  created_by INTEGER NOT NULL REFERENCES users(id),
+  -- RESTRICT, not CASCADE: deleting the row would destroy the attribution an
+  -- incident needs. Deleting a user who still holds keys must fail loudly so
+  -- the revoke step cannot be silently skipped. Part 2 adds that step to the
+  -- user-delete path; until an endpoint exists no key can be created, so
+  -- nothing can hit this yet.
+  created_by INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  expires_at TEXT NOT NULL,
+  -- SEC-F1 made unstorable rather than merely handled. A T-separated value
+  -- ('2026-01-01T00:00:00Z') is what turned a string comparison into a
+  -- production expiry bypass; this makes the shape illegal at the layer it
+  -- would have to originate from. Write with toSqliteDateTime().
+  expires_at TEXT NOT NULL CHECK(expires_at LIKE '____-__-__ __:__:__'),
   last_used_at TEXT,
   revoked_at TEXT
 );
 
-CREATE INDEX idx_api_keys_key_hash ON api_keys (key_hash);
 CREATE INDEX idx_api_keys_created_by ON api_keys (created_by);


### PR DESCRIPTION
## Summary

**Part 1 of 3** for the machine-to-machine admin API. Adds the table, the generation and verification helpers, and their tests.

**It adds no endpoint and touches no existing auth path.** Nothing calls it yet, so nothing existing can regress — which is the point of splitting it out. Parts 2 (endpoints) and 3 (Bearer request path, dual-auth rejection, rate limiting, audit) follow.

## The crypto decision, which departs from the issue

#744 says to reuse `functions/utils/crypto.js` (PBKDF2). **This uses plain SHA-256**, and the reasoning is in the module header:

| | per verification |
|---|---|
| PBKDF2 @ 600,000 iterations (this repo's default) | **105.6 ms** |
| SHA-256 | **0.161 ms** |

An API key is verified on *every* request, on a platform that meters CPU. And a slow KDF buys nothing here: it exists to make offline brute force of low-entropy, human-chosen passwords expensive, and this key is **256 bits from `getRandomValues`** — unbreakable at any hash speed. A security review challenged this explicitly and found no attack a slow KDF would prevent. **Passwords keep PBKDF2; `crypto.js` is untouched.**

The digest is also **deterministic and unsalted by design** — verification looks a key up with `WHERE key_hash = ?`, so a per-row salt would break lookup entirely. That's now stated in the header so nobody "improves" it.

## Security review findings, all applied

**The entropy test could not see the RNG.** It asserted shape, length, and that two keys differ — all satisfied by a counter. Proven: swapping `getRandomValues` for a monotonic counter left the whole suite green. That mattered more than a usual vacuous test, because **the SHA-256 decision is conditional on 256 bits of entropy** — it is the premise the design rests on and the one property shape checks cannot observe. Now asserted by source scan *and* a spy proving the CSPRNG's bytes are the bytes that reach the key.

**`created_by` had no `ON DELETE`.** `users/[id].js` hard-deletes users inside a batch with `PRAGMA foreign_keys = ON`, so once a key existed that DELETE would throw and roll back its own audit row. Off the HTTP path, where the pragma defaults off, it would orphan a live key with no owner — verbatim the "departed editor's key outliving their account" the issue names. Now `ON DELETE RESTRICT`: deliberately not `CASCADE`, because deleting the row destroys the attribution an incident needs.

**SEC-F1 is now unstorable, not merely handled.** A `CHECK` constrains `expires_at` to the SQLite shape, so the `T`-separated value that caused the production expiry bypass cannot be written at all. That is stronger than parsing it correctly — and it makes the earlier tests impossible by design, so the assertion moved down a layer to *the schema refuses the shape*.

**Lifetime was a year with no ceiling** — which a part-2 endpoint calling the generator bare would have inherited, for a credential that bypasses CSRF, MFA and the cookie boundary. Now 90 days with a maximum, rejecting rather than silently clamping.

Also: the redundant `key_hash` index removed (`UNIQUE` already builds one, so it was two B-trees over one column); the SQL-expiry guard widened from one file to all of `functions/`, since part 2's list endpoint is where that mistake will live; tests added for the type guard, for `role` being read from the matched row rather than a fixture constant, and for the digest algorithm via a known answer.

## A CodeRabbit finding

`toSqliteDateTime` drops sub-second precision, so an expiry a few hundred ms out passed the "in the future" check and then serialised to the current second — a key born already dead. Now validated by round-tripping through the **stored** form, which is the only check that sees what verification will later see.

## Test plan

Every guard proven by mutation, each quoted in its commit:

- [x] `getRandomValues` → monotonic counter **fails** the entropy test *(previously passed)*
- [x] `role` hardcoded in the projection **fails** the matched-row test
- [x] digest switched to SHA-512 **fails** the known-answer test
- [x] expiry filter moved into SQL **fails** the source guard
- [x] round-trip check removed **fails** the sub-second case
- [x] `key_hash` returned to the caller **fails** the leak test
- [x] `regenerate-setup-complete.mjs` + `check-schema-drift.mjs` — clean, 30 tables / 71 indexes
- [x] `make gate` exit code **0**
- [x] `cloudflare-security-reviewer` — findings above; all three design decisions upheld
- [x] `make review` (CodeRabbit) — one Minor, applied

## Required in part 2

**Revoking a user's keys on delete and deactivation.** Deliberately not here: part 1 ships no endpoint, so no key can exist and nothing can break. `ON DELETE RESTRICT` is what makes its absence fail *loudly* rather than silently orphan a live credential.

Also flagged for part 3: **do not put a cache in front of `verifyApiKey`** — revocation is immediate today, and the issue requires it stay that way.

## Risk

Low. Inert library code plus an empty table. No endpoint reaches it and no existing path changed.

Refs #744

Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure machine-to-machine API key generation with configurable expiry dates, up to 180 days.
  - Added API key verification with role information, expiry checks, and revocation handling.
  - Added protected storage for key metadata without exposing plaintext keys.
  - Added database support for tracking key creation, usage, expiration, revocation, and ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->