### PR TITLE
test: make two suites independent of their own run order

### DIFF
--- a/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
+++ b/frontend/src/hooks/__tests__/useScrollCollapse.test.jsx
@@ -177,10 +177,10 @@ describe('useScrollCollapse', () => {
   // collapsing element itself renders — so a caller re-rendering in
   // response to a progress change can't feed back into another scroll
   // measurement and oscillate.
-  it('is driven only by scrollY, not by re-renders with no scroll event', () => {
+  it('is driven only by scrollY, not by re-renders with no scroll event', async () => {
     setScrollY(90)
     const { rerender } = render(<Harness start={40} end={140} />)
-    fireScroll()
+    await fireScroll()
     expect(screen.getByTestId('progress')).toHaveTextContent('0.5')
 
     // A prop change causing a re-render without a new scroll event must not

--- a/frontend/src/utils/__tests__/clipboard.test.js
+++ b/frontend/src/utils/__tests__/clipboard.test.js
@@ -15,6 +15,14 @@ describe('copyToClipboard', () => {
     Object.defineProperty(navigator, 'clipboard', { value: originalClipboard, configurable: true })
     document.execCommand = originalExecCommand
     vi.restoreAllMocks()
+    // copyToClipboard's execCommand fallback appends a <textarea> and only
+    // removes it after document.execCommand('copy') returns — if that call
+    // throws (as "returns false when the fallback throws" below forces), the
+    // removal is never reached and the element is orphaned in document.body
+    // for the rest of this file's shared jsdom environment. Sweep it here so
+    // a later test's "the textarea is cleaned up" assertion sees a clean DOM
+    // regardless of run order.
+    document.querySelectorAll('textarea').forEach(node => node.remove())
   })
 
   function setClipboard(value) {


### PR DESCRIPTION
Closes #1003.

## Summary

Two frontend suites passed only because Vitest ran their cases in declaration order. Shuffled, each failed **on its own**, with no other file involved — the hook suite swinging **2, then 9, then 5** failures across runs of the same file.

**Neither cause was what the issue guessed.** I had assumed leaked window/scroll state and a stubbed Clipboard API. Both wrong:

### `useScrollCollapse.test.jsx` — a floating promise, not shared state

The last test called `fireScroll()` **without awaiting it**, from a non-`async` `it()`. `fireScroll` is async and internally awaits a bare `requestAnimationFrame`.

Its own assertions still passed, because the hook applies its first measurement synchronously on mount — the value was already correct before the dispatch mattered. **So the test reported green while leaving work running.**

That orphaned frame then resolved during whichever test the shuffle ran next, closing a stale `act()` scope after RTL's global `afterEach` had already unmounted the component. That is precisely why the failure count swung and why a *different* test failed each run: the victim was whoever happened to be executing when the promise landed.

Fix is two tokens — make the callback `async`, `await` the helper. No assertion touched.

### `clipboard.test.js` — a genuinely leaked DOM node

`copyToClipboard`'s `execCommand` fallback appends a `<textarea>` and removes it **only after** `execCommand` returns. The test that deliberately makes it throw never reaches the removal, orphaning the element in `document.body` for the rest of the file.

Any ordering where that test ran first broke `falls back to execCommand…`, whose own assertion is `expect(document.querySelector("textarea")).toBeNull()`. Swept in the existing `afterEach`, with the reason written down.

## Verification — a green unshuffled run proves nothing here

That is the bug, so shuffling is the only meaningful check:

- [x] `useScrollCollapse.test.jsx` — **5 shuffled runs**, all 11/11 (was 2/9/5 failures)
- [x] `clipboard.test.js` — **5 shuffled runs**, all 5/5
- [x] **Full suite shuffled ×3** — 1322/1322 every time
- [x] Unshuffled unchanged — 1322
- [x] `make gate` exits 0 — backend **1549**, frontend **1322**
- [x] `make review` — **no findings**
- [x] Test counts unchanged (11 and 5); **no assertions modified; no source file touched**

## Found but deliberately not fixed here

`clipboard.js`'s fallback leaves its temporary `<textarea>` in the DOM when `execCommand` throws — the removal is not in a `finally`. Real, minor, and a **source** change rather than a test-order fix, so it is filed as **#1004** rather than smuggled into this PR. It is the underlying reason that suite was order-dependent; the `afterEach` sweep here treats the symptom so the tests are honest, and #1004 fixes the cause.

## Risk

Low. Tests only.

Built by Sonny · Reviewed by Theo · 🤖 [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved scroll-collapse test reliability by waiting for asynchronous scroll updates before validation.
  * Enhanced clipboard test cleanup to remove leftover temporary elements, including after fallback errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->