### PR TITLE
fix(timeline): performer chips navigate client-side, not through a 301

### DIFF
--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -1,3 +1,20 @@
+// NAVIGATION IN THIS FILE IS CLIENT-SIDE. The timeline's performer chips are
+// react-router Links, so clicking one changes the URL via pushState and React
+// renders the new route afterwards. Anything that reads rendered content with a
+// single bare `textContent()` / `page.title()` after a click can therefore
+// observe the PREVIOUS page -- typically the SetTimes brand heading -- and
+// compare the wrong string. Full page loads used to hide this by making
+// navigation and render the same event.
+//
+// waitForURL and toHaveURL do NOT help: the URL is the thing that changes first.
+// Wrap the assertion in `expect(async () => {...}).toPass()` so it retries until
+// the transition settles. Auto-retrying matchers (toBeVisible, toContainText)
+// are already safe and need no change.
+//
+// This bit three tests here, and only one of them failed locally -- a faster
+// machine renders inside the gap. Do not conclude from a green local run that a
+// bare read is safe.
+
 import { test, expect } from "@playwright/test";
 
 // The seeded upcoming event (database/seed-test-data.sql). Entering through its
@@ -31,9 +48,12 @@ test.describe("Band Profile Viewing", () => {
       // metacharacters cannot corrupt the pattern the way `new RegExp(name)` did.
       const heading = page.locator("main h1");
       await expect(heading).toBeVisible();
-      const headingText = ((await heading.textContent()) ?? "").trim();
-      expect(headingText).not.toBe("");
-      expect(linkText).toContain(headingText);
+      // POLLED -- see the note at the top of this file on client-side navigation.
+      await expect(async () => {
+        const headingText = ((await heading.textContent()) ?? "").trim();
+        expect(headingText).not.toBe("");
+        expect(linkText).toContain(headingText);
+      }).toPass({ timeout: 15000 });
 
       // Should NOT redirect to login
       await expect(page).not.toHaveURL(/\/admin\/login/);
@@ -380,8 +400,13 @@ test.describe("Band Profile Viewing", () => {
     // title a silent pass -- on the one assertion here that is SEO-critical.
     const heading = page.locator("main h1");
     await expect(heading).toBeVisible({ timeout: 15000 });
-    const headingText = ((await heading.textContent()) ?? "").trim();
-    expect(headingText).not.toBe("");
-    expect((await page.title()).toLowerCase()).toContain(headingText.toLowerCase());
+    // POLLED -- see the note at the top of this file. document.title is also set
+    // in an effect after the fetch resolves, so it settles independently of the
+    // heading; a single read can catch either one mid-transition.
+    await expect(async () => {
+      const headingText = ((await heading.textContent()) ?? "").trim();
+      expect(headingText).not.toBe("");
+      expect((await page.title()).toLowerCase()).toContain(headingText.toLowerCase());
+    }).toPass({ timeout: 15000 });
   });
 });

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -11,9 +11,9 @@
 // the transition settles. Auto-retrying matchers (toBeVisible, toContainText)
 // are already safe and need no change.
 //
-// This bit three tests here, and only one of them failed locally -- a faster
-// machine renders inside the gap. Do not conclude from a green local run that a
-// bare read is safe.
+// This has already caught three tests in this file, and only one of them failed
+// locally -- a faster machine renders inside the gap. Do not conclude from a
+// green local run that a bare read is safe.
 
 import { test, expect } from "@playwright/test";
 

--- a/e2e/band-profile-viewing.spec.js
+++ b/e2e/band-profile-viewing.spec.js
@@ -198,12 +198,23 @@ test.describe("Band Profile Viewing", () => {
     // which can exceed the default 5s timeout on a cold CI mobile run.
     const heading = page.locator("main h1");
     await expect(heading).toBeVisible({ timeout: 15000 });
-    const headingText = ((await heading.textContent()) ?? "").trim();
-    expect(headingText).not.toBe("");
-    // Identity of the profile that opened, matching the pattern the first test
-    // uses. The old form built a RegExp out of the full card text, which could
-    // not match the heading and threw on titles containing metacharacters.
-    expect(linkText).toContain(headingText);
+
+    // POLLED, because the timeline's performer chips navigate client-side. A
+    // pushState URL change lands BEFORE React renders the new route, so
+    // waitForURL above can resolve while `main h1` still holds the previous
+    // page's heading (the SetTimes brand) -- a bare textContent() read then
+    // compares the wrong string. Full page loads hid this by making navigation
+    // and render the same event.
+    //
+    // The assertion itself is unchanged: identity of the profile that opened,
+    // matching the pattern the first test uses. The old form built a RegExp out
+    // of the full card text, which could not match the heading and threw on
+    // titles containing metacharacters.
+    await expect(async () => {
+      const headingText = ((await heading.textContent()) ?? "").trim();
+      expect(headingText).not.toBe("");
+      expect(linkText).toContain(headingText);
+    }).toPass({ timeout: 15000 });
 
     // Verify content is readable on mobile
     const contentArea = page.locator('main, [role="main"], article').first();
@@ -213,26 +224,45 @@ test.describe("Band Profile Viewing", () => {
   });
 
   test("should navigate back to timeline from band profile", async ({ page }) => {
+    // This test used to assert a heading matching /schedule/i after clicking an
+    // `.or()` chain's `.first()` match. TWO things were wrong with that:
+    //
+    //   1. `.first()` in DOM order resolves to the brand link (`a[href="/"]`),
+    //      which goes to "/" -- and NO heading on "/" matches /schedule/i. The
+    //      headings there are SetTimes, Events, Happening Now, Coming Up, Past
+    //      Events. The only "schedule" heading is the sr-only h1 on
+    //      /event/<slug>, which that click never reaches.
+    //   2. The whole assertion sat behind `if (await ...isVisible())`, so when
+    //      the element was not yet visible the test passed having asserted
+    //      NOTHING. That is how an impossible assertion stayed green.
+    //
+    // It surfaced when the timeline's performer chips became router Links: the
+    // client-side transition is instant, the back affordance was visible in
+    // time, the `if` finally ran, and the impossible assertion failed.
+    //
+    // Rewritten to be unconditional and to assert something that is actually
+    // true of the destination.
     await page.goto("/");
 
-    // Navigate to band profile
-    const bandLink = page.locator('a[href*="/band/"]').or(page.locator('a[href*="/bands/"]')).first();
+    const bandLink = page.locator('a[href*="/band/"]').first();
     await expect(bandLink).toBeVisible();
     await bandLink.click();
+    await expect(page).toHaveURL(/\/band\//);
 
-    // Look for back button or home link
-    const backButton = page
-      .locator('button:has-text("Back")')
-      .or(
-        page.locator('a[href="/"]').or(page.locator('a:has-text("Home")').or(page.locator('a:has-text("Schedule")'))),
-      );
+    // The brand link is always present in the profile header, unlike
+    // "Back to Schedule", which renders only when ?fromEvent= resolves.
+    const home = page.getByRole("link", { name: /settimes/i }).first();
+    await expect(home).toBeVisible();
+    await home.click();
 
-    if (await backButton.first().isVisible()) {
-      await backButton.first().click();
-
-      // Verify we're back on timeline
-      await expect(page.getByRole("heading", { name: /schedule/i })).toBeVisible();
-    }
+    // Back on the timeline. "Events" is the events list's own <h2> and renders
+    // unconditionally; the page's h1 is the SetTimes brand.
+    await expect(page).toHaveURL(/\/$/);
+    // exact: true is load-bearing -- Playwright's name matching defaults to
+    // case-insensitive SUBSTRING, so "Events" also matches the "Past Events"
+    // heading and trips strict mode. Same collision class as an unscoped
+    // getByText.
+    await expect(page.getByRole("heading", { name: "Events", exact: true })).toBeVisible();
   });
 
   test("should handle band profile not found gracefully", async ({ page }) => {

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -975,8 +975,13 @@ function EventCard({
                 return (
                   <Badge
                     key={band.id}
-                    as="a"
-                    href={buildBandProfileHref(band.name, event.slug)}
+                    // Router Link, not a bare <a>: the four other callers of
+                    // buildBandProfileHref already use `to`. A plain anchor
+                    // costs a full page load AND -- since #985 made /band/<slug>
+                    // a 301 to /band/<id> -- a redirect hop on top of it, on the
+                    // highest-traffic page we have.
+                    as={Link}
+                    to={buildBandProfileHref(band.name, event.slug)}
                     variant={isCancelled ? 'warning' : 'default'}
                     size="md"
                     className="hover:bg-primary-500/20 cursor-pointer transition-colors inline-flex items-center gap-1.5"

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -1535,15 +1535,6 @@ describe('EventTimeline between-seasons filter copy accuracy', () => {
   })
 })
 
-// The artist chips in the expanded lineup were a bare `<a href>` while every
-// other caller of buildBandProfileHref used a router Link. That cost a full
-// page load on the highest-traffic page in the site -- and once #985 made
-// /band/<slug> a 301 to /band/<id>, a redirect hop on top of it.
-//
-// Asserting on the href alone would NOT catch a regression: react-router's Link
-// also renders <a href>, so the markup is identical either way. What separates
-// them is behaviour -- Link intercepts the click and calls preventDefault, so
-// fireEvent.click returns false. A plain anchor lets the default through.
 describe('EventTimeline artist links navigate client-side (#985 follow-up)', () => {
   // The "Performers:" chips on a COLLAPSED event card were a bare `<a href>`
   // while every other caller of buildBandProfileHref used a router Link. That

--- a/frontend/src/components/__tests__/EventTimeline.test.jsx
+++ b/frontend/src/components/__tests__/EventTimeline.test.jsx
@@ -1534,3 +1534,81 @@ describe('EventTimeline between-seasons filter copy accuracy', () => {
     expect(screen.queryByText('Browse past events — new dates will be announced here')).not.toBeInTheDocument()
   })
 })
+
+// The artist chips in the expanded lineup were a bare `<a href>` while every
+// other caller of buildBandProfileHref used a router Link. That cost a full
+// page load on the highest-traffic page in the site -- and once #985 made
+// /band/<slug> a 301 to /band/<id>, a redirect hop on top of it.
+//
+// Asserting on the href alone would NOT catch a regression: react-router's Link
+// also renders <a href>, so the markup is identical either way. What separates
+// them is behaviour -- Link intercepts the click and calls preventDefault, so
+// fireEvent.click returns false. A plain anchor lets the default through.
+describe('EventTimeline artist links navigate client-side (#985 follow-up)', () => {
+  // The "Performers:" chips on a COLLAPSED event card were a bare `<a href>`
+  // while every other caller of buildBandProfileHref used a router Link. That
+  // cost a full page load on the highest-traffic page in the site -- and once
+  // #985 made /band/<slug> a 301 to /band/<id>, a redirect hop on top of it.
+  //
+  // Note the guard these chips live behind: `!expanded && featuredBands.length`.
+  // A first version of this test expanded the card to reach them, so the section
+  // never rendered and the assertion ran against a different, already-routed
+  // link -- passing with the fix reverted. They come from the timeline payload's
+  // own `bands` array, and only while the card is collapsed.
+  //
+  // Asserting the href would NOT catch a regression either: react-router's Link
+  // renders <a href> too, so the markup is identical. Behaviour is what differs
+  // -- Link intercepts the click and calls preventDefault, so fireEvent.click
+  // returns false, where a plain anchor returns true.
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(url => {
+        if (url.startsWith('/api/events/timeline')) {
+          return Promise.resolve(
+            jsonResponse({
+              now: [],
+              upcoming: [
+                {
+                  id: 1,
+                  name: 'Link Event',
+                  slug: 'link-event',
+                  date: '2026-05-10',
+                  status: 'published',
+                  venues: [],
+                  bands: [{ id: 9, name: 'Routed Band' }],
+                  band_count: 1,
+                  venue_count: 1,
+                  ticket_url: null,
+                },
+              ],
+              past: [],
+            })
+          )
+        }
+        return Promise.reject(new Error(`Unexpected fetch URL: ${url}`))
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('intercepts a performer chip click instead of doing a full page load', async () => {
+    render(
+      <MemoryRouter>
+        <EventTimeline />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Link Event')).toBeInTheDocument()
+
+    const link = await screen.findByRole('link', { name: /Routed Band/ })
+    expect(link).toHaveAttribute('href', '/band/routed-band?fromEvent=link-event')
+
+    // false === the default was prevented === react-router handled it.
+    expect(fireEvent.click(link)).toBe(false)
+  })
+})


### PR DESCRIPTION
Follow-up to #985.

## Summary

The **"Performers:"** chips on a collapsed event card rendered `<Badge as="a" href=...>` — a real anchor — while all four other callers of `buildBandProfileHref` use a router `Link`, and **three other `Badge`s in this same file already use `as={Link}`**. It was the outlier in its own component.

Cost: a full page load instead of a client-side transition, on the **homepage timeline** — the highest-trafficked page we have (256 impressions / 19 clicks over 28 days in Search Console, the top page by a wide margin).

And since **#985 made `/band/<slug>` a 301 to `/band/<id>`**, that path became: full load → redirect → second full load. #985 added that hop; this removes it from the path real users click. External and legacy links still get the 301, which is what it is for.

## Sibling sweep

Swept every bare anchor in `frontend/src`. All the others are correct and left alone:

| site | verdict |
|---|---|
| ticket link, social links, directions | external, `target="_blank"` — correct as anchors |
| `ErrorBoundary` `href="/"` | **deliberate** full reload, to escape broken client state |
| `SubscribePage` | points at `/api/` endpoints, not routes |
| `App.jsx` → `/subscribe`, `SignupPage` → `/admin/login` | internal routes, lose SPA nav but hit **no redirect** — milder, separate class, deliberately not changed here |

So this was the only instance of the actual class: an internal link that now pays for a redirect.

## The test took three attempts, and the first two were vacuous

Both passed with the fix reverted. Recording them because each is a distinct trap:

1. **`findAllByRole(...)[0]`** selected a different artist link that was **already** a router `Link` — the expanded panel renders the same act in several places. The unscoped-selector class.
2. Asserting on **all** matching links still passed, because the test **expanded** the card — and these chips live behind `!expanded && featuredBands.length > 0`, so the section under test never rendered at all. They are fed by the timeline payload's own `bands` array, not by the details fetch.

**Asserting the `href` would not have caught it either**, which is the interesting part: `Link` renders `<a href>` too, so the markup is byte-identical. The discriminator is *behaviour* — `Link` intercepts the click and calls `preventDefault`, so `fireEvent.click` returns `false` where a plain anchor returns `true`.

I verified that discriminator in isolation before relying on it, rather than assuming:

```
plain <a>  fireEvent.click -> true
<Link>     fireEvent.click -> false
```

The final test fails with `expected true to be false` when the fix is reverted.

## Test plan

- [x] `make gate` exits 0 — backend **1549** unchanged, frontend **1304 → 1305**
- [x] `make review` (CodeRabbit) — no findings
- [x] Mutation-proven: reverting `as={Link}`/`to` to `as="a"`/`href` fails the new test
- [x] Discriminator itself verified in isolation before use
- [x] Sibling sweep across all bare anchors in `frontend/src`

## Risk

Low. One JSX attribute pair on one component. Identity meta on `/band/*` is SSR-owned and unaffected — crawlers and unfurl bots always fetch the URL directly and still get the 301 plus correct server-rendered tags.

## Related issues

Follow-up to #985. No issue filed — found while verifying that PR's effect in Search Console.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Performer badges in collapsed event timelines now use in-app navigation without triggering a full page reload.
  - Selecting a performer badge opens the correct performer profile page.
  - Improved performer profile navigation and back-navigation behaviour for more reliable browsing.
  - Back navigation now consistently returns to the event timeline with the correct page heading.
  - Improved route-transition handling so profile headings and page titles appear reliably during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->