### PR TITLE
fix(api): a malformed body no longer slips through the cascade delete (#978)

### DIFF
--- a/functions/api/admin/events/[id].js
+++ b/functions/api/admin/events/[id].js
@@ -17,7 +17,7 @@ import {
   validateDate,
   validateDoorsJson,
 } from "../../../utils/validation.js";
-import { getClientIP, getUrlId, parseJsonObjectBody } from "../../../utils/request.js";
+import { getClientIP, getUrlId, parseJsonObjectBody, parseOptionalJsonObjectBody } from "../../../utils/request.js";
 
 function parseJsonField(value, label) {
   if (value === undefined) {
@@ -767,15 +767,29 @@ export async function onRequestDelete(context) {
       .bind(eventIdNum)
       .first();
 
-    const body = await parseJsonObjectBody(request);
+    // Optional, not lenient (#978). This DELETE takes its cascade confirmation from the
+    // body OR the query string, and the admin UI sends NO body when it is not confirming
+    // -- so an empty body has to stay legal. What must not stay legal is a body that was
+    // sent and is unparseable: the lenient helper answered {} to that, identically to no
+    // body at all, so `?confirmCascade=true` with a broken body deleted the event and
+    // every performance under it while discarding the body without a word.
+    //
+    // The query-string channel is NOT the problem and is deliberately kept: a caller that
+    // puts confirmCascade in the URL has confirmed. The problem was proceeding with an
+    // irreversible delete while silently swallowing a caller bug.
+    const body = await parseOptionalJsonObjectBody(request);
     if (body === null) {
-      return new Response(JSON.stringify({ error: "Bad request", message: "Request body must be a JSON object" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({
+          error: "Bad request",
+          code: "INVALID_BODY",
+          message: "Request body must be a JSON object. Send no body, or valid JSON.",
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
     }
     const url = new URL(request.url);
-    const confirmCascade = body?.confirmCascade === true || url.searchParams.get("confirmCascade") === "true";
+    const confirmCascade = body.confirmCascade === true || url.searchParams.get("confirmCascade") === "true";
 
     if (performanceCount.count > 0 && !confirmCascade) {
       return new Response(

--- a/functions/api/admin/events/__tests__/events.test.js
+++ b/functions/api/admin/events/__tests__/events.test.js
@@ -1072,6 +1072,73 @@ describe("Event API - handler integration", () => {
     expect(data.affected_performance_count).toBe(1);
   });
 
+  // #978 -- the cascade delete takes confirmation from the body OR the query string, and
+  // a malformed body used to be indistinguishable from no body at all (both became {}),
+  // so a broken body plus ?confirmCascade=true deleted the event while silently
+  // discarding the caller's bug. These four pin every corner of that.
+  describe("cascade delete and a malformed body (#978)", () => {
+    const setup = () => {
+      const { env, rawDb } = createTestEnv({ role: "admin" });
+      const ev = insertEvent(rawDb, { name: "CascadeBody", slug: "cascade-body" });
+      insertBand(rawDb, { name: "AttachedBand", event_id: ev.id });
+      return { env, rawDb, ev };
+    };
+    const del = (ev, { query = "", body } = {}) =>
+      new Request(`https://example.test/api/admin/events/${ev.id}${query}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json", "x-test-role": "admin" },
+        ...(body === undefined ? {} : { body }),
+      });
+
+    it("rejects a malformed body even with ?confirmCascade=true, and deletes nothing", async () => {
+      const { env, rawDb, ev } = setup();
+
+      const res = await eventIdHandler.onRequestDelete({
+        request: del(ev, { query: "?confirmCascade=true", body: "{oops" }),
+        env,
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).code).toBe("INVALID_BODY");
+      // The assertion that matters: the row survived. A 400 that still deleted would
+      // pass a status-only check.
+      expect(rawDb.prepare("SELECT id FROM events WHERE id = ?").get(ev.id)).toBeDefined();
+    });
+
+    it("still allows NO body with ?confirmCascade=true -- the API affordance is kept", async () => {
+      const { env, rawDb, ev } = setup();
+
+      const res = await eventIdHandler.onRequestDelete({
+        request: del(ev, { query: "?confirmCascade=true" }),
+        env,
+      });
+
+      expect(res.status).toBe(200);
+      expect(rawDb.prepare("SELECT id FROM events WHERE id = ?").get(ev.id)).toBeUndefined();
+    });
+
+    it("still answers 409 for no body and no confirmation -- the admin UI's own path", async () => {
+      const { env, rawDb, ev } = setup();
+
+      const res = await eventIdHandler.onRequestDelete({ request: del(ev), env });
+
+      expect(res.status).toBe(409);
+      expect(rawDb.prepare("SELECT id FROM events WHERE id = ?").get(ev.id)).toBeDefined();
+    });
+
+    it("rejects a JSON null body rather than treating it as no body", async () => {
+      const { env, rawDb, ev } = setup();
+
+      const res = await eventIdHandler.onRequestDelete({
+        request: del(ev, { query: "?confirmCascade=true", body: "null" }),
+        env,
+      });
+
+      expect(res.status).toBe(400);
+      expect(rawDb.prepare("SELECT id FROM events WHERE id = ?").get(ev.id)).toBeDefined();
+    });
+  });
+
   it("PATCH can update date and status to published", async () => {
     const { env, rawDb } = createTestEnv({ role: "editor" });
     const ev = insertEvent(rawDb, {

--- a/functions/utils/__tests__/request.test.js
+++ b/functions/utils/__tests__/request.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseJsonObjectBody, parseJsonObjectBodyStrict } from "../request.js";
+import { parseJsonObjectBody, parseJsonObjectBodyStrict, parseOptionalJsonObjectBody } from "../request.js";
 
 function requestWithBody(body) {
   return new Request("https://example.test/", {
@@ -53,5 +53,50 @@ describe("parseJsonObjectBodyStrict", () => {
   it("returns a valid object unchanged", async () => {
     const body = { name: "SetTimes", nested: { enabled: true } };
     await expect(parseJsonObjectBodyStrict(requestWithBody(JSON.stringify(body)))).resolves.toEqual(body);
+  });
+});
+
+describe("parseOptionalJsonObjectBody", () => {
+  // The whole point of this helper is telling "no body" apart from "broken body".
+  // The other two collapse them: request.json() throws identically for both.
+  it.each([
+    ["no body at all", undefined],
+    ["an empty string", ""],
+    ["only whitespace", "  \n\t "],
+  ])("returns {} for %s", async (_label, body) => {
+    const request = new Request("https://example.test/", {
+      method: "DELETE",
+      ...(body === undefined ? {} : { body }),
+    });
+    await expect(parseOptionalJsonObjectBody(request)).resolves.toEqual({});
+  });
+
+  it.each([
+    ["malformed JSON", "{oops"],
+    ["null", "null"],
+    ["an array", "[]"],
+    ["a string", '"str"'],
+    ["a number", "42"],
+  ])("returns null for %s", async (_label, body) => {
+    await expect(parseOptionalJsonObjectBody(requestWithBody(body))).resolves.toBeNull();
+  });
+
+  it("returns a valid object unchanged", async () => {
+    const body = { confirmCascade: true };
+    await expect(parseOptionalJsonObjectBody(requestWithBody(JSON.stringify(body)))).resolves.toEqual(body);
+  });
+
+  it("is the ONLY helper that separates an empty body from a malformed one", async () => {
+    // Pinned as a comparison, because this difference is the entire reason it exists --
+    // if a future change collapses it, this fails rather than the difference going quiet.
+    const empty = () => new Request("https://example.test/", { method: "DELETE" });
+    await expect(parseOptionalJsonObjectBody(empty())).resolves.toEqual({});
+    await expect(parseOptionalJsonObjectBody(requestWithBody("{oops"))).resolves.toBeNull();
+
+    await expect(parseJsonObjectBody(empty())).resolves.toEqual({});
+    await expect(parseJsonObjectBody(requestWithBody("{oops"))).resolves.toEqual({});
+
+    await expect(parseJsonObjectBodyStrict(empty())).resolves.toBeNull();
+    await expect(parseJsonObjectBodyStrict(requestWithBody("{oops"))).resolves.toBeNull();
   });
 });

--- a/functions/utils/request.js
+++ b/functions/utils/request.js
@@ -68,6 +68,44 @@ export async function parseJsonObjectBodyStrict(request) {
 }
 
 /**
+ * For an endpoint whose body is OPTIONAL but, if sent, must be valid.
+ *
+ * The distinction the other two helpers cannot make: `{}` means "no body was sent",
+ * and that is different from "a body was sent and it is garbage". Both of the others
+ * collapse those together -- request.json() throws identically on an empty body and on
+ * `{oops`, so the lenient helper answers `{}` to both and the strict one answers null
+ * to both. Neither is right here: rejecting the empty case breaks every DELETE that
+ * legitimately sends no body, and accepting the malformed case means a destructive
+ * request proceeds while silently ignoring a client error.
+ *
+ * That second half is #978. `DELETE /api/admin/events/:id` takes its cascade
+ * confirmation from the body OR the query string, so `?confirmCascade=true` with an
+ * unparseable body deleted the event and its performances while discarding the body
+ * without a word. The confirmation itself is fine -- a client that puts it in the URL
+ * has confirmed -- but a malformed body is a bug in the caller, and the answer to a
+ * caller bug on a destructive path is 400, not "proceed and hope".
+ *
+ * @param {Request} request - the request whose body is read and CONSUMED (read-once)
+ * @returns {Promise<object|null>} `{}` when no body was sent (or only whitespace); the
+ *   object for a valid object body; `null` when a body WAS sent and is malformed, or
+ *   parses to a JSON `null`, an array, or a bare scalar
+ */
+export async function parseOptionalJsonObjectBody(request) {
+  // request.text() rather than request.json(), because an empty body is the case that
+  // has to be told apart from a broken one, and json() throws the same way for both.
+  const raw = await request.text();
+  if (raw.trim() === "") {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Extract the id segment that follows a path segment and run it through
  * validateId(). Returns the validateId() result plus the raw segment so
  * callers that special-case non-numeric ids (e.g. "profile_" band ids)


### PR DESCRIPTION
## Summary

`DELETE /api/admin/events/:id` takes its cascade confirmation from the body **or** the query string. The lenient body helper answers `{}` to a malformed body and `{}` to **no body at all** — `request.json()` throws identically for both — so `?confirmCascade=true` with an unparseable body deleted the event and every performance under it, while discarding the caller's bug without a word.

This is **option 2** of the three laid out in #978, as recommended there. The query-string channel is *not* the problem and is deliberately kept: a caller that puts `confirmCascade` in the URL has confirmed. The problem was proceeding with an irreversible delete while silently swallowing a client error.

Closes #978

## What changed

The fix needed a distinction neither existing helper could make, which is why this is a **third** helper rather than a swap to the strict one:

| body | lenient | strict | **optional (new)** |
|---|---|---|---|
| none | `{}` | `null` | **`{}`** |
| malformed | `{}` | `null` | **`null`** |
| `null` / `[]` / scalar | `null` | `null` | **`null`** |
| valid object | obj | obj | **obj** |

**Strict was the tempting choice and would have been wrong.** The admin UI sends **no body** when it is not confirming — `adminApi.js:512` builds `payload = null` and omits the `body` key entirely — so rejecting the empty case would have broken the ordinary delete path. `parseOptionalJsonObjectBody` reads `request.text()` precisely so an empty body can be told apart from a broken one.

| File | Change |
|---|---|
| `functions/utils/request.js` | `parseOptionalJsonObjectBody()` — optional body, but invalid if sent |
| `functions/api/admin/events/[id].js` | cascade delete uses it; 400 `INVALID_BODY` on a sent-but-broken body |
| `functions/api/admin/events/__tests__/events.test.js` | 4 regression tests |
| `functions/utils/__tests__/request.test.js` | 10 helper tests, incl. a three-way comparison pinning the difference |

## Security / correctness notes

**Sibling sweep.** `confirmCascade` is the only query-string confirmation flag in `functions/`. Seven `onRequestDelete` handlers read a body, but none of the other six gate a destructive action on one — so this is a single-site fix, not a class. Nothing bypasses the body helpers via `request.text()` + `JSON.parse` either.

**The tests assert the row's fate, not just the status.** A 400 that still deleted would sail past a status-only check.

**Proven by mutation**, with the mutation verified present in the file before trusting the result: reverting to the lenient helper turns the malformed case red. The other three tests pass under both helpers *by design* — they pin behaviour that must **not** change (no body + confirm still deletes; no body + no confirm still 409s).

## Verification

- [x] Tests: **1483 backend** (was 1469), 1239 frontend, 0 failures
- [x] ESLint: 0 errors
- [x] Format check: clean
- [x] Build: green
- [x] `validate:openapi`: n/a (spec unchanged)
- [x] `make review-wip` (CodeRabbit): **no findings**
- [x] Mutation-proven, with the mutation asserted present before trusting the result
- [x] Manual: verified the admin UI's own two paths (no body + confirm, no body + no confirm) still behave identically

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event deletion now accepts requests without a body when cascade confirmation is provided through the query string.
  * Malformed, `null`, array, or scalar request bodies now return a clear `400` error without deleting the event.
  * Existing confirmation requirements and conflict responses remain unchanged.

* **Tests**
  * Added coverage for absent, blank, malformed, and non-object request bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->