### PR TITLE
docs: Vol. 18 is published with an empty lineup, so we are not between seasons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,12 @@ workflow and the full invariant catalogue live in `CLAUDE.md` — read it before
 
 settimes.ca — a **lean, highly performant** multi-venue live-music event platform for Waterloo
 Region, ON. Fan-facing (schedule builder, band profiles, archives) and admin tooling are equal
-priority. Next edition: **Long Weekend Band Crawl Vol. 18 — October 11, 2026** (drafted, not yet
-published). Vol. 17 and Buddies Fest 2 both shipped in August 2026 and are archived, so the site
-is currently between seasons — every "upcoming" surface is legitimately empty until Vol. 18 is
-published. See `season_state` in the canon below before calling such a zero a bug.
+priority. Next edition: **Long Weekend Band Crawl Vol. 18 — October 11, 2026**, **published
+since 2026-08-28 with an empty lineup** (the supported "Lineup TBA" state) and live to the public
+now. Vol. 17 and Buddies Fest 2 both shipped in August 2026 and are archived. Event-driven
+surfaces are populated again; the iCal feed is still empty because it joins performances, and
+that zero is not the between-seasons zero. See `season_state` in the canon below before calling
+any such zero a bug.
 
 Machine-readable canon (venues, events, constants, doctrines): **`ground-truth.json`**.
 Read it before asserting facts about events, venues, or dates — do not re-derive or guess.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ The durable part is the method:
 
 ## Mission & Scope
 
-settimes.ca is the multi-venue/multi-artist event platform for **Waterloo Region** (Kitchener-Waterloo, ON). The next edition is **Long Weekend Band Crawl Vol. 18** on **October 11, 2026** (event 37, `lwbc18`, single-day).
+settimes.ca is the multi-venue/multi-artist event platform for **Waterloo Region** (Kitchener-Waterloo, ON). The next edition is **Long Weekend Band Crawl Vol. 18** on **October 11, 2026** (event 37, `lwbc18`, single-day) — **`published` since 2026-08-28, with an empty lineup** (the supported "Lineup TBA" state; see the empty-lineup override under event visibility). It is live to the public now.
 
 - **Focus:** Waterloo Region. This governs **product language** — marketing copy, meta descriptions, SEO targeting, "where this is for" statements. It is not a censor on fact: the platform has hosted an event outside the region (Buddies Fest 2, Tillsonburg) and those records stay accurate wherever they appear. The specific drift this rule exists to prevent is describing the site as serving Ottawa, which it does not.
 - **Brand:** settimes.ca — no rebranding
@@ -259,7 +259,18 @@ settimes.ca is the multi-venue/multi-artist event platform for **Waterloo Region
 
 **Shipped editions** (both `status = 'archived'`): Vol. 17 (event 21, 2026-08-02, 22 bands across 6 King St N venues — Blue Room, Princess Cafe, Prohibition Warehouse, Revive Karaoke, Room 47, Roost) and Buddies Fest 2 (event 36, 2026-08-07→09, Tillsonburg — the first multi-day production event). Their lineups and venue rosters are live data now, not spec; read them from D1 rather than from this file.
 
-**Between seasons is a supported state, not a bug.** With Vol. 17 and BF2 archived and Vol. 18 still a draft, every "upcoming" surface is legitimately empty — `/api/events/public` (which defaults to `upcoming=true`) and the iCal feed both correctly return zero, while `/api/stats/public` and the sitemap stay fully populated from the archived editions. `EventTimeline` has a dedicated between-seasons empty state and auto-expands Past for exactly this window. Before treating such a zero as a bug, check whether any event is actually `published`.
+**Between seasons is a supported state, not a bug** — and as of 2026-08-28 we are no longer in it. Vol. 18 is `published` with zero performances, so the surfaces split into two groups that a stale reading of this section would get wrong:
+
+| Surface | Now | Why |
+|---|---|---|
+| `/api/events/public` (defaults `upcoming=true`) | **1** (`lwbc18`) | event-driven; a published future event qualifies |
+| `/api/events/timeline` | `now` 0, `upcoming` **1**, `past` 10 | same |
+| **iCal feed** | **still 0** | `LEFT JOIN performances` — no announced sets, no `VEVENT`s |
+| `/api/stats/public`, `sitemap.xml` | populated (283 performances, 277 URLs) | archived editions |
+
+**The iCal zero is the trap.** It reads identically to the between-seasons zero and means something entirely different: *published event, lineup not yet announced*, not *no published event*. Diagnose the two apart by asking which layer the surface reads — an **event**-driven surface or a **performance**-driven one — rather than by the number.
+
+`EventTimeline` still has its dedicated between-seasons empty state and auto-expands Past; that path is now dormant rather than gone, and will be live again after Vol. 18 is archived. Before treating any such zero as a bug, check both halves: is an event actually `published`, **and** does it have performances?
 
 Canonical active roadmap: `docs/ROADMAP.md`. Use it for handoffs between Claude, OpenCode, and humans.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,7 +29,7 @@ Build SetTimes.ca into the best multi-venue and multi-artist event platform for 
 - Preserve after-midnight sorting from `frontend/src/utils/bandUtils.js` (`AFTER_MIDNIGHT_THRESHOLD_HOUR = 6`, never remove/lower).
 - Multi-day: single-day events stay byte-identical (NULL `performance_date`); never show a "Day 1" label on single-day events (gate on `isMultiDay`).
 
-## Status Summary (2026-08-11)
+## Status Summary (2026-08-28)
 
 **Two editions shipped in August 2026, and Vol. 18 is now published.** Vol. 17 ran 2026-08-02 and Buddies Fest 2 ran 2026-08-07→09 — the latter proving the multi-day epic (#543) in production. Both are archived. Vol. 18 (event 37) went `published` on 2026-08-28 with **zero performances**.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Canonical active roadmap for SetTimes.ca. Use this file for handoffs between Claude, OpenCode, and humans.
 
-Last updated: 2026-08-11
+Last updated: 2026-08-28
 
 ## Mission
 
@@ -12,7 +12,7 @@ Build SetTimes.ca into the best multi-venue and multi-artist event platform for 
 
 - Region: Waterloo Region, currently focused on Kitchener-Waterloo. This governs **product language** — marketing copy, meta descriptions, SEO targeting, statements about who the site is for. It does not override fact: the platform has hosted an event outside the region (Buddies Fest 2, Tillsonburg, 2026-08-07→09) and that record stays accurate wherever it appears.
 - Brand: SetTimes.ca. Do not rebrand.
-- Next event: Long Weekend Band Crawl Vol. 18, October 11, 2026 (event 37, `lwbc18`, single day). Currently `status = 'draft'` with an empty lineup.
+- Next event: Long Weekend Band Crawl Vol. 18, October 11, 2026 (event 37, `lwbc18`, single day). **`status = 'published'` since 2026-08-28 with an empty lineup** — the supported "Lineup TBA" state, live to the public. `reveal_mode = 0`, so a performance row is publicly visible the moment it is written and can fire follower email: adding the lineup *is* the announcement.
 - Shipped editions (both archived): Vol. 17 (event 21, 2026-08-02, 22 bands / 6 venues) and Buddies Fest 2 (event 36, 2026-08-07→09, Tillsonburg — the first multi-day production event). Lineups and venue rosters are live D1 data now, not spec.
 - Venues used by Vol. 17: Blue Room (inside Revive Karaoke), Princess Cafe, Prohibition Warehouse, Revive Karaoke, Room 47, Roost — all King St N, Waterloo.
 - Priority balance: fan-facing experience and admin tooling are both critical.
@@ -31,9 +31,9 @@ Build SetTimes.ca into the best multi-venue and multi-artist event platform for 
 
 ## Status Summary (2026-08-11)
 
-**Two editions have now shipped on this platform and the season is over.** Vol. 17 ran 2026-08-02 and Buddies Fest 2 ran 2026-08-07→09 — the latter proving the multi-day epic (#543) in production. Both are archived. Vol. 18 is drafted for 2026-10-11 and not yet published.
+**Two editions shipped in August 2026, and Vol. 18 is now published.** Vol. 17 ran 2026-08-02 and Buddies Fest 2 ran 2026-08-07→09 — the latter proving the multi-day epic (#543) in production. Both are archived. Vol. 18 (event 37) went `published` on 2026-08-28 with **zero performances**.
 
-**The site is between seasons, which is a supported state.** Every "upcoming" surface is legitimately empty until Vol. 18 is published: `/api/events/public` defaults to `upcoming=true`, and the iCal feed only emits future events, so both correctly return zero while `/api/stats/public` and the sitemap stay fully populated from the archive. `EventTimeline` has a dedicated between-seasons state and auto-expands Past for this window. Check whether anything is `published` before treating such a zero as a bug.
+**The site left the between-seasons window on 2026-08-28, and the remaining zeros no longer all mean the same thing.** Publishing re-populated the *event*-driven surfaces — `/api/events/public` (defaults `upcoming=true`) returns 1, `/api/events/timeline` returns `now` 0 / `upcoming` 1 / `past` 10 — while the *performance*-driven ones stayed empty: the iCal feed `LEFT JOIN`s `performances`, so with no announced sets it emits no `VEVENT`s. **That iCal zero reads exactly like the between-seasons zero and means something else entirely** — published event, lineup not yet announced. Tell them apart by asking which layer a surface reads, not by the number. `/api/stats/public` and the sitemap remain populated from the archive throughout. `EventTimeline` keeps its dedicated between-seasons state and Past auto-expand; that path is dormant now and live again once Vol. 18 is archived. Before treating any such zero as a bug, check both halves: is an event actually `published`, **and** does it have performances?
 
 **Postmortem worth carrying forward (2026-08-10, #800):** archiving BF2 took the public site dark. `events.is_published` was deprecated by migration 0005 but never dropped, and `archive.js` zeroed it alongside setting `status='archived'` — so when the last un-archived event was closed out, 13 public read paths gated on the dead column all returned zero rows at once. Every **public event-visibility query** now goes through `functions/utils/eventVisibility.js`. Two source-scanning guards enforce it: no `is_published` read or write anywhere outside `__tests__/**` and `utils/eventVisibility.js` itself (both sides of the build boundary — the admin exemptions came out with #799 part 1, and the shared-test-schema exemption came out with #799 part 2 once migration 0059 dropped the column, which is what proves the retirement complete), and no non-admin file querying `events` without importing the shared visibility helper (the scan matches the helper *names* — `…EventStatusSql`, `concludedEventSql` — so a hand-written inline `status` predicate does not satisfy it; one canonical home is the point). Two files are exempt by design and named in that guard — `api/metrics.js` (a write-path existence check projecting only `id`) and `utils/timeConflicts.js` (imported solely by admin, which must see drafts). The column and its two indexes are dropped as of migration 0059 (#799 part 2); both guards stay in the suite permanently as regression protection, not merely historical record.
 
@@ -106,7 +106,7 @@ Next: none currently open in this track. There remain deliberately two canonical
 The tracker is the source of truth. Every item from the previous (2026-07-07) list has since closed — #554, #555, #556, #542, #551, #550, #466, #510. The current queue is correctness debt plus Vol.-18 prep:
 
 1. **#766** — `functions/api/test-utils.js` hand-maintains a third, ungated copy of the schema.
-2. **Vol. 18 prep** — publish event 37, then book and announce the lineup. Publishing is what re-populates every "upcoming" surface.
+2. **Vol. 18 prep** — event 37 is published (2026-08-28); artist *profiles* are being staged now. **Performances are held until the set times arrive from the promoter.** On a `reveal_mode = 0` event a performance row is public immediately and can fire follower email, so booking the lineup is the public announcement — not a preparatory step. Profiles are safe to stage meanwhile because `/api/artists` INNER JOINs `performances`, so a profile with no set is publicly invisible.
 
 Closed since the last revision: **#787** (recap gating, fixed by #802 — the sitemap, SSR and the JSON API now share one `concludedEventSql()` definition of "concluded", so a published-but-unarchived past event is no longer an indexable soft-404 when Vol. 18 ends); **#799** (dead `events.is_published` column retired — part 1 stopped every read/write, part 2 dropped the column and its two indexes via migration 0059, replacing them with `idx_events_status_date` on `(status, date)`); **#746** (the two private re-encodings of the 6 AM after-midnight threshold now import from the canonical server-side home instead); **#797** (the ignored `<meta name="keywords">` is gone from `BandProfilePage`, taking its now-empty `<Helmet>` and `react-helmet-async` import with it).
 

--- a/ground-truth.json
+++ b/ground-truth.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Machine-readable project canon for agents and humans. Slow-moving facts only — live data (lineups, band profiles, counts) belongs to the database, not this file. Update via PR when canon changes; bump verified_at when a human or agent re-verifies against production.",
-  "verified_at": "2026-08-11",
+  "verified_at": "2026-08-28",
   "project": {
     "name": "SetTimes",
     "domain": "https://settimes.ca",
@@ -23,14 +23,17 @@
     "db_id": 37,
     "date": "2026-10-11",
     "end_date": null,
-    "status": "draft",
+    "status": "published",
     "band_count": 0,
-    "_note": "Not yet published and no lineup booked. Doors/show/ages/venues are not set — do not carry Vol. 17's forward as if they were. Publishing this event is what re-populates every 'upcoming' surface."
+    "reveal_mode": 0,
+    "_note": "Published 2026-08-28 with an EMPTY lineup — the supported 'Lineup TBA' state, live to the public now. Doors/show/ages/venues are not set — do not carry Vol. 17's forward as if they were. reveal_mode is 0, so is_announced never gates visibility: a performance row is publicly visible the instant it is written, and the is_announced 0→1 transition can fire follower email. Adding the lineup IS the announcement, not a step toward it."
   },
   "season_state": {
-    "state": "between_seasons",
-    "explanation": "No event has status='published'. /api/events/public defaults to upcoming=true and the iCal feed only emits future events, so BOTH correctly return zero, while /api/stats/public and the sitemap stay fully populated from the archive. This is a supported state, not an outage — check whether anything is published before treating such a zero as a bug.",
-    "published_count": 0
+    "state": "published_lineup_tba",
+    "explanation": "Vol. 18 is published with ZERO performances, so surfaces split by which layer they read. EVENT-driven surfaces are populated: /api/events/public (defaults upcoming=true) returns 1, /api/events/timeline returns now 0 / upcoming 1 / past 10. PERFORMANCE-driven surfaces are still empty: the iCal feed LEFT JOINs performances, so it emits no VEVENTs. That iCal zero reads identically to the between-seasons zero and means something different — published event, lineup not announced. Diagnose the two apart by asking which layer a surface reads, never by the number. Before calling any such zero a bug, check BOTH halves: is an event published, AND does it have performances?",
+    "published_count": 1,
+    "performance_count_upcoming": 0,
+    "between_seasons_note": "'between_seasons' was the state until 2026-08-28 and will be again after Vol. 18 is archived. EventTimeline still has its dedicated empty state for it; that path is dormant, not gone."
   },
   "venues_vol17": [
     { "db_id": 16, "name": "Blue Room (Inside Revive Karaoke)", "address": "28 King St N, Waterloo" },
@@ -45,11 +48,11 @@
     "jane_bond": "Jane Bond (db_id 17) is Vol-16 only",
     "historical_2022": "Vol 1/2 venues (Dive Bar 85 King N, Revive Game Bar 90 King N, Pin Up Arcade Bar 8-247 King N) have no venue rows — they live in events.venue_info JSON; 85 King N is now Roost, Revive later moved to 28"
   },
-  "published_events": [],
-  "draft_events": [
+  "published_events": [
     { "db_id": 37, "slug": "lwbc18", "name": "Long Weekend Band Crawl Vol. 18", "date": "2026-10-11" }
   ],
-  "_archived_events_note": "Chronological ascending. Every past edition is archived — as of 2026-08-11 this is the complete public catalogue (19 events), and it is what /api/stats/public, the sitemap and the recap pages are built from.",
+  "draft_events": [],
+  "_archived_events_note": "Chronological ascending. Every past edition is archived — 19 events as of 2026-08-28, and they are what /api/stats/public and the recap pages are built from. The public catalogue is these PLUS the published lwbc18, which the sitemap also carries; only the archive feeds the stats and recaps.",
   "archived_events": [
     { "db_id": 33, "slug": "lwbc01", "date": "2022-05-22" },
     { "db_id": 34, "slug": "lwbc02", "date": "2022-07-31" },


### PR DESCRIPTION
## Summary

`CLAUDE.md` said *"Vol. 18 still a draft"* and built its entire **between-seasons** section on that. Event 37 has been `published` since 2026-08-28 with zero performances — the supported **"Lineup TBA"** state — so the claim that *"every upcoming surface is legitimately empty"* is no longer true.

A one-word swap would have left the rest of the paragraph wrong, so the section is rewritten against **measured** production values rather than reasoning:

| Surface | Now | Why |
|---|---|---|
| `/api/events/public` (defaults `upcoming=true`) | **1** (`lwbc18`) | event-driven; a published future event qualifies |
| `/api/events/timeline` | `now` 0, `upcoming` **1**, `past` 10 | same |
| **iCal feed** | **still 0** | `LEFT JOIN performances` — no announced sets, no `VEVENT`s |
| `/api/stats/public`, `sitemap.xml` | populated (283 performances, 277 URLs) | archived editions |

## The part worth documenting

**The iCal zero is the trap.** It is byte-identical to the between-seasons zero and means the opposite: *published event, lineup not yet announced* — not *no published event*.

The two are told apart by asking **which layer the surface reads** (event-driven vs performance-driven), never by the number. That distinction is now in the doc, because the old text actively taught the wrong diagnosis: it said "check whether any event is actually `published`", which would return "yes, one" and leave the reader no closer to understanding why iCal is empty.

`EventTimeline`'s between-seasons empty state is **dormant, not dead** — it returns once Vol. 18 archives, so the code is not stale even though the doc was.

## Security / correctness notes

None — documentation only, no code paths touched.

## Verification

- [x] Every number in the new table pulled from live production, not inferred
- [x] The iCal `LEFT JOIN performances` claim verified in `functions/api/feeds/ical.js:52`
- [x] Tests: 1483 backend / 1239 frontend, 0 failures
- [x] ESLint: 0 errors · Format check: clean · Build: green
- [x] `validate:openapi`: n/a (spec unchanged)

**Context:** surfaced while entering the Vol. 18 artist profiles (part 1 of 2) that Zack sent through today.

---
Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project status to reflect the public release of Vol. 18 with an empty lineup.
  * Clarified that event-driven surfaces show Vol. 18, while the performance-based iCal feed remains empty.
  * Documented archived-edition statistics, sitemap information, and validation guidance for zero-result surfaces.
  * Recorded Vol. 18’s published-event catalogue and the expected return of the between-seasons timeline state after archiving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->