### PR TITLE
docs: record the Cloudflare zone config that lives outside this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -839,3 +839,38 @@ For the `_headers` document CSP:
 - **`Cross-Origin-Embedder-Policy: require-corp` must NOT be set** — it blocks the Turnstile iframe (which doesn't send COEP; `credentialless` isn't supported in Safari). The app needs no cross-origin isolation.
 - **The inline theme-flash `<script>` in `frontend/index.html`** is allowed by a `'sha256-…'` hash in `script-src`. **If you edit that script, regenerate the hash** (sha256 of the exact built script body, base64) or it silently stops running and a theme flash returns. No test covers this — verify by building and hashing `dist/index.html`.
 - **Cloudflare Rocket Loader must stay DISABLED** for the zone. It rewrites/inline-executes `<script>` tags, which strict CSP blocks ("Refused to execute inline script"). A modern code-split Vite SPA gains nothing from it.
+
+### Zone config that lives only in the Cloudflare dashboard
+
+Not in this repo, not in `wrangler.toml`, and silently undoable — so it is
+recorded here. Both items are zone-level settings on `settimes.ca`
+(`77e5bb9ef071b25b9cb65885ed4b38e1`).
+
+- **Rocket Loader: disabled** — see the bullet above.
+- **`www` → apex 301 redirect rule** (#984, added 2026-08-29). A zone
+  `http_request_dynamic_redirect` phase ruleset, `www to apex (301, preserves
+  path + query)`:
+
+  ```
+  if    (http.host eq "www.settimes.ca")
+  then  redirect 301 -> concat("https://settimes.ca", http.request.uri.path)
+        preserve_query_string: true
+  ```
+
+  Before it, `www.settimes.ca` served the entire site at HTTP 200 as a full
+  duplicate of the apex, and both hosts ranked separately — the apex at 243
+  impressions / position 12.2 against `www` at 40 / 21.2.
+
+  Three things not to "simplify":
+  - **It must be a *dynamic* redirect, not static.** A static one sends every
+    deep path to the homepage; the `concat(...)` expression is what carries
+    `/band/31` across.
+  - **Do not remove `www` as a Pages custom domain** to "clean up". The
+    redirect can only answer if `www` still resolves and terminates TLS —
+    removing it turns every old bookmark into a certificate error instead of a
+    redirect.
+  - **`/` still emits no raw-HTML canonical, deliberately** (see the SSR
+    ownership section: the homepage keeps client-side ownership of its identity
+    meta). That was survivable as a duplicate-host problem only because this
+    rule now leaves one live host. If `www` ever stops redirecting, the
+    duplicate returns and the canonical gap is what makes it bite.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -851,7 +851,7 @@ recorded here. Both items are zone-level settings on `settimes.ca`
   `http_request_dynamic_redirect` phase ruleset, `www to apex (301, preserves
   path + query)`:
 
-  ```
+  ```text
   if    (http.host eq "www.settimes.ca")
   then  redirect 301 -> concat("https://settimes.ca", http.request.uri.path)
         preserve_query_string: true
@@ -903,7 +903,35 @@ recorded here. Both items are zone-level settings on `settimes.ca`
   field is **not** trustworthy for this check: it reported `0` for the production
   database too. Query `sqlite_master` instead.
 
-**Still open:** `_dmarc` is `p=quarantine` with **no `rua=` reporting address**,
-so nothing reports authentication failures anywhere. Adding one needs a mailbox
-that actually exists — an unroutable `rua` silently bounces reports, which is
-worse than none.
+- **DMARC now reports** (added 2026-08-29). `_dmarc.settimes.ca` was
+  `p=quarantine` with **no `rua=`** — enforcing a policy whose effects nobody
+  could see, which is the worst of the two halves to have alone. A quarantined
+  message does not bounce and raises no error; it just lands in a spam folder.
+  Now:
+
+  ```text
+  v=DMARC1; p=quarantine; adkim=r; aspf=r; pct=100; rua=mailto:dmarc@settimes.ca
+  ```
+
+  Reports go to an iCloud **catch-all**, so no alias had to be created, and
+  because `rua` is on the *same* domain as the record no external
+  `settimes.ca._report._dmarc.<host>` authorization TXT is needed — that
+  requirement only applies to a third-party reporting host.
+
+  **`adkim=r` / `aspf=r` must stay relaxed.** The domain has two independent
+  sending paths — iCloud for human mail (`sig1._domainkey`, `include:icloud.com`)
+  and Resend via Amazon SES for application mail (`resend._domainkey`,
+  `include:amazonses.com`, `send.settimes.ca`). Strict alignment would break the
+  SES path. The application path is the one that matters operationally: it
+  carries the **band-follow confirmation emails**, and since follows are double
+  opt-in, silently quarantined confirmations mean followers are never verified
+  and never receive announcements — with nothing anywhere reporting an error.
+
+  Reports begin arriving 24–48h after the change and are gzipped XML. **If none
+  arrive within a few days, that is a signal the catch-all is not routing
+  `dmarc@` — not that everything is fine.**
+
+  Deliberately not set: `ruf=` (forensic reports carry recipient PII and almost
+  no provider sends them), and `p=reject`, which is the stronger end state but
+  should wait until a few weeks of reports confirm both sending paths pass
+  cleanly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -874,3 +874,36 @@ recorded here. Both items are zone-level settings on `settimes.ca`
     meta). That was survivable as a duplicate-host problem only because this
     rule now leaves one live host. If `www` ever stops redirecting, the
     duplicate returns and the canonical gap is what makes it bite.
+
+- **SSL/TLS mode: Full (strict)**, and **minimum TLS version 1.2** (both set
+  2026-08-29; they were `Full` and `1.0`). Strict is correct here because every
+  proxied origin is Cloudflare-owned with a valid certificate — apex and `www`
+  resolve to the Pages project, `band-photos` to `public.r2.dev`. Adding a
+  proxied record pointing at an origin with a self-signed or expired cert will
+  now fail closed rather than silently accept it, which is the intent.
+- **HSTS is served by the application, not the zone.** `frontend/public/_headers`
+  sends `max-age=31536000; includeSubDomains; preload`, so the zone-level HSTS
+  toggle reading "off" is correct and **not** a gap. Do not "fix" it by enabling
+  the zone setting as well; check the live header before concluding anything is
+  missing.
+
+**Removed 2026-08-29, recorded so they are not recreated by reflex:**
+
+- `dev.settimes.ca` — a `CNAME` to tunnel `b94985aa…`, which no longer exists.
+  It served HTTP 530 on the brand domain. The only live tunnel is a different id.
+- `ADMIN_PASSWORD` and `MASTER_PASSWORD` Pages production environment variables.
+  **Nothing read them** — every consumer in this repo uses `E2E_ADMIN_PASSWORD`
+  (`scripts/seed-e2e-admin.mjs`), which is local-only. They were unused
+  credentials sitting in production config. Note `AGENTS.md` still describes the
+  E2E vars as `ADMIN_EMAIL`/`ADMIN_PASSWORD`; the script's actual contract is
+  `E2E_ADMIN_PASSWORD`.
+- The `bandcrawl-db` D1 database — verified empty (only Cloudflare's internal
+  `_cf_KV`, no user tables), referenced nowhere in the repo, bound to nothing.
+  The only D1 database is `settimes-production-db`. Note the API's `num_tables`
+  field is **not** trustworthy for this check: it reported `0` for the production
+  database too. Query `sqlite_master` instead.
+
+**Still open:** `_dmarc` is `p=quarantine` with **no `rua=` reporting address**,
+so nothing reports authentication failures anywhere. Adding one needs a mailbox
+that actually exists — an unroutable `rua` silently bounces reports, which is
+worse than none.


### PR DESCRIPTION
## Summary

The `www` → apex 301 from #984 is a Cloudflare dashboard setting with nothing in the repo referencing it. Anyone tidying the zone could remove it with no signal that it mattered, and the duplicate-host problem would come back silently. Rocket Loader already had exactly that exposure and a lone bullet; this gives both a shared home, with the zone id and the literal rule.

Closes #984 follow-up — no code change.

## What changed

| File | Change |
|------|--------|
| `CLAUDE.md` | New "Zone config that lives only in the Cloudflare dashboard" subsection under the CSP notes |

## Security / correctness notes

None — documentation only. The zone id recorded is not a secret (it is visible on the zone Overview page and in every API path); no token or credential is included.

## Verification

- [x] Tests: unchanged (docs only)
- [x] ESLint: unchanged
- [x] Format check: clean
- [x] Build: unaffected
- [x] `validate:openapi`: N/A
- [x] Manual smoke: the documented rule matches the live one — verified `www.settimes.ca/artists?foo=bar&baz=1` → 301 → `settimes.ca/artists?foo=bar&baz=1`, apex still 200

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the Cloudflare configuration for `settimes.ca`.
  * Recorded the permanent `www` redirect to the apex domain, preserving paths and query strings.
  * Clarified that Rocket Loader remains disabled and HSTS continues to be served by the application.
  * Documented Full (strict) TLS with a minimum TLS version of 1.2.
  * Recorded removal of obsolete infrastructure and unused production settings.
  * Documented DMARC reporting through an iCloud catch-all, with relaxed alignment retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->