### PR TITLE
chore: block pushes that would exceed the CodeRabbit hourly limit

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,87 @@
+#!/bin/sh
+# Guard against CodeRabbit rate-limit overage.
+#
+# CodeRabbit Pro allows 5 PR reviews per developer per ROLLING HOUR. Past that,
+# the usage-based add-on (enabled on this account) processes the review and
+# BILLS for it rather than pausing -- so there is no natural brake. Every push
+# to a PR branch is a review.
+#
+# The expensive failure is CONCENTRATION, not volume: five pushes across a day
+# cost nothing, four in half an hour bills. PR #998 burned 4 reviews in ~25
+# minutes on a two-line change, because fixes were pushed one at a time instead
+# of batched.
+#
+# WAITING IS FREE. The window is rolling, so the budget refills on its own.
+# Override only when landing NOW actually matters -- a show-day fix, a
+# production incident, or someone blocked on you:
+#
+#     CODERABBIT_OVERAGE=1 git push
+#
+# Deliberately POSIX sh with no gh/jq/network: a hook that fails open when a
+# tool is missing is worse than no hook, and this must not add latency or a
+# failure mode to every push.
+
+set -eu
+
+WINDOW_SECONDS=3600
+LIMIT=5
+WARN_AT=3
+DEFAULT_BRANCH=main
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# Pushes to the default branch do not open or update a PR, so they cost nothing.
+[ "$branch" = "$DEFAULT_BRANCH" ] && exit 0
+[ -z "$branch" ] && exit 0
+
+git_dir=$(git rev-parse --git-dir)
+log="$git_dir/coderabbit-push-log"
+now=$(date +%s)
+cutoff=$((now - WINDOW_SECONDS))
+
+# Drop entries outside the rolling window before counting.
+if [ -f "$log" ]; then
+    awk -v c="$cutoff" '$1 >= c' "$log" > "$log.tmp" 2>/dev/null || : > "$log.tmp"
+    mv "$log.tmp" "$log"
+else
+    : > "$log"
+fi
+
+count=$(wc -l < "$log" | tr -d ' ')
+[ -z "$count" ] && count=0
+
+if [ "$count" -ge "$LIMIT" ]; then
+    oldest=$(head -n 1 "$log" | cut -d' ' -f1)
+    wait_min=$(( (oldest + WINDOW_SECONDS - now + 59) / 60 ))
+    [ "$wait_min" -lt 1 ] && wait_min=1
+
+    if [ "${CODERABBIT_OVERAGE:-}" = "1" ]; then
+        printf '\n  ⚠  CodeRabbit: %s reviews already used this hour — this one BILLS.\n' "$count" >&2
+        printf '     Overriding because CODERABBIT_OVERAGE=1.\n\n' >&2
+    else
+        printf '\n  ✋ Push blocked: %s CodeRabbit reviews used in the last hour (limit %s).\n\n' "$count" "$LIMIT" >&2
+        printf '     The next review would exceed the window and BILL via the usage add-on.\n' >&2
+        printf '     Waiting is free — the budget refills in ~%s min.\n\n' "$wait_min" >&2
+        printf '     Batch your remaining fixes and push once.\n' >&2
+        printf '     If this genuinely must land now (show day, incident, someone blocked):\n\n' >&2
+        printf '         CODERABBIT_OVERAGE=1 git push\n\n' >&2
+        exit 1
+    fi
+elif [ "$count" -ge "$WARN_AT" ]; then
+    remaining=$((LIMIT - count))
+    printf '\n  ⚠  CodeRabbit: %s reviews used this hour, %s left before pushes bill.\n' "$count" "$remaining" >&2
+    printf '     Batch what is left rather than pushing per fix.\n\n' >&2
+fi
+
+# Recorded BEFORE the remote accepts the push, which over-counts when a push is
+# rejected or the network drops: a slot is consumed for a review that never ran.
+# That is deliberate. git has no post-push hook, so the alternatives are to log
+# here or to reconcile later against the remote-tracking ref -- and reconciling
+# under-counts, because an amended commit that WAS pushed (and WAS reviewed)
+# becomes unreachable after the next force-push.
+#
+# Over-counting costs an occasional spurious block, cleared for free by waiting
+# or by CODERABBIT_OVERAGE=1. Under-counting costs money. Given the hook exists
+# only to prevent the second, it errs toward the first on purpose.
+echo "$now $branch" >> "$log"
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -28,11 +28,40 @@ LIMIT=5
 WARN_AT=3
 DEFAULT_BRANCH=main
 
-branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+# pre-push receives one line per ref being updated on STDIN:
+#
+#     <local-ref> <local-sha> <remote-ref> <remote-sha>
+#
+# Read that rather than the checked-out branch. HEAD is the wrong signal: you
+# can push a branch you are not on (`git push origin feat:feat` from main), push
+# HEAD to a different remote branch, push several branches at once, or push a
+# tag -- and each of those either misses a review or invents one.
+#
+# Eligible == a non-delete update to refs/heads/<anything but the default>.
+# Tags and notes open no PR; a deletion (all-zero local sha) closes one.
+eligible=0
+eligible_refs=""
+while read -r _local_ref local_sha remote_ref _remote_sha; do
+    [ -z "${remote_ref:-}" ] && continue
 
-# Pushes to the default branch do not open or update a PR, so they cost nothing.
-[ "$branch" = "$DEFAULT_BRANCH" ] && exit 0
-[ -z "$branch" ] && exit 0
+    case "$remote_ref" in
+        "refs/heads/$DEFAULT_BRANCH") continue ;;
+        refs/heads/*) ;;
+        *) continue ;;
+    esac
+
+    case "${local_sha:-}" in
+        *[!0]*) ;;
+        *) continue ;;
+    esac
+
+    eligible=$((eligible + 1))
+    eligible_refs="$eligible_refs${remote_ref#refs/heads/} "
+done
+
+# Nothing here triggers a review: a tag, a deletion, a push to the default
+# branch, or an invocation with no ref updates at all.
+[ "$eligible" -eq 0 ] && exit 0
 
 git_dir=$(git rev-parse --git-dir)
 log="$git_dir/coderabbit-push-log"
@@ -50,7 +79,7 @@ fi
 count=$(wc -l < "$log" | tr -d ' ')
 [ -z "$count" ] && count=0
 
-if [ "$count" -ge "$LIMIT" ]; then
+if [ $((count + eligible)) -gt "$LIMIT" ]; then
     oldest=$(head -n 1 "$log" | cut -d' ' -f1)
     wait_min=$(( (oldest + WINDOW_SECONDS - now + 59) / 60 ))
     [ "$wait_min" -lt 1 ] && wait_min=1
@@ -67,7 +96,7 @@ if [ "$count" -ge "$LIMIT" ]; then
         printf '         CODERABBIT_OVERAGE=1 git push\n\n' >&2
         exit 1
     fi
-elif [ "$count" -ge "$WARN_AT" ]; then
+elif [ $((count + eligible)) -ge "$WARN_AT" ]; then
     remaining=$((LIMIT - count))
     printf '\n  ⚠  CodeRabbit: %s reviews used this hour, %s left before pushes bill.\n' "$count" "$remaining" >&2
     printf '     Batch what is left rather than pushing per fix.\n\n' >&2
@@ -83,5 +112,8 @@ fi
 # Over-counting costs an occasional spurious block, cleared for free by waiting
 # or by CODERABBIT_OVERAGE=1. Under-counting costs money. Given the hook exists
 # only to prevent the second, it errs toward the first on purpose.
-echo "$now $branch" >> "$log"
+# One entry per branch actually updated -- pushing two PR branches costs two.
+for ref in $eligible_refs; do
+    echo "$now $ref" >> "$log"
+done
 exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -838,6 +838,27 @@ Requires the CodeRabbit CLI (`brew install --cask coderabbit`, then `coderabbit 
 
 `make gate` deliberately does **not** include it — `gate` must stay fast and offline-capable; `review` needs the network and takes minutes.
 
+### CodeRabbit costs money past 5 reviews an hour — batch your pushes
+
+**Every push to a PR branch triggers a review.** CodeRabbit Pro allows **5 PR reviews per developer per ROLLING HOUR**, and this account has the usage-based add-on enabled — so past that, reviews are **not paused, they are billed**. There is no natural brake; the discipline has to come from the workflow.
+
+**The expensive failure is concentration, not volume.** The same number of pushes spread across a day costs nothing, because the window keeps refilling. PR #998 burned **4 reviews in ~25 minutes on a two-line change** — which, with #997's review already inside the same rolling hour, is what reached the limit of 5. Fixes went out one at a time instead of batched — a stale comment, then an E2E failure, then an incomplete sweep of that same failure, then a nit on prose added two pushes earlier. Three of the four were avoidable by reading the diff and running the right suite locally first.
+
+`make hooks` installs a tracked `pre-push` guard (`.githooks/pre-push`, wired via `core.hooksPath`). It warns at 3 reviews in the window and **blocks at 5**, reporting how many minutes until the budget refills. Run it once per clone — hooks are not cloned with the repo.
+
+**The rule for overriding is urgency to land, NOT issue priority.** Priority is the wrong axis: a p1 fixed correctly costs one review, while a p3 botched four times costs four — overage comes from *rework*, not importance, and a "p1 only" rule would license sloppiness exactly where correctness matters most.
+
+**Waiting is free.** The window is rolling, so the budget refills on its own. Ask only whether this must land *before it refills*:
+
+- show day, a production incident, or someone blocked on you → override
+- everything else → batch the remaining fixes and push once
+
+```bash
+CODERABBIT_OVERAGE=1 git push   # emergencies only; it bills
+```
+
+The hook is deliberately POSIX `sh` with no `gh`, `jq`, or network call — one that fails open when a tool is missing is worse than none, and it runs on every push. `lint-sh` globs `*.sh`, which would have skipped it silently, so that target now lists `.githooks/*` explicitly.
+
 ### Before every push (including follow-up commits during PR review)
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ export E2E_ADMIN_PASSWORD
 
 .PHONY: help install build dev format format-check lint lint-md lint-sh lint-yaml lint-sql lint-json \
 	lint-all test test-backend test-frontend gate review review-wip validate-openapi schema-check \
-	probe-links e2e e2e-setup e2e-serve e2e-run e2e-clean
+	probe-links e2e e2e-setup e2e-serve e2e-run e2e-clean hooks
 
 # CodeRabbit emits PostHog telemetry errors when egress is blocked. They are
 # noise, not review failures — the review still exits 0. They appear on BOTH
@@ -86,11 +86,14 @@ lint-md: ## markdownlint across the docs we maintain (see .markdownlint-cli2.jso
 # exactly the failure `lint-md` had before it reached .PHONY.
 
 # File lists come from $(LINT_FILES); see its definition for the scope rules.
-lint-sh: ## shellcheck every shell script (tracked + untracked, minus gitignored)
+# .githooks/* is listed explicitly: those files are shell but carry NO .sh
+# extension, so the '*.sh' glob alone would silently skip them -- a linter that
+# does not see a file is indistinguishable from one that passes it.
+lint-sh: ## shellcheck every shell script incl. git hooks (tracked + untracked, minus gitignored)
 	@command -v shellcheck >/dev/null 2>&1 || { \
 		echo "shellcheck not found. Install: brew install shellcheck"; exit 1; }
 	@list=$$(mktemp); \
-	$(LINT_FILES) '*.sh' > "$$list" || { rm -f "$$list"; \
+	$(LINT_FILES) '*.sh' '.githooks/*' > "$$list" || { rm -f "$$list"; \
 		echo "lint: could not enumerate files (git ls-files failed)"; exit 1; }; \
 	rc=0; while IFS= read -r f; do \
 		[ -f "$$f" ] || continue; \
@@ -160,6 +163,12 @@ test-frontend: ## Frontend unit tests
 test: test-backend test-frontend ## All unit tests
 
 gate: format format-check lint-all test build ## FULL pre-commit gate — run before every commit
+
+hooks: ## Install the tracked git hooks (pre-push CodeRabbit rate-limit guard)
+	@git config core.hooksPath .githooks
+	@echo "core.hooksPath -> .githooks"
+	@echo "pre-push now guards the CodeRabbit rolling-hour limit (5 reviews/hour)."
+	@echo "Override for a genuine emergency: CODERABBIT_OVERAGE=1 git push"
 
 review: ## AI code review of this branch vs origin/main — run BEFORE opening a PR
 	@command -v coderabbit >/dev/null 2>&1 || { \


### PR DESCRIPTION
Adds a tracked `pre-push` hook so a burst of pushes cannot quietly bill for CodeRabbit reviews.

## Why

Every push to a PR branch triggers a review. Pro allows **5 per developer per rolling hour**, and this account has the **usage-based add-on enabled** — so past that, reviews are **not paused, they are billed**. There is no natural brake, which makes it purely a discipline problem. Discipline is what failed.

**PR #998 burned 4 reviews in ~25 minutes on a two-line production change:**

| push | cause | avoidable |
|---|---|---|
| open PR | — | no |
| stale comment | I created it with a careless splice and did not read my own diff | **yes** |
| E2E failure | CI found it; running E2E locally first would have | **yes** |
| incomplete sweep of that same failure | grep window was 6 lines, should have been the whole file | **yes** |
| style nit | on prose I added two pushes earlier | **yes** |

With #997's review already inside the same rolling hour, that is what reached the limit. Compare **#997: 1 review** — delegated, diff read, gate run, pushed once.

## What it does

`.githooks/pre-push` warns at 3 reviews in the window and **blocks at 5**, reporting how many minutes until the budget refills. `make hooks` wires it via `core.hooksPath`; run once per clone, since git does not clone hooks.

Deliberately POSIX `sh` with no `gh`, `jq`, or network call — a hook that fails open when a tool is missing is worse than no hook, and this runs on every push. Pushes to `main` are skipped: they open no PR and cost nothing. State lives in `.git/`, so it is never tracked.

## The rule: urgency to land, not issue priority

Priority is the wrong axis. A p1 fixed correctly costs one review; a p3 botched four times costs four — **overage tracks rework, not importance**, and a "p1 only" rule would license sloppiness exactly where correctness matters most.

**Waiting is free**, since the window is rolling. So the only question is whether this must land *before it refills*:

- show day, a production incident, or someone blocked on you → `CODERABBIT_OVERAGE=1 git push`
- everything else → batch the remaining fixes and push once

## Deliberate design decision, flagged for review

The hook records **before** the remote accepts the push, so a rejected or failed push over-counts. That is intentional and documented in-file: git has no post-push hook, and the alternative — reconciling against the remote-tracking ref afterwards — **under-counts**, because an amended commit that *was* pushed and *was* reviewed becomes unreachable after the next force-push.

Over-counting costs an occasional spurious block, cleared free by waiting or the override. Under-counting costs money. The hook exists only to prevent the second, so it errs toward the first.

## `lint-sh` could not see it

The target globbed `'*.sh'`, and this file has no extension — it would have been skipped **silently**. `lint-sh` now lists `.githooks/*` explicitly. A linter that cannot see a file is indistinguishable from one that passes it.

## Test plan

- [x] `make gate` exits 0 — backend **1549**, frontend **1305**
- [x] `make review` clean after addressing both findings
- [x] **Verified against all six paths in a throwaway repo, not assumed:** skips `main`; allows and records on a clean window; warns at 3; **blocks at 5 (exit 1)** with a correct "~50 min" refill estimate; allows at 5 under `CODERABBIT_OVERAGE=1`; prunes entries older than the window and allows again
- [x] `lint-sh` coverage proven by mutation — a deliberately broken hook fails with 6 shellcheck findings, passes once restored
- [x] Exercised live: this PR's own push ran through the hook and recorded one entry

## Risk

Low, and locally scoped. No production code. The hook only affects pushes from a clone that has run `make hooks`, and `--no-verify` bypasses it.

## Related issues

None — arose from a workflow cost observed directly.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a push safeguard that tracks eligible branch updates over a rolling one-hour period.
  - Ignores tag deletions and default-branch updates when applying review limits.
  - Warns as the threshold approaches and blocks excessive review requests by default.
  - Supports an emergency override for urgent pushes.

- **Documentation**
  - Added guidance on review usage, batching changes, override criteria, and setup requirements.

- **Chores**
  - Added a setup command for enabling the safeguard.
  - Expanded shell-lint coverage for supporting configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->