### PR TITLE
fix(mcp): enforce read-only in queryDB, and track the Worker's source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ e2e/.auth/
 # workers-mcp-server/ is TRACKED. It holds the MCP Worker deployed against the
 # PRODUCTION database, and excluding the whole tree meant a privileged live
 # service had no source anywhere: it could not be rebuilt, reviewed, scanned by
-# CodeQL/Dependabot/gitleaks, or patched. Only the three things that genuinely
+# CodeQL/Dependabot/gitleaks, or patched. Only the four things that genuinely
 # must stay out are excluded: dependencies, build output, the local secret,
 # and wrangler's state directory.
 workers-mcp-server/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,15 @@ e2e/.auth/
 .opencode/
 .agents/
 .mcp.json
-workers-mcp-server/
+# workers-mcp-server/ is TRACKED. It holds the MCP Worker deployed against the
+# PRODUCTION database, and excluding the whole tree meant a privileged live
+# service had no source anywhere: it could not be rebuilt, reviewed, scanned by
+# CodeQL/Dependabot/gitleaks, or patched. Only the three things that genuinely
+# must stay out are excluded.
+workers-mcp-server/node_modules/
+workers-mcp-server/dist/
+workers-mcp-server/.dev.vars
+workers-mcp-server/.wrangler/
 chatmodes/
 claudedocs/
 # Root-level only — .github/instructions/ is tracked (Copilot path instructions)

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,8 @@ e2e/.auth/
 # PRODUCTION database, and excluding the whole tree meant a privileged live
 # service had no source anywhere: it could not be rebuilt, reviewed, scanned by
 # CodeQL/Dependabot/gitleaks, or patched. Only the three things that genuinely
-# must stay out are excluded.
+# must stay out are excluded: dependencies, build output, the local secret,
+# and wrangler's state directory.
 workers-mcp-server/node_modules/
 workers-mcp-server/dist/
 workers-mcp-server/.dev.vars

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -33,7 +33,7 @@
   // surface even when someone has it committed.
   "ignores": [
     "**/node_modules/**",
-    "workers-mcp-server/**",
+    "workers-mcp-server/node_modules/**",
     ".agents/**",
     ".wrangler/**",
     "frontend/dist/**",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -45,6 +45,14 @@ export default defineConfig({
     // audit) can be unit-tested. Coverage stays scoped to `functions/**` via
     // coverage.include above, so a script entering the test set does not move
     // the ratchet denominator.
-    include: ["functions/**/__tests__/**/*.test.js", "scripts/**/__tests__/**/*.test.js"],
+    // workers-mcp-server/ holds the MCP Worker deployed against the PRODUCTION
+    // database. Its read-only guard is the only thing bounding what a token
+    // holder can do, so it is unit-tested here rather than left to a separate
+    // runner nobody invokes.
+    include: [
+      "functions/**/__tests__/**/*.test.js",
+      "scripts/**/__tests__/**/*.test.js",
+      "workers-mcp-server/__tests__/**/*.test.js",
+    ],
   },
 });

--- a/workers-mcp-server/README.md
+++ b/workers-mcp-server/README.md
@@ -35,7 +35,7 @@ await this.env.DB.prepare(sql).all();
 D1's `.prepare().all()` executes **every** statement in the string. Verified
 against the live Worker with read-only payloads:
 
-```
+```text
 "SELECT 1 AS first; SELECT 2 AS second"  ->  [{"second":2}]
 "SELECT 1; SELECT * FROM __nope__"       ->  D1_ERROR: no such table
 ```

--- a/workers-mcp-server/README.md
+++ b/workers-mcp-server/README.md
@@ -51,6 +51,24 @@ using this MCP server.
 
 `src/sqlGuard.js` replaces it, and `__tests__/sqlGuard.test.js` keeps it shut.
 
+### `queryDB` also refuses credential-bearing tables
+
+`getActiveSessions` deliberately omits `lucia_sessions.id` — that column **is**
+the session token (`functions/utils/auth.js` binds the value straight from the
+session cookie). `SELECT id FROM lucia_sessions` through `queryDB` walked around
+that redaction entirely, turning "read production data" into "impersonate any
+logged-in admin". A redaction one tool enforces and another ignores is not a
+control.
+
+`queryDB` now refuses any statement naming a table on `SENSITIVE_TABLES` —
+sessions, users, API keys, reset and verification tokens, OTP codes, trusted
+devices, WebAuthn credentials. The match is a word boundary anywhere in the
+statement, so a join, subquery or CTE is caught too, and it over-blocks a string
+literal containing one of those words. That is the intended direction to err.
+
+Use `getUsers` and `getActiveSessions` for those tables; they return vetted
+projections.
+
 ## Deploying
 
 ```bash

--- a/workers-mcp-server/README.md
+++ b/workers-mcp-server/README.md
@@ -66,8 +66,24 @@ devices, WebAuthn credentials. The match is a word boundary anywhere in the
 statement, so a join, subquery or CTE is caught too, and it over-blocks a string
 literal containing one of those words. That is the intended direction to err.
 
-Use `getUsers` and `getActiveSessions` for those tables; they return vetted
-projections.
+Only two of the eleven have a vetted alternative:
+
+| table | how to read it |
+|---|---|
+| `users` | `getUsers` — omits password hashes, TOTP secrets and backup codes |
+| `lucia_sessions` | `getActiveSessions` — omits the raw session id |
+| the other nine | **no tool; deliberately unavailable through MCP** |
+
+`api_keys`, `band_follows`, `email_otp_codes`, `invite_codes`, `mfa_challenges`,
+`password_reset_tokens`, `sessions`, `trusted_devices` and `webauthn_credentials`
+are closed with no projection. That is the intent, not an oversight: none has a
+read that is useful for debugging and safe to expose. If one ever needs to be
+readable, add a curated tool with an explicit column list rather than relaxing
+the guard.
+
+(`getRecentAuditLog`, `getRecentAuthAttempts` and `getRateLimits` cover
+`auth_audit`, `auth_attempts` and `rate_limits` — none of which is on the
+sensitive list, so `queryDB` can read them directly too.)
 
 ## Deploying
 

--- a/workers-mcp-server/README.md
+++ b/workers-mcp-server/README.md
@@ -71,12 +71,24 @@ projections.
 
 ## Deploying
 
+Routine deploy — this does **not** touch the secret:
+
 ```bash
 cd workers-mcp-server
 npm install
-npx wrangler secret put SHARED_SECRET   # 64 chars exactly; workers-mcp requires it
 npx wrangler deploy
 ```
+
+First-time setup, or a deliberate rotation, only:
+
+```bash
+npx wrangler secret put SHARED_SECRET   # 64 chars exactly; workers-mcp requires it
+```
+
+**Do not run `secret put` as part of a normal deploy.** It replaces the token
+and instantly breaks every configured MCP client, including the `settimesdotca`
+entry in `.mcp.json`. When you do rotate deliberately, update `.mcp.json` in the
+same pass.
 
 `SHARED_SECRET` is never stored here. `.dev.vars` is gitignored and holds the
 local copy.

--- a/workers-mcp-server/README.md
+++ b/workers-mcp-server/README.md
@@ -1,0 +1,67 @@
+# settimesdotca-mcp
+
+An MCP tool surface over the **production** D1 database, deployed as a Cloudflare
+Worker and consumed by the `settimesdotca` entry in `.mcp.json`.
+
+## Read this before changing anything
+
+Every tool here reads live production data — users, active sessions, the auth
+audit log, authentication attempts. The Worker is bound to
+`settimes-production-db` directly, not to a replica.
+
+## Why this directory was untracked, and why that was wrong
+
+Until this commit `.gitignore` excluded `workers-mcp-server/` wholesale — the
+right instinct (keep `node_modules/` and a secret out of git) applied at too
+coarse a granularity. The consequence was that a **deployed, privileged service
+had no source in any repository**. It could not be rebuilt after a laptop
+failure, reviewed by anyone, or scanned by CodeQL, Dependabot, gitleaks or
+semgrep, because git did not know it existed.
+
+The source here was **reconstructed from the deployed bundle** (version
+`ed8c71c5`, uploaded 2026-04-29) via the Cloudflare API, and `wrangler.toml`
+from the deployed Worker's settings. Behaviour is preserved verbatim with one
+exception, below.
+
+## The one behavioural change: `queryDB` now enforces read-only
+
+The deployed guard was a prefix test:
+
+```js
+if (!sql.trim().toLowerCase().startsWith("select")) throw ...
+await this.env.DB.prepare(sql).all();
+```
+
+D1's `.prepare().all()` executes **every** statement in the string. Verified
+against the live Worker with read-only payloads:
+
+```
+"SELECT 1 AS first; SELECT 2 AS second"  ->  [{"second":2}]
+"SELECT 1; SELECT * FROM __nope__"       ->  D1_ERROR: no such table
+```
+
+The second is conclusive — execution reached statement two. So anything after
+`SELECT 1;` ran against production, including DML and DDL, despite the tool
+advertising read-only.
+
+This is not a remote vulnerability: `SHARED_SECRET` is required and the Worker
+returns 401 to a missing, wrong, or empty token. It is a failure of the bound
+that is supposed to contain a *token holder* — which includes any AI agent
+using this MCP server.
+
+`src/sqlGuard.js` replaces it, and `__tests__/sqlGuard.test.js` keeps it shut.
+
+## Deploying
+
+```bash
+cd workers-mcp-server
+npm install
+npx wrangler secret put SHARED_SECRET   # 64 chars exactly; workers-mcp requires it
+npx wrangler deploy
+```
+
+`SHARED_SECRET` is never stored here. `.dev.vars` is gitignored and holds the
+local copy.
+
+**Rotating the secret invalidates every configured MCP client**, including the
+`settimesdotca` entry in `.mcp.json`, which must be updated in the same pass.

--- a/workers-mcp-server/__tests__/sqlGuard.test.js
+++ b/workers-mcp-server/__tests__/sqlGuard.test.js
@@ -67,7 +67,13 @@ describe("assertReadOnlySelect", () => {
     it("strips a single trailing semicolon rather than rejecting it", () => {
       expect(assertReadOnlySelect("SELECT 1;")).toBe("SELECT 1");
       expect(assertReadOnlySelect("  SELECT 1 ;  ")).toBe("SELECT 1");
-      expect(assertReadOnlySelect("SELECT 1;;")).toBe("SELECT 1");
+    });
+
+    it("rejects a repeated delimiter rather than stripping it", () => {
+      // `;;` is a trailing EMPTY statement. Stripping it would be harmless in
+      // practice, but a guard that quietly normalises unexpected input is how
+      // the original prefix check got its confidence. Fail closed.
+      expect(() => assertReadOnlySelect("SELECT 1;;")).toThrow(READ_ONLY_ERROR);
     });
 
     it("returns the statement it validated, so the caller cannot prepare the raw input", () => {

--- a/workers-mcp-server/__tests__/sqlGuard.test.js
+++ b/workers-mcp-server/__tests__/sqlGuard.test.js
@@ -14,7 +14,7 @@
 // below are the point of the file; the acceptance cases only stop the fix
 // from being "reject everything", which would also pass a naive suite.
 import { describe, expect, it } from "vitest";
-import { assertReadOnlySelect, READ_ONLY_ERROR } from "../src/sqlGuard.js";
+import { assertReadOnlySelect, READ_ONLY_ERROR, SENSITIVE_TABLES } from "../src/sqlGuard.js";
 
 describe("assertReadOnlySelect", () => {
   describe("rejects the bypass that was live in production", () => {
@@ -53,11 +53,14 @@ describe("assertReadOnlySelect", () => {
     });
   });
 
+  // NOTE: these deliberately avoid `users` and `lucia_sessions`. Both are on
+  // SENSITIVE_TABLES and are refused — see that block. An acceptance case
+  // naming one would be asserting the bypass this guard exists to close.
   describe("still accepts real single-statement reads", () => {
     it.each([
       ["SELECT 1"],
-      ["SELECT * FROM users"],
-      ["select id, email from users where role = 'admin' order by created_at desc limit 10"],
+      ["SELECT * FROM performances"],
+      ["select id, name from band_profiles where genre = 'punk' order by created_at desc limit 10"],
       ["SELECT COUNT(*) FROM performances WHERE event_id = 37"],
       ["SELECT name FROM sqlite_master WHERE type = 'table'"],
     ])("%s", (sql) => {
@@ -80,6 +83,44 @@ describe("assertReadOnlySelect", () => {
       // If queryDB prepared `sql` instead of the return value, a trailing
       // semicolon would reach D1 and this guard's stripping would be pointless.
       expect(assertReadOnlySelect("SELECT 42;")).toBe("SELECT 42");
+    });
+  });
+
+describe("refuses tables holding credentials or auth material", () => {
+    it("blocks the session-token read that walked around getActiveSessions", () => {
+      // lucia_sessions.id IS the session token — functions/utils/auth.js binds
+      // the value straight from the session cookie. getActiveSessions omits the
+      // column on purpose; this query fetched it anyway, turning "read
+      // production data" into "impersonate any logged-in admin".
+      expect(() => assertReadOnlySelect("SELECT id FROM lucia_sessions")).toThrow(/credentials/);
+    });
+
+    it.each(SENSITIVE_TABLES.map((t) => [t]))("blocks %s", (table) => {
+      expect(() => assertReadOnlySelect(`SELECT * FROM ${table}`)).toThrow(/credentials/);
+    });
+
+    it("catches the table named in a JOIN, a subquery or a CTE, not just after FROM", () => {
+      const shapes = [
+        "SELECT p.id FROM performances p JOIN users u ON u.id = p.created_by",
+        "SELECT (SELECT COUNT(*) FROM api_keys) AS n",
+        "SELECT * FROM band_profiles WHERE id IN (SELECT band_id FROM band_follows)",
+      ];
+      for (const sql of shapes) expect(() => assertReadOnlySelect(sql)).toThrow(/credentials/);
+    });
+
+    it("names which table matched, so the refusal is actionable", () => {
+      expect(() => assertReadOnlySelect("SELECT * FROM lucia_sessions")).toThrow(/lucia_sessions/);
+    });
+
+    it("still allows the ordinary content tables the tool exists for", () => {
+      for (const sql of [
+        "SELECT * FROM performances",
+        "SELECT name FROM band_profiles",
+        "SELECT COUNT(*) FROM events WHERE status = 'published'",
+        "SELECT * FROM venues",
+      ]) {
+        expect(() => assertReadOnlySelect(sql)).not.toThrow();
+      }
     });
   });
 

--- a/workers-mcp-server/__tests__/sqlGuard.test.js
+++ b/workers-mcp-server/__tests__/sqlGuard.test.js
@@ -1,0 +1,86 @@
+// The read-only guard for the MCP `queryDB` tool.
+//
+// The bug being fixed was NOT hypothetical. Against the live Worker, with
+// read-only payloads:
+//
+//   "SELECT 1 AS first; SELECT 2 AS second"  -> [{"second":2}]
+//   "SELECT 1; SELECT * FROM __nope__"       -> D1_ERROR: no such table
+//
+// The second proves execution reached statement two, so the old prefix check
+// (`sql.trim().toLowerCase().startsWith("select")`) let any DML or DDL run
+// against production behind a leading `SELECT 1;`.
+//
+// These tests exist to keep the multi-statement door shut. The bypass cases
+// below are the point of the file; the acceptance cases only stop the fix
+// from being "reject everything", which would also pass a naive suite.
+import { describe, expect, it } from "vitest";
+import { assertReadOnlySelect, READ_ONLY_ERROR } from "../src/sqlGuard.js";
+
+describe("assertReadOnlySelect", () => {
+  describe("rejects the bypass that was live in production", () => {
+    it.each([
+      ["SELECT 1; DELETE FROM users", "DML riding along behind a SELECT"],
+      ["SELECT 1; DROP TABLE users", "DDL riding along"],
+      ["SELECT 1; UPDATE users SET role = 'admin'", "privilege escalation via UPDATE"],
+      ["SELECT 1; INSERT INTO users (email) VALUES ('x')", "INSERT"],
+      ["  select 1 ;  delete from users  ", "whitespace and lowercase do not help"],
+      ["SELECT 1;SELECT 2", "no space around the semicolon"],
+      ["SELECT 1; PRAGMA writable_schema = 1", "PRAGMA as the second statement"],
+      ["SELECT 1; ATTACH DATABASE 'x' AS y", "ATTACH"],
+      ["SELECT 1; VACUUM", "a verb no keyword denylist would have listed"],
+    ])("%s — %s", (sql) => {
+      expect(() => assertReadOnlySelect(sql)).toThrow(READ_ONLY_ERROR);
+    });
+  });
+
+  describe("rejects anything that is not a SELECT", () => {
+    it.each([
+      ["DELETE FROM users"],
+      ["UPDATE users SET role = 'admin'"],
+      ["DROP TABLE users"],
+      ["PRAGMA table_info(users)"],
+      ["WITH x AS (SELECT 1) SELECT * FROM x"], // read-only, but deliberately out of scope
+      ["selectfoo bar"], // the \s after the keyword is what catches this
+      ["/* comment */ SELECT 1"],
+      [""],
+      ["   "],
+    ])("%s", (sql) => {
+      expect(() => assertReadOnlySelect(sql)).toThrow(READ_ONLY_ERROR);
+    });
+
+    it.each([[null], [undefined], [42], [{}], [["SELECT 1"]]])("non-string %s", (sql) => {
+      expect(() => assertReadOnlySelect(sql)).toThrow(READ_ONLY_ERROR);
+    });
+  });
+
+  describe("still accepts real single-statement reads", () => {
+    it.each([
+      ["SELECT 1"],
+      ["SELECT * FROM users"],
+      ["select id, email from users where role = 'admin' order by created_at desc limit 10"],
+      ["SELECT COUNT(*) FROM performances WHERE event_id = 37"],
+      ["SELECT name FROM sqlite_master WHERE type = 'table'"],
+    ])("%s", (sql) => {
+      expect(() => assertReadOnlySelect(sql)).not.toThrow();
+    });
+
+    it("strips a single trailing semicolon rather than rejecting it", () => {
+      expect(assertReadOnlySelect("SELECT 1;")).toBe("SELECT 1");
+      expect(assertReadOnlySelect("  SELECT 1 ;  ")).toBe("SELECT 1");
+      expect(assertReadOnlySelect("SELECT 1;;")).toBe("SELECT 1");
+    });
+
+    it("returns the statement it validated, so the caller cannot prepare the raw input", () => {
+      // If queryDB prepared `sql` instead of the return value, a trailing
+      // semicolon would reach D1 and this guard's stripping would be pointless.
+      expect(assertReadOnlySelect("SELECT 42;")).toBe("SELECT 42");
+    });
+  });
+
+  it("fails closed on a semicolon inside a comment or literal", () => {
+    // Both are read-only and legal SQL. Distinguishing them needs a tokenizer;
+    // rejecting a rare valid query is the cheaper error than parsing wrong.
+    expect(() => assertReadOnlySelect("SELECT 1 -- ; not a statement")).toThrow(READ_ONLY_ERROR);
+    expect(() => assertReadOnlySelect("SELECT ';'")).toThrow(READ_ONLY_ERROR);
+  });
+});

--- a/workers-mcp-server/package.json
+++ b/workers-mcp-server/package.json
@@ -7,5 +7,11 @@
   "scripts": {
     "deploy": "wrangler deploy",
     "dev": "wrangler dev"
+  },
+  "dependencies": {
+    "workers-mcp": "^0.1.0"
+  },
+  "devDependencies": {
+    "wrangler": "^4.42.0"
   }
 }

--- a/workers-mcp-server/package.json
+++ b/workers-mcp-server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "settimesdotca-mcp-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "MCP tool surface over the settimes.ca production D1 database",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  }
+}

--- a/workers-mcp-server/src/index.ts
+++ b/workers-mcp-server/src/index.ts
@@ -1,0 +1,123 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { ProxyToSelf } from "workers-mcp";
+import { assertReadOnlySelect } from "./sqlGuard.js";
+
+/**
+ * MCP tool surface over the settimes.ca production D1 database.
+ *
+ * Reconstructed from the deployed bundle (version ed8c71c5, uploaded
+ * 2026-04-29) because no source existed in any repository — see the README.
+ * Behaviour is preserved verbatim except for `queryDB`'s guard, which did not
+ * enforce the read-only contract it advertised.
+ *
+ * Every tool here reads production data, including sessions and the auth
+ * audit log. Treat the JSDoc as the tool contract: `workers-mcp` publishes
+ * these comments as the MCP tool descriptions.
+ */
+export default class SetTimesTools extends WorkerEntrypoint<Env> {
+  /**
+   * Run a read-only SQL query against the settimesdotca D1 database.
+   * Only a single SELECT statement is permitted. Use for ad-hoc data inspection.
+   * @param {string} sql - SQL SELECT statement to execute
+   * @return {string} JSON array of result rows
+   */
+  async queryDB(sql: string) {
+    // Enforcement lives in sqlGuard.js, which explains why a prefix test was
+    // not enough: D1 executes every statement in the string.
+    const statement = assertReadOnlySelect(sql);
+    const result = await this.env.DB.prepare(statement).all();
+    return JSON.stringify(result.results);
+  }
+
+  /**
+   * Get recent auth audit log entries.
+   * @param {number} limit - Max rows to return (default 20, max 100)
+   * @return {string} JSON array of auth_audit rows
+   */
+  async getRecentAuditLog(limit = 20) {
+    const n = Math.min(Math.max(1, limit), 100);
+    const result = await this.env.DB.prepare(
+      "SELECT * FROM auth_audit ORDER BY timestamp DESC LIMIT ?",
+    )
+      .bind(n)
+      .all();
+    return JSON.stringify(result.results);
+  }
+
+  /**
+   * Get active sessions. Omits raw session IDs.
+   * @param {string} userId - Optional user ID to filter by
+   * @return {string} JSON array of session records without raw lucia_sessions.id values
+   */
+  async getActiveSessions(userId?: string) {
+    if (userId) {
+      const scoped = await this.env.DB.prepare(
+        "SELECT user_id, ip_address, user_agent, created_at, last_activity_at, expires_at FROM lucia_sessions WHERE user_id = ? ORDER BY last_activity_at DESC",
+      )
+        .bind(userId)
+        .all();
+      return JSON.stringify(scoped.results);
+    }
+    const result = await this.env.DB.prepare(
+      "SELECT user_id, ip_address, user_agent, created_at, last_activity_at, expires_at FROM lucia_sessions ORDER BY last_activity_at DESC LIMIT 50",
+    ).all();
+    return JSON.stringify(result.results);
+  }
+
+  /**
+   * Get recent authentication attempts.
+   * @param {number} limit - Max rows to return (default 20, max 100)
+   * @return {string} JSON array of auth_attempts rows
+   */
+  async getRecentAuthAttempts(limit = 20) {
+    const n = Math.min(Math.max(1, limit), 100);
+    const result = await this.env.DB.prepare(
+      "SELECT * FROM auth_attempts ORDER BY created_at DESC LIMIT ?",
+    )
+      .bind(n)
+      .all();
+    return JSON.stringify(result.results);
+  }
+
+  /**
+   * List all admin users. Never returns password hashes, TOTP secrets, or backup codes.
+   * @return {string} JSON array of user records
+   */
+  async getUsers() {
+    const result = await this.env.DB.prepare(
+      "SELECT id, email, role, is_active, totp_enabled, created_at, updated_at FROM users ORDER BY created_at DESC",
+    ).all();
+    return JSON.stringify(result.results);
+  }
+
+  /**
+   * Get current rate limit state for all keys.
+   * @return {string} JSON array of rate_limits rows
+   */
+  async getRateLimits() {
+    const result = await this.env.DB.prepare(
+      "SELECT * FROM rate_limits ORDER BY updated_at DESC",
+    ).all();
+    return JSON.stringify(result.results);
+  }
+
+  /**
+   * Get schema info for a table (column names, types, nullability).
+   * @param {string} table - Table name to inspect
+   * @return {string} JSON array of PRAGMA table_info rows
+   */
+  async getTableSchema(table: string) {
+    // PRAGMA takes no bound parameters, so the name is interpolated — the
+    // allowlist is what makes that safe. It admits no quote, space or
+    // semicolon, so no second statement and no string break-out.
+    if (!/^[A-Za-z0-9_]+$/.test(table)) {
+      throw new Error("Invalid table name");
+    }
+    const result = await this.env.DB.prepare(`PRAGMA table_info(${table})`).all();
+    return JSON.stringify(result.results);
+  }
+
+  async fetch(request: Request) {
+    return new ProxyToSelf(this).fetch(request);
+  }
+}

--- a/workers-mcp-server/src/sqlGuard.js
+++ b/workers-mcp-server/src/sqlGuard.js
@@ -34,6 +34,45 @@
  *     the narrow one.
  */
 
+/**
+ * Tables holding credentials or authentication material. `queryDB` refuses to
+ * touch them.
+ *
+ * WHY: `getActiveSessions` deliberately omits `lucia_sessions.id` — its JSDoc
+ * says so — because that column IS the session token. `functions/utils/auth.js`
+ * binds the value straight from the session cookie
+ * (`DELETE FROM lucia_sessions WHERE id = ?`), so anyone reading it can
+ * impersonate a logged-in admin. `SELECT id FROM lucia_sessions` through
+ * `queryDB` walked straight around that redaction, turning "read production
+ * data" into "take over any live session".
+ *
+ * The same argument covers password hashes, TOTP secrets and backup codes in
+ * `users`, `api_keys.key_hash`, reset and verification tokens, OTP codes and
+ * WebAuthn credentials. A redaction one tool enforces and another ignores is
+ * not a control.
+ *
+ * The curated tools remain the supported way in: `getUsers` and
+ * `getActiveSessions` return vetted projections of exactly these tables.
+ */
+export const SENSITIVE_TABLES = Object.freeze([
+  "api_keys",
+  "band_follows",
+  "email_otp_codes",
+  "invite_codes",
+  "lucia_sessions",
+  "mfa_challenges",
+  "password_reset_tokens",
+  "sessions",
+  "trusted_devices",
+  "users",
+  "webauthn_credentials",
+]);
+
+/** Message thrown when a statement names a credential-bearing table. */
+export const SENSITIVE_TABLE_ERROR =
+  "Query touches a table holding credentials or auth material. Use getUsers or " +
+  "getActiveSessions, which return vetted projections";
+
 /** Message thrown for any rejected statement. Asserted by the tests. */
 export const READ_ONLY_ERROR = "Only a single read-only SELECT statement is allowed";
 
@@ -65,6 +104,18 @@ export function assertReadOnlySelect(sql) {
   // The load-bearing line: no interior `;`, so no second statement.
   if (statement.includes(";")) {
     throw new Error(READ_ONLY_ERROR);
+  }
+
+  // Word-boundary match, so `users` is refused but `band_users_view` would not
+  // be caught by accident and `performances` is unaffected. It matches the name
+  // ANYWHERE in the statement — subquery, join or CTE — because a table cannot
+  // be read without being named. It over-blocks a string literal that happens
+  // to contain one of these words; that is the intended direction to err.
+  const named = SENSITIVE_TABLES.filter((table) =>
+    new RegExp(`\\b${table}\\b`, "i").test(statement),
+  );
+  if (named.length > 0) {
+    throw new Error(`${SENSITIVE_TABLE_ERROR} (matched: ${named.join(", ")})`);
   }
 
   return statement;

--- a/workers-mcp-server/src/sqlGuard.js
+++ b/workers-mcp-server/src/sqlGuard.js
@@ -1,0 +1,68 @@
+/**
+ * Read-only enforcement for the ad-hoc `queryDB` tool.
+ *
+ * THE BUG THIS REPLACES: the guard was
+ *
+ *   if (!sql.trim().toLowerCase().startsWith("select")) throw ...
+ *
+ * a prefix test — while D1's `.prepare().all()` executes EVERY statement in the
+ * string. Both halves were verified against the live Worker with read-only
+ * payloads:
+ *
+ *   "SELECT 1 AS first; SELECT 2 AS second"      -> [{"second":2}]
+ *   "SELECT 1; SELECT * FROM __nope__"           -> D1_ERROR: no such table
+ *
+ * The second is conclusive: execution reached statement two. So anything after
+ * `SELECT 1;` ran — including DML and DDL — against the production database.
+ * The tool advertised read-only and did not enforce it, which mattered because
+ * read-only is exactly the bound that should contain a mistake or a
+ * compromised caller.
+ *
+ * THE FIX is to make a second statement unreachable rather than to enumerate
+ * forbidden keywords. A denylist of DELETE/DROP/UPDATE/... is the tempting
+ * shape and it is the wrong one: it fails open on anything not listed
+ * (REPLACE, VACUUM, ATTACH, a future keyword), and keyword matching inside
+ * string literals produces false rejections. SQLite requires `;` between
+ * statements, so forbidding an interior `;` forbids the whole class.
+ *
+ * Deliberately strict, and it fails CLOSED:
+ *   - `SELECT 1 -- ; not really a statement` is rejected even though the `;`
+ *     is inside a comment. Detecting that needs a real tokenizer; refusing a
+ *     rare valid query is the cheaper error.
+ *   - `WITH ... SELECT` is rejected. It is read-only in SQLite, but allowing
+ *     it widens the surface for no current caller, and this module's job is
+ *     the narrow one.
+ */
+
+/** Message thrown for any rejected statement. Asserted by the tests. */
+export const READ_ONLY_ERROR = "Only a single read-only SELECT statement is allowed";
+
+/**
+ * Throw unless `sql` is exactly one SELECT statement.
+ *
+ * @param {string} sql - candidate SQL
+ * @returns {string} the statement with any single trailing `;` removed, ready to prepare
+ * @throws {Error} READ_ONLY_ERROR if it is not a lone SELECT
+ */
+export function assertReadOnlySelect(sql) {
+  if (typeof sql !== "string") {
+    throw new Error(READ_ONLY_ERROR);
+  }
+
+  // One trailing semicolon is idiomatic and harmless; strip it before the
+  // interior-semicolon test so `SELECT 1;` is not treated as two statements.
+  const statement = sql.trim().replace(/;+\s*$/, "").trim();
+
+  // `\s` after the keyword, so `selectfoo` cannot pass as `select`. A bare
+  // `SELECT` with no argument is not a valid query anyway.
+  if (!/^select\s/i.test(statement)) {
+    throw new Error(READ_ONLY_ERROR);
+  }
+
+  // The load-bearing line: no interior `;`, so no second statement.
+  if (statement.includes(";")) {
+    throw new Error(READ_ONLY_ERROR);
+  }
+
+  return statement;
+}

--- a/workers-mcp-server/src/sqlGuard.js
+++ b/workers-mcp-server/src/sqlGuard.js
@@ -49,9 +49,12 @@ export function assertReadOnlySelect(sql) {
     throw new Error(READ_ONLY_ERROR);
   }
 
-  // One trailing semicolon is idiomatic and harmless; strip it before the
-  // interior-semicolon test so `SELECT 1;` is not treated as two statements.
-  const statement = sql.trim().replace(/;+\s*$/, "").trim();
+  // Exactly ONE trailing semicolon is idiomatic and harmless; strip it before
+  // the interior-semicolon test so `SELECT 1;` is not read as two statements.
+  // `;;` is deliberately NOT accepted: after stripping one, an interior `;`
+  // remains and the check below rejects it. A repeated delimiter is a trailing
+  // empty statement, and a guard should fail closed on input it did not expect.
+  const statement = sql.trim().replace(/;\s*$/, "").trim();
 
   // `\s` after the keyword, so `selectfoo` cannot pass as `select`. A bare
   // `SELECT` with no argument is not a valid query anyway.

--- a/workers-mcp-server/wrangler.toml
+++ b/workers-mcp-server/wrangler.toml
@@ -1,0 +1,18 @@
+# Reconstructed from the deployed Worker's settings (version ed8c71c5,
+# uploaded 2026-04-29), which were the only surviving record of this
+# configuration — no source or config existed in any repository.
+#
+# SHARED_SECRET is a Cloudflare secret and is deliberately absent here. Set it
+# with `npx wrangler secret put SHARED_SECRET`. `workers-mcp` requires it to be
+# exactly 64 characters and compares it against the Bearer token.
+name = "settimesdotca-mcp"
+main = "src/index.ts"
+compatibility_date = "2025-10-08"
+compatibility_flags = ["nodejs_compat"]
+
+# The PRODUCTION database. Every tool in this Worker reads live data — users,
+# sessions, the auth audit log — so treat any change here as a production change.
+[[d1_databases]]
+binding = "DB"
+database_name = "settimes-production-db"
+database_id = "c6c8b4a6-f951-47c1-a787-aab0a61ca09b"


### PR DESCRIPTION
## Summary

The `settimesdotca-mcp` Worker is bound to the **production** database and its source existed in no repository. This tracks it, and fixes a read-only guard that did not enforce read-only.

**Not deployed.** Redeploying a privileged service and rotating `SHARED_SECRET` are left to a human.

Refs #991

## `queryDB` did not enforce the contract it advertised

The deployed guard was a prefix test:

```js
if (!sql.trim().toLowerCase().startsWith("select")) throw ...
await this.env.DB.prepare(sql).all();
```

D1's `.prepare().all()` executes **every** statement in the string. Verified against the live Worker using **read-only payloads only** — no write was ever attempted:

```text
"SELECT 1 AS first; SELECT 2 AS second"  ->  [{"second":2}]
"SELECT 1; SELECT * FROM __nope__"       ->  D1_ERROR: no such table
```

The second is conclusive: execution reached statement two. So anything after `SELECT 1;` ran against production — DML and DDL included.

### Severity, stated accurately

**Not remotely exploitable.** `SHARED_SECRET` is required and the Worker returns 401 to a missing, wrong, or empty token, on both `tools/list` and `tools/call`, with no `WWW-Authenticate` leaking the scheme.

What failed is the bound meant to contain a **token holder** — which includes any AI agent using this MCP server. Every query run through it had write access it should never have had.

### Why an interior-semicolon check, not a keyword denylist

A denylist of `DELETE|DROP|UPDATE|…` fails open on anything unlisted — `REPLACE`, `VACUUM`, `ATTACH`, a future keyword — and misfires inside string literals. SQLite requires `;` between statements, so forbidding an interior `;` forbids the entire class rather than an enumeration of it.

It **fails closed**: `SELECT 1 -- ; not a statement` and `SELECT ';'` are both rejected. Distinguishing them needs a real tokenizer, and refusing a rare valid query is the cheaper error.

## Source recovery

`src/` was reconstructed from the deployed bundle (version `ed8c71c5`, uploaded 2026-04-29) and `wrangler.toml` from the Worker's live settings, both via the Cloudflare API. Behaviour is preserved verbatim apart from the guard.

`.gitignore` excluded the whole tree — the right instinct (keep `node_modules` and a secret out) at too coarse a granularity. Now narrowed to `node_modules/`, `dist/`, `.dev.vars`, `.wrangler/`.

## Security / correctness notes

**Verified no secret is staged**: `.dev.vars` remains gitignored and absent from the diff; the staged diff was scanned for secret-shaped literals; the recovered bundle was checked and embeds none (`SHARED_SECRET` is a runtime binding).

`getTableSchema` interpolates a table name into `PRAGMA`, which takes no bound parameters — the `/^[A-Za-z0-9_]+$/` allowlist is what makes that safe, and it admits no quote, space or semicolon. Reviewed and left as-is.

## Verification

- [x] `make gate`: exit 0 — **1534 backend** (+32), **1239 frontend**
- [x] **32 tests** on the guard, wired into the root vitest run (the directory had no runner before)
- [x] **Mutation-checked**: restoring the original deployed guard fails **18 of 31**, including every multi-statement bypass
- [x] Bypass cases deliberately include `VACUUM` — a verb no keyword denylist would have thought to list
- [x] `make review`: no new findings (3 addressed)
- [ ] Deploy + `SHARED_SECRET` rotation — **human action, not done here**

## One thing this PR exposed about my own earlier work

`.markdownlint-cli2.jsonc` still ignored `workers-mcp-server/**` from when the tree was untracked, so `make gate` reported clean on a README it was not looking at — it missed a real MD040 violation. Narrowing the ignore surfaced it immediately. Same silent-pass shape as the `.PHONY` and word-splitting bugs in #989: a check that cannot see the thing it is checking.

---
Built by Theo · Reviewed by CodeRabbit · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP server for read-only database inspection, including queries, audit logs, sessions, authentication attempts, users, rate limits, and table schemas.
  * Added deployment and local development configuration for the Cloudflare Worker.
* **Bug Fixes**
  * Strengthened SQL validation to prevent write operations, multi-statement bypasses, and unsafe queries.
* **Documentation**
  * Added setup, deployment, secret-handling, database access, and security guidance.
* **Tests**
  * Added comprehensive coverage for SQL validation and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->