### PR TITLE
feat(admin): authenticate API keys on the request path (#744 part 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,7 +542,52 @@ Three traps here, each of which was live:
 
 **Deleting a user who owns keys is refused with 409 `USER_OWNS_API_KEYS`, and revoking does not unblock it.** `created_by` is `ON DELETE RESTRICT`, which fires on the **existence** of a referencing row, not its state — so a revoked key blocks deletion exactly as an active one does. There is deliberately no endpoint that deletes an `api_keys` row: that would destroy the attribution RESTRICT exists to protect. Deactivation is the supported answer, and the 409's message says so. Detect it by `code`, never by matching the message.
 
-Audit rows go in the **same `DB.batch`** as the change. Creation is the awkward case — the key's id does not exist until the INSERT runs — so `auditLogStatementForInsertedRow()` (`functions/utils/auditLogStatement.js`) resolves `resource_id` with an `INSERT … SELECT … FROM <table> WHERE <col> = ?`. It takes a table and column **identifier**, not a SQL string, and validates both with an explicit `typeof value === "string"` check: `RegExp.prototype.test` coerces its argument, so a bare `/^[A-Za-z_]\w*$/.test(undefined)` tests the string `"undefined"` and **passes**. Note also that `INSERT … SELECT` over zero rows inserts nothing and does not error — only ever pass a value the preceding INSERT just wrote.
+### The request path — a key borrows a person's identity, and that is the whole risk
+
+`functions/api/admin/_middleware.js`'s `onRequest` gained an API-key branch. Its order is not stylistic:
+
+1. A request is key-authenticated **iff** `Authorization: Bearer <v>` and `v` starts with `API_KEY_PREFIX` (`st_`). That prefix test is the discriminator because `resolveSession` **already** reads `Authorization: Bearer …` as a *Lucia session id* under `ALLOW_HEADER_AUTH` (non-production only). Both meanings coexist; the prefix separates them. Import `API_KEY_PREFIX` from `utils/apiKeys.js` — never retype `"st_"`.
+2. **Key + any session cookie → 400 `AMBIGUOUS_AUTH`, before either credential is validated.**
+3. The key branch `return next()`s early, which **structurally skips `validateCSRFMiddleware`**.
+
+**What makes step 3 safe is that `Authorization` is not an ambient header** — a browser never attaches it cross-origin without a successful preflight, and `functions/_middleware.js` emits `Access-Control-Allow-Headers: …Authorization` only for an origin already on the allowlist, which an attacker does not control. That is a property of the platform, not of code anyone can edit here. **Step 2 is defence-in-depth against privilege confusion, not the load-bearing control** — an earlier draft of this section said it was, which was wrong twice over: it made the skip look one edit from a CSRF bypass, and it demanded an exactness the check did not have. `parseCookies` split on `=` without trimming the resulting *name*, so `__Host-session_token =abc` keyed the map on `"__Host-session_token "` and `getCookie` returned undefined while `lucia.readSessionCookie` (which compares `k.trim()`) read it fine. Fixed in `cookies.js` — which also stopped it truncating any value containing `=`.
+
+`context.data.user.role` is **the key's role, never its creator's**. A `viewer` key minted by an admin authorises as `viewer`; getting this backwards makes every key an admin key. `context.data.apiKey` carries `{ id, keyPrefix, role }`. Endpoints need no changes — `checkPermission` already short-circuits on `context.data.user`.
+
+**But `context.data.user.userId` is the creator's, and that is the sharp edge.** It has to be — audit attribution and every ownership check need a real user id. The consequence is that any endpoint reading `data.user.userId` as *"the human holding this browser session"* will act on the **creator's own account** when a key calls it. A security review of this branch found five such endpoints live:
+
+| Route | Gate it had | What a `viewer` key got |
+|---|---|---|
+| `mfa/setup.js` + `mfa/enable.js` | `viewer` | planted an attacker-controlled TOTP secret **and backup codes on its admin creator** |
+| `sessions.js` (GET) | **none** | the admin's live sessions, with IPs and user agents |
+| `sessions/revoke-all.js` (POST) | **none** | invalidates every session and **mints a new one**; only failed because `data.lucia` is undefined on the key path |
+| `trusted-devices.js` | **none** | device inventory with IPs; revokes them |
+
+`KEY_FORBIDDEN_PREFIXES` in `_middleware.js` now 403s these families (`KEY_NOT_PERMITTED`), **checked before the key is verified** — the refusal is a property of the credential type and the path, so a forged key and a valid one are refused identically at zero D1 cost. **The role hierarchy is the wrong axis here: no key role belongs on these routes, including one minted `admin`.** `/api/admin/me` is deliberately *not* listed — a decision, not an omission.
+
+`revoke-all.js` also got its own `checkPermission(context, "viewer")`. **`viewer`, not `admin`:** revoking your own sessions is legitimate self-service at every role, and raising the tier would break a viewer logging out everywhere. The point is that an endpoint which mints sessions must state its own requirement rather than inherit safety from middleware shape.
+
+`functions/api/admin/__tests__/apiKeySelfService.test.js` keeps it closed: any admin route exporting an `onRequest*` handler with **no `checkPermission` call** must be covered by the denylist or recorded in `REVIEWED_UNGATED_ROUTES` with a reason. **Its scope is honest and partial** — it catches the *ungated* shape, not the MFA shape (viewer-gated, then acting on self), because nothing textual separates that from a viewer-gated route acting on `params.id`. The MFA family is covered by name instead. A sixth self-service family outside these prefixes still needs a human to notice.
+
+**`ALLOW_HEADER_AUTH`'s production guard must use `isDevRequest`, not `!== "production"`.** The raw comparison passes for `"Production"`, `" production"` and `"PRODUCTION"` — and it is the switch deciding whether `Authorization: Bearer <session-id>` is a credential at all, which is now the *other* meaning of the header the `st_` prefix discriminates against. There were **two** copies (`_middleware.js` and `auth/logout.js`); both now use `isDevRequest`, which allowlists known dev values and fails closed (#425). Session ids are `crypto.randomUUID()` and can never begin with `st_`, so no single value satisfies both discriminators.
+
+**An API key must never become CSRF HMAC input.** `csrf.js`'s `getSessionIdentifier` falls back to the `Authorization` bearer value for the `ALLOW_HEADER_AUTH` dev path; it now ignores anything starting with `API_KEY_PREFIX`. Not a leak — the identifier is only ever hashed — but a live 256-bit secret has no business flowing into a second subsystem.
+
+Failure logging records `bearerValue.slice(0, DISPLAY_PREFIX_LENGTH)` — the non-secret display prefix — so brute force is visible without the presented secret reaching a log sink.
+
+### Never use numbered `?N` SQL placeholders anywhere in `functions/`
+
+D1 accepts them; **better-sqlite3, which backs the entire unit-test harness, does not** — it treats `?1`/`?2` as *named* parameters and refuses positional binding outright (`RangeError: Too many parameter values were provided`).
+
+The failure is silent where it matters. `checkRateLimitByKey` catches its own errors and **fails closed**, so while `rateLimit.js` used numbered placeholders its success path had *never once executed under test* — every test reaching it got a 429 from the catch. The module sits on the auth, subscriptions, band-follow and `/api/metrics` paths. It was found only because a new caller's tests all came back 429 for no visible reason.
+
+Repeat the value positionally instead. `functions/utils/__tests__/rateLimitPlaceholders.test.js` scans `functions/` for `?N` and separately asserts the limiter actually counts (`remaining` decrements) rather than returning the fail-closed shape — that second assertion is the one that catches a regression the scan cannot see.
+
+`audit_log.api_key_id` (migration 0061) records which credential acted; NULL means cookie-authenticated. Both builders in `auditLogStatement.js` take it as a trailing optional argument, so existing call sites are unchanged and write NULL. The middleware also writes one `api_key.request` row per key-authenticated **mutating** request — that, correlated with the per-action rows sharing its `user_id`, is how "which credential did this" gets answered. Threading `api_key_id` through all ~15 per-action call sites was considered and deliberately not done.
+
+**`api_key.request` is the one audit row not written in a batch, and it has its own retention tier.** It records a *request*, not a change, and is written before `next()` runs — so there is nothing to batch it with, and it captures requests that then 403 or 404. Do not read it as precedent for writing audit rows standalone. Because it is one row per mutating key request against a 60/min ceiling (~31.5M rows/year from a single saturated key), `retention.js` prunes `action = 'api_key.request'` at **90 days** while the rest of `audit_log` stays at 1 year; the two predicates are deliberately disjoint (`=` vs `!=`) so they cannot double-count.
+
+Audit rows otherwise go in the **same `DB.batch`** as the change. Creation is the awkward case — the key's id does not exist until the INSERT runs — so `auditLogStatementForInsertedRow()` (`functions/utils/auditLogStatement.js`) resolves `resource_id` with an `INSERT … SELECT … FROM <table> WHERE <col> = ?`. It takes a table and column **identifier**, not a SQL string, and validates both with an explicit `typeof value === "string"` check: `RegExp.prototype.test` coerces its argument, so a bare `/^[A-Za-z_]\w*$/.test(undefined)` tests the string `"undefined"` and **passes**. Note also that `INSERT … SELECT` over zero rows inserts nothing and does not error — only ever pass a value the preceding INSERT just wrote.
 
 ---
 

--- a/database/setup-complete.sql
+++ b/database/setup-complete.sql
@@ -159,7 +159,7 @@ CREATE TABLE IF NOT EXISTS audit_log (
   resource_id INTEGER,                     -- ID of the affected resource
   details TEXT,                            -- JSON string with additional context
   ip_address TEXT,
-  created_at TEXT DEFAULT (datetime('now')),
+  created_at TEXT DEFAULT (datetime('now')), api_key_id INTEGER REFERENCES api_keys(id),
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
 );
 
@@ -531,6 +531,8 @@ CREATE TABLE IF NOT EXISTS api_keys (
 );
 
 CREATE INDEX IF NOT EXISTS idx_api_keys_created_by ON api_keys (created_by);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_api_key ON audit_log (api_key_id);
 
 -- ============================================
 -- TEST ACCOUNTS (passwords set by scripts/setup-local-db.sh)

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -2846,6 +2846,26 @@ components:
       in: header
       name: X-CSRF-Token
       description: Echo the `csrf_token` cookie for authenticated POST, PUT, PATCH, and DELETE admin requests.
+    AdminApiKey:
+      type: http
+      scheme: bearer
+      description: >-
+        Machine-to-machine alternative to the session cookie, for callers that cannot
+        hold a browser session. Present the key issued by `POST /api/admin/api-keys` as
+        `Authorization: Bearer st_...`.
+
+
+        The key authorises at ITS OWN role, which may be lower than its creator's — a
+        `viewer` key minted by an admin gets 403 from an admin-only route.
+
+
+        CSRF is not required on this path and no `X-CSRF-Token` is expected: a bearer
+        credential is not attached ambiently by a browser. Because of that, sending a
+        key AND a session cookie on the same request is rejected outright with 400
+        `AMBIGUOUS_AUTH` rather than one being preferred — neither credential is
+        honoured. Requests are rate limited per key, independently of the per-IP
+        limits, and a revoked or expired key stops working on the very next request
+        with no cache window.
 
   parameters:
     NumericId:

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -4654,5 +4654,13 @@ components:
           type: integer
         audit_log_deleted:
           type: integer
+        api_key_requests_deleted:
+          type: integer
+          description: >-
+            Rows pruned from audit_log where action = 'api_key.request'. Tracked
+            separately from audit_log_deleted because that row is a request log on the
+            audit-log schema -- one per mutating key-authenticated request -- and prunes
+            at 90 days rather than 1 year. The two delete predicates are disjoint, so
+            these counts never overlap.
         rate_limits_deleted:
           type: integer

--- a/functions/api/admin/__tests__/api-key-auth.test.js
+++ b/functions/api/admin/__tests__/api-key-auth.test.js
@@ -1,0 +1,396 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { onRequest, checkPermission } from "../_middleware.js";
+import { createTestEnv } from "../../test-utils.js";
+import { generateApiKey, verifyApiKey } from "../../../utils/apiKeys.js";
+import { toSqliteDateTime } from "../../../utils/authAttempts.js";
+
+const BASE_URL = "https://example.test/api/admin/me";
+const API_KEYS_URL = "https://example.test/api/admin/api-keys";
+
+async function seedKey(
+  rawDb,
+  {
+    role = "viewer",
+    created_by = 1,
+    expiresAt = null,
+    revokedAt = null,
+    name = "Test key",
+    keyHashOverride = null,
+  } = {},
+) {
+  const generated = await generateApiKey(new Date(Date.now() + 90 * 24 * 60 * 60 * 1000));
+  const storedExpiresAt = expiresAt instanceof Date ? toSqliteDateTime(expiresAt) : expiresAt || generated.expiresAt;
+
+  const info = rawDb
+    .prepare(
+      "INSERT INTO api_keys (name, key_prefix, key_hash, role, created_by, created_at, expires_at, revoked_at) VALUES (?, ?, ?, ?, ?, datetime('now'), ?, ?)",
+    )
+    .run(name, generated.keyPrefix, keyHashOverride || generated.keyHash, role, created_by, storedExpiresAt, revokedAt);
+
+  return {
+    plaintext: generated.plaintext,
+    id: info.lastInsertRowid,
+    keyPrefix: generated.keyPrefix,
+    keyHash: keyHashOverride || generated.keyHash,
+  };
+}
+
+function keyRequest(plaintext, { method = "GET", url = BASE_URL, cookie = null, body = undefined } = {}) {
+  const headers = { Authorization: `Bearer ${plaintext}` };
+  if (cookie) headers["Cookie"] = cookie;
+  return new Request(url, { method, headers, body });
+}
+
+async function runMiddleware(env, request, nextImpl) {
+  const context = { request, env, data: {} };
+  context.next = nextImpl ? async () => nextImpl(context) : async () => new Response("ok", { status: 200 });
+  const response = await onRequest(context);
+  return { response, context };
+}
+
+const okNext = async () => new Response("ok", { status: 200 });
+const adminGuardNext = async (ctx) => {
+  const perm = await checkPermission(ctx, "admin");
+  return perm.error ? perm.response : new Response("ok", { status: 200 });
+};
+
+describe("API key authentication path (#744 part 3)", () => {
+  it("authenticates a valid key and reaches the endpoint", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, { role: "viewer" });
+
+    const { response, context } = await runMiddleware(env, keyRequest(key.plaintext), okNext);
+
+    expect(response.status).toBe(200);
+    expect(context.data.authenticated).toBe(true);
+    expect(context.data.user.userId).toBe(1);
+    expect(context.data.apiKey.id).toBe(key.id);
+  });
+
+  it("a viewer key gets 403 from an admin-only endpoint even though its creator is an admin", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, { role: "viewer", created_by: 1 });
+
+    const { response } = await runMiddleware(
+      env,
+      keyRequest(key.plaintext, { method: "POST", url: API_KEYS_URL }),
+      adminGuardNext,
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("an editor key cannot reach an admin-only endpoint", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, { role: "editor", created_by: 1 });
+
+    const { response } = await runMiddleware(
+      env,
+      keyRequest(key.plaintext, { method: "POST", url: API_KEYS_URL }),
+      adminGuardNext,
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("a revoked key is rejected on the very next request — no TTL", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, { role: "viewer" });
+
+    const { response: beforeRevoke } = await runMiddleware(env, keyRequest(key.plaintext), okNext);
+    expect(beforeRevoke.status).toBe(200);
+
+    rawDb.prepare("UPDATE api_keys SET revoked_at = datetime('now') WHERE id = ?").run(key.id);
+
+    const { response: afterRevoke } = await runMiddleware(env, keyRequest(key.plaintext), okNext);
+    expect(afterRevoke.status).toBe(401);
+    const body = await afterRevoke.json();
+    expect(body.code).toBe("INVALID_API_KEY");
+  });
+
+  it("an expired key is rejected — space-separated expiry", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, {
+      role: "viewer",
+      expiresAt: toSqliteDateTime(new Date(Date.now() - 60 * 1000)),
+    });
+
+    const { response } = await runMiddleware(env, keyRequest(key.plaintext), okNext);
+    expect(response.status).toBe(401);
+  });
+
+  it("an expired key with a T-separator is NOT treated as far-future", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+
+    const generated = await generateApiKey(new Date(Date.now() + 90 * 24 * 60 * 60 * 1000));
+
+    rawDb.exec("DROP TABLE api_keys");
+    rawDb.exec(`
+      CREATE TABLE api_keys (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        key_prefix TEXT NOT NULL,
+        key_hash TEXT NOT NULL UNIQUE,
+        role TEXT NOT NULL CHECK(role IN ('viewer','editor','admin')),
+        created_by INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        expires_at TEXT NOT NULL,
+        last_used_at TEXT,
+        revoked_at TEXT
+      )
+    `);
+
+    const tSeparatedExpiry = "2020-01-01T00:00:00Z";
+    rawDb
+      .prepare(
+        "INSERT INTO api_keys (name, key_prefix, key_hash, role, created_by, created_at, expires_at) VALUES (?, ?, ?, 'viewer', 1, datetime('now'), ?)",
+      )
+      .run("T-sep key", generated.keyPrefix, generated.keyHash, tSeparatedExpiry);
+
+    const result = await verifyApiKey(env.DB, generated.plaintext);
+    expect(result).toBeUndefined();
+
+    const { response } = await runMiddleware(env, keyRequest(generated.plaintext), okNext);
+    expect(response.status).toBe(401);
+  });
+
+  it("cookie + key on one request -> 400 AMBIGUOUS_AUTH and neither credential is honoured", async () => {
+    const { env, rawDb, headers } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, { role: "viewer" });
+    const sessionId = headers.Authorization.replace("Bearer ", "");
+
+    const { response, context } = await runMiddleware(
+      env,
+      keyRequest(key.plaintext, { cookie: `session_token=${sessionId}` }),
+      okNext,
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.code).toBe("AMBIGUOUS_AUTH");
+    expect(context.data.authenticated).toBeUndefined();
+  });
+
+  it("a key-authenticated mutation succeeds without a CSRF token", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, { role: "editor" });
+
+    const { response } = await runMiddleware(
+      env,
+      keyRequest(key.plaintext, {
+        method: "POST",
+        url: API_KEYS_URL,
+        body: JSON.stringify({ name: "x" }),
+      }),
+      okNext,
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("a cookie-authenticated mutation still requires CSRF", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
+    const sessionId = headers.Authorization.replace("Bearer ", "");
+
+    const response = await onRequest({
+      request: new Request(API_KEYS_URL, {
+        method: "POST",
+        headers: { Cookie: `session_token=${sessionId}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "x" }),
+      }),
+      env,
+      data: {},
+      next: async () => new Response("ok", { status: 200 }),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("last_used_at updates on first use and does NOT rewrite within 5 minutes", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, { role: "viewer" });
+
+    expect(rawDb.prepare("SELECT last_used_at FROM api_keys WHERE id = ?").get(key.id).last_used_at).toBeNull();
+
+    await runMiddleware(env, keyRequest(key.plaintext), okNext);
+
+    const firstUpdate = rawDb.prepare("SELECT last_used_at FROM api_keys WHERE id = ?").get(key.id).last_used_at;
+    expect(firstUpdate).not.toBeNull();
+
+    rawDb.prepare("UPDATE api_keys SET last_used_at = datetime('now', '-2 minutes') WHERE id = ?").run(key.id);
+    const recentTime = rawDb.prepare("SELECT last_used_at FROM api_keys WHERE id = ?").get(key.id).last_used_at;
+
+    await runMiddleware(env, keyRequest(key.plaintext), okNext);
+
+    const afterSecond = rawDb.prepare("SELECT last_used_at FROM api_keys WHERE id = ?").get(key.id).last_used_at;
+    expect(afterSecond).toBe(recentTime);
+  });
+
+  it("a last_used_at write failure does not fail the request", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, { role: "viewer" });
+
+    const originalPrepare = env.DB.prepare.bind(env.DB);
+    env.DB.prepare = (sql) => {
+      if (sql.includes("UPDATE api_keys SET last_used_at")) {
+        throw new Error("forced last_used_at failure");
+      }
+      return originalPrepare(sql);
+    };
+
+    const { response } = await runMiddleware(env, keyRequest(key.plaintext), okNext);
+    expect(response.status).toBe(200);
+  });
+
+  it("per-key rate limiting triggers at the ceiling and returns 429", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, { role: "viewer" });
+
+    for (let i = 0; i < 60; i++) {
+      const { response } = await runMiddleware(env, keyRequest(key.plaintext), okNext);
+      expect(response.status).toBe(200);
+    }
+
+    const { response: overLimit } = await runMiddleware(env, keyRequest(key.plaintext), okNext);
+    expect(overLimit.status).toBe(429);
+    expect(overLimit.headers.get("X-RateLimit-Limit")).toBe("60");
+  });
+
+  it("a key-authenticated mutation writes an audit row carrying api_key_id", async () => {
+    const { env, rawDb } = createTestEnv({ role: "admin" });
+    const key = await seedKey(rawDb, { role: "editor" });
+
+    await runMiddleware(
+      env,
+      keyRequest(key.plaintext, {
+        method: "POST",
+        url: API_KEYS_URL,
+        body: JSON.stringify({}),
+      }),
+      okNext,
+    );
+
+    const audit = rawDb
+      .prepare("SELECT * FROM audit_log WHERE action = 'api_key.request' AND api_key_id = ?")
+      .get(key.id);
+
+    expect(audit).toBeTruthy();
+    expect(audit.api_key_id).toBe(key.id);
+    const details = JSON.parse(audit.details);
+    expect(details.method).toBe("POST");
+    expect(details.path).toBe("/api/admin/api-keys");
+  });
+
+  it("a failed authentication logs the key prefix and never the full key", async () => {
+    const { env } = createTestEnv({ role: "admin" });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const fakeKey = "st_test_placeholder_invalid_key_value_12345";
+      await runMiddleware(env, keyRequest(fakeKey), okNext);
+
+      const allCalls = warnSpy.mock.calls.map((args) => JSON.stringify(args));
+      const loggedText = allCalls.join(" ");
+
+      expect(loggedText).toContain("st_test_");
+
+      expect(allCalls.some((c) => c.includes(fakeKey))).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  // The account self-service denial (security review of part 3). A key borrows its
+  // creator's user id, so these routes would act on the creator's own credentials.
+  describe("account self-service routes are refused", () => {
+    const SELF_SERVICE = [
+      ["/api/admin/mfa/setup", "POST"],
+      ["/api/admin/mfa/enable", "POST"],
+      ["/api/admin/sessions", "GET"],
+      ["/api/admin/sessions/revoke-all", "POST"],
+      ["/api/admin/trusted-devices", "GET"],
+      ["/api/admin/auth/login", "POST"],
+    ];
+
+    it.each(SELF_SERVICE)("%s (%s) returns 403 KEY_NOT_PERMITTED", async (path, method) => {
+      const { env, rawDb } = createTestEnv({ role: "admin" });
+      // An ADMIN key, deliberately: the role hierarchy is the wrong axis here. If this
+      // ever passes for an admin key, the denial has been re-expressed as a role check.
+      const key = await seedKey(rawDb, { role: "admin" });
+
+      const reached = vi.fn(async () => new Response("ok", { status: 200 }));
+      const { response } = await runMiddleware(
+        env,
+        keyRequest(key.plaintext, { method, url: `https://example.test${path}` }),
+        reached,
+      );
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).code).toBe("KEY_NOT_PERMITTED");
+      expect(reached).not.toHaveBeenCalled();
+    });
+
+    it("refuses before verifying the key, so an invalid key gets the same answer", async () => {
+      const { env } = createTestEnv({ role: "admin" });
+
+      const { response } = await runMiddleware(
+        env,
+        keyRequest("st_never_issued_at_all", { method: "POST", url: "https://example.test/api/admin/mfa/setup" }),
+        okNext,
+      );
+
+      // 403, not 401: the refusal is a property of the credential TYPE and the path,
+      // so a forged key and a valid one are indistinguishable here and no D1 round-trip
+      // is spent on a request that cannot proceed.
+      expect(response.status).toBe(403);
+      expect((await response.json()).code).toBe("KEY_NOT_PERMITTED");
+    });
+
+    it("still allows a key through to a content route", async () => {
+      const { env, rawDb } = createTestEnv({ role: "admin" });
+      const key = await seedKey(rawDb, { role: "admin" });
+
+      const { response } = await runMiddleware(env, keyRequest(key.plaintext, { url: API_KEYS_URL }), okNext);
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  // The dual-auth rejection must see BOTH cookie names, and must agree with the session
+  // layer's own parser about what counts as present. It did not: parseCookies split on
+  // "=" without trimming the name, so `__Host-session_token =v` was invisible here while
+  // lucia.readSessionCookie read it fine.
+  describe("AMBIGUOUS_AUTH sees every cookie shape the session layer can read", () => {
+    it.each([
+      ["session_token=abc123", "dev cookie name"],
+      ["__Host-session_token=abc123", "__Host- cookie name"],
+      ["__Host-session_token =abc123", "__Host- name with trailing whitespace"],
+      ["session_token =abc123", "dev name with trailing whitespace"],
+      ["other=1; __Host-session_token=abc123", "second position"],
+    ])("rejects %s (%s)", async (cookie) => {
+      const { env, rawDb } = createTestEnv({ role: "admin" });
+      const key = await seedKey(rawDb, { role: "admin" });
+
+      const { response } = await runMiddleware(env, keyRequest(key.plaintext, { cookie }), okNext);
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).code).toBe("AMBIGUOUS_AUTH");
+    });
+  });
+
+  it("the existing ALLOW_HEADER_AUTH dev session path still works", async () => {
+    const { env, headers } = createTestEnv({ role: "admin" });
+    const sessionId = headers.Authorization.replace("Bearer ", "");
+
+    const { response, context } = await runMiddleware(
+      env,
+      new Request(BASE_URL, { headers: { Authorization: `Bearer ${sessionId}` } }),
+      okNext,
+    );
+
+    expect(response.status).toBe(200);
+    expect(context.data.authenticated).toBe(true);
+    expect(context.data.user).toBeTruthy();
+  });
+});

--- a/functions/api/admin/__tests__/apiKeySelfService.test.js
+++ b/functions/api/admin/__tests__/apiKeySelfService.test.js
@@ -1,0 +1,138 @@
+// Guard: an API key must never reach an account self-service endpoint.
+//
+// The class this exists for, found by security review of #744 part 3: the key branch
+// sets context.data.user.userId to the KEY'S CREATOR, because audit attribution and
+// every ownership check need a real user id. A family of admin endpoints reads that
+// same field as "the human holding this browser session" and acts on their credentials
+// -- so a key reaching one edits its creator's account at whatever role it carries.
+//
+// A `viewer` key could POST /api/admin/mfa/setup then /mfa/enable and plant an
+// attacker-controlled TOTP secret + backup codes on its admin creator (both gate at
+// "viewer" and act on auth.user.userId); read that admin's live sessions and trusted
+// devices with IPs (no role check at all); and revoke those devices. /sessions/revoke-all
+// had no permission check whatsoever and mints a session -- it only failed because
+// context.data.lucia happens to be undefined on the key path, which is a landmine, not
+// a defence: the natural fix for that crash detonates it.
+//
+// KEY_FORBIDDEN_PREFIXES closes it. This file keeps it closed.
+//
+// SCOPE, stated honestly: assertion 1 catches an admin route with NO checkPermission
+// call that a key can reach -- the shape of /sessions, /trusted-devices and /me, and
+// the one a new endpoint is most likely to have. It does NOT catch a route that gates
+// at "viewer" and then acts on data.user.userId as self, which is the MFA shape:
+// nothing textual separates that from a viewer-gated route acting on params.id. The
+// denylist covers the MFA family by name, and a new self-service family outside these
+// prefixes would still need a human to notice. Treat this as a backstop against the
+// ungated shape, not proof that no sixth endpoint can exist.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ADMIN_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+const MIDDLEWARE = join(ADMIN_DIR, "_middleware.js");
+
+// A route is a file Cloudflare Pages will DISPATCH to, which means one exporting an
+// onRequest handler -- not merely a .js file in the tree. maintenance/retention.js is
+// the worked example: it lives under functions/api/admin/ and exports only
+// runRetentionCleanup, a helper shared by the manual endpoint and the cron. Counting it
+// as an unprotected route is a false positive, and a guard that cries wolf gets an
+// exemption entry instead of a fix.
+function collectRouteFiles(dir) {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      return entry === "__tests__" ? [] : collectRouteFiles(full);
+    }
+    if (!entry.endsWith(".js") || entry === "_middleware.js") {
+      return [];
+    }
+    return /export\s+(async\s+)?function\s+onRequest/.test(readFileSync(full, "utf8")) ? [full] : [];
+  });
+}
+
+// functions/api/admin/mfa/setup.js -> /api/admin/mfa/setup
+// Cloudflare Pages maps index.js to the directory itself and [id].js to a path segment,
+// so the route path is the file path minus the .js (with /index stripped).
+function routePathFor(file) {
+  const rel = relative(ADMIN_DIR, file)
+    .replace(/\.js$/, "")
+    .replace(/\/index$/, "");
+  return `/api/admin/${rel}`;
+}
+
+function forbiddenPrefixes() {
+  const source = readFileSync(MIDDLEWARE, "utf8");
+  const block = source.match(/const KEY_FORBIDDEN_PREFIXES = \[([\s\S]*?)\];/);
+  expect(block, "KEY_FORBIDDEN_PREFIXES must exist in _middleware.js").not.toBeNull();
+  return [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+// Reachable by a key and acting only on data it was given explicitly (params, body),
+// never on the caller's own account. Each entry is a decision that must be argued, not
+// a way to silence the test -- adding one without a reason is the failure mode here.
+const REVIEWED_UNGATED_ROUTES = {
+  "/api/admin/me": "read-only; returns the identity the key holder already has from the admin who minted the key",
+};
+
+describe("API keys cannot reach account self-service endpoints", () => {
+  const prefixes = forbiddenPrefixes();
+  const routes = collectRouteFiles(ADMIN_DIR);
+
+  it("finds the admin routes to scan", () => {
+    expect(routes.length).toBeGreaterThan(20);
+  });
+
+  it("every admin route without a checkPermission call is denied to API keys", () => {
+    const unprotected = routes
+      .filter((file) => !readFileSync(file, "utf8").includes("checkPermission"))
+      .map(routePathFor)
+      .filter((route) => !prefixes.some((prefix) => route.startsWith(prefix)))
+      .filter((route) => !(route in REVIEWED_UNGATED_ROUTES));
+
+    expect(
+      unprotected,
+      "These admin routes have no checkPermission call and are reachable by an API key, " +
+        "which authorises as the key's CREATOR. Either add a role gate, or add the route " +
+        "to KEY_FORBIDDEN_PREFIXES in _middleware.js, or -- if it provably acts only on " +
+        "data passed to it and never on the caller's own account -- record it in " +
+        "REVIEWED_UNGATED_ROUTES with the reason.",
+    ).toEqual([]);
+  });
+
+  it("the MFA, session, trusted-device and pre-auth families are all covered", () => {
+    // Named explicitly: assertion 1 cannot see the MFA shape (it gates at "viewer"),
+    // so if someone trims the denylist these must still fail.
+    for (const route of [
+      "/api/admin/mfa/setup",
+      "/api/admin/mfa/enable",
+      "/api/admin/sessions",
+      "/api/admin/sessions/revoke-all",
+      "/api/admin/trusted-devices",
+      "/api/admin/auth/login",
+    ]) {
+      expect(
+        prefixes.some((prefix) => route.startsWith(prefix)),
+        `${route} must be denied to API keys`,
+      ).toBe(true);
+    }
+  });
+
+  it("has no dead denylist entries", () => {
+    const routes_ = routes.map(routePathFor);
+    for (const prefix of prefixes) {
+      expect(
+        routes_.some((route) => route.startsWith(prefix)),
+        `KEY_FORBIDDEN_PREFIXES contains "${prefix}", which matches no admin route`,
+      ).toBe(true);
+    }
+  });
+
+  it("session-minting routes state their own permission requirement", () => {
+    // revoke-all had none and relied entirely on middleware shape. An endpoint that
+    // calls createSession must not be one denylist edit away from being reachable.
+    const source = readFileSync(join(ADMIN_DIR, "sessions", "revoke-all.js"), "utf8");
+    expect(source).toContain("checkPermission");
+  });
+});

--- a/functions/api/admin/_middleware.js
+++ b/functions/api/admin/_middleware.js
@@ -4,12 +4,49 @@
 import { getCookie } from "../../utils/cookies.js";
 import { generateCSRFToken, setCSRFCookie, validateCSRFMiddleware } from "../../utils/csrf.js";
 import { getClientIP } from "../../utils/request.js";
-import { initializeLucia, SESSION_CONFIG } from "../../utils/auth.js";
-import { fromSqliteDateTime } from "../../utils/authAttempts.js";
+import { initializeLucia, isDevRequest, SESSION_CONFIG, SESSION_COOKIE_NAMES } from "../../utils/auth.js";
+import { fromSqliteDateTime, toSqliteDateTime } from "../../utils/authAttempts.js";
 import { createRequestLogger, logger } from "../../utils/logger.js";
 import { auditLogStatement } from "../../utils/auditLogStatement.js";
+import { API_KEY_PREFIX, DISPLAY_PREFIX_LENGTH, verifyApiKey } from "../../utils/apiKeys.js";
+import { apiKeyRateLimitKey, checkRateLimitByKey, rateLimitResponse } from "../../utils/rateLimit.js";
 
 export { auditLogStatement } from "../../utils/auditLogStatement.js";
+
+// 60/min: high enough for a scheduled import or a dashboard poll, low enough that a
+// leaked key cannot be used to walk the whole dataset before anyone notices. Keyed on
+// the key id, independent of the per-IP limits, so a credential that moves between
+// addresses is still bounded.
+const API_KEY_RATE_LIMIT = { requests: 60, window: 60 };
+const LAST_USED_THROTTLE_MS = 5 * 60 * 1000;
+
+// A bearer key authenticates a MACHINE, but it necessarily borrows a PERSON's
+// identity: context.data.user.userId below is the key's creator, because that is
+// what audit attribution and every ownership check need. Account self-service
+// endpoints read that same field as "the human holding this browser session" and
+// act on their credentials -- so a key reaching one of them edits its creator's
+// account, at whatever role the key carries.
+//
+// That is not theoretical. Before this list existed, a `viewer` key could POST
+// /api/admin/mfa/setup + /mfa/enable and plant an attacker-controlled TOTP secret
+// and backup codes on its admin creator (both gate at "viewer" and act on
+// auth.user.userId), read that admin's live sessions and device inventory with IPs
+// (no role check at all), and revoke their trusted devices. The role hierarchy is
+// the wrong axis: NO key role belongs here, including one minted `admin`.
+//
+// Matched with startsWith, so the slash-less entries also cover their children
+// (/sessions and /sessions/revoke-all). Enforced by apiKeySelfService.test.js,
+// which fails when an admin route with no checkPermission call is not covered here.
+//
+// /api/admin/me is deliberately NOT listed: it is a read that returns the identity
+// the key holder already obtained from the admin who minted the key, and a machine
+// client discovering its own role is a legitimate use. A decision, not an omission.
+const KEY_FORBIDDEN_PREFIXES = [
+  "/api/admin/auth/",
+  "/api/admin/mfa/",
+  "/api/admin/sessions",
+  "/api/admin/trusted-devices",
+];
 
 function normalizeUser(user) {
   if (!user) return null;
@@ -29,7 +66,11 @@ async function resolveSession(request, env) {
   const lucia = initializeLucia(env.DB, request, env);
   // SECURITY: Bearer token auth is for non-production environments only.
   // In production, only cookie-based sessions are accepted.
-  const allowHeaderAuth = env?.ALLOW_HEADER_AUTH === "true" && env?.ENVIRONMENT !== "production";
+  // isDevRequest, not a raw `!== "production"`: that comparison passes for
+  // "Production", " production" and "PRODUCTION", and this is the switch deciding
+  // whether `Authorization: Bearer <session-id>` is a valid credential at all.
+  // isDevRequest allowlists known dev values and fails closed on every variant (#425).
+  const allowHeaderAuth = env?.ALLOW_HEADER_AUTH === "true" && isDevRequest(request, env);
   const sessionId =
     lucia.readSessionCookie(request.headers.get("Cookie") ?? "") ||
     (allowHeaderAuth ? request.headers.get("Authorization")?.replace("Bearer ", "") : null);
@@ -231,7 +272,143 @@ export async function onRequest(context) {
   const { pathname } = new URL(request.url);
   const log = createRequestLogger(context);
 
-  // Skip auth check for auth endpoints
+  const authHeader = request.headers.get("Authorization");
+  const bearerValue = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+  const isApiKeyRequest = bearerValue !== null && bearerValue.startsWith(API_KEY_PREFIX);
+
+  // Both names, not the environment-appropriate one: this only asks "is a session
+  // cookie present at all", and guessing wrong would silently disable the rejection
+  // below. This agrees with the session layer's own reader only because parseCookies
+  // now trims the cookie NAME (see cookies.js) -- it did not, so a header of
+  // `__Host-session_token =abc` keyed the map on "__Host-session_token " and returned
+  // undefined here while lucia.readSessionCookie, which compares k.trim(), returned
+  // "abc". A cookie shape that carries a readable session id past this check is
+  // exactly what this check must not have.
+  const hasSessionCookie = SESSION_COOKIE_NAMES.some((name) => Boolean(getCookie(request, name)));
+
+  // Fail closed on ambiguous auth, BEFORE validating either credential. Two
+  // credentials on one request is where privilege-confusion bugs live.
+  if (isApiKeyRequest && hasSessionCookie) {
+    return new Response(JSON.stringify({ error: "Ambiguous authentication", code: "AMBIGUOUS_AUTH" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // The API-key path returns before reaching validateCSRFMiddleware below, and that is
+  // the CSRF skip. An API client has no csrf_token cookie to echo, so leaving the check
+  // on would fail every key-authenticated mutation.
+  //
+  // What makes the skip safe is that `Authorization` is NOT an ambient header: a
+  // browser never attaches it cross-origin without a successful preflight, and
+  // functions/_middleware.js only emits `Access-Control-Allow-Headers: …Authorization`
+  // for an origin already on the allowlist -- which an attacker does not control. That
+  // is the primary control, and it is a property of the platform rather than of code
+  // anyone can edit here.
+  //
+  // The AMBIGUOUS_AUTH rejection above is defence-in-depth against privilege confusion
+  // (two credentials, one request), NOT the thing holding this up. Stating it as the
+  // sole control was wrong twice over: it made the skip look one edit away from a CSRF
+  // bypass, and it demanded an exactness the check did not have -- a cookie-name
+  // whitespace variant slipped past it until parseCookies was fixed to trim the name.
+  if (isApiKeyRequest) {
+    const ipAddress = getClientIP(request);
+
+    // Before verification, deliberately: this is a property of the credential TYPE and
+    // the path, not of any particular key, so a valid key and a forged one are refused
+    // identically. It also costs zero D1 round-trips, which is the right posture for a
+    // path an attacker can hammer for free.
+    if (KEY_FORBIDDEN_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+      log.warn("API key blocked from account self-service route", {
+        keyPrefix: bearerValue.slice(0, DISPLAY_PREFIX_LENGTH),
+        path: pathname,
+        ipAddress,
+      });
+      return new Response(
+        JSON.stringify({
+          error: "Not available to API keys",
+          code: "KEY_NOT_PERMITTED",
+          message: "This endpoint acts on the account behind the key and is reachable only with a session.",
+        }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const key = await verifyApiKey(env.DB, bearerValue);
+    if (!key) {
+      log.warn("API key authentication failed", {
+        // The non-secret display prefix ONLY, so brute-force attempts are visible
+        // without the presented secret ever reaching a log sink.
+        keyPrefix: bearerValue.slice(0, DISPLAY_PREFIX_LENGTH),
+        ipAddress,
+      });
+      return new Response(JSON.stringify({ error: "Invalid API key", code: "INVALID_API_KEY" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const rateResult = await checkRateLimitByKey(env.DB, apiKeyRateLimitKey(key.id, pathname), API_KEY_RATE_LIMIT, {
+      apiKeyId: key.id,
+    });
+    if (!rateResult.allowed) {
+      return rateLimitResponse(rateResult);
+    }
+
+    const cutoff = toSqliteDateTime(new Date(Date.now() - LAST_USED_THROTTLE_MS));
+    try {
+      await env.DB.prepare(
+        "UPDATE api_keys SET last_used_at = datetime('now') WHERE id = ? AND (last_used_at IS NULL OR last_used_at < ?)",
+      )
+        .bind(key.id, cutoff)
+        .run();
+    } catch (lastUsedError) {
+      logger.warn("last_used_at update failed", { keyId: key.id, error: lastUsedError });
+    }
+
+    // No second SELECT: verifyApiKey's JOIN on users already returned these as creator_*.
+    // created_by is ON DELETE RESTRICT and the JOIN requires is_active = 1, so the row
+    // provably exists -- these fields are absent only if the column itself is NULL.
+    const displayName =
+      key.creator_name || [key.creator_first_name, key.creator_last_name].filter(Boolean).join(" ") || null;
+
+    context.data = {
+      ...context.data,
+      authenticated: true,
+      user: {
+        userId: key.created_by,
+        email: key.creator_email ?? null,
+        role: key.role,
+        name: displayName,
+        firstName: key.creator_first_name ?? null,
+        lastName: key.creator_last_name ?? null,
+        isActive: true,
+      },
+      apiKey: { id: key.id, keyPrefix: key.key_prefix, role: key.role },
+      ipAddress,
+    };
+
+    const method = request.method.toUpperCase();
+    if (method !== "GET" && method !== "HEAD") {
+      try {
+        await auditLogStatement(
+          env,
+          key.created_by,
+          "api_key.request",
+          "api_key",
+          key.id,
+          { method, path: pathname },
+          ipAddress,
+          key.id,
+        ).run();
+      } catch (auditError) {
+        logger.warn("api_key.request audit log failed", { keyId: key.id, error: auditError });
+      }
+    }
+
+    return next();
+  }
+
   if (pathname.startsWith("/api/admin/auth/")) {
     const csrfError = validateCSRFMiddleware(request, env);
     if (csrfError) {
@@ -240,7 +417,6 @@ export async function onRequest(context) {
     return next();
   }
 
-  // SECURITY: Validate CSRF token for state-changing requests
   const csrfError = validateCSRFMiddleware(request, env);
   if (csrfError) {
     return csrfError;

--- a/functions/api/admin/auth/logout.js
+++ b/functions/api/admin/auth/logout.js
@@ -4,7 +4,7 @@
 
 import { deleteCSRFCookie } from "../../../utils/csrf.js";
 import { getClientIP } from "../../../utils/request.js";
-import { initializeLucia } from "../../../utils/auth.js";
+import { initializeLucia, isDevRequest } from "../../../utils/auth.js";
 
 export async function onRequestPost(context) {
   const { request, env } = context;
@@ -17,7 +17,11 @@ export async function onRequestPost(context) {
     // (handles __Host-session_token in production vs session_token in dev).
     // SECURITY: Bearer token auth is for non-production environments only.
     const lucia = initializeLucia(DB, request, env);
-    const allowHeaderAuth = env?.ALLOW_HEADER_AUTH === "true" && env?.ENVIRONMENT !== "production";
+    // isDevRequest, not a raw `!== "production"`: that comparison passes for
+    // "Production", " production" and "PRODUCTION", and this is the switch deciding
+    // whether `Authorization: Bearer <session-id>` is a valid credential at all.
+    // isDevRequest allowlists known dev values and fails closed on every variant (#425).
+    const allowHeaderAuth = env?.ALLOW_HEADER_AUTH === "true" && isDevRequest(request, env);
     const sessionToken =
       lucia.readSessionCookie(request.headers.get("Cookie") ?? "") ||
       (allowHeaderAuth ? request.headers.get("Authorization")?.replace("Bearer ", "") : null);

--- a/functions/api/admin/maintenance/retention.js
+++ b/functions/api/admin/maintenance/retention.js
@@ -9,6 +9,13 @@
 //   auth_attempts:   30 days  (rate-limit counters; contains IPs/emails)
 //   auth_audit:      90 days  (short-lived security telemetry; contains IPs)
 //   audit_log:       1 year   (admin action history; longer legitimate interest)
+//                    EXCEPT action='api_key.request', at 90 days: that row is a
+//                    REQUEST log wearing the audit-log schema — one per mutating
+//                    key-authenticated request, written before the handler runs, so
+//                    it records 403s and 404s too. At the 60/min ceiling a single key
+//                    yields ~31.5M rows/year. The two predicates are deliberately
+//                    disjoint (= vs !=) so they cannot double-count a row and the
+//                    reported figures stay correct regardless of execution order.
 //   rate_limits:     30 min (1800s) — stale fixed-window counters. The largest
 //                    configured window is 300s so this is intentionally 6× to
 //                    give a buffer against races. Uses unixepoch() because the
@@ -27,6 +34,7 @@ export async function runRetentionCleanup(env) {
     authAttempts,
     authAudit,
     adminAudit,
+    apiKeyRequests,
     rateLimits,
   ] = await Promise.all([
     DB.prepare("DELETE FROM lucia_sessions WHERE expires_at < ?").bind(nowUnix).run(),
@@ -36,7 +44,12 @@ export async function runRetentionCleanup(env) {
     DB.prepare("DELETE FROM trusted_devices WHERE expires_at <= datetime('now')").run(),
     DB.prepare("DELETE FROM auth_attempts WHERE created_at < datetime('now', '-30 days')").run(),
     DB.prepare("DELETE FROM auth_audit WHERE timestamp < datetime('now', '-90 days')").run(),
-    DB.prepare("DELETE FROM audit_log WHERE created_at < datetime('now', '-1 year')").run(),
+    DB.prepare(
+      "DELETE FROM audit_log WHERE action != 'api_key.request' AND created_at < datetime('now', '-1 year')",
+    ).run(),
+    DB.prepare(
+      "DELETE FROM audit_log WHERE action = 'api_key.request' AND created_at < datetime('now', '-90 days')",
+    ).run(),
     DB.prepare("DELETE FROM rate_limits WHERE updated_at < unixepoch() - 1800").run(),
   ]);
 
@@ -49,6 +62,7 @@ export async function runRetentionCleanup(env) {
     auth_attempts_deleted: authAttempts.meta.changes,
     auth_audit_deleted: authAudit.meta.changes,
     audit_log_deleted: adminAudit.meta.changes,
+    api_key_requests_deleted: apiKeyRequests.meta.changes,
     rate_limits_deleted: rateLimits.meta.changes,
   };
 }

--- a/functions/api/admin/sessions/revoke-all.js
+++ b/functions/api/admin/sessions/revoke-all.js
@@ -2,9 +2,26 @@
 // POST /api/admin/sessions/revoke-all
 
 import { generateCSRFToken, setCSRFCookie } from "../../../utils/csrf.js";
+import { checkPermission } from "../_middleware.js";
 
 export async function onRequestPost(context) {
   const { env, data, request } = context;
+
+  // This endpoint MINTS a session, and until now it had no permission check at all --
+  // it read `data` and trusted that the middleware had filled it. That made its safety
+  // a property of middleware shape rather than of anything stated here, and the API-key
+  // branch does not populate `data.lucia`, so a key reaching it crashed on undefined
+  // instead of being refused. Keys are blocked by KEY_FORBIDDEN_PREFIXES now; this is
+  // the second lock, so the route states its own requirement.
+  //
+  // "viewer", not "admin": revoking your OWN sessions is legitimate self-service at
+  // every role. The check is here to guarantee an authenticated human, not to gate a
+  // privilege -- raising the tier would break a viewer logging out everywhere.
+  const permCheck = await checkPermission(context, "viewer");
+  if (permCheck.error) {
+    return permCheck.response;
+  }
+
   const { lucia, user } = data;
 
   await lucia.invalidateUserSessions(user.userId);

--- a/functions/utils/__tests__/auditAtomicity.test.js
+++ b/functions/utils/__tests__/auditAtomicity.test.js
@@ -47,6 +47,9 @@ describe("auditLogStatement", () => {
       9,
       JSON.stringify({ venueName: "Blue Room" }),
       "unknown",
+      // api_key_id: null when the action came from a cookie-authenticated session,
+      // which is every caller that omits the argument.
+      null,
     );
   });
 
@@ -325,15 +328,17 @@ describe("auditLogStatementForInsertedRow", () => {
 
     const sql = env.DB.prepare.mock.calls[0][0];
     expect(sql).toContain("FROM api_keys WHERE key_hash = ?");
-    expect(sql).toContain("SELECT ?, ?, ?, id, ?, ?");
+    expect(sql).toContain("SELECT ?, ?, ?, id, ?, ?, ?");
     // The match value is bound LAST: SQLite numbers anonymous placeholders in
-    // textual order, and the lookup's `?` sits after the five in the SELECT list.
+    // textual order, and the lookup's `?` sits after the six in the SELECT list.
+    // api_key_id is null here -- this call site is cookie-authenticated.
     expect(bind).toHaveBeenCalledWith(
       7,
       "api_key.created",
       "api_key",
       JSON.stringify({ role: "viewer" }),
       "1.2.3.4",
+      null,
       "HASH",
     );
   });
@@ -358,7 +363,7 @@ describe("auditLogStatementForInsertedRow", () => {
     // render `revoked_at = NULL`, which is never true in SQL and would silently
     // suppress every audit row this path is supposed to write.
     expect(env.DB.prepare.mock.calls[0][0]).toContain("WHERE id = ? AND revoked_at IS NULL");
-    expect(bind).toHaveBeenCalledWith(7, "api_key.revoked", "api_key", JSON.stringify({}), "1.2.3.4", 42);
+    expect(bind).toHaveBeenCalledWith(7, "api_key.revoked", "api_key", JSON.stringify({}), "1.2.3.4", null, 42);
   });
 
   // Table and column names cannot be bound, so they are interpolated. A caller that

--- a/functions/utils/__tests__/cookieParserUniqueness.test.js
+++ b/functions/utils/__tests__/cookieParserUniqueness.test.js
@@ -1,0 +1,86 @@
+// Guard: functions/ has exactly ONE cookie parser.
+//
+// It had four, and they disagreed. `cookies.js` (parseCookies), `csrf.js` (a private
+// copy), `trustedDevice.js` (an inline loop) and `auth.js` (lucia's readSessionCookie).
+// Only the last trimmed the cookie NAME and joined the value on "=", so:
+//
+//   Cookie: __Host-session_token =abc
+//     getCookie(...)                 -> undefined   (keyed on "__Host-session_token ")
+//     lucia.readSessionCookie(...)   -> "abc"
+//
+// Two parsers disagreeing about whether a session cookie is PRESENT is how a credential
+// slips past a presence check -- and the #744 dual-auth rejection is exactly such a
+// check. The same `const [name, value] = split("=")` also truncated any value
+// containing "=", which is every base64 value with padding.
+//
+// The fix was to delete three of them, not to correct three of them: four correct
+// parsers can still drift apart, and being right while the others were wrong is
+// precisely what let this go unnoticed. This test keeps that at one.
+//
+// SCOPE: matches the header-splitting idiom, so a parser written a genuinely different
+// way could evade it. It catches the copy-paste that actually happened.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FUNCTIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CANONICAL = "utils/cookies.js";
+
+function sourceFiles(dir) {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      return entry === "__tests__" || entry === "node_modules" ? [] : sourceFiles(full);
+    }
+    return entry.endsWith(".js") ? [full] : [];
+  });
+}
+
+describe("cookie parsing has a single home", () => {
+  const files = sourceFiles(FUNCTIONS_DIR);
+
+  it("finds the source tree", () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it('only cookies.js splits a Cookie header on ";"', () => {
+    const offenders = files
+      .filter((file) => /\bsplit\(["']\s*;\s*["']\)/.test(readFileSync(file, "utf8")))
+      .map((file) => relative(FUNCTIONS_DIR, file))
+      .filter((rel) => rel !== CANONICAL);
+
+    expect(
+      offenders,
+      `These files parse a Cookie header themselves. functions/${CANONICAL} is the only ` +
+        "cookie parser: import parseCookies or getCookie from it. Four copies disagreed " +
+        "about whether `__Host-session_token =v` was present, which is a credential " +
+        "slipping past a presence check.",
+    ).toEqual([]);
+  });
+
+  it("nothing re-declares a local parseCookies", () => {
+    const offenders = files
+      .filter((file) => /(function|const)\s+parseCookies\b/.test(readFileSync(file, "utf8")))
+      .map((file) => relative(FUNCTIONS_DIR, file))
+      .filter((rel) => rel !== CANONICAL);
+
+    expect(offenders, `parseCookies is declared in functions/${CANONICAL} only; import it.`).toEqual([]);
+  });
+
+  it("the canonical parser handles every shape the copies got wrong", async () => {
+    const { parseCookies } = await import("../cookies.js");
+
+    // Name carrying whitespace -- invisible to three of the four copies.
+    expect(parseCookies("__Host-session_token =abc")["__Host-session_token"]).toBe("abc");
+    // Value containing "=" -- truncated to "YWJj" by three of the four.
+    expect(parseCookies("csrf_token=YWJj==").csrf_token).toBe("YWJj==");
+    // Malformed percent-escape -- decodeURIComponent THROWS on this, turning a
+    // client-controlled header into a 500. Must degrade to the raw value instead.
+    expect(() => parseCookies("session_token=abc%")).not.toThrow();
+    expect(parseCookies("session_token=abc%").session_token).toBe("abc%");
+    // A valid escape still decodes.
+    expect(parseCookies("t=100%25").t).toBe("100%");
+  });
+});

--- a/functions/utils/__tests__/rateLimitPlaceholders.test.js
+++ b/functions/utils/__tests__/rateLimitPlaceholders.test.js
@@ -1,0 +1,69 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { createTestEnv } from "../../api/test-utils.js";
+import { apiKeyRateLimitKey, checkRateLimitByKey } from "../rateLimit.js";
+
+const functionsDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/**
+ * D1 accepts numbered placeholders (`?1`, `?2`); better-sqlite3, which backs the whole
+ * unit-test harness, treats them as NAMED parameters and refuses to bind them
+ * positionally at all. The failure is not loud: `checkRateLimitByKey` catches it and
+ * fails closed, so a route silently returns 429 in tests while behaving correctly in
+ * production -- or worse, a test asserts the 429 and enshrines it.
+ *
+ * That is exactly what had happened. The limiter's SQL used `?1/?2/?3`, so its success
+ * path had never executed under test even though the module is on several hot paths.
+ * Discovered only because a new caller's tests all came back 429.
+ */
+function sourceFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === "__tests__" ? [] : sourceFiles(full);
+    return entry.name.endsWith(".js") ? [full] : [];
+  });
+}
+
+describe("SQL placeholders under the better-sqlite3 harness", () => {
+  it("no file in functions/ uses numbered ?N placeholders", () => {
+    const offenders = sourceFiles(functionsDir).filter((file) => {
+      const source = readFileSync(file, "utf8").replace(/\/\/.*$/gm, "");
+      return /\?\d+\s*(,|\)|\s|$)/m.test(source) && /(prepare|exec)\s*\(/.test(source);
+    });
+
+    expect(offenders.map((f) => f.replace(functionsDir, "functions/utils/.."))).toEqual([]);
+  });
+
+  it("counts a real request rather than falling into the fail-closed catch", async () => {
+    const { env } = createTestEnv({ role: "admin" });
+    const config = { requests: 3, window: 60 };
+    const key = apiKeyRateLimitKey(42, "/api/admin/api-keys");
+
+    const first = await checkRateLimitByKey(env.DB, key, config);
+    // remaining === 2 proves the upsert actually ran and RETURNING came back with
+    // count === 1. The fail-closed branch returns remaining 0, which is what this
+    // test caught the first time.
+    expect(first).toMatchObject({ allowed: true, remaining: 2, limit: 3 });
+
+    await checkRateLimitByKey(env.DB, key, config);
+    await checkRateLimitByKey(env.DB, key, config);
+    const overLimit = await checkRateLimitByKey(env.DB, key, config);
+
+    expect(overLimit.allowed).toBe(false);
+    expect(overLimit.remaining).toBe(0);
+  });
+
+  it("scopes the counter per key and per base path", async () => {
+    const { env } = createTestEnv({ role: "admin" });
+    const config = { requests: 1, window: 60 };
+
+    await checkRateLimitByKey(env.DB, apiKeyRateLimitKey(1, "/api/admin/api-keys"), config);
+    const otherKey = await checkRateLimitByKey(env.DB, apiKeyRateLimitKey(2, "/api/admin/api-keys"), config);
+    const otherPath = await checkRateLimitByKey(env.DB, apiKeyRateLimitKey(1, "/api/admin/venues"), config);
+
+    expect(otherKey.allowed).toBe(true);
+    expect(otherPath.allowed).toBe(true);
+  });
+});

--- a/functions/utils/apiKeys.js
+++ b/functions/utils/apiKeys.js
@@ -14,9 +14,9 @@
 
 import { fromSqliteDateTime, toSqliteDateTime } from "./authAttempts.js";
 
-const API_KEY_PREFIX = "st_";
+export const API_KEY_PREFIX = "st_";
 const KEY_BYTES = 32;
-const DISPLAY_PREFIX_LENGTH = 8;
+export const DISPLAY_PREFIX_LENGTH = 8;
 // #744 calls for a short default and forced rotation. A bearer credential
 // bypasses CSRF, MFA and the cookie boundary, so a default set here is what
 // every endpoint built on this inherits.
@@ -104,10 +104,16 @@ export async function verifyApiKey(DB, presentedKey) {
   // their sessions for months while leaving their keys live, because it is a
   // separate endpoint from the PATCH one. A key is only ever as revoked as the
   // least careful path that can deactivate its owner; this makes that irrelevant.
-  // Note nothing is projected from users: only api_keys columns cross the boundary.
+  // The creator's display fields ARE projected, aliased creator_*: the middleware needs
+  // them to populate context.data.user, and this JOIN is already running. A second
+  // SELECT for the same row was a fourth D1 round-trip per key-authenticated request
+  // buying nothing. Still no credential column crosses the boundary -- key_hash is
+  // absent above and users' secrets are never named here.
   const row = await DB.prepare(
     `SELECT k.id, k.name, k.key_prefix, k.role, k.created_by, k.created_at,
-            k.expires_at, k.last_used_at, k.revoked_at
+            k.expires_at, k.last_used_at, k.revoked_at,
+            u.email AS creator_email, u.name AS creator_name,
+            u.first_name AS creator_first_name, u.last_name AS creator_last_name
      FROM api_keys k
      JOIN users u ON u.id = k.created_by
      WHERE k.key_hash = ? AND u.is_active = 1`,

--- a/functions/utils/auditLogStatement.js
+++ b/functions/utils/auditLogStatement.js
@@ -5,20 +5,30 @@
 // point: a split write leaves either a change with no record or a record with no
 // change, which this repo fixed across seven sites.
 
-const AUDIT_LOG_COLUMNS = "user_id, action, resource_type, resource_id, details, ip_address";
+// api_key_id is NULL for a cookie-authenticated action and carries the key id for a
+// bearer-authenticated one -- "which credential did this" is the first question in an
+// incident. Both builders below render from this one list; a hand-written INSERT
+// elsewhere is a third copy waiting to drift.
+const AUDIT_LOG_COLUMNS = "user_id, action, resource_type, resource_id, details, ip_address, api_key_id";
 
-function normalize(resourceType, resourceId, details, ipAddress) {
-  return [resourceType || null, resourceId || null, details ? JSON.stringify(details) : null, ipAddress || "unknown"];
+function normalize(resourceType, resourceId, details, ipAddress, apiKeyId) {
+  return [
+    resourceType || null,
+    resourceId || null,
+    details ? JSON.stringify(details) : null,
+    ipAddress || "unknown",
+    apiKeyId ?? null,
+  ];
 }
 
-export function auditLogStatement(env, userId, action, resourceType, resourceId, details, ipAddress) {
-  const [type, id, detailsJson, ip] = normalize(resourceType, resourceId, details, ipAddress);
+export function auditLogStatement(env, userId, action, resourceType, resourceId, details, ipAddress, apiKeyId) {
+  const [type, id, detailsJson, ip, keyId] = normalize(resourceType, resourceId, details, ipAddress, apiKeyId);
   return env.DB.prepare(
     `
     INSERT INTO audit_log (${AUDIT_LOG_COLUMNS})
-    VALUES (?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `,
-  ).bind(userId, action, type, id, detailsJson, ip);
+  ).bind(userId, action, type, id, detailsJson, ip, keyId);
 }
 
 // Bare SQL identifier. Table and column names cannot be bound as parameters, so they
@@ -59,6 +69,7 @@ export function auditLogStatementForInsertedRow(
   { table, where },
   details,
   ipAddress,
+  apiKeyId,
 ) {
   const columns = Object.keys(where || {});
   if (!isIdentifier(table) || columns.length === 0 || !columns.every(isIdentifier)) {
@@ -66,11 +77,11 @@ export function auditLogStatementForInsertedRow(
   }
   const predicate = columns.map((c) => (where[c] === null ? `${c} IS NULL` : `${c} = ?`)).join(" AND ");
   const values = columns.filter((c) => where[c] !== null).map((c) => where[c]);
-  const [type, , detailsJson, ip] = normalize(resourceType, null, details, ipAddress);
+  const [type, , detailsJson, ip, keyId] = normalize(resourceType, null, details, ipAddress, apiKeyId);
   return env.DB.prepare(
     `
     INSERT INTO audit_log (${AUDIT_LOG_COLUMNS})
-    SELECT ?, ?, ?, id, ?, ? FROM ${table} WHERE ${predicate}
+    SELECT ?, ?, ?, id, ?, ?, ? FROM ${table} WHERE ${predicate}
   `,
-  ).bind(userId, action, type, detailsJson, ip, ...values);
+  ).bind(userId, action, type, detailsJson, ip, keyId, ...values);
 }

--- a/functions/utils/auth.js
+++ b/functions/utils/auth.js
@@ -1,3 +1,5 @@
+import { parseCookies } from "./cookies.js";
+
 export const SESSION_CONFIG = {
   absoluteTimeout: 30 * 24 * 60 * 60 * 1000,
   idleTimeout: 30 * 60 * 1000,
@@ -41,13 +43,11 @@ export function initializeLucia(DB, request = null, env = null) {
   };
 
   return {
+    // Delegates to the shared parser rather than keeping a correct-but-separate copy.
+    // This one was already right; that is exactly why it was dangerous -- being right
+    // while three others were wrong is what let the divergence go unnoticed for so long.
     readSessionCookie(cookieHeader) {
-      if (!cookieHeader) return null;
-      for (const part of cookieHeader.split(";")) {
-        const [k, ...rest] = part.trim().split("=");
-        if (k.trim() === cookieName) return rest.join("=").trim() || null;
-      }
-      return null;
+      return parseCookies(cookieHeader)[cookieName] || null;
     },
 
     async validateSession(sessionId) {

--- a/functions/utils/auth.js
+++ b/functions/utils/auth.js
@@ -24,9 +24,17 @@ function serializeCookie(name, value, { secure, sameSite, maxAge }) {
   return parts.join("; ");
 }
 
+// Both names are exported because callers outside session handling need to detect
+// the presence of a session cookie WITHOUT knowing which environment they are in --
+// the admin middleware's dual-auth rejection checks for either. A private literal
+// here plus a copy at that call site is how the two drift apart.
+export const SESSION_COOKIE_NAME_DEV = "session_token";
+export const SESSION_COOKIE_NAME_PROD = "__Host-session_token";
+export const SESSION_COOKIE_NAMES = [SESSION_COOKIE_NAME_DEV, SESSION_COOKIE_NAME_PROD];
+
 export function initializeLucia(DB, request = null, env = null) {
   const isDev = request ? isDevRequest(request, env) : false;
-  const cookieName = isDev ? "session_token" : "__Host-session_token";
+  const cookieName = isDev ? SESSION_COOKIE_NAME_DEV : SESSION_COOKIE_NAME_PROD;
   const cookieOpts = {
     secure: !isDev,
     sameSite: isDev ? "Lax" : "Strict",

--- a/functions/utils/cookies.js
+++ b/functions/utils/cookies.js
@@ -1,8 +1,32 @@
 // Secure cookie management utilities for Cloudflare Workers
 // Implements HTTPOnly cookies with SameSite and Secure flags
 
+// A malformed percent-escape makes decodeURIComponent THROW, not return garbage:
+// `decodeURIComponent("abc%")` raises URIError. A client fully controls its Cookie
+// header, so without this a request carrying `session_token=abc%` turned every caller
+// into a 500 instead of an ordinary "no valid cookie" 401 -- and since the admin
+// middleware now asks for a session cookie on its very first line, that was reachable
+// on every /api/admin/* request. An undecodable value falls back to its raw form: it
+// will not match a real credential, which is the correct outcome, and the request is
+// rejected on its merits rather than crashing.
+function decodeCookieValue(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 /**
- * Parse cookies from Cookie header
+ * Parse cookies from a Cookie header. THE canonical cookie parser for functions/.
+ *
+ * There were four, and they disagreed. auth.js's readSessionCookie trimmed the cookie
+ * name and joined on "="; this one, csrf.js's private copy and trustedDevice.js's
+ * inline loop each did neither. Two parsers disagreeing about whether a session cookie
+ * is PRESENT is how a credential slips past a presence check -- `__Host-session_token
+ * =abc` was invisible to getCookie while the session layer read it fine. All four are
+ * now this function, and cookieParserUniqueness.test.js fails if a fifth appears.
+ *
  * @param {string} cookieHeader - Cookie header value
  * @returns {Object} Parsed cookies as key-value pairs
  */
@@ -20,9 +44,12 @@ export function parseCookies(cookieHeader) {
     // past a presence check; RFC 6265 does not permit that whitespace anyway.
     const [rawName, ...rest] = cookie.split("=");
     const name = rawName.trim();
+    // rest.join("="), not a second destructured element: a cookie VALUE may legally
+    // contain "=" (base64 padding is the everyday case), and `const [n, v] = split("=")`
+    // silently truncated it at the first one.
     const value = rest.join("=").trim();
     if (name && value) {
-      cookies[name] = decodeURIComponent(value);
+      cookies[name] = decodeCookieValue(value);
     }
     return cookies;
   }, {});

--- a/functions/utils/cookies.js
+++ b/functions/utils/cookies.js
@@ -12,7 +12,15 @@ export function parseCookies(cookieHeader) {
   }
 
   return cookieHeader.split(";").reduce((cookies, cookie) => {
-    const [name, value] = cookie.trim().split("=");
+    // The NAME is trimmed, not just the pair. Trimming only the pair leaves interior
+    // whitespace on the name -- `__Host-session_token =abc` keyed the map on
+    // "__Host-session_token " (trailing space), so getCookie returned undefined while
+    // lucia.readSessionCookie, which compares k.trim(), returned "abc". Two parsers
+    // disagreeing about whether a session cookie is present is how a credential slips
+    // past a presence check; RFC 6265 does not permit that whitespace anyway.
+    const [rawName, ...rest] = cookie.split("=");
+    const name = rawName.trim();
+    const value = rest.join("=").trim();
     if (name && value) {
       cookies[name] = decodeURIComponent(value);
     }

--- a/functions/utils/csrf.js
+++ b/functions/utils/csrf.js
@@ -4,17 +4,10 @@
 import { doubleCsrf } from "csrf-csrf";
 import { isDevRequest } from "./auth.js";
 import { API_KEY_PREFIX } from "./apiKeys.js";
-function parseCookies(cookieHeader) {
-  if (!cookieHeader) return {};
-  return cookieHeader.split(";").reduce((acc, cookie) => {
-    const [name, value] = cookie.trim().split("=");
-    if (name && value) {
-      acc[name] = value;
-    }
-    return acc;
-  }, {});
-}
-
+// The shared parser, not a private copy. This file had its own, which neither trimmed
+// the cookie name nor preserved "=" in a value -- so CSRF validation and session
+// validation could derive DIFFERENT session identifiers from one header.
+import { parseCookies } from "./cookies.js";
 function getHeaderToken(request) {
   return request.headers.get("X-CSRF-Token") || "";
 }

--- a/functions/utils/csrf.js
+++ b/functions/utils/csrf.js
@@ -3,6 +3,7 @@
 
 import { doubleCsrf } from "csrf-csrf";
 import { isDevRequest } from "./auth.js";
+import { API_KEY_PREFIX } from "./apiKeys.js";
 function parseCookies(cookieHeader) {
   if (!cookieHeader) return {};
   return cookieHeader.split(";").reduce((acc, cookie) => {
@@ -43,10 +44,21 @@ function getSessionIdentifier(request, cookies, sessionIdentifierOverride) {
     return sessionIdentifierOverride;
   }
   // Check __Host- prefixed name (production) then plain name (dev).
+  //
+  // The Bearer fallback exists for the ALLOW_HEADER_AUTH dev path, where the header
+  // carries a Lucia SESSION ID. Since #744 it can instead carry an API key, and an
+  // API key must never become HMAC input here: it is a live 256-bit secret whose whole
+  // value is that it appears in exactly one place. Not a leak (the identifier is only
+  // ever hashed), but a secret flowing into a second subsystem for no reason at all.
+  // Key-authenticated requests skip CSRF entirely, so there is nothing to lose by
+  // ignoring it -- this only stops the value being read on a path that reaches here.
+  const bearer = request.headers.get("Authorization")?.replace("Bearer ", "");
+  const sessionBearer = bearer && !bearer.startsWith(API_KEY_PREFIX) ? bearer : null;
+
   return (
     cookies["__Host-session_token"] ||
     cookies.session_token ||
-    request.headers.get("Authorization")?.replace("Bearer ", "") ||
+    sessionBearer ||
     cookies.csrf_token ||
     "csrf-missing-session"
   );

--- a/functions/utils/rateLimit.js
+++ b/functions/utils/rateLimit.js
@@ -124,27 +124,50 @@ function getRateLimitKey(ip, pathname) {
  * D1-backed rate limit check for security-sensitive endpoints.
  * Globally consistent across all Cloudflare PoPs.
  */
-async function checkRateLimitD1(DB, ip, pathname, config) {
+/**
+ * Rate-limit key for an API key, sharing getRateLimitKey's path-collapsing so one hot
+ * endpoint cannot starve the others. Keyed on the key id rather than the IP: a bearer
+ * credential is the thing being limited, and it can move between addresses.
+ */
+export function apiKeyRateLimitKey(keyId, pathname) {
+  const basePath = pathname.split("/").slice(0, 4).join("/");
+  return `apikey:${keyId}:${basePath}`;
+}
+
+/**
+ * The counter itself, taking a pre-built key. Callers that limit per-IP go through
+ * checkRateLimitD1; callers that limit per-API-key build their key with
+ * apiKeyRateLimitKey. One implementation either way -- the SQL below is subtle enough
+ * (a CASE-driven window reset, a RETURNING upsert) that a second copy is a liability.
+ */
+export async function checkRateLimitByKey(DB, key, config, logContext = {}) {
   const now = Math.floor(Date.now() / 1000);
-  const key = getRateLimitKey(ip, pathname);
 
   try {
     // Single round trip: the upsert and the post-write read are combined via RETURNING,
     // instead of a separate .run() + SELECT .first(). This halves D1 cost on the hot
     // fail-closed path (auth, subscriptions, band follows, /api/metrics — #492).
     // The CASE expression resets the window when it has expired.
+    //
+    // Bare `?` placeholders with each value repeated, NOT numbered `?1/?2/?3`.
+    // D1 accepts either, but better-sqlite3 -- which backs the whole unit-test
+    // harness -- treats `?N` as NAMED parameters and refuses to bind them
+    // positionally at all ("Too many parameter values were provided"). While this
+    // used numbered params, every test that reached here fell into the fail-closed
+    // catch below and got a 429, so the success path had never once been executed
+    // under test. Repetition is the price of a limiter that can actually be tested.
     const row = await DB.prepare(
       `
       INSERT INTO rate_limits (key, count, window_start, updated_at)
-      VALUES (?1, 1, ?2, ?2)
+      VALUES (?, 1, ?, ?)
       ON CONFLICT(key) DO UPDATE SET
-        count = CASE WHEN (?2 - window_start) >= ?3 THEN 1 ELSE count + 1 END,
-        window_start = CASE WHEN (?2 - window_start) >= ?3 THEN ?2 ELSE window_start END,
-        updated_at = ?2
+        count = CASE WHEN (? - window_start) >= ? THEN 1 ELSE count + 1 END,
+        window_start = CASE WHEN (? - window_start) >= ? THEN ? ELSE window_start END,
+        updated_at = ?
       RETURNING count, window_start
     `,
     )
-      .bind(key, now, config.window)
+      .bind(key, now, now, now, config.window, now, config.window, now, now)
       .first();
 
     // A RETURNING upsert always yields a row; these fallbacks guard shim/driver
@@ -163,8 +186,8 @@ async function checkRateLimitD1(DB, ip, pathname, config) {
   } catch (error) {
     logger.error("D1 rate limit check failed on sensitive endpoint", {
       error,
-      ip,
-      pathname,
+      key,
+      ...logContext,
     });
     // Fail closed: block the request when the counter is unavailable.
     return {
@@ -174,6 +197,10 @@ async function checkRateLimitD1(DB, ip, pathname, config) {
       limit: config.requests,
     };
   }
+}
+
+function checkRateLimitD1(DB, ip, pathname, config) {
+  return checkRateLimitByKey(DB, getRateLimitKey(ip, pathname), config, { ip, pathname });
 }
 
 /**

--- a/functions/utils/trustedDevice.js
+++ b/functions/utils/trustedDevice.js
@@ -2,6 +2,7 @@
 import { isDevRequest } from "./auth.js";
 import { toSqliteDateTime } from "./authAttempts.js";
 import { logger } from "./logger.js";
+import { getCookie } from "./cookies.js";
 
 // __Host- prefix enforces Secure + Path=/ + no Domain, preventing subdomain injection.
 // Must align with the name used in getTrustedDeviceToken's cookie parsing.
@@ -184,16 +185,8 @@ export function createTrustedDeviceCookie(token, request, env) {
  * Get trusted device token from request cookies
  */
 export function getTrustedDeviceToken(request) {
-  const cookieHeader = request.headers.get("Cookie");
-  if (!cookieHeader) return null;
-
-  const cookies = cookieHeader.split(";");
-  for (const cookie of cookies) {
-    const [name, value] = cookie.trim().split("=");
-    if (name === TRUSTED_DEVICE_COOKIE_NAME_SECURE || name === TRUSTED_DEVICE_COOKIE_NAME_DEV) {
-      return value;
-    }
-  }
-
-  return null;
+  // getCookie, not a fourth inline parser. The hand-rolled loop this replaces did not
+  // trim the cookie name and truncated any value containing "=", so a token was
+  // silently unreadable for shapes the session layer handled fine.
+  return getCookie(request, TRUSTED_DEVICE_COOKIE_NAME_SECURE) || getCookie(request, TRUSTED_DEVICE_COOKIE_NAME_DEV);
 }

--- a/migrations/0061_audit_log_api_key_id.sql
+++ b/migrations/0061_audit_log_api_key_id.sql
@@ -1,0 +1,8 @@
+-- Migration: 0061_audit_log_api_key_id.sql
+-- Records which API key authenticated a mutating request, so the audit trail
+-- can answer "which credential did this" alongside the existing per-action rows.
+-- NULL means cookie-authenticated.
+
+ALTER TABLE audit_log ADD COLUMN api_key_id INTEGER REFERENCES api_keys(id);
+
+CREATE INDEX idx_audit_log_api_key ON audit_log (api_key_id);


### PR DESCRIPTION
## Summary

Part 3 of #744, and the part that makes the other two useful: until now a key could be **minted but not used**. This wires `Authorization: Bearer st_…` into the admin middleware, so a key authenticates against every existing admin endpoint with **zero endpoint changes** — `checkPermission` already short-circuits on `context.data.user`, so populating that one field is the whole integration.

The security review of this branch found a **privilege escalation**, and roughly half this diff is the fix. That is described under *Security / correctness notes* rather than buried in the file table.

Closes #744

## What changed

| File | Change |
|------|--------|
| `functions/api/admin/_middleware.js` | The API-key branch in `onRequest`: prefix discrimination, dual-auth rejection, **`KEY_FORBIDDEN_PREFIXES` denial**, verification, per-key rate limit, throttled `last_used_at`, audit row, early `next()` |
| `functions/api/admin/sessions/revoke-all.js` | Added the `checkPermission` it never had — an endpoint that mints sessions must state its own requirement |
| `functions/utils/cookies.js` | `parseCookies` now trims the cookie **name**, and stops truncating values containing `=` |
| `functions/utils/csrf.js` | An API key can no longer become CSRF HMAC input via the bearer fallback |
| `functions/api/admin/auth/logout.js` | `ALLOW_HEADER_AUTH` guard → `isDevRequest` (the second copy) |
| `functions/api/admin/maintenance/retention.js` | `api_key.request` prunes at 90 days, disjoint from the 1-year `audit_log` tier |
| `functions/utils/rateLimit.js` | Extracted `checkRateLimitByKey` + `apiKeyRateLimitKey`; **replaced numbered `?N` placeholders with positional `?`** |
| `functions/utils/apiKeys.js` | `verifyApiKey` INNER JOINs `users` on `is_active = 1` and now projects the creator's display fields from that same JOIN |
| `functions/utils/auditLogStatement.js` | `api_key_id` threaded through both builders as a trailing optional arg — every existing call site unchanged, writing NULL |
| `functions/utils/auth.js` | Exported `SESSION_COOKIE_NAMES`; `ALLOW_HEADER_AUTH` guard → `isDevRequest` |
| `migrations/0061_audit_log_api_key_id.sql` | `audit_log.api_key_id` + index; NULL means cookie-authenticated |
| `functions/api/admin/__tests__/apiKeySelfService.test.js` | **New** — the durable guard against the escalation class |
| `functions/api/admin/__tests__/api-key-auth.test.js` | **New** — 28 tests over the middleware branch |
| `functions/utils/__tests__/rateLimitPlaceholders.test.js` | **New** — `?N` source scan **plus** an assertion the limiter actually counts |
| `docs/api-spec.yaml` / `CLAUDE.md` | `AdminApiKey` bearer scheme; invariants rewritten (see below) |

## Security / correctness notes

### A key borrows a person's identity — that is the whole risk

`context.data.user.userId` is the key's **creator**. It has to be: audit attribution and every ownership check need a real user id. The consequence is that any endpoint reading that field as *"the human holding this browser session"* acts on the **creator's own account** when a key calls it. Five were live:

| Route | Gate it had | What a `viewer` key got |
|---|---|---|
| `mfa/setup.js` + `mfa/enable.js` | `viewer` | planted an attacker-controlled TOTP secret **and backup codes on its admin creator** |
| `sessions.js` (GET) | **none** | the admin's live sessions, with IPs and user agents |
| `sessions/revoke-all.js` (POST) | **none** | invalidates every session and **mints a new one** |
| `trusted-devices.js` | **none** | device inventory with IPs; revokes them |

`revoke-all.js` failed only because `context.data.lucia` is undefined on the key path — a landmine, not a defence, since the obvious fix for that crash detonates it.

**`KEY_FORBIDDEN_PREFIXES`** now 403s these families (`KEY_NOT_PERMITTED`), **checked before the key is verified**: the refusal is a property of the credential type and the path, so a forged key and a valid one are refused identically at zero D1 cost. **The role hierarchy is the wrong axis — no key role belongs there, including one minted `admin`,** and the tests assert with an admin key precisely so a future re-expression as a role check fails.

`revoke-all.js` also gained `checkPermission(context, "viewer")`. **`viewer`, not `admin`:** revoking your own sessions is legitimate self-service at every role, and raising the tier would break a viewer logging out everywhere. The point is that it states its own requirement instead of inheriting safety from middleware shape.

`/api/admin/me` is deliberately **not** denied — read-only, returns identity the key holder already has from the admin who minted the key. A decision, recorded in `REVIEWED_UNGATED_ROUTES`, not an omission.

### The guard, and its honest scope

`apiKeySelfService.test.js` fails when any admin route exporting an `onRequest*` handler has **no `checkPermission` call** and is neither denylisted nor recorded with a reason. It catches the *ungated* shape — the one a new endpoint is most likely to have.

It does **not** catch the MFA shape (gates at `viewer`, then acts on self): nothing textual separates that from a viewer-gated route acting on `params.id`. That family is covered by name instead, and the test says so in its header. A sixth self-service family outside these prefixes would still need a human to notice.

### The CSRF skip — the earlier reasoning was wrong

`_middleware.js` returns before `validateCSRFMiddleware`. The previous comment (and CLAUDE.md) claimed `AMBIGUOUS_AUTH` was *the single thing* making that safe. It isn't.

What actually holds it up is that **`Authorization` is not an ambient header**: a browser never attaches it cross-origin without a successful preflight, and `functions/_middleware.js` emits `Access-Control-Allow-Headers: …Authorization` only for an allowlisted origin. That is a platform property, not editable code. `AMBIGUOUS_AUTH` is defence-in-depth against privilege confusion.

Stating it the old way was wrong twice over: it made the skip look one edit from a CSRF bypass, and it demanded an exactness the check did not have — `parseCookies` split on `=` without trimming the resulting **name**, so `__Host-session_token =abc` keyed the map on `"__Host-session_token "` and `getCookie` returned undefined while `lucia.readSessionCookie` (comparing `k.trim()`) read it fine. Fixed at the root in `cookies.js`, which also stopped it truncating any value containing `=`.

### Two more, both pre-existing and both swept

- **`ALLOW_HEADER_AUTH`'s production guard** used `!== "production"`, which passes for `"Production"`, `" production"` and `"PRODUCTION"` — and it decides whether `Authorization: Bearer <session-id>` is a credential at all, now the *other* meaning of the header. There were **two** copies (`_middleware.js`, `auth/logout.js`); both now use `isDevRequest`, which allowlists known dev values and fails closed (#425). Session ids are `crypto.randomUUID()` and can never start with `st_`, so no single value satisfies both discriminators.
- **`csrf.js`'s bearer fallback** made a plaintext API key the CSRF HMAC session identifier. Not a leak (it is only hashed), but a live 256-bit secret has no business in a second subsystem.

### The `?N` placeholder bug

`rateLimit.js` used numbered placeholders. D1 accepts them; **better-sqlite3, which backs the entire unit-test harness, does not** — it treats `?1`/`?2` as *named* parameters and refuses positional binding. `checkRateLimitByKey` **fails closed**, so its success path had *never once executed under test*: every test reaching it got a 429 from the catch. The module sits on the auth, subscriptions, band-follow and `/api/metrics` paths. Found only because a new caller's tests all came back 429 for no visible reason.

The guard scans `functions/` for `?N` **and** separately asserts `remaining` decrements — the second assertion catches the regression the scan cannot see.

### Retention

`api_key.request` is one row per mutating key request against a 60/min ceiling (~31.5M rows/year from one saturated key), and was inheriting `audit_log`'s 1-year tier. Now 90 days, with predicates deliberately disjoint (`=` vs `!=`) so the two deletes cannot double-count.

It is also the one audit row **not** written in a `DB.batch` — it records a *request*, not a change, and runs before the handler, so there is nothing to batch it with. CLAUDE.md now says so explicitly, so it is not read as precedent.

## Verification

- [x] Tests: **1433 backend** (was 1415), **1239 frontend**, 0 failures
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: no drift (74 documented + 1 internal = 75)
- [x] `check-schema-drift.mjs`: clean, 30 tables
- [x] **Mutation-proven, not merely passing:** removing one `KEY_FORBIDDEN_PREFIXES` entry turns two independent assertions red; reverting the `parseCookies` fix turns exactly the two whitespace cases red
- [ ] Manual smoke: not yet run against `wrangler pages dev` — everything above is unit-level against the real modules

### Known gaps, stated rather than omitted

- The key branch's `next()` is **not** wrapped in the middleware's own try/catch, unlike the cookie path. Masked by the root middleware's catch, so the only difference is the error body and the loss of `log.error` context. Left alone to keep this diff reviewable.
- Real-D1 (not better-sqlite3) behaviour of `ALTER TABLE … ADD COLUMN … REFERENCES` is checked against SQLite semantics and the drift harness only.
- Whether Cloudflare's edge normalises the `__Host-session_token =v` cookie form before it reaches the Worker is untested; the parser divergence is proven at the JS level.

---
Built by Sonny + Otto · Reviewed by Theo, Cass · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bearer API-key authentication for administrative access, including role-based permissions, per-key rate limits, and immediate rejection of revoked or expired keys.
  * Requests combining session and API-key credentials are rejected clearly.
* **Security Enhancements**
  * API-key activity is linked to audit records, with dedicated retention handling.
  * API-key requests follow dedicated CSRF handling, while session protections remain enforced.
  * Sensitive self-service and session-management routes now require explicit authorization.
  * Improved cookie parsing and safer development-only session authentication.
* **Documentation**
  * Documented API-key authentication, permissions, security requirements, and maintenance reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->