### PR TITLE
feat(admin): API key create/list/revoke endpoints (#744 part 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,6 +521,31 @@ Enforced via `checkPermission(context, "viewer"|"editor"|"admin")` in `functions
 
 ---
 
+## API keys (#744) — a credential's life is tied to its creator's
+
+`api_keys` rows are bearer credentials minted by an admin (`POST /api/admin/api-keys`, plaintext returned **exactly once**; there is no reveal endpoint and never will be). `functions/utils/apiKeys.js` owns generation and verification; the digest is deliberately **SHA-256, fast and unsalted** — read that file's header before "fixing" it to PBKDF2. The secret is 256 bits of `getRandomValues`, so there is no dictionary to slow down, and `WHERE key_hash = ?` cannot work against a per-row salt.
+
+**Anything that changes a user's standing must revoke their keys, and there is more than one such endpoint.** `api_keys.role` is frozen at creation and never reconciled against its creator's current role, so an unrevoked key keeps whatever privilege it was minted with:
+
+| Path | Must revoke |
+|---|---|
+| `PATCH /api/admin/users/:id` with a falsy `isActive` | yes |
+| `PATCH /api/admin/users/:id` with a **changed `role`** | yes — otherwise a demoted admin keeps an admin-scoped key and can re-promote themselves |
+| `POST /api/admin/users/:id/toggle-status` (deactivating) | yes |
+| Reactivation, or a PATCH re-sending the role the user already has | **no** — revocation is one-way |
+
+Three traps here, each of which was live:
+
+- **`toggle-status.js` is a second, separate deactivation endpoint.** It is not a thin wrapper over the PATCH path — it has its own handler, and it deactivated accounts and deleted their sessions for months while leaving keys untouched. Grep `is_active =` rather than assuming one path — four hits, three of which write `users`: the two above plus `api/auth/activate.js`, which only ever writes `1`. The fourth, `utils/bandProfileFields.js`, writes `band_profiles.is_active` and is unrelated.
+- **`isActive` is read by truthiness at every other site in `users/[id].js`** — the last-admin guard, the `is_active` write, and the `deactivated_at` stamp all use `!isActive`. A revocation gated on `isActive === false` therefore misses `{"isActive": 0}`, which deactivates the user everywhere else. Match the surrounding convention.
+- **`verifyApiKey` INNER JOINs `users` and requires `is_active = 1`.** That is a backstop for a fourth path nobody has written yet, not the primary control — the explicit revocations above are. Do not delete it as redundant; it exists precisely because "every path remembers" was already false once.
+
+**Deleting a user who owns keys is refused with 409 `USER_OWNS_API_KEYS`, and revoking does not unblock it.** `created_by` is `ON DELETE RESTRICT`, which fires on the **existence** of a referencing row, not its state — so a revoked key blocks deletion exactly as an active one does. There is deliberately no endpoint that deletes an `api_keys` row: that would destroy the attribution RESTRICT exists to protect. Deactivation is the supported answer, and the 409's message says so. Detect it by `code`, never by matching the message.
+
+Audit rows go in the **same `DB.batch`** as the change. Creation is the awkward case — the key's id does not exist until the INSERT runs — so `auditLogStatementForInsertedRow()` (`functions/utils/auditLogStatement.js`) resolves `resource_id` with an `INSERT … SELECT … FROM <table> WHERE <col> = ?`. It takes a table and column **identifier**, not a SQL string, and validates both with an explicit `typeof value === "string"` check: `RegExp.prototype.test` coerces its argument, so a bare `/^[A-Za-z_]\w*$/.test(undefined)` tests the string `"undefined"` and **passes**. Note also that `INSERT … SELECT` over zero rows inserts nothing and does not error — only ever pass a value the preceding INSERT just wrote.
+
+---
+
 ## Pulling a band from a live lineup
 
 **Use the cancel toggle (`is_cancelled = 1`). Do not un-announce, and do not delete the row.**

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -2480,6 +2480,11 @@ paths:
       tags:
         - Admin - Users
       summary: Delete a user
+      description: >-
+        Refused with 409 (code USER_OWNS_API_KEYS) while the user owns any API keys.
+        Revoking does not clear this -- the foreign key is ON DELETE RESTRICT, which
+        fires on the existence of the row rather than its state. Deactivate the user
+        instead: that revokes their keys and preserves both records.
       security:
         - AdminSessionCookie: []
           CsrfToken: []
@@ -2494,6 +2499,8 @@ paths:
                 $ref: "#/components/schemas/MessageResponse"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/ServerError"
 
@@ -2623,6 +2630,92 @@ paths:
                 $ref: "#/components/schemas/MessageResponse"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /api/admin/api-keys:
+    get:
+      tags:
+        - Admin - API Keys
+      summary: List API keys
+      description: >-
+        Returns metadata only. The stored hash is never projected and the plaintext
+        key is never recoverable after creation.
+      security:
+        - AdminSessionCookie: []
+      responses:
+        "200":
+          description: API key list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiKeysResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/ServerError"
+    post:
+      tags:
+        - Admin - API Keys
+      summary: Create an API key
+      description: >-
+        Returns the plaintext key exactly once, in this response. It is not stored and
+        there is no endpoint that can reveal it again.
+      security:
+        - AdminSessionCookie: []
+          CsrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApiKeyCreateRequest"
+      responses:
+        "201":
+          description: API key created; contains the only copy of the plaintext key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiKeyCreateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /api/admin/api-keys/{id}:
+    delete:
+      tags:
+        - Admin - API Keys
+      summary: Revoke an API key
+      description: >-
+        Sets revoked_at and takes effect immediately; the row is kept so the audit
+        trail retains it. Revoking is one-way and a second revoke returns 409.
+      security:
+        - AdminSessionCookie: []
+          CsrfToken: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: API key revoked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/ServerError"
 
@@ -4398,6 +4491,83 @@ components:
           type: boolean
         inviteCode:
           $ref: "#/components/schemas/GenericRecord"
+
+    ApiKeyCreateRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        role:
+          type: string
+          enum:
+            - viewer
+            - editor
+            - admin
+          default: viewer
+          description: Defaults to the least privilege that is useful, not to the creator's role.
+        expiresAt:
+          type: string
+          format: date-time
+          description: >-
+            Must be in the future and no more than 180 days out. Omit for the 90-day
+            default.
+
+    ApiKey:
+      type: object
+      description: API key metadata. Never carries the stored hash.
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        key_prefix:
+          type: string
+          description: The first 8 characters of the key, for identifying it in a list.
+        role:
+          type: string
+          enum:
+            - viewer
+            - editor
+            - admin
+        created_by:
+          type: integer
+        created_at:
+          type: string
+        expires_at:
+          type: string
+        last_used_at:
+          type: string
+          nullable: true
+        revoked_at:
+          type: string
+          nullable: true
+
+    ApiKeysResponse:
+      type: object
+      properties:
+        apiKeys:
+          type: array
+          items:
+            $ref: "#/components/schemas/ApiKey"
+
+    ApiKeyCreateResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        apiKey:
+          allOf:
+            - $ref: "#/components/schemas/ApiKey"
+            - type: object
+              properties:
+                plaintext:
+                  type: string
+                  description: >-
+                    The only copy of the secret. Returned once here and never again.
 
     AuditLogResponse:
       type: object

--- a/functions/api/admin/api-keys.js
+++ b/functions/api/admin/api-keys.js
@@ -1,0 +1,129 @@
+// Admin API key collection endpoints
+// POST /api/admin/api-keys - Create an API key (admin only)
+// GET /api/admin/api-keys - List API keys (admin only)
+
+import { checkPermission } from "./_middleware.js";
+import { auditLogStatementForInsertedRow } from "../../utils/auditLogStatement.js";
+import { generateApiKey } from "../../utils/apiKeys.js";
+import { toSqliteDateTime } from "../../utils/authAttempts.js";
+import { FIELD_LIMITS, isValidRole, sanitizeString, validationErrorResponse } from "../../utils/validation.js";
+import { getClientIP } from "../../utils/request.js";
+
+const API_KEY_COLUMNS = "id, name, key_prefix, role, created_by, created_at, expires_at, last_used_at, revoked_at";
+
+export async function onRequestGet(context) {
+  const { env } = context;
+  const { DB } = env;
+
+  const permCheck = await checkPermission(context, "admin");
+  if (permCheck.error) {
+    return permCheck.response;
+  }
+
+  try {
+    const result = await DB.prepare(`SELECT ${API_KEY_COLUMNS} FROM api_keys ORDER BY created_at DESC, id DESC`).all();
+
+    return new Response(JSON.stringify({ apiKeys: result.results || [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+    });
+  } catch (error) {
+    console.error("Error fetching API keys:", error);
+    return new Response(JSON.stringify({ error: "Failed to fetch API keys" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const { DB } = env;
+
+  const permCheck = await checkPermission(context, "admin");
+  if (permCheck.error) {
+    return permCheck.response;
+  }
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const name = sanitizeString(body.name || "");
+    const role = body.role || "viewer";
+
+    if (!name || name.length > FIELD_LIMITS.shortText.max) {
+      return validationErrorResponse(`Name must be between 1 and ${FIELD_LIMITS.shortText.max} characters`);
+    }
+    if (!isValidRole(role)) {
+      return validationErrorResponse("Role must be admin, editor, or viewer");
+    }
+
+    let requestedExpiry;
+    if (body.expiresAt !== undefined) {
+      requestedExpiry = new Date(body.expiresAt);
+    }
+    let generated;
+    try {
+      generated = await generateApiKey(requestedExpiry);
+    } catch (error) {
+      return validationErrorResponse(error.message);
+    }
+    const user = permCheck.user;
+    const ipAddress = getClientIP(request);
+
+    // Bound rather than left to the column default, so the response can report the
+    // stored value exactly without a second read. See the response note below.
+    const createdAt = toSqliteDateTime(new Date());
+
+    const [insert] = await DB.batch([
+      DB.prepare(
+        `INSERT INTO api_keys (name, key_prefix, key_hash, role, created_by, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(name, generated.keyPrefix, generated.keyHash, role, user.userId, createdAt, generated.expiresAt),
+      // The new key's id does not exist until the INSERT above runs, so the audit row
+      // resolves it by lookup -- keeping both writes in one atomic batch.
+      auditLogStatementForInsertedRow(
+        env,
+        user.userId,
+        "api_key.created",
+        "api_key",
+        { table: "api_keys", matchColumn: "key_hash", matchValue: generated.keyHash },
+        { role },
+        ipAddress,
+      ),
+    ]);
+
+    // The row is assembled from what was just written rather than read back. A second
+    // query here would sit OUTSIDE the batch, so a transient failure on it would return
+    // 500 for a key that is already live -- and its plaintext, which exists only in this
+    // response, would be gone. Worse, a null result spreads to nothing, handing back a
+    // secret with no id to revoke it by.
+    return new Response(
+      JSON.stringify({
+        success: true,
+        apiKey: {
+          id: insert.meta.last_row_id,
+          name,
+          key_prefix: generated.keyPrefix,
+          role,
+          created_by: user.userId,
+          created_at: createdAt,
+          expires_at: generated.expiresAt,
+          last_used_at: null,
+          revoked_at: null,
+          // The only copy of the secret. Never stored, never recoverable.
+          plaintext: generated.plaintext,
+        },
+      }),
+      {
+        status: 201,
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+      },
+    );
+  } catch (error) {
+    console.error("Error creating API key:", error);
+    return new Response(JSON.stringify({ error: "Failed to create API key" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/functions/api/admin/api-keys.js
+++ b/functions/api/admin/api-keys.js
@@ -46,7 +46,15 @@ export async function onRequestPost(context) {
   }
 
   try {
-    const body = await request.json().catch(() => ({}));
+    // `.catch(() => ({}))` only covers a PARSE failure. A body of literal `null`
+    // parses fine and resolves to null, so reading a field off it throws a
+    // TypeError that surfaces as an opaque 500 instead of a 400. Arrays parse
+    // fine too. Neither is an object we can read a name from.
+    const parsed = await request.json().catch(() => ({}));
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return validationErrorResponse("Request body must be a JSON object");
+    }
+    const body = parsed;
     const name = sanitizeString(body.name || "");
     const role = body.role || "viewer";
 
@@ -86,7 +94,7 @@ export async function onRequestPost(context) {
         user.userId,
         "api_key.created",
         "api_key",
-        { table: "api_keys", matchColumn: "key_hash", matchValue: generated.keyHash },
+        { table: "api_keys", where: { key_hash: generated.keyHash } },
         { role },
         ipAddress,
       ),

--- a/functions/api/admin/api-keys/[id].js
+++ b/functions/api/admin/api-keys/[id].js
@@ -1,0 +1,57 @@
+// Admin API key item endpoint
+// DELETE /api/admin/api-keys/:id - Revoke an API key (admin only)
+
+import { checkPermission } from "../_middleware.js";
+import { auditLogStatement } from "../../../utils/auditLogStatement.js";
+import { getClientIP } from "../../../utils/request.js";
+import { validateId } from "../../../utils/validation.js";
+
+export async function onRequestDelete(context) {
+  const { request, env, params } = context;
+  const { DB } = env;
+  const permCheck = await checkPermission(context, "admin");
+  if (permCheck.error) {
+    return permCheck.response;
+  }
+
+  const { valid, value: keyId } = validateId(params.id);
+  if (!valid) {
+    return new Response(JSON.stringify({ error: "Invalid ID", code: "INVALID_ID" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const key = await DB.prepare("SELECT id, revoked_at FROM api_keys WHERE id = ?").bind(keyId).first();
+    if (!key) {
+      return new Response(JSON.stringify({ error: "Not found", message: "API key not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (key.revoked_at !== null) {
+      return new Response(JSON.stringify({ error: "Conflict", message: "API key is already revoked" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const user = permCheck.user;
+    await DB.batch([
+      DB.prepare("UPDATE api_keys SET revoked_at = datetime('now') WHERE id = ? AND revoked_at IS NULL").bind(keyId),
+      auditLogStatement(env, user.userId, "api_key.revoked", "api_key", keyId, {}, getClientIP(request)),
+    ]);
+
+    return new Response(JSON.stringify({ success: true, message: "API key revoked" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("Error revoking API key:", error);
+    return new Response(JSON.stringify({ error: "Failed to revoke API key" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/functions/api/admin/api-keys/[id].js
+++ b/functions/api/admin/api-keys/[id].js
@@ -2,7 +2,7 @@
 // DELETE /api/admin/api-keys/:id - Revoke an API key (admin only)
 
 import { checkPermission } from "../_middleware.js";
-import { auditLogStatement } from "../../../utils/auditLogStatement.js";
+import { auditLogStatementForInsertedRow } from "../../../utils/auditLogStatement.js";
 import { getClientIP } from "../../../utils/request.js";
 import { validateId } from "../../../utils/validation.js";
 
@@ -38,10 +38,33 @@ export async function onRequestDelete(context) {
     }
 
     const user = permCheck.user;
-    await DB.batch([
+    // The read above is advisory: two concurrent revokes both see revoked_at IS NULL
+    // and both reach here. The UPDATE's own predicate is what actually decides, so the
+    // audit row carries the IDENTICAL predicate and runs FIRST -- the loser's SELECT
+    // then finds nothing (the winner's UPDATE has already committed) and it writes no
+    // record. Without that, the loser updates zero rows but still logs a revocation
+    // that never happened, which is precisely the split-brain the audit trail exists
+    // to rule out.
+    const [, update] = await DB.batch([
+      auditLogStatementForInsertedRow(
+        env,
+        user.userId,
+        "api_key.revoked",
+        "api_key",
+        { table: "api_keys", where: { id: keyId, revoked_at: null } },
+        {},
+        getClientIP(request),
+      ),
       DB.prepare("UPDATE api_keys SET revoked_at = datetime('now') WHERE id = ? AND revoked_at IS NULL").bind(keyId),
-      auditLogStatement(env, user.userId, "api_key.revoked", "api_key", keyId, {}, getClientIP(request)),
     ]);
+
+    // Report what the write actually did, not what the advisory read predicted.
+    if ((update.meta?.changes ?? 0) === 0) {
+      return new Response(JSON.stringify({ error: "Conflict", message: "API key is already revoked" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
 
     return new Response(JSON.stringify({ success: true, message: "API key revoked" }), {
       status: 200,

--- a/functions/api/admin/api-keys/__tests__/api-keys.test.js
+++ b/functions/api/admin/api-keys/__tests__/api-keys.test.js
@@ -194,6 +194,16 @@ describe("Admin API keys API", () => {
     expect(queries.filter((sql) => sql.includes("api_keys"))).toEqual([]);
   });
 
+  // Least privilege, and deliberately NOT the creator's role -- every key is minted
+  // by an admin, so inheriting would make every key an admin key.
+  it("defaults an omitted role to viewer rather than the creator's admin", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const { body } = await createKey(env, headers, { name: "No role given" });
+
+    expect(body.apiKey.role).toBe("viewer");
+    expect(rawDb.prepare("SELECT role FROM api_keys WHERE id = ?").get(body.apiKey.id).role).toBe("viewer");
+  });
+
   it("rejects creating a key with an invalid role", async () => {
     const { env, headers } = createTestEnv({ role: "admin" });
     const { response } = await createKey(env, headers, { name: "Bad role", role: "superuser" });

--- a/functions/api/admin/api-keys/__tests__/api-keys.test.js
+++ b/functions/api/admin/api-keys/__tests__/api-keys.test.js
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+import { createTestEnv } from "../../../test-utils.js";
+import * as collectionHandler from "../../api-keys.js";
+import * as itemHandler from "../[id].js";
+import * as userItemHandler from "../../users/[id].js";
+import * as toggleStatusHandler from "../../users/[id]/toggle-status.js";
+import { verifyApiKey } from "../../../../utils/apiKeys.js";
+
+function jsonRequest(url, method, headers, body) {
+  return new Request(url, {
+    method,
+    headers: { "Content-Type": "application/json", ...headers },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+async function createKey(env, headers, body = { name: "Deploy key" }) {
+  const response = await collectionHandler.onRequestPost({
+    request: jsonRequest("https://example.test/api/admin/api-keys", "POST", headers, body),
+    env,
+  });
+  return { response, body: await response.json() };
+}
+
+describe("Admin API keys API", () => {
+  it.each(["viewer", "editor"])("rejects %s from every API-key route", async (role) => {
+    const { env, headers } = createTestEnv({ role });
+    const create = await collectionHandler.onRequestPost({
+      request: jsonRequest("https://example.test/api/admin/api-keys", "POST", headers, { name: "Nope" }),
+      env,
+    });
+    const list = await collectionHandler.onRequestGet({
+      request: new Request("https://example.test/api/admin/api-keys", { headers }),
+      env,
+    });
+    const revoke = await itemHandler.onRequestDelete({
+      request: new Request("https://example.test/api/admin/api-keys/1", { method: "DELETE", headers }),
+      env,
+      params: { id: "1" },
+    });
+
+    expect(create.status).toBe(403);
+    expect(list.status).toBe(403);
+    expect(revoke.status).toBe(403);
+  });
+
+  it("creates a key once, stores only its hash, and records its id and role", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const { response, body } = await createKey(env, headers, { name: " Nightly deploy\u0000 ", role: "editor" });
+
+    expect(response.status).toBe(201);
+    expect(body.apiKey).toMatchObject({ name: "Nightly deploy", role: "editor" });
+    expect(body.apiKey.plaintext).toMatch(/^st_[A-Za-z0-9_-]{43}$/);
+    expect(body.apiKey).not.toHaveProperty("key_hash");
+
+    const stored = rawDb.prepare("SELECT * FROM api_keys WHERE id = ?").get(body.apiKey.id);
+    expect(stored.key_hash).not.toBe(body.apiKey.plaintext);
+    expect(stored.key_hash).not.toContain(body.apiKey.plaintext);
+    expect(stored.expires_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+
+    const audit = rawDb
+      .prepare("SELECT * FROM audit_log WHERE action = 'api_key.created' AND resource_id = ?")
+      .get(body.apiKey.id);
+    expect(audit).toBeTruthy();
+    expect(JSON.parse(audit.details)).toEqual({ role: "editor" });
+  });
+
+  it("lists explicit safe columns and never serialises the stored hash", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const created = await createKey(env, headers);
+    const stored = rawDb.prepare("SELECT key_hash FROM api_keys WHERE id = ?").get(created.body.apiKey.id);
+
+    const response = await collectionHandler.onRequestGet({
+      request: new Request("https://example.test/api/admin/api-keys", { headers }),
+      env,
+    });
+    const serialised = JSON.stringify(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(serialised).not.toContain(stored.key_hash);
+    expect(serialised).not.toContain(created.body.apiKey.plaintext);
+    expect(serialised).toContain('"key_prefix"');
+  });
+
+  it("revokes a key immediately and rejects a second revoke", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const created = await createKey(env, headers);
+    const keyId = created.body.apiKey.id;
+
+    // Assert the key verifies BEFORE the revoke, or the post-revoke assertion below
+    // passes just as well against a verifyApiKey that never resolves anything.
+    await expect(verifyApiKey(env.DB, created.body.apiKey.plaintext)).resolves.toMatchObject({ id: keyId });
+
+    const revoke = await itemHandler.onRequestDelete({
+      request: new Request(`https://example.test/api/admin/api-keys/${keyId}`, { method: "DELETE", headers }),
+      env,
+      params: { id: String(keyId) },
+    });
+    expect(revoke.status).toBe(200);
+    expect(rawDb.prepare("SELECT revoked_at FROM api_keys WHERE id = ?").get(keyId).revoked_at).toBeTruthy();
+    await expect(verifyApiKey(env.DB, created.body.apiKey.plaintext)).resolves.toBeUndefined();
+
+    const second = await itemHandler.onRequestDelete({
+      request: new Request(`https://example.test/api/admin/api-keys/${keyId}`, { method: "DELETE", headers }),
+      env,
+      params: { id: String(keyId) },
+    });
+    expect(second.status).toBe(409);
+  });
+
+  it("rejects an invalid id without querying api_keys", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
+    const originalPrepare = env.DB.prepare;
+    const queries = [];
+    env.DB.prepare = (sql) => {
+      queries.push(sql);
+      return originalPrepare.call(env.DB, sql);
+    };
+
+    const response = await itemHandler.onRequestDelete({
+      request: new Request("https://example.test/api/admin/api-keys/not-an-id", { method: "DELETE", headers }),
+      env,
+      params: { id: "not-an-id" },
+    });
+
+    expect(response.status).toBe(400);
+    // `toContain` compares array elements by identity, so an asymmetric matcher passed
+    // to it never matches and the assertion is vacuous. Predicate over the strings.
+    expect(queries.filter((sql) => sql.includes("api_keys"))).toEqual([]);
+  });
+
+  it("rejects creating a key with an invalid role", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
+    const { response } = await createKey(env, headers, { name: "Bad role", role: "superuser" });
+    expect(response.status).toBe(400);
+  });
+
+  it("refuses to delete a user who owns keys without deleting the user", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    rawDb
+      .prepare("INSERT INTO users (email, role, name, password_hash) VALUES (?, ?, ?, 'placeholder')")
+      .run("key-owner@test.com", "editor", "Key Owner");
+    const owner = rawDb.prepare("SELECT id FROM users WHERE email = ?").get("key-owner@test.com");
+    await createKey(env, headers, { name: "Owned key" });
+    rawDb.prepare("UPDATE api_keys SET created_by = ? WHERE name = ?").run(owner.id, "Owned key");
+
+    const response = await userItemHandler.onRequestDelete({
+      request: new Request(`https://example.test/api/admin/users/${owner.id}`, { method: "DELETE", headers }),
+      env,
+      params: { id: String(owner.id) },
+    });
+
+    const payload = await response.json();
+    expect(response.status).toBe(409);
+    expect(payload.code).toBe("USER_OWNS_API_KEYS");
+    // Revoking does not clear ON DELETE RESTRICT, so the message must not tell the
+    // operator to revoke -- it points at deactivation, the path that actually works.
+    expect(payload.message).toContain("User owns 1 API key");
+    expect(payload.message).toContain("Deactivate the user instead");
+    expect(payload.message).not.toMatch(/revoke .*first/i);
+    expect(rawDb.prepare("SELECT id FROM users WHERE id = ?").get(owner.id)).toBeTruthy();
+  });
+
+  // `false` is the shape the admin UI sends; `0` is the one that regressed. Every
+  // other isActive site in users/[id].js reads truthiness, so all falsy values
+  // deactivate the user -- and each must revoke their keys with it.
+  it.each([false, 0])("revokes active keys when a user is deactivated with isActive=%s", async (isActive) => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    rawDb
+      .prepare("INSERT INTO users (email, role, name, password_hash) VALUES (?, ?, ?, 'placeholder')")
+      .run("deactivate-owner@test.com", "editor", "Deactivate Owner");
+    const owner = rawDb.prepare("SELECT id FROM users WHERE email = ?").get("deactivate-owner@test.com");
+    const created = await createKey(env, headers, { name: "Active owned key" });
+    rawDb.prepare("UPDATE api_keys SET created_by = ? WHERE id = ?").run(owner.id, created.body.apiKey.id);
+
+    const response = await userItemHandler.onRequestPatch({
+      request: jsonRequest(`https://example.test/api/admin/users/${owner.id}`, "PATCH", headers, { isActive }),
+      env,
+      params: { id: String(owner.id) },
+    });
+
+    expect(response.status).toBe(200);
+    // The user really was deactivated -- otherwise "keys revoked" would be trivially
+    // true for a request that changed nothing at all.
+    expect(rawDb.prepare("SELECT is_active FROM users WHERE id = ?").get(owner.id).is_active).toBe(0);
+    expect(
+      rawDb.prepare("SELECT revoked_at FROM api_keys WHERE id = ?").get(created.body.apiKey.id).revoked_at,
+    ).toBeTruthy();
+    await expect(verifyApiKey(env.DB, created.body.apiKey.plaintext)).resolves.toBeUndefined();
+  });
+
+  // The second deactivation path. It is a different endpoint from the PATCH above,
+  // and it silently skipped key revocation -- the exact "departed account keeps a
+  // live credential" case #744 exists to close. Both paths get the same assertion.
+  it("revokes active keys when a user is deactivated via toggle-status", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    rawDb
+      .prepare("INSERT INTO users (email, role, name, password_hash) VALUES (?, ?, ?, 'placeholder')")
+      .run("toggle-owner@test.com", "editor", "Toggle Owner");
+    const owner = rawDb.prepare("SELECT id FROM users WHERE email = ?").get("toggle-owner@test.com");
+    const created = await createKey(env, headers, { name: "Toggle owned key" });
+    rawDb.prepare("UPDATE api_keys SET created_by = ? WHERE id = ?").run(owner.id, created.body.apiKey.id);
+
+    const response = await toggleStatusHandler.onRequestPost({
+      request: new Request(`https://example.test/api/admin/users/${owner.id}/toggle-status`, {
+        method: "POST",
+        headers,
+      }),
+      env,
+      params: { id: String(owner.id) },
+    });
+
+    expect(response.status).toBe(200);
+    expect(rawDb.prepare("SELECT is_active FROM users WHERE id = ?").get(owner.id).is_active).toBe(0);
+    expect(
+      rawDb.prepare("SELECT revoked_at FROM api_keys WHERE id = ?").get(created.body.apiKey.id).revoked_at,
+    ).toBeTruthy();
+    // The pre-existing session teardown must survive the move into the batch.
+    expect(rawDb.prepare("SELECT COUNT(*) as c FROM lucia_sessions WHERE user_id = ?").get(owner.id).c).toBe(0);
+  });
+
+  // The backstop for a THIRD deactivation path nobody has written yet: a key whose
+  // owner is inactive must not verify even if its own revoked_at was never set.
+  it("refuses to verify a key whose owner is inactive, even when the key is unrevoked", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    rawDb
+      .prepare("INSERT INTO users (email, role, name, password_hash) VALUES (?, ?, ?, 'placeholder')")
+      .run("ghost-owner@test.com", "editor", "Ghost Owner");
+    const owner = rawDb.prepare("SELECT id FROM users WHERE email = ?").get("ghost-owner@test.com");
+    const created = await createKey(env, headers, { name: "Orphaned key" });
+    rawDb.prepare("UPDATE api_keys SET created_by = ? WHERE id = ?").run(owner.id, created.body.apiKey.id);
+
+    await expect(verifyApiKey(env.DB, created.body.apiKey.plaintext)).resolves.toMatchObject({
+      id: created.body.apiKey.id,
+    });
+
+    // Deactivate the row directly, bypassing every endpoint -- that is the point.
+    rawDb.prepare("UPDATE users SET is_active = 0 WHERE id = ?").run(owner.id);
+
+    expect(rawDb.prepare("SELECT revoked_at FROM api_keys WHERE id = ?").get(created.body.apiKey.id).revoked_at).toBe(
+      null,
+    );
+    await expect(verifyApiKey(env.DB, created.body.apiKey.plaintext)).resolves.toBeUndefined();
+  });
+
+  // api_keys.role is frozen at creation. Without this, demoting an admin leaves a
+  // bearer credential still carrying "admin" -- which, once the Bearer path lands,
+  // they could use to re-promote themselves. Demotion has to be demotion.
+  it.each([
+    ["admin", "viewer"],
+    ["viewer", "editor"],
+  ])("revokes active keys when a user's role changes from %s to %s", async (from, to) => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    rawDb
+      .prepare("INSERT INTO users (email, role, name, password_hash) VALUES (?, ?, ?, 'placeholder')")
+      .run("role-change@test.com", from, "Role Change");
+    const owner = rawDb.prepare("SELECT id FROM users WHERE email = ?").get("role-change@test.com");
+    const created = await createKey(env, headers, { name: "Role-bound key", role: from });
+    rawDb.prepare("UPDATE api_keys SET created_by = ? WHERE id = ?").run(owner.id, created.body.apiKey.id);
+
+    const response = await userItemHandler.onRequestPatch({
+      request: jsonRequest(`https://example.test/api/admin/users/${owner.id}`, "PATCH", headers, { role: to }),
+      env,
+      params: { id: String(owner.id) },
+    });
+
+    expect(response.status).toBe(200);
+    expect(rawDb.prepare("SELECT role FROM users WHERE id = ?").get(owner.id).role).toBe(to);
+    expect(
+      rawDb.prepare("SELECT revoked_at FROM api_keys WHERE id = ?").get(created.body.apiKey.id).revoked_at,
+    ).toBeTruthy();
+  });
+
+  it("leaves keys alone when a PATCH re-sends the role the user already has", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    rawDb
+      .prepare("INSERT INTO users (email, role, name, password_hash) VALUES (?, ?, ?, 'placeholder')")
+      .run("same-role@test.com", "editor", "Same Role");
+    const owner = rawDb.prepare("SELECT id FROM users WHERE email = ?").get("same-role@test.com");
+    const created = await createKey(env, headers, { name: "Kept key" });
+    rawDb.prepare("UPDATE api_keys SET created_by = ? WHERE id = ?").run(owner.id, created.body.apiKey.id);
+
+    const response = await userItemHandler.onRequestPatch({
+      request: jsonRequest(`https://example.test/api/admin/users/${owner.id}`, "PATCH", headers, { role: "editor" }),
+      env,
+      params: { id: String(owner.id) },
+    });
+
+    expect(response.status).toBe(200);
+    expect(rawDb.prepare("SELECT revoked_at FROM api_keys WHERE id = ?").get(created.body.apiKey.id).revoked_at).toBe(
+      null,
+    );
+  });
+
+  it("leaves keys alone when a user is reactivated", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    rawDb
+      .prepare("INSERT INTO users (email, role, name, password_hash, is_active) VALUES (?, ?, ?, 'placeholder', 0)")
+      .run("reactivate-owner@test.com", "editor", "Reactivate Owner");
+    const owner = rawDb.prepare("SELECT id FROM users WHERE email = ?").get("reactivate-owner@test.com");
+    const created = await createKey(env, headers, { name: "Untouched key" });
+    rawDb.prepare("UPDATE api_keys SET created_by = ? WHERE id = ?").run(owner.id, created.body.apiKey.id);
+
+    const response = await userItemHandler.onRequestPatch({
+      request: jsonRequest(`https://example.test/api/admin/users/${owner.id}`, "PATCH", headers, { isActive: true }),
+      env,
+      params: { id: String(owner.id) },
+    });
+
+    expect(response.status).toBe(200);
+    expect(rawDb.prepare("SELECT revoked_at FROM api_keys WHERE id = ?").get(created.body.apiKey.id).revoked_at).toBe(
+      null,
+    );
+  });
+});

--- a/functions/api/admin/api-keys/__tests__/api-keys.test.js
+++ b/functions/api/admin/api-keys/__tests__/api-keys.test.js
@@ -108,6 +108,71 @@ describe("Admin API keys API", () => {
     expect(second.status).toBe(409);
   });
 
+  // The precondition read is advisory: two concurrent revokes both see revoked_at
+  // IS NULL and both reach the batch. Simulated deterministically by revoking the row
+  // between that read and the batch -- exactly what the losing request observes.
+  it("returns 409 and writes no audit row when it loses a concurrent revoke", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const created = await createKey(env, headers);
+    const keyId = created.body.apiKey.id;
+
+    const originalBatch = env.DB.batch.bind(env.DB);
+    env.DB.batch = (statements) => {
+      // The other request won while this one was between its read and its write.
+      rawDb.prepare("UPDATE api_keys SET revoked_at = datetime('now') WHERE id = ?").run(keyId);
+      return originalBatch(statements);
+    };
+
+    const response = await itemHandler.onRequestDelete({
+      request: new Request(`https://example.test/api/admin/api-keys/${keyId}`, { method: "DELETE", headers }),
+      env,
+      params: { id: String(keyId) },
+    });
+
+    expect(response.status).toBe(409);
+    // The loser must not claim a revocation it did not perform.
+    expect(rawDb.prepare("SELECT COUNT(*) as c FROM audit_log WHERE action = 'api_key.revoked'").get().c).toBe(0);
+  });
+
+  it("writes exactly one audit row for a revoke that wins", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const created = await createKey(env, headers);
+    const keyId = created.body.apiKey.id;
+
+    const response = await itemHandler.onRequestDelete({
+      request: new Request(`https://example.test/api/admin/api-keys/${keyId}`, { method: "DELETE", headers }),
+      env,
+      params: { id: String(keyId) },
+    });
+
+    expect(response.status).toBe(200);
+    const audit = rawDb
+      .prepare("SELECT resource_id FROM audit_log WHERE action = 'api_key.revoked' AND resource_type = 'api_key'")
+      .all();
+    expect(audit).toHaveLength(1);
+    expect(audit[0].resource_id).toBe(keyId);
+  });
+
+  // `.catch(() => ({}))` only catches a PARSE error. `null` and arrays parse fine.
+  it.each([
+    ["null", "null"],
+    ["an array", '["name"]'],
+    ["a bare string", '"hello"'],
+  ])("returns 400 rather than 500 for a body that is %s", async (_label, raw) => {
+    const { env, headers } = createTestEnv({ role: "admin" });
+
+    const response = await collectionHandler.onRequestPost({
+      request: new Request("https://example.test/api/admin/api-keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...headers },
+        body: raw,
+      }),
+      env,
+    });
+
+    expect(response.status).toBe(400);
+  });
+
   it("rejects an invalid id without querying api_keys", async () => {
     const { env, headers } = createTestEnv({ role: "admin" });
     const originalPrepare = env.DB.prepare;

--- a/functions/api/admin/users/[id].js
+++ b/functions/api/admin/users/[id].js
@@ -2,7 +2,7 @@
 // PATCH /api/admin/users/:id - Update user
 // DELETE /api/admin/users/:id - Delete user (soft delete)
 
-import { checkPermission, auditLog } from "../_middleware.js";
+import { checkPermission } from "../_middleware.js";
 import { auditLogStatement } from "../../../utils/auditLogStatement.js";
 import { getClientIP } from "../../../utils/request.js";
 import { validateId } from "../../../utils/validation.js";
@@ -224,29 +224,58 @@ export async function onRequestPatch(context) {
     // Add user ID to values
     values.push(userId);
 
-    // Execute update
-    await DB.prepare(
-      `
-      UPDATE users
-      SET ${updates.join(", ")}
-      WHERE id = ?
-    `,
-    )
-      .bind(...values)
-      .run();
+    const mutationStatements = [
+      DB.prepare(
+        `
+        UPDATE users
+        SET ${updates.join(", ")}
+        WHERE id = ?
+      `,
+      ).bind(...values),
+    ];
 
-    // Audit log
-    await auditLog(
-      env,
-      currentUser.userId,
-      "user.updated",
-      "user",
-      userId,
-      {
-        changes: { role, name, firstName, lastName, isActive },
-      },
-      ipAddress,
+    // Truthiness, not `=== false`, to match the three sites above (the last-admin
+    // guard, the is_active write, and the deactivated_at stamp). A body of
+    // `{"isActive": 0}` deactivates the user at every one of them, so it must
+    // revoke their keys here too or the departed account keeps a live credential.
+    const deactivating = isActive !== undefined && !isActive;
+    // api_keys.role is frozen at creation and never reconciled against its creator's
+    // current role, so a demotion would otherwise leave a bearer credential still
+    // carrying the role the user just lost -- letting them re-promote themselves with
+    // it once the Bearer path exists. Any role change revokes, not just a demotion:
+    // deciding which direction is "safe" needs the rank hierarchy, and over-revoking
+    // is the fail-safe error. Reissuing a key is cheap; an un-demotable admin is not.
+    const roleChanged = role !== undefined && role !== user.role;
+    if (deactivating || roleChanged) {
+      mutationStatements.push(
+        DB.prepare("UPDATE api_keys SET revoked_at = datetime('now') WHERE created_by = ? AND revoked_at IS NULL").bind(
+          userId,
+        ),
+      );
+    }
+    if (deactivating) {
+      // Matches users/[id]/toggle-status.js, the other endpoint that deactivates.
+      // enforceSession already rejects an inactive user, so this is tidiness rather
+      // than a live hole -- but two deactivation paths doing different amounts of
+      // work is precisely the shape of the bug this change exists to fix.
+      mutationStatements.push(DB.prepare("DELETE FROM lucia_sessions WHERE user_id = ?").bind(userId));
+    }
+
+    mutationStatements.push(
+      auditLogStatement(
+        env,
+        currentUser.userId,
+        "user.updated",
+        "user",
+        userId,
+        {
+          changes: { role, name, firstName, lastName, isActive },
+        },
+        ipAddress,
+      ),
     );
+
+    await DB.batch(mutationStatements);
 
     // Fetch updated user
     const updatedUser = await DB.prepare(
@@ -361,6 +390,29 @@ export async function onRequestDelete(context) {
           },
         );
       }
+    }
+
+    // api_keys.created_by is ON DELETE RESTRICT, and RESTRICT fires on the EXISTENCE
+    // of a referencing row, not its state -- so revoking a key does NOT unblock this,
+    // and there is deliberately no endpoint that deletes the row (that would destroy
+    // the attribution RESTRICT exists to protect). Deactivation is the supported path:
+    // it revokes every active key and leaves both records intact.
+    const apiKeyCount = await DB.prepare("SELECT COUNT(*) as count FROM api_keys WHERE created_by = ?")
+      .bind(userId)
+      .first();
+    if (apiKeyCount.count > 0) {
+      const plural = apiKeyCount.count === 1 ? "" : "s";
+      return new Response(
+        JSON.stringify({
+          error: "Cannot delete user",
+          code: "USER_OWNS_API_KEYS",
+          message: `User owns ${apiKeyCount.count} API key${plural}, which must keep their creator for attribution. Deactivate the user instead -- that revokes their key${plural} and preserves both records.`,
+        }),
+        {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     // Hard delete with cleanup of references

--- a/functions/api/admin/users/[id]/toggle-status.js
+++ b/functions/api/admin/users/[id]/toggle-status.js
@@ -2,7 +2,8 @@
 // POST /api/admin/users/[id]/toggle-status
 // Returns: { success: true } or error
 
-import { checkPermission, auditLog } from "../../_middleware.js";
+import { checkPermission } from "../../_middleware.js";
+import { auditLogStatement } from "../../../../utils/auditLogStatement.js";
 import { getClientIP } from "../../../../utils/request.js";
 import { validateId } from "../../../../utils/validation.js";
 
@@ -57,42 +58,52 @@ export async function onRequestPost(context) {
 
     // Toggle user status
     const newStatus = targetUser.is_active === 1 ? 0 : 1;
-    await DB.prepare(
-      `
+    const statements = [
+      DB.prepare(
+        `
       UPDATE users
       SET is_active = ?, updated_at = datetime('now')
       WHERE id = ?
     `,
-    )
-      .bind(newStatus, userId)
-      .run();
+      ).bind(newStatus, userId),
+    ];
 
-    // If deactivating, invalidate all sessions for this user
     if (newStatus === 0) {
-      await DB.prepare(
-        `
-        DELETE FROM lucia_sessions
-        WHERE user_id = ?
-      `,
-      )
-        .bind(userId)
-        .run();
+      // Deactivation must cut every credential the account holds, not just its
+      // sessions. verifyApiKey's INNER JOIN on users.is_active = 1 is a backstop for
+      // a path that forgets this, not a replacement for it: the join follows the
+      // account, so it would hand the key back the moment the account is reactivated,
+      // while an explicit revocation is permanent. This mirrors the same revocation in
+      // the PATCH path of users/[id].js -- both endpoints deactivate, so both must do
+      // it. Reactivation deliberately does NOT restore keys; revocation is one-way,
+      // exactly as it is at the revoke endpoint.
+      statements.push(
+        DB.prepare("DELETE FROM lucia_sessions WHERE user_id = ?").bind(userId),
+        DB.prepare("UPDATE api_keys SET revoked_at = datetime('now') WHERE created_by = ? AND revoked_at IS NULL").bind(
+          userId,
+        ),
+      );
     }
 
-    // Audit log the action
-    await auditLog(
-      env,
-      user.userId,
-      newStatus === 1 ? "user.activated" : "user.deactivated",
-      "user",
-      userId,
-      {
-        adminEmail: user.email,
-        targetEmail: targetUser.email,
-        newStatus: newStatus === 1 ? "active" : "inactive",
-      },
-      ipAddress,
+    statements.push(
+      auditLogStatement(
+        env,
+        user.userId,
+        newStatus === 1 ? "user.activated" : "user.deactivated",
+        "user",
+        userId,
+        {
+          adminEmail: user.email,
+          targetEmail: targetUser.email,
+          newStatus: newStatus === 1 ? "active" : "inactive",
+        },
+        ipAddress,
+      ),
     );
+
+    // One batch: D1 has no BEGIN/COMMIT, so this is the only way the status change,
+    // the credential teardown and the audit row cannot disagree with each other.
+    await DB.batch(statements);
 
     return new Response(
       JSON.stringify({

--- a/functions/utils/__tests__/apiKeys.test.js
+++ b/functions/utils/__tests__/apiKeys.test.js
@@ -85,7 +85,19 @@ describe("apiKeys", () => {
     await expect(generateApiKey("2027-01-01")).rejects.toThrow(/valid Date/i);
     // Sub-second expiry: passes the "in the future" check, then truncates to
     // the current second on the way to storage -- a key born already dead.
-    await expect(generateApiKey(new Date(Date.now() + 200))).rejects.toThrow(/once stored/i);
+    //
+    // The clock is pinned to a whole second because otherwise this test IS the
+    // truncation it describes: run in the last 200ms of a second, now+200ms
+    // crosses into the NEXT second, truncation lands in the future, and the key
+    // is legitimately valid. Measured before pinning: it failed on 200 of 1000
+    // millisecond offsets, so roughly one run in five.
+    const wholeSecond = new Date("2026-08-26T12:00:00.000Z").getTime();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(wholeSecond);
+    try {
+      await expect(generateApiKey(new Date(wholeSecond + 200))).rejects.toThrow(/once stored/i);
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it("rejects anything that is not a plausible key, without throwing", async () => {

--- a/functions/utils/__tests__/auditAtomicity.test.js
+++ b/functions/utils/__tests__/auditAtomicity.test.js
@@ -318,7 +318,7 @@ describe("auditLogStatementForInsertedRow", () => {
       7,
       "api_key.created",
       "api_key",
-      { table: "api_keys", matchColumn: "key_hash", matchValue: "HASH" },
+      { table: "api_keys", where: { key_hash: "HASH" } },
       { role: "viewer" },
       "1.2.3.4",
     );
@@ -340,16 +340,41 @@ describe("auditLogStatementForInsertedRow", () => {
 
   // Table and column names cannot be bound, so they are interpolated. A caller that
   // ever passes a variable there must fail loudly rather than build the injection.
+  it("renders a null value as IS NULL and leaves it unbound", () => {
+    const bind = vi.fn(() => ({ run: vi.fn() }));
+    const env = { DB: { prepare: vi.fn(() => ({ bind })) } };
+
+    auditLogStatementForInsertedRow(
+      env,
+      7,
+      "api_key.revoked",
+      "api_key",
+      { table: "api_keys", where: { id: 42, revoked_at: null } },
+      {},
+      "1.2.3.4",
+    );
+
+    // The IS NULL half must NOT consume a placeholder -- binding null instead would
+    // render `revoked_at = NULL`, which is never true in SQL and would silently
+    // suppress every audit row this path is supposed to write.
+    expect(env.DB.prepare.mock.calls[0][0]).toContain("WHERE id = ? AND revoked_at IS NULL");
+    expect(bind).toHaveBeenCalledWith(7, "api_key.revoked", "api_key", JSON.stringify({}), "1.2.3.4", 42);
+  });
+
+  // Table and column names cannot be bound, so they are interpolated. A caller that
+  // ever passes a variable there must fail loudly rather than build the injection.
   it.each([
-    ["api_keys; DROP TABLE users --", "key_hash"],
-    ["api_keys", "key_hash = '' OR 1=1 --"],
-    ["", "key_hash"],
-    [undefined, "key_hash"],
-  ])("refuses a non-identifier table=%s column=%s", (table, matchColumn) => {
+    ["api_keys; DROP TABLE users --", { key_hash: "x" }],
+    ["api_keys", { "key_hash = '' OR 1=1 --": "x" }],
+    ["", { key_hash: "x" }],
+    [undefined, { key_hash: "x" }],
+    ["api_keys", {}],
+    ["api_keys", undefined],
+  ])("refuses a non-identifier table=%s where=%s", (table, where) => {
     const env = { DB: { prepare: vi.fn() } };
-    expect(() =>
-      auditLogStatementForInsertedRow(env, 7, "a", "t", { table, matchColumn, matchValue: "x" }, null, "ip"),
-    ).toThrow(/bare SQL identifiers/);
+    expect(() => auditLogStatementForInsertedRow(env, 7, "a", "t", { table, where }, null, "ip")).toThrow(
+      /bare SQL identifiers/,
+    );
     expect(env.DB.prepare).not.toHaveBeenCalled();
   });
 });

--- a/functions/utils/__tests__/auditAtomicity.test.js
+++ b/functions/utils/__tests__/auditAtomicity.test.js
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { auditLogStatement } from "../auditLogStatement.js";
+import { auditLogStatement, auditLogStatementForInsertedRow } from "../auditLogStatement.js";
 import { onRequestPatch } from "../../api/admin/bands/bulk.js";
 import { createTestEnv, insertBand, insertEvent, insertVenue } from "../../api/test-utils.js";
 
@@ -305,5 +305,51 @@ describe("bulk PATCH audit atomicity", () => {
 
     expect(response.status).toBe(200);
     expect((await response.json()).updated).toBe(1);
+  });
+});
+
+describe("auditLogStatementForInsertedRow", () => {
+  it("resolves resource_id by lookup and binds every other value", () => {
+    const bind = vi.fn(() => ({ run: vi.fn() }));
+    const env = { DB: { prepare: vi.fn(() => ({ bind })) } };
+
+    auditLogStatementForInsertedRow(
+      env,
+      7,
+      "api_key.created",
+      "api_key",
+      { table: "api_keys", matchColumn: "key_hash", matchValue: "HASH" },
+      { role: "viewer" },
+      "1.2.3.4",
+    );
+
+    const sql = env.DB.prepare.mock.calls[0][0];
+    expect(sql).toContain("FROM api_keys WHERE key_hash = ?");
+    expect(sql).toContain("SELECT ?, ?, ?, id, ?, ?");
+    // The match value is bound LAST: SQLite numbers anonymous placeholders in
+    // textual order, and the lookup's `?` sits after the five in the SELECT list.
+    expect(bind).toHaveBeenCalledWith(
+      7,
+      "api_key.created",
+      "api_key",
+      JSON.stringify({ role: "viewer" }),
+      "1.2.3.4",
+      "HASH",
+    );
+  });
+
+  // Table and column names cannot be bound, so they are interpolated. A caller that
+  // ever passes a variable there must fail loudly rather than build the injection.
+  it.each([
+    ["api_keys; DROP TABLE users --", "key_hash"],
+    ["api_keys", "key_hash = '' OR 1=1 --"],
+    ["", "key_hash"],
+    [undefined, "key_hash"],
+  ])("refuses a non-identifier table=%s column=%s", (table, matchColumn) => {
+    const env = { DB: { prepare: vi.fn() } };
+    expect(() =>
+      auditLogStatementForInsertedRow(env, 7, "a", "t", { table, matchColumn, matchValue: "x" }, null, "ip"),
+    ).toThrow(/bare SQL identifiers/);
+    expect(env.DB.prepare).not.toHaveBeenCalled();
   });
 });

--- a/functions/utils/apiKeys.js
+++ b/functions/utils/apiKeys.js
@@ -96,9 +96,21 @@ export async function verifyApiKey(DB, presentedKey) {
   // The hash equality check lives in the WHERE clause -- an exact comparison
   // performed by SQLite -- so re-comparing the column in JS would prove nothing
   // that the lookup has not already established.
+  //
+  // The INNER JOIN on users is a backstop, not the primary control: every
+  // deactivation path already revokes the account's keys explicitly, so this only
+  // matters if a future path forgets to. It is here because forgetting is exactly
+  // what happened -- users/[id]/toggle-status.js deactivated accounts and killed
+  // their sessions for months while leaving their keys live, because it is a
+  // separate endpoint from the PATCH one. A key is only ever as revoked as the
+  // least careful path that can deactivate its owner; this makes that irrelevant.
+  // Note nothing is projected from users: only api_keys columns cross the boundary.
   const row = await DB.prepare(
-    `SELECT id, name, key_prefix, role, created_by, created_at, expires_at, last_used_at, revoked_at
-     FROM api_keys WHERE key_hash = ?`,
+    `SELECT k.id, k.name, k.key_prefix, k.role, k.created_by, k.created_at,
+            k.expires_at, k.last_used_at, k.revoked_at
+     FROM api_keys k
+     JOIN users u ON u.id = k.created_by
+     WHERE k.key_hash = ? AND u.is_active = 1`,
   )
     .bind(presentedHash)
     .first();

--- a/functions/utils/auditLogStatement.js
+++ b/functions/utils/auditLogStatement.js
@@ -31,35 +31,46 @@ const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const isIdentifier = (value) => typeof value === "string" && IDENTIFIER.test(value);
 
 /**
- * Audit a row whose id does not exist until the INSERT ahead of it in the same batch
- * has run, by resolving `resource_id` with a lookup instead of a literal.
+ * Audit a row by looking its id up in `table` rather than passing a literal, so the
+ * record can be written in the SAME batch as the change it describes. Two cases need
+ * this, and they are the same shape:
  *
- * Deliberately takes an identifier and a bound value rather than a SQL string: a
+ * - **Creation**, where the id does not exist until the INSERT ahead of it has run:
+ *   `{ table: "api_keys", where: { key_hash: hash } }`
+ * - **A conditional change**, where the audit row must appear only if the change
+ *   actually applied. Give the audit row the SAME predicate as the UPDATE and put it
+ *   FIRST in the batch, so a request that loses a race writes neither:
+ *   `{ table: "api_keys", where: { id, revoked_at: null } }`
+ *
+ * Deliberately takes identifiers and bound values rather than a SQL string: a
  * `sql`-shaped parameter on a shared helper is the signature a future caller reaches
- * for with a table name off a request body.
+ * for with a table name off a request body. A `null` value renders as `IS NULL`.
  *
- * `matchColumn` must be UNIQUE, or the lookup can resolve to a different row. Note
- * that `INSERT ... SELECT` over zero rows inserts nothing and does NOT error, so a
- * value that matches no row silently produces no audit record -- pass the value the
- * preceding INSERT just wrote, never one that might be absent.
+ * `where` must select at most one row, or the lookup can resolve to a different one.
+ * Note that `INSERT ... SELECT` over zero rows inserts nothing and does NOT error --
+ * that silence is the point in the conditional case and a hazard in the creation
+ * case, where you must pass a value the preceding INSERT just wrote.
  */
 export function auditLogStatementForInsertedRow(
   env,
   userId,
   action,
   resourceType,
-  { table, matchColumn, matchValue },
+  { table, where },
   details,
   ipAddress,
 ) {
-  if (!isIdentifier(table) || !isIdentifier(matchColumn)) {
-    throw new Error("auditLogStatementForInsertedRow: table and matchColumn must be bare SQL identifiers");
+  const columns = Object.keys(where || {});
+  if (!isIdentifier(table) || columns.length === 0 || !columns.every(isIdentifier)) {
+    throw new Error("auditLogStatementForInsertedRow: table and where keys must be bare SQL identifiers");
   }
+  const predicate = columns.map((c) => (where[c] === null ? `${c} IS NULL` : `${c} = ?`)).join(" AND ");
+  const values = columns.filter((c) => where[c] !== null).map((c) => where[c]);
   const [type, , detailsJson, ip] = normalize(resourceType, null, details, ipAddress);
   return env.DB.prepare(
     `
     INSERT INTO audit_log (${AUDIT_LOG_COLUMNS})
-    SELECT ?, ?, ?, id, ?, ? FROM ${table} WHERE ${matchColumn} = ?
+    SELECT ?, ?, ?, id, ?, ? FROM ${table} WHERE ${predicate}
   `,
-  ).bind(userId, action, type, detailsJson, ip, matchValue);
+  ).bind(userId, action, type, detailsJson, ip, ...values);
 }

--- a/functions/utils/auditLogStatement.js
+++ b/functions/utils/auditLogStatement.js
@@ -1,15 +1,65 @@
+// Audit-log statement builders.
+//
+// Both return a prepared statement rather than executing it, so callers can put the
+// audit row in the SAME `DB.batch()` as the change it records. That atomicity is the
+// point: a split write leaves either a change with no record or a record with no
+// change, which this repo fixed across seven sites.
+
+const AUDIT_LOG_COLUMNS = "user_id, action, resource_type, resource_id, details, ip_address";
+
+function normalize(resourceType, resourceId, details, ipAddress) {
+  return [resourceType || null, resourceId || null, details ? JSON.stringify(details) : null, ipAddress || "unknown"];
+}
+
 export function auditLogStatement(env, userId, action, resourceType, resourceId, details, ipAddress) {
+  const [type, id, detailsJson, ip] = normalize(resourceType, resourceId, details, ipAddress);
   return env.DB.prepare(
     `
-    INSERT INTO audit_log (user_id, action, resource_type, resource_id, details, ip_address)
+    INSERT INTO audit_log (${AUDIT_LOG_COLUMNS})
     VALUES (?, ?, ?, ?, ?, ?)
   `,
-  ).bind(
-    userId,
-    action,
-    resourceType || null,
-    resourceId || null,
-    details ? JSON.stringify(details) : null,
-    ipAddress || "unknown",
-  );
+  ).bind(userId, action, type, id, detailsJson, ip);
+}
+
+// Bare SQL identifier. Table and column names cannot be bound as parameters, so they
+// are interpolated -- and therefore must be proven to be identifiers first. Callers
+// pass literals today; this is what keeps that true if one ever passes a variable.
+// Note the typeof: RegExp.prototype.test coerces its argument with String(), so a
+// bare `IDENTIFIER.test(undefined)` tests the string "undefined" -- and passes,
+// building `FROM undefined WHERE ...`. Same for null. The type check is the guard.
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const isIdentifier = (value) => typeof value === "string" && IDENTIFIER.test(value);
+
+/**
+ * Audit a row whose id does not exist until the INSERT ahead of it in the same batch
+ * has run, by resolving `resource_id` with a lookup instead of a literal.
+ *
+ * Deliberately takes an identifier and a bound value rather than a SQL string: a
+ * `sql`-shaped parameter on a shared helper is the signature a future caller reaches
+ * for with a table name off a request body.
+ *
+ * `matchColumn` must be UNIQUE, or the lookup can resolve to a different row. Note
+ * that `INSERT ... SELECT` over zero rows inserts nothing and does NOT error, so a
+ * value that matches no row silently produces no audit record -- pass the value the
+ * preceding INSERT just wrote, never one that might be absent.
+ */
+export function auditLogStatementForInsertedRow(
+  env,
+  userId,
+  action,
+  resourceType,
+  { table, matchColumn, matchValue },
+  details,
+  ipAddress,
+) {
+  if (!isIdentifier(table) || !isIdentifier(matchColumn)) {
+    throw new Error("auditLogStatementForInsertedRow: table and matchColumn must be bare SQL identifiers");
+  }
+  const [type, , detailsJson, ip] = normalize(resourceType, null, details, ipAddress);
+  return env.DB.prepare(
+    `
+    INSERT INTO audit_log (${AUDIT_LOG_COLUMNS})
+    SELECT ?, ?, ?, id, ?, ? FROM ${table} WHERE ${matchColumn} = ?
+  `,
+  ).bind(userId, action, type, detailsJson, ip, matchValue);
 }


### PR DESCRIPTION
## Summary

Part 2 of #744: three admin-only endpoints on top of the storage layer merged in #973, plus the user-lifecycle integration that stops a key outliving its creator.

| Endpoint | Behaviour |
|---|---|
| `POST /api/admin/api-keys` | Returns the plaintext **exactly once**. Never stored, no reveal endpoint. Role defaults to `viewer` — least privilege, not the creator's role. |
| `GET /api/admin/api-keys` | Explicit column projection; `key_hash` is not among them. |
| `DELETE /api/admin/api-keys/:id` | Sets `revoked_at`, keeps the row for the audit trail. A second revoke is `409`, not a silent success. |

Both responses carry `Cache-Control: no-store`. Every route calls `checkPermission(context, "admin")` before touching the DB; every mutation's audit row is in the same `DB.batch` as the write.

The create response is assembled from what was just written rather than read back. A second query would sit *outside* the batch, so a transient failure on it would return 500 for a key that is already live — and lose the only copy of its secret.

## A key's life is tied to its creator's standing

`api_keys.role` is frozen at creation and never reconciled against its creator's current role, so anything that changes that standing revokes their keys:

- **Deactivation, via both endpoints that can deactivate.** `users/[id]/toggle-status.js` is a separate handler, not a wrapper over the PATCH path. It deleted sessions on deactivation while leaving keys live — the exact "departed editor's key outliving their account" case this issue names. Found by sweeping `is_active =` rather than trusting that one path existed.
- **A role change.** Without it, a demoted admin keeps an admin-scoped bearer credential and can re-promote themselves with it once the Bearer path lands in part 3. Any role change revokes, not just a demotion: deciding which direction is safe needs the rank hierarchy, and over-revoking is the fail-safe error.

`verifyApiKey` additionally INNER JOINs `users` and requires `is_active = 1`. That is a **backstop** for a fourth path nobody has written yet, not a replacement for the explicit revocations — the join follows the account and would hand the key back on reactivation, while a revocation is permanent.

**Deleting a user who owns keys is refused with `409 USER_OWNS_API_KEYS`, and revoking does not unblock it.** `created_by` is `ON DELETE RESTRICT`, which fires on the *existence* of a referencing row, not its state. No endpoint deletes an `api_keys` row — that would destroy the attribution RESTRICT exists to protect — so the message points at deactivation, which actually works.

## Review findings fixed in the same pass

| Finding | Why it mattered |
|---|---|
| Revocation gated on `isActive === false` | Every other `isActive` site in `users/[id].js` reads truthiness, so `{"isActive": 0}` deactivated the user everywhere and revoked nothing. |
| `expect(queries).not.toContain(expect.stringContaining(...))` | `toContain` compares array elements by identity, so an asymmetric matcher never matches. Proven vacuous by mutation: the assertion passed with the guard deleted and the query running. |
| `auditLogStatementForInsertedRow` took a raw SQL string | Now takes a table/column **identifier**, validated with an explicit `typeof` check — `RegExp.prototype.test` coerces its argument, so `/^[A-Za-z_]\w*$/.test(undefined)` tests `"undefined"` and passes. My own test caught that. |
| Two copies of the `audit_log` column list | Both builders now share one constant. |
| Stale comment claiming `verifyApiKey` has no owner check | Invalidated by the JOIN added in this same change. Caught by CodeRabbit. |

## Test plan

- [x] `make gate` exits 0 — **1388 backend**, **1239 frontend**, 0 lint errors
- [x] `npm run validate:openapi` — no route drift; both new paths and the new 409 documented
- [x] `make review-wip` (CodeRabbit) — 11 files, no remaining findings
- [x] `cloudflare-security-reviewer` — no HIGH; its MEDIUM (role demotion) and three LOWs are all fixed above
- [x] **Every new assertion proven by mutation** — each guard broken, confirmed RED, restored, confirmed GREEN
- [x] Sibling sweep for both bug classes (`toContain` + asymmetric matcher; strict-vs-truthy `isActive`) across `functions/`, `frontend/src`, `scripts` — no other instances

Covered: non-admin refused on all three routes · plaintext returned once and the stored hash is not it · list never serialises the hash (asserted on the serialised body) · revoke is immediate and `verifyApiKey` stops resolving (asserted verifying *before* the revoke too, so the after-check cannot be vacuous) · invalid `:id` rejected before any query · user delete 409s and leaves the user intact · deactivation revokes via both endpoints and for both `false` and `0` · role change revokes, same-role re-save does not · reactivation does not restore keys · a key whose owner is inactive does not verify even when unrevoked.

## Out of scope

Part 3 — the Bearer request path, dual-auth rejection, per-key rate limiting, and audit-by-key-id — remains open. **Do not add a cache in front of `verifyApiKey`:** revocation is required to be effective immediately.

Closes #744 (part 2 of 3).

Built by Otto · Reviewed by Theo · Security review by Cass · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin API-key management, including creation, metadata listing, one-time secret delivery, and immediate revocation.
  * API keys are automatically revoked when an owner is deactivated or changes role.
  * Inactive account owners can no longer authenticate with API keys.

* **Bug Fixes**
  * User deletion now clearly reports conflicts when API keys remain; deactivation is recommended instead.

* **Documentation**
  * Expanded API documentation with API-key lifecycle details, responses, schemas, and security requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->