### PR TITLE
refactor(admin): extract LineupTab's pure logic into admin/utils

### DIFF
--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -22,10 +22,15 @@ import { buildPickerFormData, buildEmptyPickerFormData } from './utils/pickerFor
 import { buildDayOptions, isMultiDayEvent } from './utils/dayOptions'
 import {
   buildDayNumberMap,
+  buildConflictsByBandId,
   deriveGenreSuggestions,
   deriveOriginSuggestions,
   filterRosterBands,
+  getActiveBands,
+  mergeConflicts,
+  selectAllBandIds,
   sortRosterBands,
+  updateSelectedIds,
 } from './utils/lineupRoster'
 import { formatFestivalDate } from '../utils/festivalDays'
 
@@ -134,10 +139,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
   // builder never offers a retired band as a schedulable option. Origin/genre
   // suggestion lists below intentionally keep using the unfiltered `allBands`
   // — reusing a retired band's origin/genre value is harmless.
-  const activeBands = useMemo(
-    () => allBands.filter(band => band.is_active !== 0 && band.is_active !== false),
-    [allBands]
-  )
+  const activeBands = useMemo(() => getActiveBands(allBands), [allBands])
 
   const originCitySuggestions = useMemo(() => deriveOriginSuggestions(allBands, 'city'), [allBands])
   const originRegionSuggestions = useMemo(() => deriveOriginSuggestions(allBands, 'region'), [allBands])
@@ -498,9 +500,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
   // backend checkConflicts day-scoping; NULL performance_date inherits eventDate,
   // keeping single-day behavior unchanged.
   const conflictsByBandId = useMemo(() => {
-    const map = new Map()
-    for (const band of bands) map.set(band.id, detectConflicts(band, bands, selectedEvent?.date))
-    return map
+    return buildConflictsByBandId(bands, selectedEvent?.date)
   }, [bands, selectedEvent?.date])
 
   const formConflicts = useMemo(() => {
@@ -529,22 +529,15 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
   ])
 
   const combinedConflicts = useMemo(
-    () => ({
-      overlaps: [...new Set([...formConflicts.overlaps, ...serverConflicts.overlaps])],
-      conflicts: [...new Set([...formConflicts.conflicts, ...serverConflicts.conflicts])],
-    }),
+    () => mergeConflicts(formConflicts, serverConflicts),
     [formConflicts, serverConflicts]
   )
 
   // Select logic
   const handleSelect = (id, checked) => {
-    setSelectedIds(prev => {
-      const next = new Set(prev)
-      checked ? next.add(id) : next.delete(id)
-      return next
-    })
+    setSelectedIds(prev => updateSelectedIds(prev, id, checked))
   }
-  const handleSelectAll = checked => setSelectedIds(checked ? new Set(filteredBands.map(b => b.id)) : new Set())
+  const handleSelectAll = checked => setSelectedIds(selectAllBandIds(filteredBands, checked))
 
   const clearBulkState = () => {
     setSelectedIds(new Set())

--- a/frontend/src/admin/utils/__tests__/lineupRoster.test.js
+++ b/frontend/src/admin/utils/__tests__/lineupRoster.test.js
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildConflictsByBandId,
   buildDayNumberMap,
   deriveGenreSuggestions,
   deriveOriginSuggestions,
   filterRosterBands,
+  getActiveBands,
+  mergeConflicts,
+  selectAllBandIds,
   sortRosterBands,
+  updateSelectedIds,
 } from '../lineupRoster'
 
 const band = (id, over = {}) => ({
@@ -107,6 +112,11 @@ describe('sortRosterBands', () => {
     // must sort after 23:00 rather than first. This is the recurring bug class.
     const bands = [band(1, { start_time: '01:00' }), band(2, { start_time: '23:00' }), band(3, { start_time: '20:00' })]
     expect(sortRosterBands(bands, { key: null }, deps).map(b => b.id)).toEqual([3, 2, 1])
+  })
+
+  it('honours after-midnight ordering for the explicit start-time key', () => {
+    const bands = [band(1, { start_time: '01:00' }), band(2, { start_time: '23:00' })]
+    expect(sortRosterBands(bands, { key: 'start_time', direction: 'asc' }, deps).map(b => b.id)).toEqual([2, 1])
   })
 
   it('sorts by name with articles stripped (#587)', () => {
@@ -238,5 +248,61 @@ describe('buildDayNumberMap', () => {
 
   it('is empty for a single-day event, which has no day options', () => {
     expect(buildDayNumberMap([]).size).toBe(0)
+  })
+})
+
+describe('getActiveBands', () => {
+  it('excludes numeric and boolean inactive profiles', () => {
+    const bands = [band(1), band(2, { is_active: 0 }), band(3, { is_active: false }), band(4, { is_active: 1 })]
+    expect(getActiveBands(bands).map(b => b.id)).toEqual([1, 4])
+  })
+
+  it('does not mutate the roster', () => {
+    const bands = [band(1)]
+    expect(getActiveBands(bands)).not.toBe(bands)
+  })
+})
+
+describe('buildConflictsByBandId', () => {
+  it('maps each performance id to its conflict result', () => {
+    const first = band(1, { event_id: 1, venue_id: 2, start_time: '20:00', end_time: '22:00' })
+    const second = band(2, { event_id: 1, venue_id: 2, start_time: '21:00', end_time: '23:00' })
+    const result = buildConflictsByBandId([first, second], '2026-10-11')
+    expect(result.get(1).overlaps).toEqual(['Band 2'])
+    expect(result.get(2).overlaps).toEqual(['Band 1'])
+  })
+
+  it('returns an empty map for an empty roster', () => {
+    expect(buildConflictsByBandId([]).size).toBe(0)
+  })
+})
+
+describe('mergeConflicts', () => {
+  it('combines conflict names while preserving first-seen order', () => {
+    expect(
+      mergeConflicts({ overlaps: ['A'], conflicts: ['B', 'C'] }, { overlaps: ['A', 'D'], conflicts: ['C'] })
+    ).toEqual({
+      overlaps: ['A', 'D'],
+      conflicts: ['B', 'C'],
+    })
+  })
+
+  it('handles missing conflict lists', () => {
+    expect(mergeConflicts({}, {})).toEqual({ overlaps: [], conflicts: [] })
+  })
+})
+
+describe('selection helpers', () => {
+  it('adds and removes one id without mutating the source set', () => {
+    const original = new Set([1])
+    expect(updateSelectedIds(original, 2, true)).toEqual(new Set([1, 2]))
+    expect(updateSelectedIds(original, 1, false)).toEqual(new Set())
+    expect(original).toEqual(new Set([1]))
+  })
+
+  it('selects filtered ids or clears the selection', () => {
+    const bands = [band(1), band(2)]
+    expect(selectAllBandIds(bands, true)).toEqual(new Set([1, 2]))
+    expect(selectAllBandIds(bands, false)).toEqual(new Set())
   })
 })

--- a/frontend/src/admin/utils/lineupRoster.js
+++ b/frontend/src/admin/utils/lineupRoster.js
@@ -1,7 +1,13 @@
 import { sortableName } from '../../utils/sortableName'
 import { parseOrigin } from '../../utils/parseOrigin'
 import { DEFAULT_GENRES, getNormalizedGenreSuggestions } from '../../utils/genres'
-import { adjustForMidnight, deriveDurationMinutes, parseTimeToMinutes, sortBandsByStart } from './timeUtils'
+import {
+  adjustForMidnight,
+  deriveDurationMinutes,
+  detectConflicts,
+  parseTimeToMinutes,
+  sortBandsByStart,
+} from './timeUtils'
 
 /**
  * Pure roster logic for LineupTab — what an operator sees, and in what order.
@@ -15,6 +21,17 @@ import { adjustForMidnight, deriveDurationMinutes, parseTimeToMinutes, sortBands
  * Every function here takes its collaborators as arguments instead of closing
  * over component state, so a test supplies them without a render.
  */
+
+/**
+ * Keep retired profiles out of the lineup picker while retaining them for
+ * origin and genre suggestions.
+ *
+ * @param {Array<object>} bands
+ * @returns {Array<object>}
+ */
+export function getActiveBands(bands) {
+  return (bands ?? []).filter(band => band.is_active !== 0 && band.is_active !== false)
+}
 
 /**
  * Narrow the roster by search text, venue, and festival day.
@@ -164,4 +181,57 @@ export function deriveGenreSuggestions(bands) {
  */
 export function buildDayNumberMap(dayOptions) {
   return new Map((dayOptions ?? []).map((opt, index) => [opt.value, index + 1]))
+}
+
+/**
+ * Pre-compute conflict results by performance id for the lineup table.
+ *
+ * @param {Array<object>} bands
+ * @param {string} [eventDate]
+ * @returns {Map<number|string, {overlaps: string[], conflicts: string[]}>}
+ */
+export function buildConflictsByBandId(bands, eventDate) {
+  const conflicts = new Map()
+  for (const band of bands ?? []) conflicts.set(band.id, detectConflicts(band, bands, eventDate))
+  return conflicts
+}
+
+/**
+ * Merge client- and server-reported conflict names without duplicates.
+ *
+ * @param {{overlaps?: string[], conflicts?: string[]}} formConflicts
+ * @param {{overlaps?: string[], conflicts?: string[]}} serverConflicts
+ * @returns {{overlaps: string[], conflicts: string[]}}
+ */
+export function mergeConflicts(formConflicts = {}, serverConflicts = {}) {
+  return {
+    overlaps: [...new Set([...(formConflicts.overlaps ?? []), ...(serverConflicts.overlaps ?? [])])],
+    conflicts: [...new Set([...(formConflicts.conflicts ?? []), ...(serverConflicts.conflicts ?? [])])],
+  }
+}
+
+/**
+ * Apply one checkbox change without mutating the existing selection set.
+ *
+ * @param {Set<number|string>} selectedIds
+ * @param {number|string} id
+ * @param {boolean} checked
+ * @returns {Set<number|string>}
+ */
+export function updateSelectedIds(selectedIds, id, checked) {
+  const next = new Set(selectedIds)
+  if (checked) next.add(id)
+  else next.delete(id)
+  return next
+}
+
+/**
+ * Build the selection represented by a select-all checkbox.
+ *
+ * @param {Array<{id: number|string}>} bands
+ * @param {boolean} checked
+ * @returns {Set<number|string>}
+ */
+export function selectAllBandIds(bands, checked) {
+  return checked ? new Set((bands ?? []).map(band => band.id)) : new Set()
 }


### PR DESCRIPTION
## Summary

`LineupTab.jsx` is the largest admin component (1,148 lines, 46 hooks) and loaded in **zero** tests. This moves five pure functions into `admin/utils/lineupRoster.js` and tests them there.

Refs #908

**Delegated to OpenCode** (`opencode-go/gpt-5.6-luna`, **$0.0966**). The diff was reviewed and the gate re-run here rather than accepted on the delegate's report.

## Why extraction, not mounting the component

Frontend coverage counts only files a test loads. Mounting a 1,148-line component to raise coverage *lowers* the global percentage and can break the ratchet in `frontend/vitest.config.js`. Small pure modules raise it — **1239 → 1248 frontend tests**.

`admin/utils/` is where this repo already keeps that logic: 11 modules, 10 with dedicated tests. The new functions went into the existing `lineupRoster.js` rather than inventing new files.

## The win is real but modest, and worth being plain about

**1148 → 1141 lines.** Seven lines.

Most of what remains is handlers closing over component state — genuinely not pure, and correctly left alone. Reducing the 46 hooks needs a different technique than extraction, and #908 stays open for it. This is one honest slice, not a fix for the whole complaint.

## Security / correctness notes

Pure refactor, no behaviour change. Verified here rather than taken on report:

- **After-midnight threshold** is imported from `timeUtils`, never re-declared — the source-scanning guard in `afterMidnightThreshold.test.js` still holds.
- **No second list of artist link fields** introduced; `bandFields.js` remains the single source of truth.
- Backend untouched (1502 before and after).

## Verification

- [x] `make gate`: exit 0 — **1502 backend**, **1248 frontend** (+9)
- [x] Diff read line by line; invariant checks run independently of the delegate
- [x] `make review` (CodeRabbit): **no findings**
- [x] Frontend coverage ratchet passes
- [ ] Manual smoke: not run — pure extraction with no behaviour change, covered by the new unit tests

## Note on the delegation

The delegate flagged that its baseline of 1,534 backend tests did not match the 1,502 it measured, and asked rather than papering over it. **It was right and my brief was wrong** — 1,534 includes tests from #992, which is not merged. Worth recording as an instance of a delegate reporting a discrepancy instead of quietly adjusting to it.

---
Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lineup selection by excluding inactive bands from lineup-picker results while preserving them for related suggestions.
  * Improved conflict handling by combining server and client conflict details without duplicates.
  * Preserved correct after-midnight ordering for lineup times.

* **Tests**
  * Added coverage for active-band filtering, conflict handling, bulk selection, and individual selection updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->