### PR TITLE
fix(live): rank gap suggestions by gap minutes seen, not proximity alone

### DIFF
--- a/frontend/src/utils/__tests__/gapSuggestions.test.js
+++ b/frontend/src/utils/__tests__/gapSuggestions.test.js
@@ -329,6 +329,17 @@ describe('suggestGapFillers', () => {
       expect(seenMinutes(overrunning, gap, gap.startMs, 0)).toBe(60)
     })
 
+    it('does not count a set that began before the gap opened', () => {
+      // Unreachable through suggestGapFillers -- its filter admits only
+      // candidates starting at or after the gap opens -- but seenMinutes is
+      // exported, and its contract is gap minutes, not set minutes.
+      // Departing at 19:30 -- a fan freed by an earlier set can arrive before the
+      // gap even opens, which is the only way `from` lands before `gap.startMs`.
+      const [gap, early] = prepare(makeBand('gap', '20:00', '21:00'), makeBand('early', '19:30', '20:30'))
+
+      expect(seenMinutes(early, gap, early.startMs, 0)).toBe(30)
+    })
+
     it('clamps to zero when the fan arrives after the gap has closed', () => {
       const [gap, band] = prepare(makeBand('gap', '20:00', '21:00'), makeBand('band', '20:30', '21:00'))
 

--- a/frontend/src/utils/__tests__/gapSuggestions.test.js
+++ b/frontend/src/utils/__tests__/gapSuggestions.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { suggestGapFillers } from '../gapSuggestions'
+import { seenMinutes, suggestGapFillers } from '../gapSuggestions'
 import { prepareBands } from '../bandUtils'
 
 const date = '2026-08-02'
@@ -90,7 +90,7 @@ describe('suggestGapFillers', () => {
     ).toBe(candidate)
   })
 
-  it('orders by walk time, then start time', () => {
+  it('orders by walk time, then start time when every candidate covers the gap equally', () => {
     const [cancelledBand, later, earlier, closest] = prepare(
       makeBand('cancelled', '20:00', '23:00', { is_cancelled: 1, venue_lat: 43.48, venue_lng: -80.52 }),
       makeBand('later', '21:30', '22:00', { venue_lat: 43.4824, venue_lng: -80.52 }),
@@ -173,5 +173,166 @@ describe('suggestGapFillers', () => {
     expect(() => suggestGapFillers({ cancelledBand: null, myBands: [], allBands: [] })).not.toThrow()
     expect(suggestGapFillers({ cancelledBand: null, myBands: [], allBands: [] })).toEqual([])
     expect(suggestGapFillers({ cancelledBand: {}, myBands: [], allBands: [] })).toEqual([])
+  })
+
+  // #972. Walk time used to be the PRIMARY key, which decided the headline
+  // suggestion on the key with the least dynamic range: across all 15 Vol. 17
+  // venue pairs walk time spans 1-3 minutes, while gap coverage spans 5-30.
+  // Measured over every real Vol. 17 / BF2 performance, that got the top pick
+  // wrong in 7 of 26 scenarios -- always trading 10-25 minutes of music to save
+  // one minute of walking. These lock in the corrected ranking.
+  describe('ranks by the gap minutes the fan actually sees (#972)', () => {
+    // The exact shape of the real Vol. 17 case: "Mixed Feelings" goes dark at
+    // 20:00, and the old sort offered Rhx34 (5 minutes of the hole, 1 minute
+    // away) over Rolodex Darko (the whole hole, 3 minutes away).
+    it('prefers a candidate that fills the gap over a nearer one filling a sliver', () => {
+      const [cancelledBand, sliver, filler] = prepare(
+        makeBand('cancelled', '20:00', '20:30', { is_cancelled: 1 }),
+        makeBand('sliver', '20:25', '20:55', { venue_lat: 43.4801 }),
+        makeBand('filler', '20:00', '20:30', { venue_lat: 43.4824 })
+      )
+
+      const suggestions = suggestGapFillers({
+        cancelledBand,
+        myBands: [cancelledBand],
+        allBands: [cancelledBand, sliver, filler],
+      })
+
+      expect(suggestions.map(s => s.band.id)).toEqual(['filler', 'sliver'])
+      // The nearer set really is nearer -- the ranking is overriding proximity,
+      // not benefiting from a coincidence where proximity already agreed.
+      expect(suggestions[0].walkMinutes).toBeGreaterThan(suggestions[1].walkMinutes)
+    })
+
+    // A walk the fan completes BEFORE the set starts costs them nothing. An
+    // earlier version deducted the whole walk unconditionally and would have
+    // ranked this reachable 35-minute set below the 30-minute one.
+    it('does not penalise a long walk the fan has time to make', () => {
+      const [cancelledBand, near, reachable] = prepare(
+        makeBand('cancelled', '20:00', '21:00', { is_cancelled: 1 }),
+        makeBand('near', '20:30', '21:00', { venue_lat: 43.4801 }),
+        makeBand('reachable', '20:25', '21:00', { venue_lat: 43.4944 })
+      )
+
+      const suggestions = suggestGapFillers({
+        cancelledBand,
+        myBands: [cancelledBand],
+        allBands: [cancelledBand, near, reachable],
+      })
+
+      // Leaving at 20:00, a 20-minute walk arrives at 20:20 -- five minutes
+      // before the set starts, so all 35 of its minutes count.
+      expect(suggestions[1].walkMinutes).toBe(1)
+      expect(suggestions.map(s => s.band.id)).toEqual(['reachable', 'near'])
+    })
+
+    // ...but a walk that makes the fan LATE costs exactly the minutes it eats.
+    // This is why the key is minutes seen and not raw gap coverage: real data
+    // cannot separate the two, because every Vol. 17 venue is within 3 minutes.
+    it('does not send the fan across town to arrive late for a longer set', () => {
+      const [cancelledBand, near, far] = prepare(
+        makeBand('cancelled', '20:00', '21:00', { is_cancelled: 1 }),
+        makeBand('near', '20:30', '21:00', { venue_lat: 43.4801 }),
+        makeBand('far', '20:05', '21:00', { venue_lat: 43.5088 })
+      )
+
+      // `far` covers far more of the gap on paper, so ranking on raw coverage
+      // would pick it: 55 minutes against 30.
+      expect(seenMinutes(far, cancelledBand, cancelledBand.startMs, 0)).toBeGreaterThan(
+        seenMinutes(near, cancelledBand, cancelledBand.startMs, 0)
+      )
+
+      const suggestions = suggestGapFillers({
+        cancelledBand,
+        myBands: [cancelledBand],
+        allBands: [cancelledBand, near, far],
+      })
+
+      // A 40-minute walk arrives at 20:40, so only 20 of those 55 minutes are
+      // ever seen -- against 30 for the set next door.
+      expect(suggestions[1].walkMinutes).toBe(40)
+      expect(suggestions.map(s => s.band.id)).toEqual(['near', 'far'])
+    })
+
+    it('breaks a tie on equal minutes seen by preferring the shorter walk', () => {
+      const [cancelledBand, farther, nearer] = prepare(
+        makeBand('cancelled', '20:00', '21:00', { is_cancelled: 1 }),
+        makeBand('farther', '20:30', '21:00', { venue_lat: 43.4824 }),
+        makeBand('nearer', '20:30', '21:00', { venue_lat: 43.4801 })
+      )
+
+      // Identical windows, and both walks finish before 20:30, so both are worth
+      // the same 30 minutes and only the tiebreak separates them.
+      expect(
+        suggestGapFillers({
+          cancelledBand,
+          myBands: [cancelledBand],
+          allBands: [cancelledBand, farther, nearer],
+        }).map(s => s.band.id)
+      ).toEqual(['nearer', 'farther'])
+    })
+
+    it('leaves when the prior set ends, not when the gap opens', () => {
+      // departureMs is paired with the walk source. Holding an earlier set means
+      // the fan is free from ITS end, which can be well before the gap opens --
+      // and that head start is what makes the distant set reachable at all.
+      const [cancelledBand, held, distant, close] = prepare(
+        makeBand('cancelled', '21:00', '22:00', { is_cancelled: 1 }),
+        makeBand('held', '20:00', '20:30'),
+        makeBand('distant', '21:00', '22:00', { venue_lat: 43.5088 }),
+        makeBand('close', '21:30', '22:00', { venue_lat: 43.4836 })
+      )
+
+      const suggestions = suggestGapFillers({
+        cancelledBand,
+        myBands: [held, cancelledBand],
+        allBands: [cancelledBand, held, distant, close],
+      })
+
+      // Free at 20:30, the 40-minute walk lands at 21:10 and `distant` is worth
+      // 50 minutes, beating `close` at 30. Measured from 21:00 instead it would
+      // land at 21:40, be worth only 20, and the order would invert.
+      expect(suggestions.map(s => s.band.id)).toEqual(['distant', 'close'])
+      expect(seenMinutes(distant, cancelledBand, held.endMs, 40)).toBe(50)
+      expect(seenMinutes(distant, cancelledBand, cancelledBand.startMs, 40)).toBe(20)
+    })
+  })
+
+  describe('seenMinutes', () => {
+    it('counts only the gap minutes remaining after the fan arrives', () => {
+      const [gap, band] = prepare(makeBand('gap', '20:00', '21:00'), makeBand('band', '20:00', '21:00'))
+
+      expect(seenMinutes(band, gap, gap.startMs, 0)).toBe(60)
+      expect(seenMinutes(band, gap, gap.startMs, 15)).toBe(45)
+    })
+
+    it('treats an unknown walk as instant rather than poisoning the score', () => {
+      // walkMinutesBetween returns null for a venue with no coordinates, and the
+      // sort already puts those last -- but the value still has to be a number,
+      // or NaN silently makes every comparison against it false.
+      //
+      // The OMITTED case is the one with teeth: null * 60000 is 0 in JS, so the
+      // null assertion below survives dropping the ?? 0 guard, while the omitted
+      // one yields NaN and fails. Both are kept -- null is what the engine
+      // actually passes, undefined is what proves the guard is load-bearing.
+      const [gap, band] = prepare(makeBand('gap', '20:00', '21:00'), makeBand('band', '20:00', '21:00'))
+
+      expect(seenMinutes(band, gap, gap.startMs, null)).toBe(60)
+      expect(seenMinutes(band, gap, gap.startMs)).toBe(60)
+    })
+
+    it('clamps the end at the gap, so overrun earns no extra credit', () => {
+      // The candidate is still suggested -- the filter never rejects one that
+      // runs long -- it just does not outrank a set that fills the dead time now.
+      const [gap, overrunning] = prepare(makeBand('gap', '20:00', '21:00'), makeBand('overrunning', '20:00', '23:00'))
+
+      expect(seenMinutes(overrunning, gap, gap.startMs, 0)).toBe(60)
+    })
+
+    it('clamps to zero when the fan arrives after the gap has closed', () => {
+      const [gap, band] = prepare(makeBand('gap', '20:00', '21:00'), makeBand('band', '20:30', '21:00'))
+
+      expect(seenMinutes(band, gap, gap.startMs, 180)).toBe(0)
+    })
   })
 })

--- a/frontend/src/utils/gapSuggestions.js
+++ b/frontend/src/utils/gapSuggestions.js
@@ -1,5 +1,7 @@
 import { walkMinutesBetween } from './walkTime'
 
+const MS_PER_MINUTE = 60000
+
 function hasValidWindow(band) {
   return (
     band &&
@@ -8,6 +10,49 @@ function hasValidWindow(band) {
     band.startMs > 0 &&
     band.endMs > band.startMs
   )
+}
+
+/**
+ * Minutes of the gap the fan actually SEES, given when they can leave and how
+ * long the walk takes.
+ *
+ * Walking only costs music when it makes the fan LATE. A 20-minute walk to a set
+ * that starts 25 minutes from now costs nothing; the same walk to a set starting
+ * in 5 minutes costs 15 minutes of it. Deducting the whole walk unconditionally
+ * (the first version of this) understates every candidate the fan has time to
+ * reach, and would have ranked a reachable 35-minute set below a 30-minute one.
+ *
+ * This is the ranking key rather than walk time alone (#972). Measured against
+ * every real Vol. 17 and Buddies Fest 2 performance, walk time was the PRIMARY
+ * key while having almost no dynamic range to sort on -- 1-3 minutes across all
+ * 15 Vol. 17 venue pairs, since the whole crawl fits in ~250 m of King St N and
+ * `walkMinutesBetween` floors at 1. Gap coverage spans 5-30 minutes over the
+ * same scenarios. So the old ordering decided the headline suggestion on its
+ * lowest-information key, and got it wrong in 7 of 26 scenarios -- every time
+ * trading 10-25 minutes of music to save a single minute of walking.
+ *
+ * The end is clamped to the gap because the feature answers "what fills the hole
+ * your cancelled set left". A candidate running past the gap is still SUGGESTED
+ * -- the filter never rejects one, and it only ever survives when the fan holds
+ * nothing after -- it just earns no extra credit for time outside the hole,
+ * which would otherwise rank a late-starting long set above one that fills the
+ * dead time immediately.
+ *
+ * An unknown walk time is treated as instant rather than poisoning the value
+ * with NaN; those candidates are already sorted last by the null check in the
+ * sort, so this only ever orders two unknowns against each other.
+ *
+ * @param {{startMs: number, endMs: number}} band - a prepared candidate
+ * @param {{startMs: number, endMs: number}} gap - the cancelled set's window
+ * @param {number} departureMs - when the fan is free to start walking
+ * @param {number|null} walkMinutes - walking time to the candidate's venue
+ * @returns {number} minutes of the gap actually seen, never negative
+ */
+export function seenMinutes(band, gap, departureMs, walkMinutes) {
+  const arrivalMs = departureMs + (walkMinutes ?? 0) * MS_PER_MINUTE
+  const from = Math.max(band.startMs, arrivalMs)
+  const until = Math.min(band.endMs, gap.endMs)
+  return Math.max(0, Math.round((until - from) / MS_PER_MINUTE))
 }
 
 export function suggestGapFillers({ cancelledBand, myBands, allBands, maxSuggestions = 3 } = {}) {
@@ -22,6 +67,9 @@ export function suggestGapFillers({ cancelledBand, myBands, allBands, maxSuggest
     .sort((a, b) => b.startMs - a.startMs)[0]
   const sourceBand = previousBand || cancelledBand
   const sourceVenue = { latitude: sourceBand.venue_lat, longitude: sourceBand.venue_lng }
+  // Paired with sourceBand: the fan leaves the prior set's venue when it ends,
+  // or the dark venue at the moment the cancelled set would have started.
+  const departureMs = previousBand ? previousBand.endMs : cancelledBand.startMs
 
   const suggestions = allBands
     .filter(
@@ -50,10 +98,14 @@ export function suggestGapFillers({ cancelledBand, myBands, allBands, maxSuggest
     .sort((a, b) => {
       if (a.walkMinutes === null && b.walkMinutes !== null) return 1
       if (a.walkMinutes !== null && b.walkMinutes === null) return -1
-      // id is the final tiebreak so the cap is deterministic: with equal walk
-      // time and equal start time, which candidates survive `slice` would
-      // otherwise depend on the order `allBands` happened to arrive in.
+      // Most of the gap actually seen wins; walk time then start time break
+      // ties. id is the
+      // final tiebreak so the cap is deterministic: with every other key equal,
+      // which candidates survive `slice` would otherwise depend on the order
+      // `allBands` happened to arrive in.
       return (
+        seenMinutes(b.band, cancelledBand, departureMs, b.walkMinutes) -
+          seenMinutes(a.band, cancelledBand, departureMs, a.walkMinutes) ||
         a.walkMinutes - b.walkMinutes ||
         a.startsAtMs - b.startsAtMs ||
         String(a.band.id).localeCompare(String(b.band.id))

--- a/frontend/src/utils/gapSuggestions.js
+++ b/frontend/src/utils/gapSuggestions.js
@@ -38,6 +38,12 @@ function hasValidWindow(band) {
  * which would otherwise rank a late-starting long set above one that fills the
  * dead time immediately.
  *
+ * The start is clamped to the gap as well as to arrival. Nothing reaches this
+ * through `suggestGapFillers`, whose filter admits only candidates starting at
+ * or after the gap opens -- but this is exported, and a direct caller passing a
+ * set that began before the gap would otherwise be credited for minutes outside
+ * it, contradicting the "minutes of the gap" contract above.
+ *
  * An unknown walk time is treated as instant rather than poisoning the value
  * with NaN; those candidates are already sorted last by the null check in the
  * sort, so this only ever orders two unknowns against each other.
@@ -50,7 +56,7 @@ function hasValidWindow(band) {
  */
 export function seenMinutes(band, gap, departureMs, walkMinutes) {
   const arrivalMs = departureMs + (walkMinutes ?? 0) * MS_PER_MINUTE
-  const from = Math.max(band.startMs, arrivalMs)
+  const from = Math.max(gap.startMs, band.startMs, arrivalMs)
   const until = Math.min(band.endMs, gap.endMs)
   return Math.max(0, Math.round((until - from) / MS_PER_MINUTE))
 }


### PR DESCRIPTION
Closes #972

## Summary

`suggestGapFillers` sorted candidates by **walk time first**, which decided the headline "here's what fills your gap" suggestion on its lowest-information key. It now ranks on **`seenMinutes`** — the gap minutes the fan actually catches, given when they are free to leave and how long the walk takes.

## The measurement came first, and it changed the scope

The issue asked for the shape to be measured before any formula was chosen. That measurement ran against **all 55 real performances** across Vol. 17 and Buddies Fest 2 (26 scenarios that produced candidates), taking the candidate list from the shipped engine itself so the filter could not drift from the thing being measured.

**Half the issue's premise is disproven and was deliberately not built for:**

| candidates offered | scenarios |
|---|---|
| 1 | 12 |
| 2 | 9 |
| 3 | 5 |
| 4+ | **0** |

Real lineups never produce more than 3 candidates, so `maxSuggestions = 3` never displaces anything — **the top-3 set was identical in all 26 scenarios**. Ranking changes *order* here, never *membership*.

**The other half is confirmed and systematic.** The top pick changed in **7 of 26 (26.9%)**, always the same lopsided trade:

```
"Mixed Feelings" dark 30m   was: Rhx34         ( 5m seen)   now: Rolodex Darko (28m seen)
"Aversion"       dark 30m   was: Chris Murray  (15m seen)   now: Among Legends (28m seen)
"Girls Against World Domination"
                 dark 30m   was: Curt Murder   ( 5m seen)   now: The Mendozaz   (20m seen)
```

## Root cause: the sort led on its lowest-variance key

| | dynamic range |
|---|---|
| walk minutes, Vol. 17 (15 venue pairs) | **1–3 min** |
| walk minutes, BF2 (3 venue pairs) | **1–6 min** |
| gap coverage | **5–30 min** |

Every Vol. 17 venue is within ~250 m on King St N and `walkMinutesBetween` floors at 1, so the primary key had ~2 minutes of spread while the ignored one had 25. That is why the defect was systematic rather than occasional.

## Why `seenMinutes` and not gap coverage

Walking only costs music when it makes the fan **late**. A 20-minute walk to a set starting in 25 minutes costs nothing; the same walk to a set starting in 5 costs 15 of them.

- **Departure** is paired with the existing walk source: the prior set's end when the fan holds one, otherwise the moment the cancelled set would have started. A fan free at 20:30 can reach a distant set that a fan leaving at 21:00 cannot.
- **The end is clamped to the gap.** A candidate running past it is still suggested and the filter still never rejects one (per the issue's explicit "not in scope"), but it earns no credit for time outside the hole — otherwise a late-starting long set outranks one that fills the dead time immediately.

Ties still break on walk time, then start time, then #877's id tiebreak, so the cap stays deterministic.

This corrected model came out of review. The first version deducted the **whole** walk unconditionally, which understated every candidate the fan had time to reach and would have ranked a reachable 35-minute set below a 30-minute one. Real-data impact was unchanged by the correction (same 7 flips), but the model is now truthful rather than accidentally right.

`coveredMinutes` was introduced and then **removed** — once `seenMinutes` landed it was exported and referenced by nothing, which is precisely the dead-export class `CLAUDE.md` records for `CACHE_BROWSE`.

## Test plan

- [x] `make gate` exits 0 — backend **1549** unchanged, frontend **1256 → 1265**
- [x] `make review` (CodeRabbit) clean; both findings it raised were real and are fixed
- [x] Shipped code re-verified against real Vol. 17 / BF2 data: same 7 corrected picks, top-3 set still unchanged
- [x] **All seven behaviours mutation-proven** — each fails a test that passes on the shipped code:

| mutation | test that catches it |
|---|---|
| revert to walk-first ordering | sliver test |
| deduct the whole walk unconditionally | "does not penalise a long walk the fan has time to make" |
| ignore arrival (rank on raw coverage) | "does not send the fan across town to arrive late" |
| drop the end clamp | "clamps the end at the gap" |
| drop the zero clamp | "clamps to zero when the fan arrives after the gap has closed" |
| depart from the dark venue, not the prior set | "leaves when the prior set ends, not when the gap opens" |
| drop the `?? 0` walk fallback | "treats an unknown walk as instant" |

Two of those tests were **vacuous on the first attempt and rebuilt until the mutation caught them**. The departure test asserted on a direct `seenMinutes` call rather than the engine's ordering, so the departure time never mattered — it passed with the mutation applied. And in the fallback test the `null` assertion alone is not enough: `null * 60000` is `0` in JS, so only the *omitted*-argument case yields `NaN` and fails. Both are kept, with a comment saying which one is load-bearing.

## Risk

Low. One module, no API or schema change, no change to which candidates are offered — only their order. Fan-facing on MySchedule.

## Related issues

None.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gap suggestions now prioritize candidates based on the amount of the cancelled gap that can actually be reached.
  * Walking time, departure timing, candidate availability, and gap boundaries are considered when ranking suggestions.
  * Suggestions account for departures after a held set and candidates with unknown walking times.

* **Bug Fixes**
  * Improved handling of visible gap coverage, including clamping results to the gap’s start and end times.
  * Added clearer tie-breaking for candidates with equal coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->