### PR TITLE
chore: add a sponsorship config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,20 @@
+# Sponsorship for settimes.ca — the Waterloo Region live-music platform.
+#
+# Sponsorship supports what it costs to keep the platform running and open:
+# the domain, Cloudflare Pages/D1/R2, transactional email, and the time to
+# keep the lineups accurate during a show.
+#
+# GitHub renders a "Sponsor" button on the repo from this file. Each key is a
+# platform; every value is a username or URL on that platform.
+
+github: BreakableHoodie
+
+# Alternatives, if a platform that pays out sooner is wanted. Uncomment one and
+# fill in the handle; several can be listed at once and GitHub shows them all.
+#
+# ko_fi: <handle>            # fastest to set up, one-time + monthly, 0% on donations
+# buy_me_a_coffee: <handle>  # similar, ~5% platform fee
+# liberapay: <handle>        # recurring only, non-profit, very low fees
+# open_collective: <slug>    # transparent public ledger; fiscal-host fee applies
+# polar: <handle>
+# custom: ["https://settimes.ca/support"]   # up to 4 URLs


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the repo shows a **Sponsor** button.

## Framing

Written around what sponsorship actually covers — the domain, Cloudflare Pages/D1/R2, transactional email, and the time to keep lineups accurate during a show. That is true, and it needs no other context.

## Target

`github: BreakableHoodie`.

**GitHub Sponsors is not enrolled on the account yet** — `/sponsors/BreakableHoodie` currently 302s to the profile rather than rendering a sponsor page. So the button activates once enrollment completes; the entry sits harmlessly until then.

## Why the alternatives are commented rather than chosen

Left as a decision rather than a default, since they trade off differently:

| platform | trade-off |
|---|---|
| **GitHub Sponsors** | 0% fee, native button, most trusted in a dev context — but enrollment needs identity + bank verification and takes a few days |
| **Ko-fi** | works today, no enrollment wait, 0% on donations |
| **Buy Me a Coffee** | same shape, ~5% platform fee |
| **Liberapay** | recurring only, non-profit, very low fees |
| **Open Collective** | public ledger — good for shared project funds, adds a fiscal-host fee |

Several keys can be active simultaneously; GitHub renders them all.

## What is still yours to do

1. Enrol at <https://github.com/sponsors> (identity + payout setup), **or** uncomment a platform that pays out sooner and fill in the handle.
2. After merge, confirm the Sponsor button renders on the repo page — I could not verify how GitHub displays an entry for an account that has not yet enrolled, and I would rather flag that than assert it.

## Test plan

- [x] `make gate` exits 0
- [x] `make lint-yaml` clean (exit 0)
- [x] Valid YAML, single key, 20 insertions / 0 deletions

## Risk

None. Config only; no code path touches it.

## Related issues

None.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository sponsorship information, including GitHub Sponsors and optional support links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->