### PR TITLE
chore: track the agent-tooling files a fresh clone needs

### DIFF
--- a/.opencodeignore
+++ b/.opencodeignore
@@ -1,0 +1,6 @@
+node_modules/
+.git/
+dist/
+build/
+package-lock.json
+yarn.lock

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "opencode-delegate": {
+      "source": "amElnagdy/delegate-skills",
+      "sourceType": "github",
+      "skillPath": "skills/opencode-delegate/SKILL.md",
+      "computedHash": "8c381178a81eca50f726967805f32a519679c45f959b3e22674daeaf864cb5ad"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Three files existed only on this machine — the #818 failure mode, where a committed config names files that resolve on one checkout and nowhere else, and nothing says so at runtime.

## What changed

| File | Mode | Why |
|---|---|---|
| `.opencodeignore` | `100644` | keeps `node_modules`/`.git`/`dist`/lockfiles out of what a delegated run reads |
| `skills-lock.json` | `100644` | pins the `opencode-delegate` skill by source + hash, so `npx skills add` reproduces *that* skill rather than whatever is current |
| `GEMINI.md` | **`120000`** | **symlink to `AGENTS.md`**, not a copy |

## Security / correctness notes

`GEMINI.md` was a **byte-identical duplicate** of `AGENTS.md`. Both obvious options are wrong:

- **Track the copy** → two files that must agree with nothing enforcing it. Precisely the drift hazard `CLAUDE.md` warns about repeatedly.
- **Gitignore it** → reproduces #818 from the other side. A fresh clone or a clean Otto checkout finds no `GEMINI.md` at all, and **OpenCode/agy says nothing when an instruction file is missing** — the run just proceeds with less context than the brief assumed.

A symlink avoids both. Git stores mode `120000` with a 9-byte blob containing `AGENTS.md`, so there is one source of truth *and* a fresh clone gets a working file.

Verified: `git cat-file -p <blob>` → `AGENTS.md`; `diff AGENTS.md GEMINI.md` clean through the link.

**Caveat, accepted rather than worked around:** a Windows clone without developer mode or `core.symlinks=true` materialises a text file containing `AGENTS.md`. There is no Windows in this project's toolchain (macOS dev, Linux CI).

Nothing in the repo references `GEMINI.md` by name, and it is absent from `opencode.json`'s `instructions` array, so no tooling path changes.

## Verification

- [x] Tests: 1437 backend / 1239 frontend, 0 failures
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: n/a (spec unchanged)
- [x] Symlink verified in the index as mode `120000`, blob content `AGENTS.md`
- [x] Manual: no source-scanning guard trips on the link

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added project-level ignore rules to keep generated files, metadata, and dependency lockfiles out of tracked changes.
  - Added a linked contributor guidance file for consistent project instructions.
  - Added metadata for the supported delegation skill, including its source and integrity information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->