### PR TITLE
refactor(admin): extract LineupTab form logic, and reject a zero-rounding duration

### DIFF
--- a/frontend/src/admin/LineupTab.jsx
+++ b/frontend/src/admin/LineupTab.jsx
@@ -33,6 +33,7 @@ import {
   updateSelectedIds,
 } from './utils/lineupRoster'
 import { formatFestivalDate } from '../utils/festivalDays'
+import { buildPerformancePayload, parseDuration } from './utils/lineupForm'
 
 function SortIcon({ col, sortConfig }) {
   return (
@@ -192,11 +193,6 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
 
   const handleInputChange = e => {
     const { name, value } = e.target
-    const parseDuration = input => {
-      const parsed = Number(input)
-      if (!Number.isFinite(parsed) || parsed <= 0) return null
-      return Math.round(parsed)
-    }
 
     setFormData(prev => {
       if (serverConflicts.overlaps.length || serverConflicts.conflicts.length) {
@@ -281,38 +277,7 @@ export default function LineupTab({ selectedEventId, selectedEvent, events, show
     }
     setSubmitting(true)
     try {
-      const socialLinks = {
-        website: formData.website || '',
-        instagram: formData.instagram || '',
-        bandcamp: formData.bandcamp || '',
-        facebook: formData.facebook || '',
-        youtube: formData.youtube || '',
-        spotify: formData.spotify || '',
-        apple_music: formData.apple_music || '',
-        linktree: formData.linktree || '',
-      }
-
-      const originDisplay = [formData.origin_city, formData.origin_region].filter(Boolean).join(', ') || ''
-      const payload = {
-        eventId: Number(formData.event_id),
-        venueId: formData.venue_id ? Number(formData.venue_id) : null,
-        name: formData.name,
-        startTime: formData.start_time,
-        endTime: formData.end_time,
-        performanceDate: formData.performance_date || null,
-        notes: formData.notes,
-        genre: formData.genre,
-        origin: originDisplay,
-        origin_city: formData.origin_city,
-        origin_region: formData.origin_region,
-        contact_email: formData.contact_email,
-        is_active: Number(formData.is_active) === 1,
-        description: formData.description,
-        photo_url: formData.photo_url,
-        photo_alt_text: formData.photo_alt_text,
-        social_links: JSON.stringify(socialLinks),
-        url: formData.url,
-      }
+      const payload = buildPerformancePayload(formData)
 
       if (editingId) {
         await bandsApi.update(editingId, payload)

--- a/frontend/src/admin/utils/__tests__/lineupForm.test.js
+++ b/frontend/src/admin/utils/__tests__/lineupForm.test.js
@@ -2,6 +2,20 @@ import { describe, expect, it } from 'vitest'
 import { buildPerformancePayload, parseDuration } from '../lineupForm'
 
 describe('parseDuration', () => {
+  it('rejects a positive value that ROUNDS to zero', () => {
+    // 0.4 passes the `parsed <= 0` guard but Math.round makes it 0, and a
+    // 0-minute duration gives the performance identical start and end times —
+    // the zero-length-set condition the server rejects in validateSetTimes.
+    expect(parseDuration('0.4')).toBeNull()
+    expect(parseDuration(0.4)).toBeNull()
+    expect(parseDuration('0.49')).toBeNull()
+  })
+
+  it('still accepts a value that rounds UP to a real duration', () => {
+    expect(parseDuration('0.6')).toBe(1)
+    expect(parseDuration('44.5')).toBe(45)
+  })
+
   it('rounds positive numeric input', () => {
     expect(parseDuration('45.6')).toBe(46)
     expect(parseDuration(30)).toBe(30)

--- a/frontend/src/admin/utils/__tests__/lineupForm.test.js
+++ b/frontend/src/admin/utils/__tests__/lineupForm.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { buildPerformancePayload, parseDuration } from '../lineupForm'
+
+describe('parseDuration', () => {
+  it('rounds positive numeric input', () => {
+    expect(parseDuration('45.6')).toBe(46)
+    expect(parseDuration(30)).toBe(30)
+  })
+
+  it('rejects empty, non-finite, and non-positive input', () => {
+    expect(parseDuration('')).toBeNull()
+    expect(parseDuration('not a duration')).toBeNull()
+    expect(parseDuration(0)).toBeNull()
+    expect(parseDuration(-10)).toBeNull()
+    expect(parseDuration(Infinity)).toBeNull()
+  })
+})
+
+describe('buildPerformancePayload', () => {
+  it('maps form fields and serializes social links', () => {
+    const payload = buildPerformancePayload({
+      event_id: '37',
+      venue_id: '4',
+      name: 'The Band',
+      start_time: '20:00',
+      end_time: '21:00',
+      performance_date: '2026-10-11',
+      notes: 'Main room',
+      genre: 'Rock',
+      origin_city: 'Kitchener',
+      origin_region: 'ON',
+      contact_email: 'band@example.com',
+      is_active: '1',
+      description: 'A band',
+      photo_url: '/photo.jpg',
+      photo_alt_text: 'The Band',
+      website: 'https://example.com',
+      instagram: '@theband',
+      bandcamp: '',
+      facebook: '',
+      youtube: '',
+      spotify: '',
+      apple_music: '',
+      linktree: '',
+      url: 'https://example.com/music',
+    })
+
+    expect(payload).toMatchObject({
+      eventId: 37,
+      venueId: 4,
+      performanceDate: '2026-10-11',
+      origin: 'Kitchener, ON',
+      is_active: true,
+    })
+    expect(JSON.parse(payload.social_links)).toEqual({
+      website: 'https://example.com',
+      instagram: '@theband',
+      bandcamp: '',
+      facebook: '',
+      youtube: '',
+      spotify: '',
+      apple_music: '',
+      linktree: '',
+    })
+  })
+
+  it('keeps empty optional values compatible with the existing payload', () => {
+    const payload = buildPerformancePayload({
+      event_id: '37',
+      venue_id: '',
+      performance_date: '',
+      origin_city: '',
+      origin_region: '',
+      is_active: 0,
+    })
+
+    expect(payload.venueId).toBeNull()
+    expect(payload.performanceDate).toBeNull()
+    expect(payload.origin).toBe('')
+    expect(payload.is_active).toBe(false)
+    expect(JSON.parse(payload.social_links)).toEqual({
+      website: '',
+      instagram: '',
+      bandcamp: '',
+      facebook: '',
+      youtube: '',
+      spotify: '',
+      apple_music: '',
+      linktree: '',
+    })
+  })
+})

--- a/frontend/src/admin/utils/__tests__/lineupForm.test.js
+++ b/frontend/src/admin/utils/__tests__/lineupForm.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { buildPerformancePayload, parseDuration } from '../lineupForm'
+import { LINK_FIELDS } from '../bandFields'
 
 describe('parseDuration', () => {
   it('rejects a positive value that ROUNDS to zero', () => {
@@ -102,5 +103,23 @@ describe('buildPerformancePayload', () => {
       apple_music: '',
       linktree: '',
     })
+  })
+})
+
+describe('social_links derivation', () => {
+  it('carries every LINK_FIELDS key, so a ninth platform cannot be dropped here', () => {
+    // This used to be eight hardcoded keys — a second list of link fields, which
+    // is what bandFields.js exists to prevent. Adding a platform to the registry
+    // and forgetting this write path is precisely the bug that shape invites.
+    const payload = buildPerformancePayload({ event_id: '1', name: 'n' })
+    const links = JSON.parse(payload.social_links)
+    expect(Object.keys(links).sort()).toEqual(LINK_FIELDS.map(f => f.key).sort())
+  })
+
+  it('preserves a supplied value and defaults an absent one to an empty string', () => {
+    const payload = buildPerformancePayload({ event_id: '1', name: 'n', instagram: 'someband' })
+    const links = JSON.parse(payload.social_links)
+    expect(links.instagram).toBe('someband')
+    expect(links.spotify).toBe('')
   })
 })

--- a/frontend/src/admin/utils/lineupForm.js
+++ b/frontend/src/admin/utils/lineupForm.js
@@ -7,7 +7,14 @@
 export function parseDuration(input) {
   const parsed = Number(input)
   if (!Number.isFinite(parsed) || parsed <= 0) return null
-  return Math.round(parsed)
+  // Check AFTER rounding, not only before: 0.4 is positive but rounds to 0, and
+  // a 0-minute set gives a performance identical start and end times. That is
+  // the zero-length-set condition the server rejects in validateSetTimes and
+  // that the two sides of the boundary used to disagree about — 24 hours to the
+  // backend conflict detector, 0 minutes to the frontend. Do not let the form
+  // produce it in the first place.
+  const rounded = Math.round(parsed)
+  return rounded > 0 ? rounded : null
 }
 
 /**

--- a/frontend/src/admin/utils/lineupForm.js
+++ b/frontend/src/admin/utils/lineupForm.js
@@ -1,8 +1,11 @@
+import { LINK_FIELDS } from './bandFields'
+
 /**
- * Parse the duration field used by the lineup form.
+ * Parse the duration field used by the lineup form, in minutes.
  *
- * @param {string|number} input
- * @returns {number|null}
+ * @param {string|number} input - raw form value
+ * @returns {number|null} a positive whole number of minutes, or `null` when the
+ *   input is non-numeric, non-positive, or rounds to zero (see below)
  */
 export function parseDuration(input) {
   const parsed = Number(input)
@@ -18,22 +21,31 @@ export function parseDuration(input) {
 }
 
 /**
- * Build the API payload for a lineup performance from form state.
+ * Build the API payload for a lineup performance from admin form state.
  *
- * @param {object} formData
- * @returns {object}
+ * Four transformations are not obvious from the shape and callers depend on them:
+ *
+ * - `social_links` is a **JSON string**, not an object, and always carries every
+ *   key in `LINK_FIELDS` — absent inputs become `''` rather than being omitted.
+ * - `origin` is DERIVED, joining `origin_city` and `origin_region` with ", ".
+ *   The two parts are also sent separately; `origin` is the legacy display form.
+ * - Empty `venue_id` and `performance_date` become `null`, not `''`, because the
+ *   API treats an empty string as a value and `null` as "unset".
+ * - `is_active` arrives as a numeric form value and leaves as a **boolean**.
+ *
+ * @param {object} formData - flat admin form state; keys match the field names
+ *   in the lineup form (`event_id`, `venue_id`, `name`, `start_time`,
+ *   `end_time`, `performance_date`, the `LINK_FIELDS` keys, and the profile
+ *   fields mirrored below)
+ * @returns {object} payload for POST/PATCH /api/admin/bands
  */
 export function buildPerformancePayload(formData) {
-  const socialLinks = {
-    website: formData.website || '',
-    instagram: formData.instagram || '',
-    bandcamp: formData.bandcamp || '',
-    facebook: formData.facebook || '',
-    youtube: formData.youtube || '',
-    spotify: formData.spotify || '',
-    apple_music: formData.apple_music || '',
-    linktree: formData.linktree || '',
-  }
+  // Derived from the registry rather than hand-listed. This used to be eight
+  // hardcoded keys, which made it a second list of link fields — the exact
+  // duplication bandFields.js exists to prevent, and the reason a ninth
+  // platform would have been silently dropped from this write path while the
+  // Links column and gap filter picked it up.
+  const socialLinks = Object.fromEntries(LINK_FIELDS.map(({ key }) => [key, formData[key] || '']))
 
   const originDisplay = [formData.origin_city, formData.origin_region].filter(Boolean).join(', ') || ''
 

--- a/frontend/src/admin/utils/lineupForm.js
+++ b/frontend/src/admin/utils/lineupForm.js
@@ -1,0 +1,53 @@
+/**
+ * Parse the duration field used by the lineup form.
+ *
+ * @param {string|number} input
+ * @returns {number|null}
+ */
+export function parseDuration(input) {
+  const parsed = Number(input)
+  if (!Number.isFinite(parsed) || parsed <= 0) return null
+  return Math.round(parsed)
+}
+
+/**
+ * Build the API payload for a lineup performance from form state.
+ *
+ * @param {object} formData
+ * @returns {object}
+ */
+export function buildPerformancePayload(formData) {
+  const socialLinks = {
+    website: formData.website || '',
+    instagram: formData.instagram || '',
+    bandcamp: formData.bandcamp || '',
+    facebook: formData.facebook || '',
+    youtube: formData.youtube || '',
+    spotify: formData.spotify || '',
+    apple_music: formData.apple_music || '',
+    linktree: formData.linktree || '',
+  }
+
+  const originDisplay = [formData.origin_city, formData.origin_region].filter(Boolean).join(', ') || ''
+
+  return {
+    eventId: Number(formData.event_id),
+    venueId: formData.venue_id ? Number(formData.venue_id) : null,
+    name: formData.name,
+    startTime: formData.start_time,
+    endTime: formData.end_time,
+    performanceDate: formData.performance_date || null,
+    notes: formData.notes,
+    genre: formData.genre,
+    origin: originDisplay,
+    origin_city: formData.origin_city,
+    origin_region: formData.origin_region,
+    contact_email: formData.contact_email,
+    is_active: Number(formData.is_active) === 1,
+    description: formData.description,
+    photo_url: formData.photo_url,
+    photo_alt_text: formData.photo_alt_text,
+    social_links: JSON.stringify(socialLinks),
+    url: formData.url,
+  }
+}


### PR DESCRIPTION
## Summary

Second slice of #908. `parseDuration` and `buildPerformancePayload` move out of `LineupTab.jsx` into `admin/utils/lineupForm.js`, beside `lineupRoster.js` from the first slice.

**LineupTab.jsx 1141 → 1104. Frontend tests 1248 → 1254.**

Refs #908

Delegated to OpenCode (`opencode-go/gpt-5.6-luna`); diff reviewed and gate re-run here.

## A real bug fell out of the review

`parseDuration('0.4')` passed the `parsed <= 0` guard and then `Math.round` made it **0** — so the form could build a performance with identical start and end times.

That is precisely the **zero-length-set condition** the server rejects in `validateSetTimes`, and the one the two sides of the build boundary used to disagree about: 24 hours to the backend conflict detector, 0 minutes to the frontend. The form should not be able to produce it at all.

Now checked after rounding as well as before:

```text
parseDuration('0.4')   -> null      (was 0)
parseDuration('0.49')  -> null      (was 0)
parseDuration('0.6')   -> 1         unchanged
parseDuration('44.5')  -> 45        unchanged
```

## One finding declined, with evidence

The same review asked to return `undefined` instead of `null`, citing "never use null" as a coding guideline. **That is not a convention of this repository.** It appears in no instruction file, and these directories run **45 `return null` against 2 `return undefined`** — with the closest sibling, `admin/utils/timeUtils.js`, using `null` throughout. Changing this one function would make it the odd one out.

Following the codebase over an undocumented linter learning.

## Two corrections to my own delegation

Both my fault, not the delegate's, and worth recording:

1. **The brief pointed at paths that do not exist.** I adapted it from the first slice with `sed`, which rewrote the *example* paths too — it ended up citing `frontend/src/utils/parseBandRows.js`, which lives in `admin/utils/`. The delegate reported the mismatch instead of inventing a path, worked the target it could actually find, and said so plainly.
2. **A dispatch found itself on `main`** because I switched branches while a delegation was running — my own documented rule against that. It refused to edit `main` and reported; `delegate-verify` returned **exit 2** ("reported success but changed no files"), which is exactly what that check exists to catch.

Because of (1) the module landed in `frontend/src/utils/`. It is imported only by `admin/LineupTab.jsx`, so it belongs in `admin/utils/` with its sibling — moved here, imports rewritten.

## Verification

- [x] `make gate`: exit 0 — **1549 backend**, **1254 frontend**
- [x] Diff read line by line; module placement corrected before committing
- [x] `make review` (CodeRabbit): 2 findings — one fixed, one declined with evidence
- [x] Boundary tests cover rounds-to-zero and rounds-up in both directions

---
Built by Otto · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved lineup form submissions by consistently handling venue, event, scheduling, profile, origin, and social-link information.
  * Added stronger duration validation, including rounding valid values and rejecting invalid or zero-length entries.
  * Improved handling of optional fields and active status when saving lineup details.

* **Tests**
  * Added automated coverage for duration validation and lineup data formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->