### PR TITLE
chore(lint): scope markdownlint to files we maintain, and fix what it found

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -45,6 +45,10 @@
     // MD007 list-indent disagreements with upstream's formatting. Reformatting
     // someone else's document to satisfy our linter guarantees a conflict on
     // the next sync, and their indent style is not a defect in our docs.
-    ".github/instructions/**"
+    ".github/instructions/**",
+
+    // Same reasoning, different upstream: added by "chore: track Copilot
+    // skills" (d441855). Vendored skill definitions, not ours to restyle.
+    ".github/skills/**"
   ]
 }

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,50 @@
+// markdownlint-cli2 options. Run it via `npm run lint:md`.
+//
+// USE markdownlint-cli2, NOT the `markdownlint` (cli v1) brew formula. They read
+// DIFFERENT config files — v1 reads .markdownlintignore and ignores this file
+// entirely. Two reasons cli2 is the right one here:
+//   1. CodeRabbit runs markdownlint-cli2, so a local run previews the gate
+//      instead of offering a second opinion. The devDependency pins the same
+//      version CodeRabbit uses.
+//   2. "gitignore": true below keeps the exclusion list correct on its own. A
+//      .markdownlintignore was tried and deleted: it has no gitignore option, so
+//      it needed a hand-copied duplicate of .gitignore, and it was ALREADY wrong
+//      by eight trees (archive/, instructions/, claudedocs/, plugins/,
+//      test-results/, prompts/, chatmodes/, part of docs/) within minutes of
+//      being written. That drift is the whole argument.
+//
+// RULES live in .markdownlint.json (permissive set tuned against this repo's
+// docs corpus in #663) and are still read from there — this file deliberately
+// declares no "config" key so it cannot shadow them. Canary if you change this:
+// MD013 is disabled there, and CLAUDE.md has very long lines, so MD013 must
+// report 0.
+//
+// Why any of this exists: an unscoped run reaches ~2,774 files, almost all
+// third-party READMEs. Their violations are not ours to fix and they bury the
+// handful that are — 633 findings, of which 579 were noise.
+{
+  // Respect .gitignore, so anything untracked is skipped without being listed
+  // twice. workers-mcp-server/ and .agents/ are already gitignored and are
+  // covered by this alone.
+  "gitignore": true,
+
+  // Belt-and-braces for trees that are vendored or generated but may not be
+  // gitignored on every checkout. A dependency directory is never our lint
+  // surface even when someone has it committed.
+  "ignores": [
+    "**/node_modules/**",
+    "workers-mcp-server/**",
+    ".agents/**",
+    ".wrangler/**",
+    "frontend/dist/**",
+    "**/CHANGELOG.md",
+
+    // Vendored from Microsoft's awesome-copilot, not authored here — the
+    // `applyTo:` frontmatter and "Your Mission" headings are the upstream
+    // signature. They accounted for 572 of 633 findings (90%), almost all
+    // MD007 list-indent disagreements with upstream's formatting. Reformatting
+    // someone else's document to satisfy our linter guarantees a conflict on
+    // the next sync, and their indent style is not a defect in our docs.
+    ".github/instructions/**"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -840,19 +840,26 @@ For the `_headers` document CSP:
 - **The inline theme-flash `<script>` in `frontend/index.html`** is allowed by a `'sha256-…'` hash in `script-src`. **If you edit that script, regenerate the hash** (sha256 of the exact built script body, base64) or it silently stops running and a theme flash returns. No test covers this — verify by building and hashing `dist/index.html`.
 - **Cloudflare Rocket Loader must stay DISABLED** for the zone. It rewrites/inline-executes `<script>` tags, which strict CSP blocks ("Refused to execute inline script"). A modern code-split Vite SPA gains nothing from it.
 
-### Cloudflare state that lives outside this repo
+### Where Cloudflare-facing settings actually live
 
-Not in `wrangler.toml`, not in any file here, and silently undoable — so it is
-recorded here. **It is not all one kind of thing, and the distinction decides
-where you go to change it:**
+Most of what follows is **not** in `wrangler.toml` or any other file here — it
+is Cloudflare-side state, silently undoable, with nothing in the repo to hint
+that it mattered. That is why it is written down.
 
-| layer | items |
-|---|---|
-| **Zone settings** on `settimes.ca` (`77e5bb9ef071b25b9cb65885ed4b38e1`) | Rocket Loader, the `www` → apex redirect rule, SSL mode, minimum TLS |
-| **DNS records** in that zone | the DMARC record |
-| **Pages project** config (`settimesdotca`) | environment variables |
-| **Account** resources | D1 databases |
-| **This repo**, listed here only to stop a false alarm | HSTS, which `_headers` sends |
+**The last row is the deliberate exception, and it is the point of the table.**
+HSTS *is* repo-managed; it appears here because the zone's own HSTS toggle reads
+"off", so anyone auditing Cloudflare concludes it is missing and reaches for the
+dashboard. The fix for anything HSTS-related is `frontend/public/_headers`, not
+Cloudflare. Read the layer column before changing anything — it is what tells
+you where to go:
+
+| layer | where you change it | items |
+|---|---|---|
+| **Zone settings** | Cloudflare dashboard / API, zone `settimes.ca` (`77e5bb9ef071b25b9cb65885ed4b38e1`) | Rocket Loader, the `www` → apex redirect rule, SSL mode, minimum TLS |
+| **DNS records** | same zone, DNS tab | the DMARC record |
+| **Pages project** config | Cloudflare Pages project `settimesdotca` | environment variables |
+| **Account** resources | Cloudflare account | D1 databases |
+| **This repository** | `frontend/public/_headers` | **HSTS** — listed only because the zone toggle reading "off" is correct and looks like a gap |
 
 - **Rocket Loader: disabled** — see the bullet above.
 - **`www` → apex 301 redirect rule** (#984, added 2026-08-29). A zone

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -840,11 +840,19 @@ For the `_headers` document CSP:
 - **The inline theme-flash `<script>` in `frontend/index.html`** is allowed by a `'sha256-…'` hash in `script-src`. **If you edit that script, regenerate the hash** (sha256 of the exact built script body, base64) or it silently stops running and a theme flash returns. No test covers this — verify by building and hashing `dist/index.html`.
 - **Cloudflare Rocket Loader must stay DISABLED** for the zone. It rewrites/inline-executes `<script>` tags, which strict CSP blocks ("Refused to execute inline script"). A modern code-split Vite SPA gains nothing from it.
 
-### Zone config that lives only in the Cloudflare dashboard
+### Cloudflare state that lives outside this repo
 
-Not in this repo, not in `wrangler.toml`, and silently undoable — so it is
-recorded here. Both items are zone-level settings on `settimes.ca`
-(`77e5bb9ef071b25b9cb65885ed4b38e1`).
+Not in `wrangler.toml`, not in any file here, and silently undoable — so it is
+recorded here. **It is not all one kind of thing, and the distinction decides
+where you go to change it:**
+
+| layer | items |
+|---|---|
+| **Zone settings** on `settimes.ca` (`77e5bb9ef071b25b9cb65885ed4b38e1`) | Rocket Loader, the `www` → apex redirect rule, SSL mode, minimum TLS |
+| **DNS records** in that zone | the DMARC record |
+| **Pages project** config (`settimesdotca`) | environment variables |
+| **Account** resources | D1 databases |
+| **This repo**, listed here only to stop a false alarm | HSTS, which `_headers` sends |
 
 - **Rocket Loader: disabled** — see the bullet above.
 - **`www` → apex 301 redirect rule** (#984, added 2026-08-29). A zone
@@ -905,8 +913,11 @@ recorded here. Both items are zone-level settings on `settimes.ca`
 
 - **DMARC now reports** (added 2026-08-29). `_dmarc.settimes.ca` was
   `p=quarantine` with **no `rua=`** — enforcing a policy whose effects nobody
-  could see, which is the worst of the two halves to have alone. A quarantined
-  message does not bounce and raises no error; it just lands in a spam folder.
+  could see, which is the worst of the two halves to have alone. `p` only
+  *requests* a disposition; each receiver decides for itself, and a message
+  handled as suspicious typically produces no bounce and no error the sender
+  ever sees. Failures are therefore silent by default, which is exactly why the
+  reporting half is not optional.
   Now:
 
   ```text
@@ -927,9 +938,12 @@ recorded here. Both items are zone-level settings on `settimes.ca`
   opt-in, silently quarantined confirmations mean followers are never verified
   and never receive announcements — with nothing anywhere reporting an error.
 
-  Reports begin arriving 24–48h after the change and are gzipped XML. **If none
-  arrive within a few days, that is a signal the catch-all is not routing
-  `dmarc@` — not that everything is fine.**
+  Reports typically begin arriving within 24–48h and are XML, usually gzipped
+  (compression is recommended by RFC 7489, not required — plain `.xml` is
+  valid). Both are conventions, not guarantees: providers report on their own
+  schedules and some never do. **If none arrive within a few days, treat that as
+  a prompt to check whether the catch-all routes `dmarc@` — it is a signal to
+  investigate, not proof of either a failure or of everything being fine.**
 
   Deliberately not set: `ruf=` (forensic reports carry recipient PII and almost
   no provider sends them), and `p=reject`, which is the stronger end state but

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ lint: ## ESLint, both stacks
 	npm run lint
 	cd frontend && npm run lint
 
+lint-md: ## markdownlint across the docs we maintain (see .markdownlint-cli2.jsonc)
+	npm run lint:md
+
 test-backend: ## Backend unit tests (better-sqlite3; runs fine on Apple Silicon, a few seconds)
 	npm test
 
@@ -61,7 +64,7 @@ test-frontend: ## Frontend unit tests
 
 test: test-backend test-frontend ## All unit tests
 
-gate: format format-check lint test build ## FULL pre-commit gate — run before every commit
+gate: format format-check lint lint-md test build ## FULL pre-commit gate — run before every commit
 
 review: ## AI code review of this branch vs origin/main — run BEFORE opening a PR
 	@command -v coderabbit >/dev/null 2>&1 || { \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -166,7 +166,7 @@ POST /api/admin/auth/signup
 
 ### Role Hierarchy
 
-```
+```text
 admin (level 3) > editor (level 2) > viewer (level 1)
 ```
 

--- a/docs/ADMIN_HANDBOOK.md
+++ b/docs/ADMIN_HANDBOOK.md
@@ -66,7 +66,7 @@ This handbook is for system administrators managing the SetTimes platform. It co
 
 ### Architecture Diagram
 
-```
+```text
 ┌─────────────────────────────────────┐
 │   Users (Browsers/Mobile)           │
 └──────────────┬──────────────────────┘
@@ -553,7 +553,7 @@ wrangler d1 execute settimes-production-db --file=backups/settimes-20251119.sql
 
 **Cache Strategy:**
 
-```
+```text
 /assets/*         → 1 year (immutable)
 /*.html           → no-cache
 /api/*            → no-store

--- a/docs/BACKEND_FRAMEWORK.md
+++ b/docs/BACKEND_FRAMEWORK.md
@@ -37,7 +37,7 @@
 
 ### Data Model
 
-```
+```text
 ┌─────────────┐
 │   events    │──┐
 │  (vol-5)    │  │
@@ -71,7 +71,7 @@
 
 ### API Structure
 
-```
+```text
 /api/
 ├── schedule.js                  # Public API
 │   GET ?event={slug|current}    # Returns band schedule
@@ -155,7 +155,7 @@
 
 ### Event Lifecycle
 
-```
+```text
 ┌──────────────┐
 │   DRAFT      │  Admin creates event, unpublished
 │    status    │  Visible only in admin panel
@@ -195,7 +195,7 @@ reject a status change on an archived row — enforced in SQL, not merely checke
 
 ### Recommended Event Naming Convention
 
-```
+```text
 slug: "vol-{N}"           → Example: "vol-5", "vol-6"
 name: "Long Weekend Band Crawl Vol. {N}"
 date: "YYYY-MM-DD"        → ISO 8601 format
@@ -285,7 +285,7 @@ ORDER BY date DESC;
 
 **Execution Order:**
 
-```
+```text
 Request
   → /functions/_middleware.js       # Global CORS, error handling
   → /functions/api/admin/_middleware.js  # Auth, rate limiting
@@ -303,7 +303,7 @@ Request
 
 **Authentication Flow:**
 
-```
+```text
 1. Admin logs in with email + password
 2. Server verifies credentials and creates session record
 3. Server sets HTTPOnly `session_token` cookie
@@ -417,21 +417,21 @@ WHERE b1.event_id = ?;
 
 **Option 1: URL Versioning**
 
-```
+```text
 /api/v1/schedule?event=vol-5
 /api/v2/schedule?event=vol-5
 ```
 
 **Option 2: Header Versioning**
 
-```
+```text
 GET /api/schedule?event=vol-5
 Accept: application/vnd.bandcrawl.v2+json
 ```
 
 **Option 3: Query Parameter**
 
-```
+```text
 /api/schedule?event=vol-5&api_version=2
 ```
 
@@ -767,7 +767,7 @@ ALTER TABLE events ADD COLUMN org_id INTEGER REFERENCES organizations(id);
 
 ### Branch Strategy
 
-```
+```text
 main (production)
   ↑
   └── dev (staging)
@@ -988,7 +988,7 @@ wrangler d1 list
 
 ### API Endpoints
 
-```
+```text
 PUBLIC:
 GET  /api/schedule?event={slug|current}
 
@@ -1012,7 +1012,7 @@ DELETE /api/admin/bands/{id}
 
 ### File Structure
 
-```
+```text
 settimes/
 ├── database/
 │   ├── schema.sql           # Table definitions

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -100,7 +100,7 @@ npm run build
 
 **Expected output:**
 
-```
+```text
 ✓ 1234 modules transformed.
 dist/index.html                  1.23 kB
 dist/assets/index-abc123.js      456.78 kB
@@ -128,7 +128,7 @@ wrangler d1 create settimes-production-db
 
 **Output:**
 
-```
+```text
 ✅ Successfully created DB 'settimes-production-db'
 
 [[d1_databases]]
@@ -192,7 +192,7 @@ wrangler d1 execute settimes-production-db --env production --file=database/seed
 
 **Expected output:**
 
-```
+```text
 🌀 Applying migration 001_initial_schema.sql
 🌀 Applying migration 002_add_audit_logs.sql
 🌀 Applying migration 003_add_sessions.sql
@@ -242,7 +242,7 @@ The system uses invite codes for admin account creation — do **not** insert pa
 
 **Production:**
 
-```
+```text
 DATABASE_ID = your-production-db-id
 ENVIRONMENT = production
 SESSION_SECRET = random-64-char-string  # Generate securely
@@ -257,7 +257,7 @@ PUBLIC_URL = https://settimes.ca
 
 **Preview (optional):**
 
-```
+```text
 DATABASE_ID = your-dev-db-id
 ENVIRONMENT = development
 SESSION_SECRET = different-random-string
@@ -311,7 +311,7 @@ openssl rand -base64 48
 
 3. **Configure Build Settings**
 
-   ```
+   ```text
    Production branch: main
    Preview branches: dev, develop
 
@@ -368,7 +368,7 @@ Cloudflare will automatically configure DNS if domain is managed by Cloudflare:
 
 **Automatic DNS Record:**
 
-```
+```text
 Type: CNAME
 Name: settimes.ca
 Target: settimes-xxx.pages.dev
@@ -377,7 +377,7 @@ Proxy: Enabled (orange cloud)
 
 **If using external DNS:**
 
-```
+```text
 Type: CNAME
 Name: settimes.ca (or www)
 Target: settimes-xxx.pages.dev
@@ -385,7 +385,7 @@ Target: settimes-xxx.pages.dev
 
 ### 3. Add www Subdomain (Optional)
 
-```
+```text
 Type: CNAME
 Name: www
 Target: settimes.ca

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -104,7 +104,7 @@ Repeat for all bands
 
 **Example Performances:**
 
-```
+```text
 Band: The Sunset Trio
 Venue: Blue Room
 Start: 7:00 PM
@@ -208,31 +208,31 @@ Your event is currently a draft (not visible to the public). To make it live:
 
 **Create Event:**
 
-```
+```text
 Events tab → Create Event → Fill form → Next → Add venues → Next → Add performers → Create
 ```
 
 **Publish Event:**
 
-```
+```text
 Events tab → Find event → Edit → Check "Published" → Save
 ```
 
 **Add Band:**
 
-```
+```text
 Performers tab → Add Performer → Fill form → Save
 ```
 
 **Edit Event:**
 
-```
+```text
 Events tab → Find event → Edit → Make changes → Save
 ```
 
 **Unpublish Event:**
 
-```
+```text
 Events tab → Find event → Edit → Uncheck "Published" → Save
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -286,14 +286,14 @@ DELETE FROM events WHERE id = <event_id>;
 
 **Example Conflict:**
 
-```
+```text
 Band A: 7:00 PM - 8:00 PM (Analog Cafe)
 Band B: 7:30 PM - 8:30 PM (Analog Cafe) ❌ CONFLICT
 ```
 
 **Fixed:**
 
-```
+```text
 Band A: 7:00 PM - 8:00 PM (Analog Cafe)
 Band B: 8:30 PM - 9:30 PM (Analog Cafe) ✅ NO CONFLICT
 ```

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -247,7 +247,7 @@ When you select an event, a **context banner** appears at the top showing:
 
 Navigation breadcrumbs show your current location:
 
-```
+```text
 All Events > Spring Festival 2025 > Performers
 ```
 
@@ -300,7 +300,7 @@ SetTimes is WCAG 2.1 AA compliant:
 
 Every band/performer automatically gets a public profile page at:
 
-```
+```text
 settimes.ca/bands/[event-slug]/[band-name]
 ```
 

--- a/docs/frontend/ADMIN_INTEGRATION_EXAMPLE.md
+++ b/docs/frontend/ADMIN_INTEGRATION_EXAMPLE.md
@@ -174,7 +174,7 @@ Already configured! Just use `/admin` path.
 
 ## File Structure After Integration
 
-```
+```text
 frontend/
 ├── src/
 │   ├── admin/

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write \"functions/**/*.{js,json}\" \"scripts/**/*.{js,mjs,json}\" \"e2e/**/*.{js,mjs}\"",
     "format:check": "prettier --check \"functions/**/*.{js,json}\" \"scripts/**/*.{js,mjs,json}\" \"e2e/**/*.{js,mjs}\"",
-    "lint": "eslint functions/ scripts/ e2e/"
+    "lint": "eslint functions/ scripts/ e2e/",
+    "lint:md": "npx -y markdownlint-cli2@0.23.2 \"**/*.md\""
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",


### PR DESCRIPTION
## Summary

`markdownlint-cli2 "**/*.md"` reached **2,774 files** in this repo and reported **633 findings**. Almost none were ours. This scopes it to files we actually maintain, then fixes everything it found — `npm run lint:md` now reports **0 issues**.

Closes nothing; no issue was filed, this came out of the Cloudflare/docs audit.

## What changed

| File | Change |
|------|--------|
| `.markdownlint-cli2.jsonc` | New. `gitignore: true` plus an explicit ignore list |
| `package.json` | One line: `npm run lint:md` |
| `SECURITY.md`, `docs/**` (8 files) | 35 fence lines given a `text` language tag |
| `CLAUDE.md` | Three accuracy corrections from CodeRabbit on the zone-config docs |

## Use `markdownlint-cli2`, not the `markdownlint` brew formula

They read **different config files**, which is easy to lose an afternoon to. cli v1 (0.49.1) ignores `.markdownlint-cli2.jsonc` entirely — it reported **33,931 findings, 33,649 from `node_modules`**, with that config sitting right there.

A `.markdownlintignore` for v1 was written and then deleted. v1 has no gitignore option, so it needs a hand-copied duplicate of `.gitignore` — and it was **already wrong by eight trees within minutes** (`archive/`, `instructions/`, `claudedocs/`, `plugins/`, `test-results/`, `prompts/`, `chatmodes/`, part of `docs/`). A config that is 90% right is worse than none, because it reads as authoritative.

The version is pinned in the **script**, not as a devDependency: adding it cost **81 lockfile packages**, a poor trade for a linter CodeRabbit already runs on every PR. `npx` pins it just as firmly with no dependency surface.

## What is excluded, and why it is not just "inconvenient"

`.github/instructions/**` and `.github/skills/**` are **vendored** — the former from Microsoft's awesome-copilot (`applyTo:` frontmatter, "Your Mission" headings), the latter added by "chore: track Copilot skills" (d441855). Between them they accounted for **578 of the 633** findings, almost all MD007 list-indent disagreements with upstream's own formatting. Restyling someone else's document to satisfy our linter buys a conflict on the next sync and fixes nothing that is ours. Three files under `.github/skills/` were tagged before this was established, and were reverted.

## Security / correctness notes

None — documentation and lint config only. No runtime code touched.

Rules still come from `.markdownlint.json` (#663): this file declares **no `config` key**, deliberately, so it cannot shadow them. Canary if you change that — MD013 is disabled there and `CLAUDE.md` has very long lines, so MD013 must report 0.

## Two things the pass turned up

- **One fence is four backticks**, legitimately, because the block contains triple backticks. The first version of the fix asserted exactly three and **aborted rather than corrupting the block**; the fix preserves the original fence width.
- **`docs/SECURITY.md` is a symlink** to `../SECURITY.md`, not a copy. That is why 36 findings map to 35 edited lines, and why one edit fixes both. Worth knowing before anyone tries to "de-duplicate" them.

## Verification

- [x] `make gate`: exit 0 — **1498 backend**, **1239 frontend**, unchanged (no runtime code touched)
- [x] `npm run lint:md`: **0 issues in 0 files** (from 633)
- [x] ESLint: 0 errors · Format check: clean · Build: green
- [x] `validate:openapi`: N/A — `docs/api-spec.yaml` unchanged
- [x] `mkdocs build --strict`: builds clean, so the published docs site is unaffected
- [x] `make review` (CodeRabbit): no new findings; the 3 previous ones are addressed in this branch
- [x] **Diff verified mechanically, not by eye**: every removed line matches a bare fence and every added line matches a text-tagged fence, in equal counts — the diff contains nothing but fence tags
- [x] Every block was read before tagging; `text` is accurate for all of them (ASCII diagrams, directory trees, console output, DNS tables, UI paths)

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved Markdown formatting across guides, handbooks, security documentation, and deployment references.
  - Clarified Cloudflare state categorization and DMARC reporting guidance.
  - Preserved existing commands, examples, and documented behaviour.

- **Chores**
  - Added Markdown linting commands and included documentation checks in the validation workflow.
  - Configured Markdown linting exclusions for generated, vendored, dependency, and changelog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->