### PR TITLE
chore: point sponsorship at Ko-fi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -5,16 +5,21 @@
 # keep the lineups accurate during a show.
 #
 # GitHub renders a "Sponsor" button on the repo from this file. Each key is a
-# platform; every value is a username or URL on that platform.
+# platform; the value is a username or URL on that platform. Several may be
+# listed at once.
 
-github: BreakableHoodie
+ko_fi: tiptophams
 
-# Alternatives, if a platform that pays out sooner is wanted. Uncomment one and
-# fill in the handle; several can be listed at once and GitHub shows them all.
+# GitHub Sponsors is not enrolled on the account yet — /sponsors/BreakableHoodie
+# currently redirects to the profile rather than a sponsor page. Uncomment once
+# enrollment (identity + payout verification) completes; it takes a few days and
+# charges no platform fee.
 #
-# ko_fi: <handle>            # fastest to set up, one-time + monthly, 0% on donations
-# buy_me_a_coffee: <handle>  # similar, ~5% platform fee
+# github: BreakableHoodie
+
+# Other options, none of them set up:
+#
+# buy_me_a_coffee: <handle>  # like ko-fi, ~5% platform fee
 # liberapay: <handle>        # recurring only, non-profit, very low fees
-# open_collective: <slug>    # transparent public ledger; fiscal-host fee applies
-# polar: <handle>
+# open_collective: <slug>    # public ledger; fiscal-host fee applies
 # custom: ["https://settimes.ca/support"]   # up to 4 URLs


### PR DESCRIPTION
Follow-up to #1000, which shipped `.github/FUNDING.yml` pointing at GitHub Sponsors.

## Change

`ko_fi: tiptophams` becomes the active target. It works **today** — no enrollment wait, and Ko-fi takes no platform fee on donations.

## Why GitHub Sponsors is commented rather than listed alongside

The account is not enrolled — `/sponsors/BreakableHoodie` still redirects to the profile rather than rendering a sponsor page. I could not verify how GitHub displays an entry for an unenrolled account without merging and looking, so listing only a target that definitely resolves avoids shipping a Sponsor button that might go nowhere.

The line is one comment away from active. Uncomment after enrolling (identity + payout verification, a few days, 0% fee); both platforms can be listed at once.

## Verification, stated honestly

- [x] `make lint-yaml` clean, `make gate` exits 0
- [x] Exactly **one** active key in the file, confirmed by stripping comments and blank lines
- [ ] **The Ko-fi URL could not be verified from here.** `ko-fi.com` sits behind a Cloudflare bot challenge, so `curl` returns `403 "Just a moment..."` rather than the page. That is an inconclusive check, not a failing one — the handle came from the account owner. Worth eyeballing the Sponsor button after merge.

## Risk

None. Config only; no code path reads it.

## Related issues

Follows #1000.

Built by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sponsorship options to enable Ko-fi support.
  * Removed the Polar sponsorship option and revised guidance for other funding platforms.
  * GitHub Sponsors remains unavailable pending account enrolment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->