### PR TITLE
fix(perf): stop /* poisoning every static asset's cache policy

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -35,7 +35,16 @@
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()
 
   # Prevent stale HTML fallback caching (SPA routes like /band/*, /event/*)
-  Cache-Control: no-cache, no-store, must-revalidate
+  # NO Cache-Control here, deliberately. A `_headers` rule COMBINES with
+  # every other matching rule (comma-joined), so a no-store on /* joined
+  # /assets/*'s `immutable` into `no-store, ..., immutable` — no-store wins,
+  # and cf-cache-status went BYPASS. Every hashed bundle was re-downloaded
+  # on every navigation and the edge cached nothing (#987).
+  #
+  # The stale-HTML risk this used to guard is already handled: Cloudflare
+  # Pages serves HTML with `public, max-age=0, must-revalidate` by default,
+  # which revalidates on every request. Verified against a real server, not
+  # assumed.
 
 # Embed widget pages — intended to be loaded in third-party iframes.
 # Cloudflare Pages merges duplicate headers across matching rules (comma-joining),

--- a/functions/__tests__/headersCachePolicy.test.js
+++ b/functions/__tests__/headersCachePolicy.test.js
@@ -31,7 +31,7 @@ const HEADERS_FILE = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "
  */
 function parseHeaders(source) {
   const rules = [];
-  let current = null;
+  let current;
   for (const raw of source.split("\n")) {
     if (!raw.trim() || raw.trim().startsWith("#")) continue;
     if (!/^\s/.test(raw)) {

--- a/functions/__tests__/headersCachePolicy.test.js
+++ b/functions/__tests__/headersCachePolicy.test.js
@@ -1,0 +1,82 @@
+// Guard: the global `/*` rule in _headers must not declare Cache-Control.
+//
+// A `_headers` rule COMBINES with every other rule matching the same path
+// rather than being overridden by the more specific one. So `/*` declaring
+// `no-cache, no-store, must-revalidate` joined with `/assets/*`'s
+// `public, max-age=31536000, immutable` to produce BOTH, comma-separated —
+// and `no-store` wins. Every content-hashed bundle was re-downloaded on every
+// navigation, and `cf-cache-status` reported BYPASS, so the edge cached
+// nothing either (#987).
+//
+// The stale-HTML risk the line was defending against is handled by the
+// platform: Pages serves HTML with `public, max-age=0, must-revalidate` by
+// default, which revalidates on every request.
+//
+// MEASURE WITH GET, NEVER HEAD. The original #987 diagnosis was half wrong
+// because it used `curl -I`: the API Functions export only `onRequestGet`, so
+// a HEAD request falls through to the SPA shell and reports the shell's
+// headers. On GET the API tiers were correct all along; only the static
+// assets were actually broken.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HEADERS_FILE = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend", "public", "_headers");
+
+/**
+ * Parse _headers into [{ path, headers: {name: value} }].
+ * A rule starts at a non-indented, non-comment line; its headers are the
+ * indented `Name: value` lines that follow.
+ */
+function parseHeaders(source) {
+  const rules = [];
+  let current = null;
+  for (const raw of source.split("\n")) {
+    if (!raw.trim() || raw.trim().startsWith("#")) continue;
+    if (!/^\s/.test(raw)) {
+      current = { path: raw.trim(), headers: {} };
+      rules.push(current);
+      continue;
+    }
+    const match = raw.trim().match(/^([A-Za-z0-9-]+):\s*(.*)$/);
+    if (match && current) current.headers[match[1].toLowerCase()] = match[2];
+  }
+  return rules;
+}
+
+describe("_headers cache policy (#987)", () => {
+  const rules = parseHeaders(readFileSync(HEADERS_FILE, "utf8"));
+
+  it("parses the file it is guarding", () => {
+    expect(rules.length).toBeGreaterThan(10);
+    expect(rules.some((r) => r.path === "/*")).toBe(true);
+    expect(rules.some((r) => r.path === "/assets/*")).toBe(true);
+  });
+
+  it("the global /* rule declares no Cache-Control", () => {
+    const star = rules.find((r) => r.path === "/*");
+    expect(
+      star.headers["cache-control"],
+      "A Cache-Control on /* is comma-JOINED into every other rule, so a no-store " +
+        "there silently poisons /assets/*'s immutable caching and forces cf-cache-status " +
+        "to BYPASS. Set cache policy on specific paths instead (#987).",
+    ).toBeUndefined();
+  });
+
+  it("hashed assets are still declared immutable", () => {
+    const assets = rules.find((r) => r.path === "/assets/*");
+    expect(assets.headers["cache-control"]).toMatch(/immutable/);
+    expect(assets.headers["cache-control"]).not.toMatch(/no-store/);
+  });
+
+  it("no rule pairs no-store with a positive max-age", () => {
+    const contradictory = rules
+      .filter((r) => {
+        const cc = r.headers["cache-control"];
+        return cc && /no-store/.test(cc) && /max-age=[1-9]/.test(cc);
+      })
+      .map((r) => `${r.path}: ${r.headers["cache-control"]}`);
+    expect(contradictory, "no-store defeats any max-age beside it").toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Content-hashed JS/CSS bundles were served with `no-store` and `cf-cache-status: BYPASS` — every navigation re-downloaded the full bundle and the edge cached nothing. One line in `_headers` caused it.

Closes #987

## Root cause

A `_headers` rule **combines** with every other rule matching the same path, comma-joined, rather than being overridden by the more specific one. So `/*`'s `no-cache, no-store, must-revalidate` was joined into `/assets/*`'s `public, max-age=31536000, immutable`:

```
cache-control: no-cache, no-store, must-revalidate, public, max-age=31536000, immutable
cf-cache-status: BYPASS
```

`no-store` wins. That poisoned all 32 asset, favicon, font and manifest rules.

The line was defending against a stale SPA shell outliving a deploy. **The platform already handles that** — Pages serves HTML with `public, max-age=0, must-revalidate` by default, which revalidates every request. Verified against a real `wrangler pages dev`, not assumed.

## I have to correct #987 — I filed it and it was half wrong

Every measurement in that issue used `curl -I`, a **HEAD** request. The API Functions export only `onRequestGet`, so a HEAD falls through to the SPA shell and reports *the shell's* headers.

| path | HEAD (what I reported) | GET (the truth) |
|---|---|---|
| `/api/events/public` | `no-store, …` | **`public, max-age=300`** ✅ |
| `/api/bands/stats/…` | `no-store, …` | **`public, max-age=60`** ✅ |
| `/sitemap.xml` | `no-store, …, max-age=3600` | **`public, max-age=3600`** ✅ |
| `/assets/index-*.js` | `no-store, …, immutable` | `no-store, …, immutable` ❌ |

**The two-tier cache design was working the whole time.** `CACHE_SHOW_CRITICAL` and `CACHE_BROWSE` reach the wire, and `cacheHeaders.test.js` was never guarding a dead system. I withdraw that claim; only the static assets were genuinely broken.

The distinction that explains both halves, now documented: **a Function's headers win and `_headers` does not override them; a static file gets every matching `_headers` rule comma-joined.**

## Measured after the fix (GET, against a real server)

```
/assets/index-*.js   public, max-age=31536000, immutable    (was: no-store, …, immutable)
/                    public, max-age=0, must-revalidate
/band/31             public, max-age=0, must-revalidate
/manifest.json       public, max-age=86400
/sitemap.xml         public, max-age=3600
/robots.txt          public, max-age=3600
/api/events/public   public, max-age=300                    (unchanged — always correct)
```

## Security / correctness notes

No behaviour change for HTML: it moves from an explicit `no-store` to the platform's `max-age=0, must-revalidate`, which still revalidates on every request. No Function response is affected — `_headers` never governed them.

## Verification

- [x] `make gate`: exit 0 — **1502 backend** (+4), **1239 frontend**
- [x] Measured against a real `wrangler pages dev` **with GET**, both before and after
- [x] Confirmed the dev server reproduces production exactly before trusting it
- [x] New guard `functions/__tests__/headersCachePolicy.test.js` — fails if `/*` regains a `Cache-Control`, if `/assets/*` loses `immutable` or gains `no-store`, or if any rule pairs `no-store` with a positive `max-age`
- [x] **Mutation-checked**: restoring the deleted line turns exactly one test red
- [x] `make review` (CodeRabbit): 1 minor, addressed
- [ ] Post-deploy: confirm `cf-cache-status` leaves `BYPASS` on a hashed asset once this is live

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated page caching behaviour to use Cloudflare Pages’ default HTML caching.
  * Preserved long-term immutable caching for versioned assets.

* **Tests**
  * Added coverage to verify caching rules for pages and versioned assets.
  * Added validation to prevent conflicting cache directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->